### PR TITLE
fix(1573): three refusal/comment inaccuracies from #1561 now state what the code observed

### DIFF
--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -86,10 +86,15 @@ function largeInstall({ defined = [], perClass } = {}) {
  * The panel's own wiring for the scoped route, reproduced verbatim in shape: the SILENCE
  * LICENCE first, then the bounded type-scoped read, then the "scoped" provenance stamp.
  */
-function panelStyleScopedRoute(fetchApi, outcomes, onScoped) {
+function panelStyleScopedRoute(
+  fetchApi,
+  outcomes,
+  onScoped,
+  unlicensedReason = "a whole-schema route ANSWERED rather than going silent",
+) {
   return async (types) => {
     if (!noBackendAnswerEstablished(outcomes)) {
-      return { defs: null, covered: [], reason: "a whole-schema route ANSWERED rather than going silent" };
+      return { defs: null, covered: [], reason: unlicensedReason };
     }
     const scoped = await fetchTypeScopedObjectInfo(types, { fetchApi, deadlineMs: SCOPED_OBJECT_INFO_DEADLINE_MS });
     if (scoped.defs && typeof onScoped === "function") onScoped(scoped);
@@ -241,7 +246,7 @@ test("#1560 B: an EVER-SEEN type now absent per class is still diagnosed as a RE
   assert.equal(node.widgets[0].value, 20, "no mutation");
 });
 
-test("#1560 B: the per-class route ALSO going silent refuses exactly as today, and SAYS a third route was tried", async () => {
+test("#1560 B: the per-class route ALSO going silent refuses exactly as today, and SAYS what the third route did", async () => {
   const reg = loadedRegistry(["SmartResolution"]);
   const node = regNode(1976, "SmartResolution", [{ name: "value", type: "INT", value: 512 }]);
   const backend = largeInstall({ perClass: () => new Promise(() => {}) }); // never settles
@@ -260,8 +265,67 @@ test("#1560 B: the per-class route ALSO going silent refuses exactly as today, a
     (err) =>
       err instanceof Error &&
       /no usable \/object_info schema was obtained/.test(err.message) &&
-      /A type-scoped \/object_info read was tried too — .*did not all answer within/.test(err.message),
+      // #1573 — the lead-in reports the OUTCOME; the reason reports the cause. On THIS path
+      // requests really were issued, and the reason says so by naming the deadline they
+      // missed. The assertion below pins that the requests happened, so the wording and the
+      // world are checked against each other rather than the wording alone.
+      /A type-scoped \/object_info read did not stand in for the whole-schema routes either — .*did not all answer within/.test(
+        err.message,
+      ),
   );
+  assert.deepEqual(
+    backend.perClassCalls(),
+    ["/object_info/SmartResolution"],
+    "the request the reason blames a deadline for really was issued",
+  );
+  assert.equal(node.widgets[0].value, 512, "no mutation");
+});
+
+test("#1573: an UNLICENSED scoped route issues NOTHING, and the refusal does not claim a read was tried", async () => {
+  // #1561's own fourth gate pass: `describeObjectInfoFailureWithScope` appended "A
+  // type-scoped /object_info read was tried too" for EVERY non-empty reason, including the
+  // ones where the route was never licensed and no request left the panel. The clause after
+  // the dash self-corrected, but the lead-in asserted an attempt that did not happen — the
+  // #982 shape, in the one sentence a stuck caller reads.
+  //
+  // Asserts the OUTPUT, not the absence of a phrase: the exact sentence the caller gets,
+  // paired with the request list that proves what actually happened.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const UNLICENSED_REASON =
+    "no whole-schema route was both CONTACTED and SILENT, and a type-scoped read " +
+    "may only stand in for one that was — it must never overrule what a route did " +
+    "establish, and it is not a substitute for a route nobody ran";
+  assert.ok(
+    src.includes("no whole-schema route was both CONTACTED and SILENT"),
+    "the reason under test is the panel's own, not one invented here",
+  );
+
+  const reg = loadedRegistry(["SmartResolution"]);
+  const node = regNode(1976, "SmartResolution", [{ name: "value", type: "INT", value: 512 }]);
+  const backend = largeInstall({ defined: ["SmartResolution"] });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "value", 768, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        describeObjectInfoFailure: () => " Tried 2 routes: a; b.",
+        // The panel's unlicensed early return, verbatim: no request is issued at all.
+        fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, ANSWERED_OUTCOMES, undefined, UNLICENSED_REASON),
+        wasTypeEverDefined: () => false,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.ok(
+        err.message.includes(
+          `A type-scoped /object_info read did not stand in for the whole-schema routes either — ${UNLICENSED_REASON}.`,
+        ),
+        `the refusal must state the outcome and the panel's own reason, verbatim. Got: ${err.message}`,
+      );
+      return true;
+    },
+  );
+  assert.deepEqual(backend.perClassCalls(), [], "not one per-class request was issued — so none may be claimed");
   assert.equal(node.widgets[0].value, 512, "no mutation");
 });
 
@@ -534,6 +598,45 @@ test("#1560: the scoped map is a well-behaved object — branding, freezing and 
   assert.doesNotThrow(() => Object.freeze(defs), "object-info-cache.js freezes its payload; this must survive the same");
   assert.deepEqual(Object.keys(defs), ["KSampler"]);
   assert.equal(defs[Symbol.iterator], undefined, "an unrelated symbol is not a class type and passes through");
+});
+
+test("#1573: ENUMERATION of the scoped map does not throw — a SERIALIZER does, and the header now says so", async () => {
+  // #1561's header claimed that "anything that ranges over the map (`Object.keys(defs).length`,
+  // a serializer) sees a small, honest object rather than a throw". The first half is true;
+  // the serializer half never was. `JSON.stringify` looks up `toJSON` and `String` looks up
+  // `toString` — neither is a class type in `covered`, so the scope trap refuses both.
+  //
+  // This pins the MEASUREMENT the header now records, in both directions, so the header
+  // cannot drift back into a claim nobody re-checked. It is not a change of behaviour: the
+  // traps are untouched and this test passes against the merged head too.
+  const backend = largeInstall({ defined: ["KSampler", "SubgraphA"] });
+  const { defs } = await fetchTypeScopedObjectInfo(["KSampler", "SubgraphA"], { fetchApi: backend.fetchApi });
+
+  assert.deepEqual(Object.keys(defs), ["KSampler", "SubgraphA"]);
+  assert.equal(Object.keys(defs).length, 2, "the example the header names by name");
+  assert.deepEqual(Object.getOwnPropertyNames(defs), ["KSampler", "SubgraphA"]);
+  assert.equal(Object.entries(defs).length, 2);
+  assert.deepEqual(Object.keys({ ...defs }), ["KSampler", "SubgraphA"], "spread copies, it does not refuse");
+  const forIn = [];
+  for (const k in defs) forIn.push(k);
+  assert.deepEqual(forIn, ["KSampler", "SubgraphA"]);
+  assert.equal(Reflect.ownKeys(defs).length, 3, "the two types plus the brand symbol");
+
+  // The other direction, stated rather than glossed. Both are FAIL-CLOSED — a throw refuses
+  // a write, it can never forge one — and no production reader serializes this map.
+  assert.throws(
+    () => JSON.stringify(defs),
+    (err) => err instanceof Error && /Cannot verify node type "toJSON"/.test(err.message),
+    "JSON.stringify looks up toJSON, which is not a covered class type",
+  );
+  assert.throws(
+    () => String(defs),
+    (err) => err instanceof Error && /Cannot verify node type "toString"/.test(err.message),
+    "and a string coercion looks up toString",
+  );
+  // Deliberately coupled to the header rather than to a phrase in it: whoever decides that
+  // `toJSON`/`toString` belong IN SCOPE will fail these two assertions, and the paragraph
+  // that says the question is still open is right above the trap they will be editing.
 });
 
 test("#1560: a hostile class name is FLATTENED before it reaches a refusal a caller reads", async () => {
@@ -818,4 +921,70 @@ test("#1560: a LIVE re-ask that SUCCEEDS is used — the brand follows the paylo
   // read, so the disclosure is the UNREADABLE one. What matters here is that the write landed
   // at all — the live re-ask licensed it, and the scoped refusal did not pre-empt that.
   assert.equal(res.option_list_unreadable, true, "the caller is still told nothing validated the value");
+});
+
+test("#1573: a LIVE type-scoped map that declared the list empty is never reported as 'not fetched live'", async () => {
+  // The third inaccuracy #1561's own gate left behind. The re-ask branch is gated on
+  // `provenance !== "live"`, and "scoped" is not "live" — so a type-scoped map reaches this
+  // refusal, which told the caller the schema "was not fetched live". It WAS: per class,
+  // moments earlier, on the very route this whole change exists to add. A scoped map is
+  // about FEWER types, never about older ones.
+  //
+  // Drives the real ladder to the real refusal and asserts the OUTPUT — plus the request
+  // list, which is what makes "fetched live" a measurement here rather than a reading.
+  const reg = loadedRegistry(["StarOllamaPromptHelper"]);
+  const widget = { name: "model", type: "combo", options: { values: OPTIONS_THROW }, value: "" };
+  const node = regNode(9, "StarOllamaPromptHelper", [widget]);
+  // The SCOPED map declares this input's option list EMPTY…
+  const backend = largeInstall({
+    defined: ["StarOllamaPromptHelper"],
+    perClass: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ StarOllamaPromptHelper: { input: { required: { model: [[], {}] } } } }),
+    }),
+  });
+  let stamp = () => "none";
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "model", "qwen3-vl:8b", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES, () => {
+          stamp = () => "scoped";
+        }),
+        // …and the whole-map re-ask lands, publishing a REAL list. That disagreement is the
+        // hole the re-ask exists to find, and it routes to this message.
+        refetchObjectInfoLive: async () => {
+          stamp = () => "live";
+          return { StarOllamaPromptHelper: { input: { required: { model: [["qwen3-vl:8b", "llama3"], {}] } } } };
+        },
+        schemaProvenance: () => stamp(),
+        refreshCombos: (fresh, targetNode, defTypeKey, nameMap) =>
+          refreshComboOptionsFromDefs(targetNode, fresh, defTypeKey, nameMap),
+        wasTypeEverDefined: () => true,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.ok(
+        err.message.includes(
+          "The schema that appeared to declare this input's option list empty has since been " +
+            "REPLACED, and the live re-read NO LONGER declares it empty",
+        ),
+        `the refusal must claim only the replacement it observed. Got: ${err.message}`,
+      );
+      assert.ok(
+        err.message.includes("either it now publishes a real option list for this input, or it no longer describes"),
+        "and it must still name both possibilities rather than choosing one",
+      );
+      return true;
+    },
+  );
+  assert.deepEqual(
+    backend.perClassCalls(),
+    ["/object_info/StarOllamaPromptHelper"],
+    "the schema that said EMPTY was fetched live, per class — which is why the old wording was false",
+  );
+  assert.equal(widget.value, "", "fails closed either way; only the wording changed");
 });

