### PR TITLE
fix(1569): recognise ComfyUI's `file_upload` so Load3D model inputs get upload handling

### DIFF
--- a/browser_tests/unit/load3d-file-upload.test.mjs
+++ b/browser_tests/unit/load3d-file-upload.test.mjs
@@ -1,0 +1,339 @@
+// panel#1569 — ComfyUI's 3D upload kind is `file_upload`, not `model_upload`.
+//
+// `UPLOAD_CONFIG_FLAGS` listed image/video/audio/`model_upload`. ComfyUI's own
+// `UploadType` enum (comfy_api/latest/_io.py) is image="image_upload",
+// audio="audio_upload", video="video_upload", model="file_upload" — and the V1
+// spelling that predates it was already `{"file_upload": True}` (the commit that
+// added Load3D, ComfyUI bdf39379). So the panel recognised a flag no ComfyUI has
+// ever emitted and did NOT recognise the one two live inputs actually carry.
+//
+// MEASURED on a live ComfyUI 0.33.2 /object_info (853 types, 529 combo inputs):
+//
+//     image_upload  4   LoadImage.image, LoadImageMask.image,
+//                       LoadImageOutput.image, Painter.mask
+//     audio_upload  1   LoadAudio.audio
+//     video_upload  1   LoadVideo.file
+//     file_upload   2   Load3D.model_file, Load3DAdvanced.model_file   <-- unrecognised
+//     model_upload  0
+//
+// The two 3D inputs serialize as the V2 shape verbatim:
+//
+//     "model_file": ["COMBO", {"multiselect": false, "options": ["none"],
+//                              "file_upload": true}]
+//
+// WHY THIS IS A WRITE-PATH CHANGE, NOT A TYPO FIX. Recognising these inputs ARMS the
+// #387 upload fallback on `panel_set_widget` for two inputs where it has always been
+// inert, so what the write path accepts must be checked in BOTH directions. It was
+// checked against the server, live, rather than reasoned about:
+//
+//   * ComfyUI's core combo-membership check is SKIPPED for this input. `Load3D`
+//     declares `validate_inputs(cls, model_file, **kwargs)`, and execution.py gates
+//     the "Value not in list" error on `x not in validate_function_inputs and not
+//     validate_has_kwargs`. Only `folder_paths.exists_annotated_filepath` decides.
+//   * So on a live 0.33.2, POST /prompt ACCEPTS `Load3D.model_file` =
+//     `meshes/cloud.ply` and `chair.glb` (both exist under input/, neither is
+//     enumerated — `Load3D.define_schema` rglobs `input/3d/` only) and REFUSES
+//     `3d/nope.glb` with "Invalid 3D model file". Combo membership is irrelevant;
+//     existence is everything. The panel refusing a non-enumerated but present file
+//     was therefore a FALSE refusal, and the fallback fixes exactly that.
+//   * ComfyUI runs NO extension check of its own here: `/prompt` accepts
+//     `3d/notes.txt`, and `/view?filename=notes.txt&subfolder=3d&type=input` answers
+//     206. `UPLOAD_KIND_EXTENSIONS.file_upload` is the ONLY thing that keeps a
+//     server-confirmed `.txt` out of a Load3D combo, so it is asserted here as a
+//     gate rather than trusted as a nicety (#240 strictness).
+//
+// The extension set is Load3D's OWN listing suffixes and must NOT be the weight-file
+// set `model_upload` carries: a `.safetensors` is not a loadable 3D asset, and the
+// two kinds sharing a set would silently admit one.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import {
+  authoritativeComboValues,
+  uploadConfigOf,
+  uploadInputAccepts,
+  uploadInputConfig,
+} from "../../web/js/lib/input-asset.js";
+import { scanComboAvailability } from "../../web/js/lib/live-combo-availability.js";
+
+const REGISTRY = { Load3D: {}, Load3DAdvanced: {}, CheckpointLoaderSimple: {} };
+
+/** The live 0.33.2 `Load3D.model_file` spec, copied from a real /object_info body. */
+const load3dSpec = (options = ["none"]) => [
+  "COMBO",
+  { multiselect: false, options, file_upload: true },
+];
+
+const defsWith = (options) => ({
+  Load3D: { input: { required: { model_file: load3dSpec(options) } } },
+  Load3DAdvanced: { input: { required: { model_file: load3dSpec(options) } } },
+  CheckpointLoaderSimple: { input: { required: { ckpt_name: [["sd15.safetensors"], {}] } } },
+});
+
+/** Mirrors refreshComboOptionsFromDefs for the V2 shape: the widget takes the fresh list. */
+function refreshFromFreshDefs(defs, target) {
+  const widget = target?.widgets?.[0];
+  const spec = defs?.[target?.type]?.input?.required?.[widget?.name];
+  const options = authoritativeComboValues(spec);
+  if (widget && Array.isArray(options)) widget.options.values = options.slice();
+}
+
+const load3dNode = (value = "none", options = ["none"]) => {
+  const widget = { name: "model_file", type: "combo", options: { values: options.slice() }, value };
+  return { node: { id: 77, type: "Load3D", widgets: [widget] }, widget };
+};
+
+// ---------------------------------------------------------------------------
+// Recognition — the flag itself
+// ---------------------------------------------------------------------------
+
+test("#1569 the live Load3D/Load3DAdvanced model_file config is recognised as an upload input", () => {
+  const defs = defsWith(["none"]);
+  for (const type of ["Load3D", "Load3DAdvanced"]) {
+    const cfg = uploadInputConfig(defs, type, "model_file");
+    assert.ok(cfg, `${type}.model_file must be recognised as an upload input`);
+    assert.equal(cfg.file_upload, true);
+  }
+  // The exact config object the live server publishes, standalone.
+  assert.ok(uploadConfigOf({ multiselect: false, options: ["none"], file_upload: true }));
+});
+
+test("#1569 the 3D kind gates on Load3D's OWN suffixes, never the weight-file set", () => {
+  const cfg = { file_upload: true };
+  // Exactly the suffixes comfy_extras/nodes_load_3d.py enumerates.
+  for (const ext of ["gltf", "glb", "obj", "fbx", "stl", "spz", "splat", "ply", "ksplat"]) {
+    assert.equal(uploadInputAccepts(cfg, `3d/chair.${ext}`), true, `.${ext} is a Load3D suffix`);
+    assert.equal(uploadInputAccepts(cfg, `3d/CHAIR.${ext.toUpperCase()}`), true, "case-insensitive");
+  }
+  // `model_upload`'s weight-file extensions are NOT 3D assets. If the two kinds ever
+  // share one Set, this is what catches it.
+  for (const ext of ["safetensors", "ckpt", "pt", "pth", "bin", "gguf", "sft", "onnx"]) {
+    assert.equal(uploadInputAccepts(cfg, `3d/weights.${ext}`), false, `.${ext} is not a 3D asset`);
+  }
+  // And the reverse: a weight-upload input must not start taking meshes.
+  assert.equal(uploadInputAccepts({ model_upload: true }, "sub/chair.glb"), false);
+  assert.equal(uploadInputAccepts({ model_upload: true }, "sub/sd15.safetensors"), true);
+  // The server serves this file 206 and ComfyUI's own /prompt validation accepts it.
+  // The panel refuses it anyway — that is the #240 overshoot, and it is deliberate.
+  assert.equal(uploadInputAccepts(cfg, "3d/notes.txt"), false);
+  assert.equal(uploadInputAccepts(cfg, "3d/noext"), false);
+});
+
+// ---------------------------------------------------------------------------
+// WRITE path — panel_set_widget, both directions
+// ---------------------------------------------------------------------------
+
+test("#1569 a server-confirmed 3D model the Load3D combo cannot list is ACCEPTED", async () => {
+  // `Load3D.define_schema` rglobs `input/3d/` only, so a file under any other input
+  // subfolder is never a combo member however fresh the fetch — yet ComfyUI's own
+  // /prompt validates it (measured). The write must succeed.
+  const { node, widget } = load3dNode();
+  let probed = null;
+  const res = await runSetWidget(node, "model_file", "meshes/cloud.ply", {
+    registry: REGISTRY,
+    getFreshObjectInfo: async () => defsWith(["none"]),
+    refreshCombos: refreshFromFreshDefs,
+    confirmServerAsset: async (v) => {
+      probed = v;
+      return true;
+    },
+  });
+  assert.equal(res.set.value, "meshes/cloud.ply");
+  assert.equal(res.server_confirmed, true);
+  assert.equal(probed, "meshes/cloud.ply");
+  assert.ok(widget.options.values.includes("meshes/cloud.ply"));
+});
+
+test("#1569 an ANNOTATED 3D value stays refused on the write path — unchanged, not newly broken", async () => {
+  // `uploadInputAccepts` reads the extension off the RAW value, so `x.glb [output]`
+  // has extension "glb [output]" and matches nothing. That is PRE-EXISTING and kind-
+  // independent — an annotated `pic.png [output]` is refused on a LoadImage the same
+  // way today — and #1569 deliberately does not change it: the read path strips the
+  // annotation before asking (live-combo-availability passes the parsed `bare` name),
+  // the write path never has. Pinned here so recognising `file_upload` cannot be read
+  // as having quietly opened that door, and so the day someone does open it, they open
+  // it for every kind at once rather than only for 3D.
+  const { node, widget } = load3dNode();
+  let probed = false;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "model_file", "3d/chair.glb [output]", {
+        registry: REGISTRY,
+        getFreshObjectInfo: async () => defsWith(["none"]),
+        refreshCombos: refreshFromFreshDefs,
+        confirmServerAsset: async () => {
+          probed = true;
+          return true;
+        },
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(probed, false);
+  assert.equal(widget.value, "none");
+  // Same verdict for the image kind, which nothing in this change touches.
+  assert.equal(uploadInputAccepts({ image_upload: true }, "sub/pic.png [output]"), false);
+});
+
+test("#1569 a 3D model file the server does NOT have stays REFUSED", async () => {
+  // Measured: ComfyUI answers this exact case "Invalid 3D model file: 3d/nope.glb".
+  const { node, widget } = load3dNode();
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "model_file", "3d/nope.glb", {
+        registry: REGISTRY,
+        getFreshObjectInfo: async () => defsWith(["none"]),
+        refreshCombos: refreshFromFreshDefs,
+        confirmServerAsset: async () => false,
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(widget.value, "none", "a refused write must not mutate the widget");
+  assert.deepEqual(widget.options.values, ["none"]);
+});
+
+test("#1569 a server-EXISTING non-3D file is REFUSED, and refused BEFORE the probe", async () => {
+  // ComfyUI would take this (`/prompt` accepts `3d/notes.txt`, `/view` serves it 206).
+  // The panel is deliberately stricter, and the refusal is decided by extension, so no
+  // network call is spent on it at all.
+  const { node, widget } = load3dNode();
+  let probed = false;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "model_file", "3d/notes.txt", {
+        registry: REGISTRY,
+        getFreshObjectInfo: async () => defsWith(["none"]),
+        refreshCombos: refreshFromFreshDefs,
+        confirmServerAsset: async () => {
+          probed = true;
+          return true;
+        },
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(probed, false, "a wrong-kind extension is refused before any server probe");
+  assert.equal(widget.value, "none");
+});
+
+test("#1569 a checkpoint name is REFUSED on a 3D input even though the server has it", async () => {
+  // The one way recognising `file_upload` could have loosened too far: if the 3D kind
+  // inherited `model_upload`'s weight extensions, this write would be accepted.
+  const { node, widget } = load3dNode();
+  let probed = false;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "model_file", "3d/sd15.safetensors", {
+        registry: REGISTRY,
+        getFreshObjectInfo: async () => defsWith(["none"]),
+        refreshCombos: refreshFromFreshDefs,
+        confirmServerAsset: async () => {
+          probed = true;
+          return true;
+        },
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(probed, false);
+  assert.equal(widget.value, "none");
+});
+
+test("#1569 a plain (non-upload) combo is still never rescued by the probe", async () => {
+  const widget = {
+    name: "ckpt_name",
+    type: "combo",
+    options: { values: ["sd15.safetensors"] },
+    value: "sd15.safetensors",
+  };
+  const node = { id: 5, type: "CheckpointLoaderSimple", widgets: [widget] };
+  let probed = false;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "ckpt_name", "3d/chair.glb", {
+        registry: REGISTRY,
+        getFreshObjectInfo: async () => defsWith(["none"]),
+        refreshCombos: refreshFromFreshDefs,
+        confirmServerAsset: async () => {
+          probed = true;
+          return true;
+        },
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(probed, false, "recognising file_upload must not arm the probe anywhere else");
+});
+
+test("#1569 an ENUMERATED 3D model is accepted by the refresh, with no probe at all", async () => {
+  const { node } = load3dNode("none", ["none"]);
+  let probed = false;
+  const res = await runSetWidget(node, "model_file", "3d/chair.glb", {
+    registry: REGISTRY,
+    getFreshObjectInfo: async () => defsWith(["none", "3d/chair.glb"]),
+    refreshCombos: refreshFromFreshDefs,
+    confirmServerAsset: async () => {
+      probed = true;
+      return true;
+    },
+  });
+  assert.equal(res.set.value, "3d/chair.glb");
+  assert.equal(res.refreshed, true);
+  assert.equal(res.server_confirmed, undefined);
+  assert.equal(probed, false, "the fresh list already lists it — nothing to probe");
+});
+
+// ---------------------------------------------------------------------------
+// READ path — panel_get_errors' live availability scan
+// ---------------------------------------------------------------------------
+
+// The READ path (panel_get_errors' live availability scan) reads a class body through
+// `parseClassCombos`, which on main recognises the V1 shape `[[...options], config]`
+// only. Live 0.33.2 publishes Load3D in the V2 shape, so on main today this scan does
+// not see `Load3D.model_file` as a combo AT ALL and never judges it — the read-path
+// half of #1569 only reaches a live server once #1568's V2 reader lands. These tests
+// therefore drive the V1 shape, which is not a hypothetical: ComfyUI shipped Load3D as
+// `(sorted(files), {"file_upload": True})` from bdf39379 (Dec 2024) until the V3
+// conversion in 440268d3. They pin the recognition this change is responsible for; the
+// shape reading is #1568's to prove.
+const load3dClassBody = (options) => ({
+  Load3D: { input: { required: { model_file: [options, { file_upload: true }] } } },
+});
+
+test("#1569 get_errors stops calling a present, non-enumerated 3D model a missing asset", async () => {
+  const probed = [];
+  const r = await scanComboAvailability(
+    [{ id: 77, type: "Load3D", widgets: [{ name: "model_file", value: "meshes/cloud.ply" }] }],
+    async () => load3dClassBody(["none"]),
+    {
+      confirmServerAsset: (value, ref) => {
+        probed.push({ value, ...ref });
+        return true;
+      },
+    },
+  );
+  assert.deepEqual(r.unavailable, [], "the server has the file; nothing to report");
+  assert.deepEqual(r.unknown ?? [], []);
+  assert.deepEqual(probed, [
+    { value: "meshes/cloud.ply", filename: "cloud.ply", subfolder: "meshes", type: "input" },
+  ]);
+});
+
+test("#1569 get_errors still reports a 3D model the server answers is ABSENT", async () => {
+  const r = await scanComboAvailability(
+    [{ id: 77, type: "Load3D", widgets: [{ name: "model_file", value: "3d/nope.glb" }] }],
+    async () => load3dClassBody(["none"]),
+    { confirmServerAsset: () => false },
+  );
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].value, "3d/nope.glb");
+});
+
+test("#1569 get_errors ABSTAINS when the 3D file check does not answer (#1357)", async () => {
+  const r = await scanComboAvailability(
+    [{ id: 77, type: "Load3D", widgets: [{ name: "model_file", value: "meshes/cloud.ply" }] }],
+    async () => load3dClassBody(["none"]),
+    { confirmServerAsset: () => null },
+  );
+  assert.deepEqual(r.unavailable, [], "an unanswered probe must never become a confirmed miss");
+  assert.equal(r.unknown.length, 1);
+  assert.match(r.unknown[0].reason, /did not answer/);
+});

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -19,8 +19,25 @@
 
 // Upload-input config flags ComfyUI attaches to an input SPEC's config object. Any
 // truthy one marks the input as one the user uploads a file into (image / video /
-// audio / 3d), whose valid values live on DISK, not only in the combo snapshot.
-const UPLOAD_CONFIG_FLAGS = ["image_upload", "video_upload", "audio_upload", "model_upload"];
+// audio / 3d model), whose valid values live on DISK, not only in the combo snapshot.
+//
+// #1569 — the 3D kind serializes as `file_upload`, NOT `model_upload`. ComfyUI's own
+// `UploadType` enum (comfy_api/latest/_io.py) is image="image_upload",
+// audio="audio_upload", video="video_upload", model="file_upload", and the V1 spelling
+// that predates it was already `{"file_upload": True}` (ComfyUI bdf39379, Dec 2024, the
+// commit that added Load3D). MEASURED on a live 0.33.2 /object_info (853 types): four
+// `image_upload`, one `audio_upload`, one `video_upload`, TWO `file_upload`
+// (Load3D.model_file, Load3DAdvanced.model_file) — and ZERO `model_upload`.
+//
+// `model_upload` is kept anyway, and that is a decision rather than an oversight. It has
+// never been a ComfyUI flag in any release — `git log -S model_upload -- '*.py'` over the
+// whole ComfyUI history returns no commit that introduces it as an input config key — so
+// it cannot be legacy for an older supported server. It is kept because a third-party pack
+// is free to invent it for a checkpoint-upload widget, dropping it could only ever REFUSE
+// a write that is accepted today, and recognising it costs nothing: `uploadInputAccepts`
+// admits a value only when the config carries the flag AND the extension matches THAT
+// flag's own kind, so an unused flag can never widen anything.
+const UPLOAD_CONFIG_FLAGS = ["image_upload", "video_upload", "audio_upload", "model_upload", "file_upload"];
 
 // Extension allowlist PER upload kind. A successful `/view?type=input` probe proves a
 // file EXISTS, not that it is a LOADABLE asset of the RIGHT kind — `/view` serves any
@@ -43,6 +60,22 @@ const UPLOAD_KIND_EXTENSIONS = {
   ]),
   model_upload: new Set([
     "safetensors", "ckpt", "pt", "pth", "bin", "gguf", "sft", "onnx",
+  ]),
+  // #1569 — the 3D-asset kind (`file_upload`), and it is NOT the weight-file kind above.
+  // These are exactly the suffixes `Load3D.define_schema` itself enumerates when it builds
+  // the combo (comfy_extras/nodes_load_3d.py: `file_path.suffix.lower() in {...}`), so a
+  // value the panel admits here is one ComfyUI's own listing would have offered had the
+  // file been under `input/3d/`. Deliberately NOT widened to `.usdz` — Preview3D declares a
+  // USDZ socket type, but Load3D's listing does not include it, and #240 says refuse where
+  // the server's own enumeration would not offer.
+  //
+  // Sharing the weight-file set would have been the wrong reuse: ComfyUI runs NO extension
+  // check of its own on this input (`Load3D.validate_inputs` only asks
+  // `exists_annotated_filepath`), so this list is the ONLY thing standing between a
+  // server-confirmed `3d/notes.txt` and a Load3D combo — measured: `/view` serves that file
+  // 206 and ComfyUI's own /prompt validation ACCEPTS it.
+  file_upload: new Set([
+    "gltf", "glb", "obj", "fbx", "stl", "spz", "splat", "ply", "ksplat",
   ]),
 };
 


### PR DESCRIPTION
Fixes #1569.

`UPLOAD_CONFIG_FLAGS` listed `image_upload`/`video_upload`/`audio_upload`/`model_upload`. ComfyUI's `UploadType` enum spells the model kind **`file_upload`**, and the V1 spelling that predates the enum was already `{"file_upload": True}` — ComfyUI `bdf39379` (Dec 2024), the commit that added `Load3D`. So the panel recognised a flag no ComfyUI has ever emitted, and did not recognise the one two live inputs actually carry.

**Review is PENDING.** Nothing here has been reviewed by anyone but its author.

## Reproduced, then fixed — against a real `/object_info`

Live ComfyUI 0.33.2 booted for this change (`--base-directory`, its own port), `GET /api/object_info`, 853 types / 529 combo inputs. `uploadConfigOf()` run against the payload verbatim:

| flag | count | inputs |
|---|---|---|
| `image_upload` | 4 | `LoadImage.image`, `LoadImageMask.image`, `LoadImageOutput.image`, `Painter.mask` |
| `audio_upload` | 1 | `LoadAudio.audio` |
| `video_upload` | 1 | `LoadVideo.file` |
| `file_upload` | 2 | `Load3D.model_file`, `Load3DAdvanced.model_file` |
| `model_upload` | **0** | — |

```
Load3D.model_file
  config = {"multiselect":false,"options":["none"],"file_upload":true}
  BEFORE  uploadConfigOf(config) = null      uploadInputAccepts(cfg,"3d/chair.glb") = false
  AFTER   uploadConfigOf(config) = CONFIG    uploadInputAccepts(cfg,"3d/chair.glb") = true
```

## The risk is downstream, not in the list

`uploadConfigOf()` has exactly two production consumers. Recognising these inputs arms both for `Load3D`/`Load3DAdvanced` for the first time.

**1. `set-widget.js` → `tryUploadAssetAccept()` — the `panel_set_widget` WRITE path.** A combo-rejected value now reaches the #387 fallback: extension gate, then a `/view?type=input` existence probe, then `addComboOption` + one revalidation. Previously inert for these two inputs, so a genuinely loadable 3D file was refused.

**2. `live-combo-availability.js` → `adjudicateUnenumerableAsset()` — `panel_get_errors`' live scan.** The #1357 abstention arms: present ⇒ not reported, absent ⇒ reported exactly as before, no answer ⇒ `unchecked`.

## What ComfyUI actually accepts for `Load3D.model_file` — measured, not assumed

Combo membership is **irrelevant** to ComfyUI on this input. `Load3D` declares `validate_inputs(cls, model_file, **kwargs)`, and `execution.py` gates the "Value not in list" error on `x not in validate_function_inputs and not validate_has_kwargs` — so the core check is skipped and only `folder_paths.exists_annotated_filepath` decides. Confirmed by POSTing each value to the live `/api/prompt`:

| `model_file` | on disk | enumerated by `Load3D` | ComfyUI `/prompt` | panel before | panel after |
|---|---|---|---|---|---|
| `3d/chair.glb` | yes | yes | **accepts** | accepts (via refresh) | accepts (via refresh, no probe) |
| `meshes/cloud.ply` | yes | no | **accepts** | **refuses (false refusal)** | accepts |
| `chair.glb` (input root) | yes | no | **accepts** | refuses | accepts |
| `3d/notes.txt` | yes | no | **accepts** | refuses | **still refuses** (deliberate) |
| `3d/nope.glb` | no | no | refuses — "Invalid 3D model file" | refuses | refuses |
| `cloud.ply [output]` | no (input only) | no | refuses | refuses | refuses |

Other measured differences from the image path:

- **Enumeration.** `Load3D.define_schema` `rglob`s `input/3d/` **recursively**, and yields values relative to the *input* dir — so every value carries at least a `3d/` prefix and a Load3D value is never a bare root filename. Anything outside `input/3d/` is unlistable however fresh the fetch.
- **Extensions.** ComfyUI's own listing filter is `{.gltf .glb .obj .fbx .stl .spz .splat .ply .ksplat}`. That is the new `UPLOAD_KIND_EXTENSIONS.file_upload`. Not widened to `.usdz`: `Preview3D` declares a USDZ socket, `Load3D`'s listing does not include it, and #240 says refuse where the server's own enumeration would not offer.
- **Upload endpoint / subfolder.** The same content-agnostic `POST /upload/image` (it writes raw bytes; a `.txt` uploads fine). The ComfyUI frontend stamps `upload_subfolder: "3d"` onto this input at `beforeRegisterNodeDef` time — client-side only, so the wire flag stays `file_upload` and the panel needs nothing for it.
- **`/view` serves 3D files.** `filename=chair.glb&subfolder=3d&type=input` with `Range: bytes=0-0` answers **206** (`application/octet-stream`); a missing file 404s. The probe the fallback already uses works unchanged for meshes.

So the extension allowlist is the **only** thing standing between a server-confirmed `3d/notes.txt` and a `Load3D` combo — ComfyUI would take that file. The panel is deliberately stricter, exactly as it is for images.

## `model_upload`: kept, and here is why

`git log -S model_upload -- '*.py'` over the whole ComfyUI history returns **no commit that introduces it as an input config key**; the only hit is an unrelated asset-tagging commit. It is not legacy for an older supported ComfyUI — it has never existed. Zero hits across the 81 custom-node packs installed on this machine either.

Kept anyway, because dropping it is a behaviour change with no measured beneficiary: a third-party pack is free to invent the name for a checkpoint-upload widget, and recognising an unused flag cannot widen anything — `uploadInputAccepts` admits a value only when the config carries the flag **and** the extension matches *that flag's own* kind. What was actually wrong was the comment claiming it was the 3D kind; that is now the measurement.

The two kinds emphatically do **not** share an extension set. `file_upload` inheriting `model_upload`'s weight-file extensions is the tempting reuse and it is mutation-tested against (M3 below).

## Verified by deleting the fix

`node --test` over the four affected files, 78 tests. Each mutation applied, verified applied, run, reverted, revert verified.

| mutation | result |
|---|---|
| **M1** delete the fix — drop `file_upload` from `UPLOAD_CONFIG_FLAGS` | **5 killed** — recognition, extension gate, write ACCEPT, and both get_errors tests |
| **M2** delete `UPLOAD_KIND_EXTENSIONS.file_upload` | **4 killed** |
| **M3** point `file_upload` at `model_upload`'s weight extensions | **5 killed**, incl. "a checkpoint name is REFUSED on a 3D input" |
| **M4** CALL SITE `set-widget.js`: `uploadInputConfig(...)` → `null` | **3 killed** — the new 3D ACCEPT plus the two pre-existing #387/#718 image tests |
| **M5** CALL SITE `set-widget.js`: drop the `uploadInputAccepts` gate | **4 killed** — every wrong-kind refusal, 3D and image |
| **M6** CALL SITE `live-combo-availability.js`: `uploadConfigOf(config)` → `config` | **SURVIVED** — 6127-test suite, zero kills |

**M6 is an equivalent mutant, and the reason is worth stating rather than waving at.** `uploadInputAccepts` iterates `UPLOAD_CONFIG_FLAGS` and returns false unless the config carries one, so a non-upload config (`ckpt_name`'s `{}`) is refused two lines later by the extension gate whether or not `uploadConfigOf` filtered it first. That line is defence in depth, not the load-bearing guard. Recorded so the next run does not re-chase it.

## Both directions of the write path

New file `browser_tests/unit/load3d-file-upload.test.mjs` — 12 tests, all driving the real `runSetWidget`/`scanComboAvailability`, with the live V2 spec copied verbatim from the measured payload.

Newly ACCEPTED: a server-confirmed 3D model the combo cannot list (`meshes/cloud.ply`). Still REFUSED: a file the server does not have; a server-EXISTING `.txt` (and refused *before* the probe, so no network call is spent); a `.safetensors` on a 3D input; a plain non-upload combo (never probes); an annotated value. And a control — an *enumerated* 3D model is still accepted by the refresh with **no probe at all**.

## Reachability — the mechanism is not just green, it runs

A green unit test proves `addComboOption` works; it does not prove it can touch the real Load3D widget. `addComboOption` refuses a **function-valued** `options.values` (a dynamic source computes its own list), so if the frontend gave `model_file` one, the fallback would fail closed and this whole change would be inert in production. It does not: ComfyUI's own `handleModelUpload` (frontend `load3d-*.js`) ends with

```js
i.options?.values?.includes(c) || i.options?.values?.push(c), i.value = c
```

— the frontend pushes into a plain array on that exact widget, which is precisely what `addComboOption` does. Same call also confirms the subfolder: `uploadFile(file, "3d")`, or `3d/<Resource Folder>` when the node property is set.

Every consumer of `uploadConfigOf` / `uploadInputConfig` / `uploadInputAccepts` was enumerated; there are two, both above. One near-miss worth naming: `node-widget-materialization.js` keeps its OWN list, `WIDGET_VALUE_CONFIG_KEYS`, which also stops at `audio_upload`. It is deliberately left alone — `inputDeclaredAsSocket` settles both live Load3D specs on `options`, which is already in that list, so no live input reaches the missing key. Adding it there would be a change with no measured effect, in a module this issue is not about.

## Overlap with #1568 (issue #745) — declared, no conflict

Disjoint files: this touches `web/js/lib/input-asset.js` only; #1568 touches `web/js/lib/live-combo-availability.js` and its own test file. Two interactions, both self-resolving in either merge order:

1. #1568's `declaresUnrecognizedUploadKind` matches `/_upload$/` on any flag `uploadConfigOf` does not know, which today includes `file_upload`. Once this lands, `uploadConfigOf` answers truthy for it, that predicate returns false, and the narrow "annotated value on an unrecognised upload kind ⇒ `unchecked`" workaround goes inert for `file_upload` while staying armed for a genuinely unknown future flag. The workaround is left in place — deleting it is #1568's call, not this PR's.
2. **The read-path half of this fix cannot reach a live server until #1568 lands.** `parseClassCombos` on `main` recognises the V1 shape only, and live 0.33.2 publishes `Load3D` in V2 — so today the scan does not see `Load3D.model_file` as a combo at all and never judges it. The get_errors tests here therefore drive the V1 shape, which is not hypothetical: ComfyUI shipped `Load3D` as `(sorted(files), {"file_upload": True})` from `bdf39379` until the V3 conversion in `440268d3`. They pin the recognition this PR owns; the shape reading is #1568's to prove. The **write** path is unaffected — `uploadInputConfig` reads the spec's config slot directly and is shape-agnostic.

## Deliberately not done

- **Annotated values on the write path stay refused.** `uploadInputAccepts` reads the extension off the raw value, so `chair.glb [output]` has extension `"glb [output]"` and matches nothing. That is pre-existing and kind-independent — an annotated `pic.png [output]` is refused on a `LoadImage` the same way today. Pinned by a test so this change cannot be read as having quietly opened that door, and so whoever does open it opens it for every kind at once.
- **`mesh_upload` is not recognised.** The ComfyUI frontend adds it (with `upload_subfolder`) in `beforeRegisterNodeDef`. It is a client-side artifact; the panel reads server defs, where `file_upload` is always present.
- **`declaresUnrecognizedUploadKind` not removed** — #1568's, and removing it would conflict.
- **`.usdz` not admitted** — see above.

## Browser coverage

Playwright, `--workers=1`, both runs on this machine back to back, against two ComfyUI 0.33.2 instances built for this change. The served panel file was verified per instance over HTTP before each run:

```
:8188 /extensions/comfyui-mcp-panel/js/lib/input-asset.js
  const UPLOAD_CONFIG_FLAGS = ["image_upload", "video_upload", "audio_upload", "model_upload"];
:8189 /extensions/comfyui-mcp-panel/js/lib/input-asset.js
  const UPLOAD_CONFIG_FLAGS = ["image_upload", "video_upload", "audio_upload", "model_upload", "file_upload"];
  file_upload: new Set([ ... ])
```

Measured, not inherited — **two A/B pairs**, each pair back to back on this machine, against two ComfyUI 0.33.2 instances with their own base directories, served panel file verified over HTTP per instance before each run:

| pair | base serves | branch serves | base | branch | failure sets |
|---|---|---|---|---|---|
| 1 | `75728263` on `:8188` | pre-rebase head on `:8189` | 19 failed / 62 passed (7.8m) | 19 failed / 62 passed (7.6m) | **identical, all 19** |
| 2 | `a1844f68` (current main) on `:8188` | rebased head on `:8189` | 18 failed / 63 passed (7.2m) | 18 failed / 63 passed (7.2m) | **identical, all 18** |

Eighteen are the standing baseline (conversation-persistence x7, chat-history-v2 x3, workflow-chat-identity x4, streaming-render, hidden-tab, pending-queue, external-orchestrator). The nineteenth in pair 1 is the known `agent-drive.spec.ts:113` flake — it fired in **both** runs of pair 1 and in **neither** run of pair 2, which is why the number legitimately moves between 18 and 19.

Honest limit: **no e2e spec exercises a Load3D node**, so these runs prove this change breaks nothing panel-visible — they do not positively exercise the new path. The positive evidence for it is the live-server measurement above and the unit tests, not Playwright.

`npm run test:unit` on the rebased head: **6159 pass / 0 fail / 1 todo**. (One run under mutation-harness load showed the known `#671 verifyInstalled` wall-clock flake; that file alone re-runs 125/125.)