--- a/web/js/lib/scoped-object-info.js
+++ b/web/js/lib/scoped-object-info.js
@@ -307,9 +307,35 @@ function scopedView(present, covered) {
       if (!inScope(prop)) refuse(prop);
       return Reflect.getOwnPropertyDescriptor(t, prop);
     },
-    // Only the types actually PRESENT are enumerated, so anything that ranges over the map
-    // (`Object.keys(defs).length`, a serializer) sees a small, honest object rather than a
-    // throw. It still cannot see the install, which is why the scope trap above exists.
+    // Only the types actually PRESENT are enumerated, so ENUMERATING the map sees a small,
+    // honest object rather than a throw. It still cannot see the install, which is why the
+    // scope trap above exists.
+    //
+    // MEASURED against this module as merged (#1561, `a1844f68`) on node v24.16.0, driving a
+    // two-type scoped map: `Object.keys` → 2 names, `Object.getOwnPropertyNames`,
+    // `Object.entries`, `for…in` and spread `{...defs}` all succeed, and `Reflect.ownKeys`
+    // returns 3 (the two types plus the brand symbol).
+    //
+    // A SERIALIZER IS NOT COVERED, and an earlier version of this note said it was. That was
+    // never true and is corrected here rather than reworded (#1573): `JSON.stringify(defs)`
+    // looks up `toJSON` and `String(defs)` looks up `toString`, neither is a class type in
+    // `covered`, so the `get` trap above REFUSES both and each THROWS — with a message that
+    // reads as though `toJSON` were a node type. Measured on the same run.
+    //
+    // It is a documented edge and not a fault today: nothing reads this map by serializing
+    // it. Checked, not assumed — every consumer of the map `set-widget.js` holds
+    // (`freshBackendDefinesType`, `assertTypeAgainstFreshBackend`, `serverDeclaresEmptyComboOptions`,
+    // `uploadInputConfig`, `refreshCombos`, `isTypeScopedObjectInfo`) reads it by KEY, and a
+    // search of `web/js` finds no `JSON.stringify` of, and no string coercion of, an
+    // `/object_info` defs map. The scope of that check is the whole scope there is: this map
+    // is built here and consumed inside the panel, it never crosses the bridge, so no
+    // orchestrator reader can reach it to serialize. The direction is fail-closed anyway — a
+    // throw refuses a write, it cannot forge one — but do not ADD a reader that serializes
+    // this map without reading the paragraph below first.
+    //
+    // Whether `toJSON`/`toString`/`Symbol.toPrimitive` should simply be IN SCOPE — none of
+    // them is a class type, and symbols already pass through — is a real question and it is
+    // a BEHAVIOUR change, so it is deliberately NOT decided here. #1573 left it open.
     ownKeys(t) {
       return Reflect.ownKeys(t);
     },

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -464,10 +464,23 @@ export async function runSetWidget(
     if (scoped && scoped.defs) freshDefs = scoped.defs;
     else if (scoped && typeof scoped.reason === "string" && scoped.reason) scopedIneligibility = scoped.reason;
   }
-  // The refusal has to be able to say a THIRD route was tried and what it did. Kept OUT of
-  // the transport list `objectInfoOracleFailureNote` renders — that array is what the two
-  // whole-map routes reported, and splicing a non-route entry into it makes a two-transport
-  // failure claim three routes tried, which is #982's own defect.
+  // The refusal has to be able to say what the THIRD route did. Kept OUT of the transport
+  // list `objectInfoOracleFailureNote` renders — that array is what the two whole-map routes
+  // reported, and splicing a non-route entry into it makes a two-transport failure claim
+  // three routes tried, which is #982's own defect.
+  //
+  // SAYS WHAT THIS SITE KNOWS, WHICH IS NOT WHETHER A REQUEST WAS ISSUED (#1573). All this
+  // line has is a non-empty `reason`, meaning the type-scoped route produced no usable map;
+  // the reason itself says why, and only SOME of the reasons involve a request. An earlier
+  // wording led with "A type-scoped /object_info read was tried too", which asserted an
+  // attempt on every one of them — REPRODUCED BY EXECUTION against the merged head: with the
+  // panel's own unlicensed reason ("no whole-schema route was both CONTACTED and SILENT…")
+  // the refusal claimed a read "was tried" while `perClassCalls()` was EMPTY, not one request
+  // issued. That is the #982 shape — the clause after the dash self-corrects, but a reader
+  // stops at the lead-in and goes looking for a request that never left. So the lead-in
+  // reports the OUTCOME (it did not stand in) and lets the reason report the cause.
+  //
+  // The condition below is byte-for-byte what it was; nothing about WHEN this fires changed.
   const describeObjectInfoFailureWithScope = () => {
     let base = "";
     try {
@@ -476,7 +489,7 @@ export async function runSetWidget(
       base = ""; // a diagnostic must never replace the refusal it is describing
     }
     if (!scopedIneligibility) return base;
-    return `${base} A type-scoped /object_info read was tried too — ${scopedIneligibility}.`;
+    return `${base} A type-scoped /object_info read did not stand in for the whole-schema routes either — ${scopedIneligibility}.`;
   };
   // The node whose TYPE to fresh-authorize. For a promoted write, follow the promotion
   // chain through any NESTED SubgraphNodes to the ULTIMATE CONCRETE backend node and
@@ -1242,11 +1255,22 @@ export async function runSetWidget(
       // asked at the moment it is used, on the near side of every await that could expire it.
       let provenance = provenanceOf(freshDefs ?? undefined);
       let authDefs = freshDefs ?? undefined;
-      // What the STALE evidence claimed, captured before it is replaced — the difference
-      // between "the server publishes a list, as it always did" and "the stale schema said
-      // empty and the live one disagrees" is the whole point of re-asking, and it cannot be
+      // What the PRIOR evidence claimed, captured before it is replaced — the difference
+      // between "the server publishes a list, as it always did" and "the schema in hand said
+      // empty and the re-read disagrees" is the whole point of re-asking, and it cannot be
       // recovered after `authDefs` is overwritten.
-      const staleDeclaredEmpty = serverDeclaresEmptyComboOptions(authDefs, authTarget?.type, comboDefInput);
+      //
+      // "PRIOR", NOT "STALE" (#1573). This used to be called `staleDeclaredEmpty`, and the
+      // refusal it feeds told the caller the schema "was not fetched live". That premise
+      // predates #1560: the gate above is `provenance !== "live"`, and "scoped" is not
+      // "live" — but a type-scoped map WAS fetched live, per class, moments earlier. It is
+      // about fewer types, never about older ones. REPRODUCED BY EXECUTION on the merged
+      // head: a scoped map declaring this input's list empty, a whole-map re-ask that
+      // publishes a real list, and the refusal below asserting the scoped read "was not
+      // fetched live" while `/object_info/<Type>` sat in the issued-request list. All this
+      // line establishes is WHICH schema said empty — the one held before the re-ask — so
+      // that is all the name and the message may claim.
+      const priorDeclaredEmpty = serverDeclaresEmptyComboOptions(authDefs, authTarget?.type, comboDefInput);
       let reAsked = false;
       if (provenance !== "live" && typeof refetchObjectInfoLive === "function") {
         try {
@@ -1438,16 +1462,24 @@ export async function runSetWidget(
             `again) and retry.`,
         );
       }
-      // The stale evidence said EMPTY and the live re-ask disagrees: the server does publish a
-      // list for this input after all. That is exactly the hole the re-ask exists to find, and
-      // it is worth its own message — the generic refusal below would report only that the
-      // widget's own callback failed, sending the caller to look at their value while the
-      // actionable fact is that a real list exists and they can pick from it.
-      if (reAsked && staleDeclaredEmpty) {
+      // The evidence held BEFORE the re-ask said EMPTY and the re-ask disagrees: the server
+      // does publish a list for this input after all. That is exactly the hole the re-ask
+      // exists to find, and it is worth its own message — the generic refusal below would
+      // report only that the widget's own callback failed, sending the caller to look at
+      // their value while the actionable fact is that a real list exists and they can pick
+      // from it.
+      //
+      // WHAT THE LEAD-IN MAY CLAIM (#1573). It used to say that schema "was not fetched
+      // live". Since #1560 that is reachable and FALSE: a type-scoped map is fetched live,
+      // per class, and is exactly the kind of schema that lands here. What this branch
+      // actually establishes is that the schema which said empty has been REPLACED and the
+      // replacement no longer says it — nothing about how the first one was obtained, which
+      // is why the sentence no longer mentions it.
+      if (reAsked && priorDeclaredEmpty) {
         throw new Error(
           `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ` +
             `${latest.message} The schema that appeared to declare this input's option list ` +
-            `empty was not fetched live, and the live re-read NO LONGER declares it empty — ` +
+            `empty has since been REPLACED, and the live re-read NO LONGER declares it empty — ` +
             // What was actually observed is a NEGATIVE: `serverDeclaresEmptyComboOptions`
             // returned false. That is true when the server publishes a real list, and equally
             // true when the re-read does not describe this input (or this type) at all. Saying


### PR DESCRIPTION
Closes #1573.

Three inaccuracies #1561's own fourth adversarial gate pass filed against its type-scoped route and deliberately left unfixed there — that PR was at its third round of fixes, and moving the head again would have meant merging a SHA the gate had not seen. #1561 has since merged as `a1844f68`.

**All three are in the refusal direction. This changes what the code says about itself and nothing about what it does.** Review is **pending** — requested from grok in a comment below; not gated, no verdict claimed.

## Re-verified against merged main before touching anything

They were filed pre-merge. Each was reproduced by execution against `origin/main` (`56fd8eb0`, which contains `a1844f68`) — **all three still held**, none was skipped.

| # | Reproduced on merged main |
|---|---|
| 1 | `JSON.stringify(defs)` on a two-type scoped map **threw**: `Cannot verify node type "toJSON"…`. `String(defs)` threw on `toString`. |
| 2 | With the panel's own unlicensed reason, the refusal said a read `was tried too` while `perClassCalls()` was `[]` — **not one request issued**. |
| 3 | Scoped map declares the list empty, whole-map re-ask publishes a real list, refusal asserts the schema `was not fetched live` while `/object_info/StarOllamaPromptHelper` sat in the issued-request list. |

## What each now says, and why that is accurate

**1. `scoped-object-info.js` — the `ownKeys` note (comment only).**

It claimed anything ranging over the map — "`Object.keys(defs).length`, a serializer" — sees a small honest object rather than a throw. Enumeration does. A serializer never did: `JSON.stringify` looks up `toJSON` and `String` looks up `toString`, neither is a class type in `covered`, so the `get` trap refuses both.

The note now **records the measurement instead of the premise** — what was measured, on which build, and what stays a trade: node v24.16.0, two-type scoped map, `Object.keys` gives 2 names, `getOwnPropertyNames` / `entries` / `for…in` / spread all succeed, `Reflect.ownKeys` gives 3 (types + brand); `JSON.stringify` and `String()` throw. It says why this is a documented edge and not a fault — every consumer reads the map **by key** (`freshBackendDefinesType`, `assertTypeAgainstFreshBackend`, `serverDeclaresEmptyComboOptions`, `uploadInputConfig`, `refreshCombos`, `isTypeScopedObjectInfo`), a repo-wide search finds no serialization of a defs map in either repo, and the direction is fail-closed regardless.

The issue asked whether `toJSON` / `toString` / `Symbol.toPrimitive` should simply be **in scope**, which would make the original comment true instead of correcting it downward. That is a **behaviour change**, so it is deliberately **not decided here** and the note says so.

**2. `set-widget.js` — "A type-scoped read was tried too".**

Appended for *every* non-empty `reason`, including the ones that issue nothing (unlicensed, no type resolved, over the type cap, no `fetchApi`, no time left). The clause after the dash self-corrects; the lead-in does not, and it is the sentence a stuck caller reads. #982's shape.

This site knows only that the route produced **no usable map**. It does not know whether a request left the panel. So the lead-in now reports the outcome and lets the reason report the cause:

> A type-scoped /object_info read **did not stand in for the whole-schema routes either** — {reason}.

True on every reason, and the ones that *did* issue requests still say so, in the reason, by naming the deadline they missed.

**3. `set-widget.js` — "the schema … was not fetched live".**

Reachable and false since #1560. The re-ask gate is `provenance !== "live"`, and `"scoped"` is not `"live"` — but a type-scoped map **is** fetched live, per class, moments earlier. It is about **fewer types, never staler ones**. What the branch actually establishes is that the schema which said empty has been replaced and the replacement no longer says it, so that is all it claims now:

> The schema that appeared to declare this input's option list empty **has since been REPLACED**, and the live re-read NO LONGER declares it empty — either it now publishes a real option list for this input, or it no longer describes this input at all.

`staleDeclaredEmpty` renamed to `priorDeclaredEmpty`: the false premise lived in the identifier that fed the message, and an identifier is prose every reader sees.

## No predicate changed

- `if (!scopedIneligibility) return base;` — untouched.
- `serverDeclaresEmptyComboOptions(authDefs, authTarget?.type, comboDefInput)` — **byte-identical expression**; only the const name moved.
- `if (reAsked && priorDeclaredEmpty)` — same two operands, renamed.
- The proxy traps in `scoped-object-info.js` are **not touched at all** — that file's diff is comment-only.

## Consumers of the changed strings

`git grep` of each literal across **both** repos, tests included:

- `"was tried too"` — **one** consumer: `browser_tests/unit/set-widget-scoped-object-info.test.mjs:263`. Updated **deliberately, not loosened**: it now asserts the new sentence *and* that `perClassCalls()` equals `["/object_info/SmartResolution"]`, so the wording and the world are checked against each other rather than the wording alone. Its title asserted the old claim too and was corrected.
- `"was not fetched live"` — **zero** consumers.
- `"a small, honest object"` — **zero** consumers.
- `staleDeclaredEmpty` — two sites, both in `set-widget.js`.
- Nothing in `comfyui-mcp` references any of them.

## Verification

`npm run test:unit` — **6169 tests, 6168 pass, 0 fail, 1 pre-existing todo**. `check-panel-scope` **OK** (needed `npm install` in the fresh worktree first — it correctly refused to run without tsc rather than printing OK). `npm run typecheck` clean. `node --check` on both touched files.

Deleting a comment fails no test, so the bar was applied where it bites — three mutations, each killing a **named** test:

| Mutation | Result |
|---|---|
| Restore `A type-scoped /object_info read was tried too` | FAILS 2 tests — the unlicensed test **and** the timeout test |
| Restore `empty was not fetched live` | FAILS `#1573: a LIVE type-scoped map that declared the list empty is never reported as 'not fetched live'` |
| Put `toJSON` / `toString` **in scope** (the open behaviour question) | FAILS `#1573: ENUMERATION of the scoped map does not throw — a SERIALIZER does` |

The third is the point of that test: it is coupled to the header by measurement, so whoever decides to widen the scope fails an assertion right beside the paragraph that says the question is open.

Tests assert the **OUTPUT** — the exact refusal sentence paired with the issued-request list — which is what the issue asked for, since #1561 shipped a broken `sanitizeName` green precisely because its test only checked that a newline was gone.

## Deliberately not done

- **No Playwright run.** Not that it passed — it was **not run**. These strings are `panel_set_widget` refusal text returned over the bridge plus two source comments; none of them renders in the sidebar, and the browser suite asserts none of them. Claiming e2e coverage here would be claiming coverage I do not have.
- **`toJSON` / `toString` / `Symbol.toPrimitive` left out of scope.** Behaviour change, its own PR, its own evidence.
- **`"the live re-read"` left as-is** in item 3's message. A re-read can be `reconnected` or `retired` (issued live, superseded in flight), so it is arguably a mild over-claim — but the read *is* issued live, no measurement shows a defect, and changing it would be a wording change with nothing behind it. Named here rather than quietly fixed.
- **#1223's over-specific claim** one sentence earlier in the same refusal — pre-existing, called out by #1561, still untouched.
- **No predicate, guard or trap adjusted** anywhere.

## The standard applied to this PR's own diff

Worth stating plainly, because it is the point of #1573 rather than a footnote: **the first version of this change committed the exact defect it exists to close.** My new `ownKeys` note claimed "a repo-wide search finds no `JSON.stringify` or string coercion of a defs map in **either repo**" — and I had only run that search on the panel repo. I grepped `comfyui-mcp` for the three changed *literals*, never for a serializer. So a comment I wrote to replace an unverified premise asserted a check I had not run.

Caught it on an adversarial re-read of my own diff, fixed it before any review started, and disclosed the head move rather than folding it in quietly. The note now states the scope it actually has — a search of `web/js` — and the structural reason that is the whole scope there is: this map is built in the panel and consumed in the panel, it never crosses the bridge, so no orchestrator reader can reach it to serialize.

That is the failure mode #1561's gate was pointing at. It is not rare, it does not announce itself, and a comment is where it survives longest.
