### PR TITLE
fix(1998): a scoped batch drives ComfyUI's own control hooks, so batch_count means N renders

### DIFF
--- a/browser_tests/fixtures/scoped-batch-two-branch.json
+++ b/browser_tests/fixtures/scoped-batch-two-branch.json
@@ -1,0 +1,562 @@
+{
+  "last_node_id": 19,
+  "last_link_id": 16,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        413,
+        389
+      ],
+      "size": [
+        425.3,
+        180.6
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 5
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            6,
+            12
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "text, watermark"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        415,
+        186
+      ],
+      "size": [
+        422.8,
+        164.3
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            4,
+            11
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "a lighthouse on a cliff at sunrise, oil painting"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [
+        473,
+        609
+      ],
+      "size": [
+        315,
+        106
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            2,
+            13
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        256,
+        256,
+        1
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        863,
+        186
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 4
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 6
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 2
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            7
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        707000,
+        "randomize",
+        4,
+        4,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1209,
+        188
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 7
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 8
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            9
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        1451,
+        189
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 9
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "cmcp1998"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        26,
+        474
+      ],
+      "size": [
+        315,
+        98
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1,
+            10
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            3,
+            5
+          ],
+          "slot_index": 1
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            8,
+            15
+          ],
+          "slot_index": 2
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "corneos7thHeavenMix_v2.safetensors"
+      ]
+    },
+    {
+      "id": 13,
+      "type": "KSampler",
+      "pos": [
+        863,
+        700
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 10
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 11
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 12
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 13
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            14
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        808000,
+        "increment",
+        4,
+        4,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 18,
+      "type": "VAEDecode",
+      "pos": [
+        1209,
+        700
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 14
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 15
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            16
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 19,
+      "type": "SaveImage",
+      "pos": [
+        1451,
+        700
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 16
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "cmcp1998B"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      4,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      2,
+      5,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      3,
+      4,
+      1,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      4,
+      6,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      5,
+      4,
+      1,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      6,
+      7,
+      0,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      7,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      8,
+      4,
+      2,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      9,
+      8,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ],
+    [
+      10,
+      4,
+      0,
+      13,
+      0,
+      "MODEL"
+    ],
+    [
+      11,
+      6,
+      0,
+      13,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      12,
+      7,
+      0,
+      13,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      13,
+      5,
+      0,
+      13,
+      3,
+      "LATENT"
+    ],
+    [
+      14,
+      13,
+      0,
+      18,
+      0,
+      "LATENT"
+    ],
+    [
+      15,
+      4,
+      2,
+      18,
+      1,
+      "VAE"
+    ],
+    [
+      16,
+      18,
+      0,
+      19,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/browser_tests/fixtures/scoped-batch-workflow.json
+++ b/browser_tests/fixtures/scoped-batch-workflow.json
@@ -1,0 +1,124 @@
+{
+  "last_node_id": 9,
+  "last_link_id": 9,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [413, 389],
+      "size": [425.3, 180.6],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [{ "name": "clip", "type": "CLIP", "link": 5 }],
+      "outputs": [{ "name": "CONDITIONING", "type": "CONDITIONING", "links": [6], "slot_index": 0 }],
+      "properties": { "Node name for S&R": "CLIPTextEncode" },
+      "widgets_values": ["text, watermark"]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [415, 186],
+      "size": [422.8, 164.3],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [{ "name": "clip", "type": "CLIP", "link": 3 }],
+      "outputs": [{ "name": "CONDITIONING", "type": "CONDITIONING", "links": [4], "slot_index": 0 }],
+      "properties": { "Node name for S&R": "CLIPTextEncode" },
+      "widgets_values": ["a lighthouse on a cliff at sunrise, oil painting"]
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [473, 609],
+      "size": [315, 106],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{ "name": "LATENT", "type": "LATENT", "links": [2], "slot_index": 0 }],
+      "properties": { "Node name for S&R": "EmptyLatentImage" },
+      "widgets_values": [256, 256, 1]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [863, 186],
+      "size": [315, 262],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        { "name": "model", "type": "MODEL", "link": 1 },
+        { "name": "positive", "type": "CONDITIONING", "link": 4 },
+        { "name": "negative", "type": "CONDITIONING", "link": 6 },
+        { "name": "latent_image", "type": "LATENT", "link": 2 }
+      ],
+      "outputs": [{ "name": "LATENT", "type": "LATENT", "links": [7], "slot_index": 0 }],
+      "properties": { "Node name for S&R": "KSampler" },
+      "widgets_values": [707000, "randomize", 4, 4, "euler", "normal", 1]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [1209, 188],
+      "size": [210, 46],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        { "name": "samples", "type": "LATENT", "link": 7 },
+        { "name": "vae", "type": "VAE", "link": 8 }
+      ],
+      "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [9], "slot_index": 0 }],
+      "properties": { "Node name for S&R": "VAEDecode" },
+      "widgets_values": []
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [1451, 189],
+      "size": [210, 58],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [{ "name": "images", "type": "IMAGE", "link": 9 }],
+      "outputs": [],
+      "properties": { "Node name for S&R": "SaveImage" },
+      "widgets_values": ["cmcp1998"]
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [26, 474],
+      "size": [315, 98],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        { "name": "MODEL", "type": "MODEL", "links": [1], "slot_index": 0 },
+        { "name": "CLIP", "type": "CLIP", "links": [3, 5], "slot_index": 1 },
+        { "name": "VAE", "type": "VAE", "links": [8], "slot_index": 2 }
+      ],
+      "properties": { "Node name for S&R": "CheckpointLoaderSimple" },
+      "widgets_values": ["corneos7thHeavenMix_v2.safetensors"]
+    }
+  ],
+  "links": [
+    [1, 4, 0, 3, 0, "MODEL"],
+    [2, 5, 0, 3, 3, "LATENT"],
+    [3, 4, 1, 6, 0, "CLIP"],
+    [4, 6, 0, 3, 1, "CONDITIONING"],
+    [5, 4, 1, 7, 0, "CLIP"],
+    [6, 7, 0, 3, 2, "CONDITIONING"],
+    [7, 3, 0, 8, 0, "LATENT"],
+    [8, 4, 2, 8, 1, "VAE"],
+    [9, 8, 0, 9, 0, "IMAGE"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/browser_tests/scoped-batch-control.spec.ts
+++ b/browser_tests/scoped-batch-control.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * mcp#1998 — a SCOPED batch must not queue N byte-identical prompts.
+ *
+ * This is the CALL-SITE test. The unit tests in
+ * `browser_tests/unit/scoped-batch-seed.test.mjs` prove the drive computes the right
+ * thing against a port of the frontend's hook; this one drives the REAL `graph_run`
+ * through the REAL bridge frame against the REAL ComfyUI frontend, and reads the seeds
+ * out of the bodies the panel actually POSTs. A helper can be perfect and unreached.
+ *
+ * NOTHING IS QUEUED. `api.fetchApi` is wrapped BEFORE the run so the panel's own scoped
+ * guard chains on top of it, and every POST /prompt is answered locally with a synthetic
+ * accepted reply. No GPU time, no model needed, no queue traffic on a shared instance —
+ * the same technique the #988 investigation used.
+ *
+ * WHAT THE BUG LOOKED LIKE HERE, measured before the fix on ComfyUI 0.33.2 /
+ * frontend 1.49.6: the four posts carried seed 707000, 707000, 707000, 707000.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { test, expect } from './fixtures/panelTest'
+import { routeWorktreeSource } from './fixtures/worktreeSource'
+
+// Resolved from the Playwright cwd, the same way worktreeSource.ts resolves web/js —
+// `import.meta` is unavailable in this suite's CommonJS transform.
+const WORKFLOW = JSON.parse(
+  readFileSync(resolve('browser_tests/fixtures/scoped-batch-workflow.json'), 'utf8')
+)
+/** ids inside that fixture. */
+const KSAMPLER_ID = '3'
+const SAVE_IMAGE_ID = 9
+const START_SEED = 707000
+
+test.beforeEach(async ({ context }) => {
+  await routeWorktreeSource(context)
+})
+
+type Posted = { seed: unknown; scoped: boolean }
+
+async function loadFixtureGraph(
+  page: import('@playwright/test').Page,
+  mode: string
+): Promise<void> {
+  await page.evaluate(
+    async ({ wf, mode, ksId, startSeed }) => {
+      const app = (window as any).app
+      await app.loadGraphData(wf, true, true, 'cmcp-1998-scoped-batch')
+      await new Promise((r) => setTimeout(r, 1500))
+      const ks = app.rootGraph._nodes.find((n: any) => String(n.id) === ksId)
+      if (!ks) throw new Error('fixture graph did not load: no KSampler')
+      ks.widgets.find((w: any) => w.name === 'control_after_generate').value = mode
+      ks.widgets.find((w: any) => w.name === 'seed').value = startSeed
+    },
+    { wf: WORKFLOW, mode, ksId: KSAMPLER_ID, startSeed: START_SEED }
+  )
+}
+
+/** Answer every POST /prompt locally and record what it carried. */
+async function interceptPrompts(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() => {
+    const api = (window as any).comfyAPI.api.api
+    ;(window as any).__posted1998 = []
+    const orig = api.fetchApi.bind(api)
+    ;(window as any).__restore1998 = () => {
+      api.fetchApi = orig
+    }
+    api.fetchApi = async (route: string, opts: any) => {
+      if (String(route).startsWith('/prompt') && opts?.method === 'POST') {
+        let body: any = null
+        try {
+          body = JSON.parse(opts.body)
+        } catch {
+          /* recorded as null, which fails the assertions loudly */
+        }
+        ;(window as any).__posted1998.push(body)
+        const n = (window as any).__posted1998.length
+        return new Response(
+          JSON.stringify({ prompt_id: `e2e-1998-${n}`, number: n, node_errors: {} }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      }
+      return orig(route, opts)
+    }
+  })
+}
+
+async function readPosted(page: import('@playwright/test').Page): Promise<Posted[]> {
+  return page.evaluate((ksId) => {
+    const posted = (window as any).__posted1998 ?? []
+    ;(window as any).__restore1998?.()
+    return posted.map((b: any) => ({
+      seed: b?.prompt?.[ksId]?.inputs?.seed,
+      scoped: Array.isArray(b?.partial_execution_targets) && b.partial_execution_targets.length > 0
+    }))
+  }, KSAMPLER_ID)
+}
+
+async function runScopedBatch(
+  page: import('@playwright/test').Page,
+  panel: any,
+  mockBridge: any,
+  mode: string,
+  batchCount: number
+): Promise<{ reply: any; posted: Posted[] }> {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await loadFixtureGraph(page, mode)
+  await interceptPrompts(page)
+  const reply = await mockBridge.command(
+    'graph_run',
+    { batch_count: batchCount, to_node_id: SAVE_IMAGE_ID },
+    45_000
+  )
+  const posted = await readPosted(page)
+  return { reply, posted }
+}
+
+test('mcp#1998 a scoped randomize batch posts a DIFFERENT seed for every item', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  const { reply, posted } = await runScopedBatch(page, panel, mockBridge, 'randomize', 4)
+
+  expect(reply.ok, JSON.stringify(reply)).toBeTruthy()
+  expect(posted, 'the panel must post one prompt per batch item').toHaveLength(4)
+
+  // The SCOPE must survive. This fix must never buy distinct seeds by dropping
+  // partial_execution_targets and running the whole graph (#556).
+  expect(posted.every((p) => p.scoped), JSON.stringify(posted)).toBe(true)
+
+  const seeds = posted.map((p) => p.seed)
+  expect(seeds[0], 'the first item still carries the seed the user can see').toBe(START_SEED)
+  expect(new Set(seeds).size, `expected four distinct seeds, got ${JSON.stringify(seeds)}`).toBe(4)
+})
+
+test('mcp#1998 a scoped FIXED batch still posts the SAME seed for every item', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  const { reply, posted } = await runScopedBatch(page, panel, mockBridge, 'fixed', 4)
+
+  expect(reply.ok, JSON.stringify(reply)).toBeTruthy()
+  expect(posted).toHaveLength(4)
+  expect(posted.every((p) => p.scoped)).toBe(true)
+
+  const seeds = posted.map((p) => p.seed)
+  expect(seeds, 'fixed means "repeat", and repeating is what the user asked for').toEqual([
+    START_SEED,
+    START_SEED,
+    START_SEED,
+    START_SEED
+  ])
+})
+
+test('mcp#1998 a scoped batch of ONE leaves ComfyUI_frontend #8774 alone', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  const { posted } = await runScopedBatch(page, panel, mockBridge, 'randomize', 1)
+
+  expect(posted).toHaveLength(1)
+  expect(posted[0].seed, 'a single scoped preview must submit exactly the visible seed').toBe(
+    START_SEED
+  )
+  // …and the widget must be untouched afterwards: upstream disables the control for a
+  // partial execution so iterating on one branch does not churn the seed, and that is
+  // only overridden for a batch.
+  const after = await page.evaluate((ksId) => {
+    const app = (window as any).app
+    const ks = app.rootGraph._nodes.find((n: any) => String(n.id) === ksId)
+    return ks?.widgets.find((w: any) => w.name === 'seed')?.value
+  }, KSAMPLER_ID)
+  expect(after).toBe(START_SEED)
+})

--- a/browser_tests/scoped-batch-control.spec.ts
+++ b/browser_tests/scoped-batch-control.spec.ts
@@ -26,6 +26,10 @@ import { routeWorktreeSource } from './fixtures/worktreeSource'
 const WORKFLOW = JSON.parse(
   readFileSync(resolve('browser_tests/fixtures/scoped-batch-workflow.json'), 'utf8')
 )
+/** Same graph plus a SECOND, independent branch: KSampler 13 -> VAEDecode 18 -> SaveImage 19. */
+const TWO_BRANCH = JSON.parse(
+  readFileSync(resolve('browser_tests/fixtures/scoped-batch-two-branch.json'), 'utf8')
+)
 /** ids inside that fixture. */
 const KSAMPLER_ID = '3'
 const SAVE_IMAGE_ID = 9
@@ -176,4 +180,77 @@ test('mcp#1998 a scoped batch of ONE leaves ComfyUI_frontend #8774 alone', async
     return ks?.widgets.find((w: any) => w.name === 'seed')?.value
   }, KSAMPLER_ID)
   expect(after).toBe(START_SEED)
+})
+
+test('mcp#1998 the drive stops at the scope — an OFF-SCOPE control is not touched', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  // GATE P1-1. Arming every node in the workflow advanced controls on branches the run
+  // never executes — a silent rewrite of the user's graph, and the opposite of the reason
+  // for overriding ComfyUI_frontend #8774 (they asked for N renders of the scope they
+  // NAMED). Measured on the rig before the fix: a batch scoped to node 9 walked the
+  // unrelated KSampler 13's seed from 808000 to 808004.
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  await page.evaluate(
+    async ({ wf }) => {
+      const app = (window as any).app
+      await app.loadGraphData(wf, true, true, 'cmcp-1998-two-branch')
+      await new Promise((r) => setTimeout(r, 1500))
+      const find = (id: string) => app.rootGraph._nodes.find((n: any) => String(n.id) === id)
+      for (const [id, seed] of [['3', 707000], ['13', 808000]] as [string, number][]) {
+        const n = find(id)
+        if (!n) throw new Error(`two-branch fixture did not load: no node ${id}`)
+        n.widgets.find((w: any) => w.name === 'control_after_generate').value = 'increment'
+        n.widgets.find((w: any) => w.name === 'seed').value = seed
+      }
+    },
+    { wf: TWO_BRANCH }
+  )
+  await interceptPrompts(page)
+
+  const reply = await mockBridge.command(
+    'graph_run',
+    { batch_count: 4, to_node_id: SAVE_IMAGE_ID },
+    45_000
+  )
+  expect(reply.ok, JSON.stringify(reply)).toBeTruthy()
+
+  const seen = await page.evaluate(() => {
+    const posted = (window as any).__posted1998 ?? []
+    ;(window as any).__restore1998?.()
+    const app = (window as any).app
+    const widget = (id: string) =>
+      app.rootGraph._nodes
+        .find((n: any) => String(n.id) === id)
+        ?.widgets.find((w: any) => w.name === 'seed')?.value
+    return {
+      inScope: posted.map((b: any) => b?.prompt?.['3']?.inputs?.seed),
+      offScope: posted.map((b: any) => b?.prompt?.['13']?.inputs?.seed),
+      offScopeWidget: widget('13')
+    }
+  })
+
+  expect(seen.inScope, 'the branch that RUNS still advances').toEqual([
+    707000, 707001, 707002, 707003
+  ])
+  expect(
+    new Set(seen.offScope).size,
+    `a branch outside the scope must be submitted unchanged, got ${JSON.stringify(seen.offScope)}`
+  ).toBe(1)
+  expect(seen.offScopeWidget, 'and its widget must not have been mutated at all').toBe(808000)
+
+  // GATE P1-2, from the same run: node 13 was never armed, so #988's repetition warning
+  // must still describe it rather than being silenced by the drive having run at all.
+  const named = JSON.stringify(reply?.result?.repeating_controls ?? [])
+  expect(named, 'an unarmed control keeps its warning').toContain('"node_id":"13"')
+  expect(
+    JSON.stringify(reply?.result?.batch_controls ?? []),
+    'and the drive must not claim it'
+  ).not.toContain('"node_id":"13"')
 })

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -741,7 +741,7 @@ test("#1998 a control detected by OPTION SHAPE is driven even when it is renamed
 
 test("#1998 observe() reports what the widget DID, not what the drive asked for", () => {
   const nodes = [controlledSeedNode(42, "randomize"), controlledSeedNode(43, "randomize", { linkFed: true })];
-  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 3 });
   queueBatch(nodes, { batchCount: 3, isPartialExecution: true });
   const seen = drive.observe();
   drive.restore();
@@ -755,7 +755,7 @@ test("#1998 observe() reports what the widget DID, not what the drive asked for"
 
 test("#1998 the note names what advanced and warns about what did not", () => {
   const nodes = [controlledSeedNode(42, "randomize"), controlledSeedNode(43, "increment", { linkFed: true })];
-  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 4 });
   queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
   const note = scopedBatchDriveNote(drive.observe(), 4);
   drive.restore();
@@ -828,9 +828,10 @@ test("#1998 a control the drive ARMED is described once, by the drive - never al
   // invariant it was reaching for is behavioural and is now asserted as such - a control
   // gets EXACTLY ONE description, and which one depends on whether it was armed.
   const armed = [controlledSeedNode(42, "randomize")];
-  const drive = driveControlHooksAcrossScopedBatch(armed);
+  const drive = driveControlHooksAcrossScopedBatch(armed, { batchCount: 4 });
   queueBatch(armed, { batchCount: 4, isPartialExecution: true });
-  const uncovered = findRepeatingControlWidgets(armed, { skip: drive.armedWidgets });
+  // The caller subtracts the ATTRIBUTED set, not merely the armed one (gate r2 P1-A).
+  const uncovered = findRepeatingControlWidgets(armed, { skip: drive.attributedWidgets() });
   const driveNote = scopedBatchDriveNote(drive.observe(), 4);
   drive.restore();
   assert.deepEqual(uncovered, [], "an armed control must not also be named by #988");
@@ -993,7 +994,7 @@ test("#1998 P1-1 CALL SITE: the drive is armed over the SCOPE, and null arms not
   );
 });
 
-test("#1998 P1-2 CALL SITE: the #988 warning is subtracted by ARMED WIDGETS, not suppressed wholesale", () => {
+test("#1998 P1-2 CALL SITE: the #988 warning is subtracted by ATTRIBUTED widgets, not suppressed wholesale", () => {
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const sites = [...src.matchAll(/const repeatingNote = ([^\n;]+)/g)].map((m) => m[1].trim());
   assert.equal(sites.length, 1);
@@ -1002,9 +1003,162 @@ test("#1998 P1-2 CALL SITE: the #988 warning is subtracted by ARMED WIDGETS, not
     "scopedBatchSeedNote(repeatingControls, batch)",
     `the note must not be gated on the observation array existing, got: ${sites[0]}`,
   );
+  // ARMED is not enough (gate r2 P1-A): a control whose hook calls came from another run
+  // was being subtracted on the strength of that run's work. Only the ATTRIBUTED set may
+  // silence #988's warning.
   assert.match(
     src,
-    /skip: controlDrive\.armedWidgets/,
-    "the subtraction must come from what was actually armed",
+    /const attributed = controlDrive\?\.attributedWidgets\?\.\(\) \?\? null;/,
+    "the subtraction must come from what the drive can PROVE it owned",
   );
+  assert.match(src, /\{ skip: attributed \}/, "and that set is what the scan skips");
+  assert.doesNotMatch(
+    src,
+    /skip: controlDrive\.armedWidgets/,
+    "subtracting the merely-armed set is gate r2 P1-A",
+  );
+  assert.match(
+    src,
+    /driveControlHooksAcrossScopedBatch\(inScope \?\? \[\], \{ batchCount: batch \}\)/,
+    "the drive cannot attribute anything without the batch size",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #1998 gate r2 — the wrapper was unscoped in TIME, the way it had been unscoped
+// in SPACE. Both reproduced by EXECUTING this module before either was fixed.
+// ---------------------------------------------------------------------------
+
+test("#1998 r2 P1-A an UNSCOPED queue inside our window is not ours: nothing is claimed", () => {
+  // BEFORE: an unrelated unscoped batch of 3 during an armed drive produced
+  //   observed:true advanced:true from 12345 to 12348 distinct:4
+  // for a scoped batch that had not run a single item.
+  const nodes = [controlledSeedNode(42, "increment")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 4 });
+  const foreign = queueBatch(nodes, { batchCount: 3, isPartialExecution: false });
+  drive.restore();
+  const o = drive.observe()[0];
+  assert.deepEqual(foreign, [12345, 12346, 12347], "the other run is left completely alone");
+  assert.equal(o.attributable, false, "its calls are not evidence about our batch");
+  assert.equal(o.advanced, false, "so we claim no advancement");
+  assert.equal(o.observed, false);
+  assert.equal(scopedBatchDriveNote(drive.observe(), 4), "", "and the note says nothing about it");
+});
+
+test("#1998 r2 P1-A an unattributed control keeps #988's warning", () => {
+  const nodes = [controlledSeedNode(42, "increment")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 4 });
+  queueBatch(nodes, { batchCount: 3, isPartialExecution: false }); // not ours
+  drive.restore();
+  assert.equal(drive.attributedWidgets().size, 0, "nothing may be subtracted");
+  const uncovered = findRepeatingControlWidgets(nodes, { skip: drive.attributedWidgets() });
+  assert.equal(uncovered.length, 1);
+  assert.match(scopedBatchSeedNote(uncovered, 4), /node 42/);
+});
+
+test("#1998 r2 P1-A attribution is EXACT: one call too few or too many is not our batch", () => {
+  for (const actual of [3, 5]) {
+    const nodes = [controlledSeedNode(42, "increment")];
+    const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 4 });
+    queueBatch(nodes, { batchCount: actual, isPartialExecution: true });
+    drive.restore();
+    assert.equal(drive.observe()[0].attributable, false, `batch of ${actual} against an expected 4`);
+  }
+  // …and the exact count does attribute.
+  const nodes = [controlledSeedNode(42, "increment")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 4 });
+  queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  const o = drive.observe()[0];
+  assert.equal(o.attributable, true);
+  assert.equal(o.advanced, true);
+  assert.equal(o.from, 12345);
+  assert.equal(o.to, 12349);
+});
+
+test("#1998 r2 P1-A without a batch size the drive attributes NOTHING (fail closed)", () => {
+  const nodes = [controlledSeedNode(42, "increment")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  assert.equal(drive.observe()[0].attributable, false, "a lenient default is how this bug happened");
+  assert.equal(drive.attributedWidgets().size, 0);
+});
+
+test("#1998 r2 P1-B overlapping drives must not resurrect a stale wrapper", () => {
+  // BEFORE: d2's restore wrote d1's wrapper back onto the widget and left it LIVE, so a
+  // later single scoped preview advanced despite isPartialExecution:true —
+  //   queueBatch(..., isPartialExecution: true) -> 12345, 12346, 12347
+  const nodes = [controlledSeedNode(42, "increment")];
+  const d1 = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 2 });
+  const d2 = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 2 });
+  d1.restore();
+  d2.restore();
+  const seeds = queueBatch(nodes, { batchCount: 3, isPartialExecution: true });
+  assert.deepEqual(seeds, [12345, 12345, 12345], "a scoped run must NOT advance once every drive is done");
+});
+
+test("#1998 r2 P1-B restoring out of order is safe in either direction", () => {
+  for (const reverse of [false, true]) {
+    const nodes = [controlledSeedNode(42, "increment")];
+    const a = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 2 });
+    const b = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 2 });
+    const order = reverse ? [b, a] : [a, b];
+    for (const d of order) d.restore();
+    assert.deepEqual(
+      queueBatch(nodes, { batchCount: 2, isPartialExecution: true }),
+      [12345, 12345],
+      `restore order ${reverse ? "b,a" : "a,b"}`,
+    );
+  }
+});
+
+test("#1998 r2 P1-B a third party wrapping on top of us is never clobbered", () => {
+  const nodes = [controlledSeedNode(42, "increment")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 2 });
+  const control = nodes[0].widgets[1];
+  // Someone else wraps AFTER us and expects to stay in the chain.
+  let foreignSaw = 0;
+  const ours = control.afterQueued;
+  control.afterQueued = function (opts) {
+    foreignSaw += 1;
+    return ours.call(this, opts);
+  };
+  const theirs = control.afterQueued;
+  drive.restore();
+  assert.equal(control.afterQueued, theirs, "our restore must not remove their wrapper");
+  queueBatch(nodes, { batchCount: 2, isPartialExecution: true });
+  assert.ok(foreignSaw > 0, "and theirs must still run");
+  assert.equal(
+    nodes[0].widgets[0].value,
+    12345,
+    "while ours, being retired, no longer advances a scoped run",
+  );
+});
+
+test("#1998 r2 the #988 scan is invariant to the drive having run — so filtering it AFTER dispatch is safe", () => {
+  // The caller subtracts post-dispatch. That is only legitimate because this scan reads
+  // control MODES and node identity, and the drive moves the GOVERNED value widget.
+  const nodes = [controlledSeedNode(42, "increment"), ksampler(7, "randomize")];
+  const before = findRepeatingControlWidgets(nodes);
+  const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 3 });
+  queueBatch(nodes, { batchCount: 3, isPartialExecution: true });
+  drive.restore();
+  assert.deepEqual(findRepeatingControlWidgets(nodes), before, "same entries before and after");
+});
+
+test("#1998 r2 P1-A the passthrough is what ignores a foreign run — not merely the call count", () => {
+  // ISOLATION. The attribution check alone was masking this: a foreign batch of a
+  // DIFFERENT size already fails the count, so removing the "is this a partial execution"
+  // passthrough changed nothing observable. Give the foreign run EXACTLY the size this
+  // drive expects, and only the passthrough can still tell the two apart.
+  const nodes = [controlledSeedNode(42, "increment")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes, { batchCount: 4 });
+  const foreign = queueBatch(nodes, { batchCount: 4, isPartialExecution: false });
+  drive.restore();
+  const o = drive.observe()[0];
+  assert.deepEqual(foreign, [12345, 12346, 12347, 12348], "the unscoped run advances on its own");
+  assert.equal(o.attributable, false, "an unscoped queue is provably not the run we override");
+  assert.equal(o.advanced, false);
+  assert.equal(drive.attributedWidgets().size, 0, "and it may not silence #988's warning");
 });

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -20,6 +20,7 @@ import {
   findRepeatingControlWidgets,
   scopedBatchSeedNote,
   driveControlHooksAcrossScopedBatch,
+  nodesInPartialExecutionScope,
   scopedBatchDriveNote,
   findRgthreeSeedNodes,
   rgthreeFixedSeedNote,
@@ -599,15 +600,23 @@ function controlledSeedNode(id, mode, { runBefore = false, startAt = 12345, link
   return { id, type: "KSampler", widgets: [seed, control, { name: "steps", value: 20 }] };
 }
 
-/** app.ts's batch loop, reduced to the part that decides what each prompt carries. */
-function queueBatch(nodes, { batchCount, isPartialExecution }) {
+/** app.ts's batch loop, reduced to the part that decides what each prompt carries.
+ *  `readNodeId` names which node's seed to report — defaulting to the first node is
+ *  fine for a one-branch fixture and silently reports `undefined` for a graph whose
+ *  first node is a loader, which is how two of these tests first went green-looking. */
+function queueBatch(nodes, { batchCount, isPartialExecution, readNodeId = null }) {
+  const seedOf = (n) => (n.widgets ?? []).find((w) => w.name === "seed")?.value;
+  const pick = () =>
+    readNodeId == null
+      ? seedOf(nodes[0])
+      : seedOf(nodes.find((n) => String(n.id) === String(readNodeId)) ?? { widgets: [] });
   const posted = [];
   for (let i = 0; i < batchCount; i++) {
     for (const n of nodes) for (const w of n.widgets ?? []) w.beforeQueued?.({ isPartialExecution });
-    posted.push(nodes.map((n) => (n.widgets ?? []).find((w) => w.name === "seed")?.value));
+    posted.push(pick());
     for (const n of nodes) for (const w of n.widgets ?? []) w.afterQueued?.({ isPartialExecution });
   }
-  return posted.map((row) => row[0]);
+  return posted;
 }
 
 test("#1998 the double reproduces the bug: a scoped batch posts one seed four times", () => {
@@ -801,22 +810,201 @@ test("#1998 CALL SITE: the drive is installed on the SCOPED path, and restored i
   // Gated on batch > 1: a scoped run of one keeps upstream #8774 behaviour. Assert on
   // the ARGUMENT EXPRESSION, not on a window of surrounding source - a window matched
   // the word "batch > 1" in the comment above the call and let a dropped gate survive.
-  const call = src.slice(install, src.indexOf(");", install) + 2);
+  // Since gate P1-1 the gate rides on the SCOPE RESOLUTION that feeds the drive, so the
+  // expression to read is that assignment, not the drive call itself.
+  const scopeAssign = src.slice(src.indexOf("const inScope =", install - 600));
+  const scopeExpr = scopeAssign.slice(0, scopeAssign.indexOf(";") + 1);
   assert.match(
-    call,
+    scopeExpr,
     /batch > 1\s*\?/,
-    `the override must be gated on batch > 1, got: ${call}`,
+    `the override must be gated on batch > 1, got: ${scopeExpr}`,
   );
 });
 
-test("#1998 CALL SITE: a driven batch does not also ship #988's contradictory warning", () => {
+test("#1998 a control the drive ARMED is described once, by the drive - never also by #988", () => {
+  // This used to assert a source-level ternary that suppressed #988's note whenever the
+  // observation array existed. Gate P1-2 showed that was the defect, not the invariant:
+  // an empty (or off-scope-only) array silenced a control that really did repeat. The
+  // invariant it was reaching for is behavioural and is now asserted as such - a control
+  // gets EXACTLY ONE description, and which one depends on whether it was armed.
+  const armed = [controlledSeedNode(42, "randomize")];
+  const drive = driveControlHooksAcrossScopedBatch(armed);
+  queueBatch(armed, { batchCount: 4, isPartialExecution: true });
+  const uncovered = findRepeatingControlWidgets(armed, { skip: drive.armedWidgets });
+  const driveNote = scopedBatchDriveNote(drive.observe(), 4);
+  drive.restore();
+  assert.deepEqual(uncovered, [], "an armed control must not also be named by #988");
+  assert.equal(scopedBatchSeedNote(uncovered, 4), "", "so #988 has nothing to say about it");
+  assert.match(driveNote, /node 42/, "and the drive note is the one that describes it");
+});
+// ---------------------------------------------------------------------------
+// #1998 gate P1-1 - the drive must be confined to the partial-execution scope.
+//
+// REPRODUCED ON THE RIG before it was fixed, with a two-branch graph and
+// `graph_run { batch_count: 4, to_node_id: 9 }` (posts captured, nothing queued):
+//
+//   partial_execution_targets  ["9"] on all four posts
+//   node 3  (in scope)   seed widget 707000 -> 707004
+//   node 13 (OFF scope)  seed widget 808000 -> 808004     <-- never executed
+//
+// and after the fix, same run:
+//
+//   node 3   posted 707000,707001,707002,707003   widget -> 707004
+//   node 13  posted 808000,808000,808000,808000   widget  = 808000 (untouched)
+// ---------------------------------------------------------------------------
+
+/** A two-branch prompt map: 3 -> 9 and 13 -> 19, sharing loader 4. */
+const twoBranchPrompt = {
+  "4": { class_type: "CheckpointLoaderSimple", inputs: {} },
+  "3": { class_type: "KSampler", inputs: { model: ["4", 0] } },
+  "9": { class_type: "SaveImage", inputs: { images: ["3", 0] } },
+  "13": { class_type: "KSampler", inputs: { model: ["4", 0] } },
+  "19": { class_type: "SaveImage", inputs: { images: ["13", 0] } },
+};
+
+const twoBranchGraph = () => ({
+  _nodes: [
+    { id: 4, type: "CheckpointLoaderSimple", widgets: [] },
+    controlledSeedNode(3, "increment", { startAt: 707000 }),
+    { id: 9, type: "SaveImage", widgets: [] },
+    controlledSeedNode(13, "increment", { startAt: 808000 }),
+    { id: 19, type: "SaveImage", widgets: [] },
+  ],
+});
+
+test("#1998 P1-1 the scope is the upstream closure of the target, nothing else", () => {
+  const g = twoBranchGraph();
+  const ids = nodesInPartialExecutionScope(g, twoBranchPrompt, ["9"])
+    .map((n) => String(n.id))
+    .sort();
+  assert.deepEqual(ids, ["3", "4", "9"], "node 13 and node 19 are not in this run");
+});
+
+test("#1998 P1-1 an OFF-SCOPE control is never armed, and its widget is untouched", () => {
+  const g = twoBranchGraph();
+  const inScope = nodesInPartialExecutionScope(g, twoBranchPrompt, ["9"]);
+  const drive = driveControlHooksAcrossScopedBatch(inScope);
+  const seeds = queueBatch(g._nodes, { batchCount: 4, isPartialExecution: true, readNodeId: 3 });
+  drive.restore();
+  const seedOf = (id) => g._nodes.find((n) => n.id === id).widgets.find((w) => w.name === "seed").value;
+  assert.deepEqual(seeds, [707000, 707001, 707002, 707003], "the IN-scope control still advances");
+  assert.equal(seedOf(13), 808000, "the OFF-scope control must not be mutated at all");
+  assert.deepEqual(
+    drive.observe().map((o) => o.node_id),
+    ["3"],
+    "and it must not be reported as advanced either",
+  );
+});
+
+test("#1998 P1-1 FAIL-CLOSED: an unprovable scope yields null, and null arms nothing", () => {
+  const g = twoBranchGraph();
+  // A root that is not a key of the prompt map: the closure cannot be computed.
+  assert.equal(nodesInPartialExecutionScope(g, twoBranchPrompt, ["404"]), null);
+  assert.equal(nodesInPartialExecutionScope(g, null, ["9"]), null, "no prompt map means unprovable");
+  assert.equal(nodesInPartialExecutionScope(g, twoBranchPrompt, []), null, "no roots means unprovable");
+  assert.equal(nodesInPartialExecutionScope(null, twoBranchPrompt, ["9"]), null);
+  // ...and arming with the caller's `?? []` fallback touches nothing.
+  const drive = driveControlHooksAcrossScopedBatch(nodesInPartialExecutionScope(g, null, ["9"]) ?? []);
+  assert.deepEqual(drive.armed, []);
+  const seeds = queueBatch(g._nodes, { batchCount: 3, isPartialExecution: true, readNodeId: 3 });
+  drive.restore();
+  assert.deepEqual(seeds, [707000, 707000, 707000], "unprovable scope keeps ComfyUI's shipped behaviour");
+});
+
+test("#1998 P1-1 a full run (no targets) is not something this function narrows", () => {
+  const g = twoBranchGraph();
+  assert.equal(nodesInPartialExecutionScope(g, twoBranchPrompt, null), null);
+});
+
+test("#1998 P1-1 the prompt RESULT shape is accepted as well as its output map", () => {
+  const g = twoBranchGraph();
+  const ids = nodesInPartialExecutionScope(g, { output: twoBranchPrompt }, ["9"]).map((n) => String(n.id));
+  assert.deepEqual(ids.sort(), ["3", "4", "9"]);
+});
+
+test("#1998 P1-1 nodesInPartialExecutionScope never throws on a malformed graph", () => {
+  assert.doesNotThrow(() => nodesInPartialExecutionScope({ _nodes: [null, {}] }, twoBranchPrompt, ["9"]));
+  assert.doesNotThrow(() => nodesInPartialExecutionScope({ _nodes: null }, twoBranchPrompt, ["9"]));
+});
+
+// ---------------------------------------------------------------------------
+// #1998 gate P1-2 — an unarmed control keeps its repetition warning.
+//
+// REPRODUCED ON THE RIG: with the IN-SCOPE control carrying only `beforeQueued`,
+// the four posts carried seed 707000 four times and `repeating_controls_note` was
+// ABSENT — the reply reported neither the fix nor the warning. The observation
+// array was NOT empty (an off-scope control had filled it), so an "is it empty"
+// check would not have caught this. Coverage is per-WIDGET, not per-array.
+//
+// After the fix, same run: posts still 707000 x4 (a single-hook control cannot be
+// driven), `batch_controls` absent (no false claim), `repeating_controls_note` present.
+// ---------------------------------------------------------------------------
+
+test("#1998 P1-2 a control with only ONE queue hook is not armed, and keeps its warning", () => {
+  const nodes = [controlledSeedNode(42, "increment")];
+  delete nodes[0].widgets[1].afterQueued;
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  assert.deepEqual(drive.armed, [], "both hooks are required - that is the frontend's own test");
+  assert.equal(drive.armedWidgets.size, 0);
+  const seeds = queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  assert.deepEqual(seeds, [12345, 12345, 12345, 12345], "so it still repeats...");
+  const uncovered = findRepeatingControlWidgets(nodes, { skip: drive.armedWidgets });
+  assert.equal(uncovered.length, 1, "an unarmed control keeps its repetition warning");
+  assert.match(scopedBatchSeedNote(uncovered, 4), /node 42/);
+});
+
+test("#1998 P1-2 skip subtracts exactly the ARMED widgets, by identity not by id", () => {
+  // Two nodes deliberately sharing an id, as a root node and a subgraph node can.
+  const armedNode = controlledSeedNode(7, "randomize");
+  const otherNode = controlledSeedNode(7, "randomize");
+  const drive = driveControlHooksAcrossScopedBatch([armedNode]);
+  const uncovered = findRepeatingControlWidgets([armedNode, otherNode], { skip: drive.armedWidgets });
+  drive.restore();
+  assert.equal(uncovered.length, 1, "matching on node_id would have silenced BOTH");
+});
+
+test("#1998 P1-2 no skip, or an empty one, leaves the shipped #988 scan untouched", () => {
+  const nodes = [ksampler(42, "randomize")];
+  const plain = findRepeatingControlWidgets(nodes);
+  assert.deepEqual(findRepeatingControlWidgets(nodes, {}), plain);
+  assert.deepEqual(findRepeatingControlWidgets(nodes, { skip: new Set() }), plain);
+  assert.deepEqual(findRepeatingControlWidgets(nodes, { skip: null }), plain);
+});
+
+test("#1998 P1-1 CALL SITE: the drive is armed over the SCOPE, and null arms nothing", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /import \{[^}]*\bnodesInPartialExecutionScope\b[^}]*\} from "\.\/lib\/scoped-batch-seed\.js"/s,
+  );
+  const install = src.indexOf("driveControlHooksAcrossScopedBatch(");
+  const call = src.slice(Math.max(0, install - 400), install + 200);
+  assert.match(
+    call,
+    /nodesInPartialExecutionScope\(rootGraph, preflightPrompt, partialTargets\)/,
+    "the drive must be handed the partial-execution scope, not the whole workflow",
+  );
+  assert.match(call, /inScope \?\? \[\]/, "an unprovable scope must arm NOTHING, never the whole graph");
+  assert.doesNotMatch(
+    src.slice(install, install + 200),
+    /collectAllGraphs/,
+    "arming over every graph is gate P1-1",
+  );
+});
+
+test("#1998 P1-2 CALL SITE: the #988 warning is subtracted by ARMED WIDGETS, not suppressed wholesale", () => {
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const sites = [...src.matchAll(/const repeatingNote = ([^\n;]+)/g)].map((m) => m[1].trim());
-  assert.equal(sites.length, 1, "the #988 note is computed somewhere unexpected - re-check this gate");
-  assert.match(
+  assert.equal(sites.length, 1);
+  assert.equal(
     sites[0],
-    /controlDriveObservations \?\s*""\s*:\s*scopedBatchSeedNote\(/,
-    `the "this batch WILL reuse the same values" note must be suppressed once the drive ran, got: ${sites[0]}`,
+    "scopedBatchSeedNote(repeatingControls, batch)",
+    `the note must not be gated on the observation array existing, got: ${sites[0]}`,
   );
-  assert.match(src, /accept\.batch_controls_note = driveNote/, "the driven result must carry its own note");
+  assert.match(
+    src,
+    /skip: controlDrive\.armedWidgets/,
+    "the subtraction must come from what was actually armed",
+  );
 });

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -19,6 +19,8 @@ import { readFileSync } from "node:fs";
 import {
   findRepeatingControlWidgets,
   scopedBatchSeedNote,
+  driveControlHooksAcrossScopedBatch,
+  scopedBatchDriveNote,
   findRgthreeSeedNodes,
   rgthreeFixedSeedNote,
   repeatingRgthreeSeeds,
@@ -519,4 +521,283 @@ test("#1339 r2 source guard: the CALL SITE uses the shared predicate, not its ow
   // It has to be imported to be callable — a bare reference would be a ReferenceError
   // that only a live panel would surface.
   assert.match(src, /import \{[^}]*\brepeatingRgthreeSeeds\b[^}]*\} from "\.\/lib\/scoped-batch-seed\.js"/s);
+});
+
+
+// ---------------------------------------------------------------------------
+// #1998 - the panel DRIVES ComfyUI's own control hooks across a scoped batch.
+//
+// THE DOUBLE BELOW IS A PORT, NOT AN INVENTION. Every branch is taken from the
+// pinned frontend's own TypeScript, recovered from the sourcemaps that ship inside
+// comfyui_frontend_package 1.49.6:
+//
+//   src/scripts/widgets.ts       valueControl.beforeQueued/afterQueued, the
+//                                Comfy.WidgetControlMode split, HAS_EXECUTED
+//   src/scripts/valueControl.ts  `if (params.isPartialExecution) return undefined`
+//                                `if (mode === 'fixed') return undefined`
+//                                computeNextNumberValue: += step / -= step / random
+//   src/scripts/app.ts           the batch loop: beforeQueued -> graphToPrompt ->
+//                                POST -> afterQueued, once per item
+//
+// It is checked against the LIVE rig: driving the real frontend through the real
+// app.queuePrompt with the outgoing /prompt bodies captured behind an interceptor
+// (ComfyUI 0.33.2 / frontend 1.49.6) produced
+//
+//   scoped   randomize -> 12345, 12345, 12345, 12345
+//   scoped   increment -> 12345, 12345, 12345, 12345
+//   unscoped increment -> 12345, 12346, 12347, 12348
+//   scoped   increment + this drive -> 12345, 12346, 12347, 12348
+//
+// which is exactly what the assertions below say.
+// ---------------------------------------------------------------------------
+
+/** A value widget plus its frontend-shaped control combo, wired the way ComfyUI wires them. */
+function controlledSeedNode(id, mode, { runBefore = false, startAt = 12345, linkFed = false } = {}) {
+  const seed = { name: "seed", value: startAt, type: "number", options: { min: 0, max: 1e15, step2: 1 } };
+  const control = {
+    name: "control_after_generate",
+    value: mode,
+    // The AUTHORITATIVE frontend shape: serialize:false + canvasOnly:true + the mode
+    // option list. isControlAfterGenerateWidget keys on exactly this.
+    options: {
+      serialize: false,
+      canvasOnly: true,
+      values: ["fixed", "increment", "decrement", "randomize"],
+    },
+  };
+  seed.linkedWidgets = [control];
+  let hasExecuted = false;
+  const applyWidgetControl = (isPartialExecution) => {
+    // widgets.ts applyWidgetControl: a governed input fed by a LINK is skipped on
+    // EVERY path - the value that executes comes from the link, not the widget.
+    if (linkFed) return;
+    // valueControl.ts nextValueForLinkedTarget - ComfyUI_frontend #8774.
+    if (isPartialExecution) return;
+    // valueControl.ts computeNextControlledValue.
+    if (control.value === "fixed") return;
+    if (control.value === "increment" || control.value === "increment-wrap") seed.value += 1;
+    else if (control.value === "decrement") seed.value -= 1;
+    else if (control.value === "randomize") seed.value = Math.floor(Math.random() * 1e15);
+  };
+  control.beforeQueued = ({ isPartialExecution } = {}) => {
+    if (runBefore) {
+      if (hasExecuted) applyWidgetControl(isPartialExecution);
+      hasExecuted = true;
+    }
+  };
+  control.afterQueued = ({ isPartialExecution } = {}) => {
+    if (!runBefore) applyWidgetControl(isPartialExecution);
+  };
+  return { id, type: "KSampler", widgets: [seed, control, { name: "steps", value: 20 }] };
+}
+
+/** app.ts's batch loop, reduced to the part that decides what each prompt carries. */
+function queueBatch(nodes, { batchCount, isPartialExecution }) {
+  const posted = [];
+  for (let i = 0; i < batchCount; i++) {
+    for (const n of nodes) for (const w of n.widgets ?? []) w.beforeQueued?.({ isPartialExecution });
+    posted.push(nodes.map((n) => (n.widgets ?? []).find((w) => w.name === "seed")?.value));
+    for (const n of nodes) for (const w of n.widgets ?? []) w.afterQueued?.({ isPartialExecution });
+  }
+  return posted.map((row) => row[0]);
+}
+
+test("#1998 the double reproduces the bug: a scoped batch posts one seed four times", () => {
+  const nodes = [controlledSeedNode(42, "randomize")];
+  assert.deepEqual(queueBatch(nodes, { batchCount: 4, isPartialExecution: true }), [12345, 12345, 12345, 12345]);
+});
+
+test("#1998 the double reproduces the WORKING case: an unscoped batch advances", () => {
+  const nodes = [controlledSeedNode(42, "increment")];
+  assert.deepEqual(queueBatch(nodes, { batchCount: 4, isPartialExecution: false }), [12345, 12346, 12347, 12348]);
+});
+
+test("#1998 DRIVEN, a scoped randomize batch posts four different seeds", () => {
+  const nodes = [controlledSeedNode(42, "randomize")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  const seeds = queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  assert.equal(new Set(seeds).size, 4, `expected four distinct seeds, got ${JSON.stringify(seeds)}`);
+  assert.equal(seeds[0], 12345, "the FIRST item still carries the seed the user can see");
+});
+
+test("#1998 DRIVEN, a scoped increment batch matches the unscoped sequence exactly", () => {
+  const scoped = [controlledSeedNode(42, "increment")];
+  const drive = driveControlHooksAcrossScopedBatch(scoped);
+  const driven = queueBatch(scoped, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  const unscoped = queueBatch([controlledSeedNode(42, "increment")], { batchCount: 4, isPartialExecution: false });
+  assert.deepEqual(driven, unscoped);
+  assert.deepEqual(driven, [12345, 12346, 12347, 12348]);
+});
+
+test("#1998 DRIVEN, decrement runs backwards - the panel does no seed arithmetic of its own", () => {
+  const nodes = [controlledSeedNode(42, "decrement")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  const seeds = queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  assert.deepEqual(seeds, [12345, 12344, 12343, 12342]);
+});
+
+test("#1998 `fixed` still repeats - and it is ComfyUI that refuses, not a panel branch", () => {
+  const nodes = [controlledSeedNode(42, "fixed")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  // The control IS armed. If the panel skipped `fixed` itself, this would be empty and
+  // the identical seeds below would prove nothing about who decided.
+  assert.equal(drive.armed.length, 1, "the fixed control must still be driven");
+  assert.equal(drive.armed[0].mode, "fixed");
+  const seeds = queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  assert.deepEqual(seeds, [12345, 12345, 12345, 12345], "a fixed control must submit N identical prompts");
+  assert.equal(scopedBatchDriveNote(drive.observe(), 4), "", "and nothing is said about it");
+});
+
+test("#1998 `fixed` repeats in Comfy.WidgetControlMode 'before' too", () => {
+  const nodes = [controlledSeedNode(42, "fixed", { runBefore: true })];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  const seeds = queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  assert.deepEqual(seeds, [12345, 12345, 12345, 12345]);
+});
+
+test("#1998 the drive works in Comfy.WidgetControlMode 'before' as well as 'after'", () => {
+  const nodes = [controlledSeedNode(42, "increment", { runBefore: true })];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  const seeds = queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  drive.restore();
+  // 'before' skips the first execution (HAS_EXECUTED), so the advance starts on item 2 -
+  // identical to what an unscoped 'before' run does.
+  assert.deepEqual(seeds, [12345, 12346, 12347, 12348]);
+});
+
+test("#1998 restore() puts #8774 back - a later scoped run repeats again", () => {
+  const nodes = [controlledSeedNode(42, "randomize")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  const driven = queueBatch(nodes, { batchCount: 2, isPartialExecution: true });
+  drive.restore();
+  assert.equal(new Set(driven).size, 2);
+  const after = queueBatch(nodes, { batchCount: 3, isPartialExecution: true });
+  assert.equal(new Set(after).size, 1, "an UNDRIVEN scoped run must behave exactly as ComfyUI ships it");
+});
+
+test("#1998 restore() is idempotent and survives a widget whose graph vanished", () => {
+  const nodes = [controlledSeedNode(42, "randomize")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  drive.restore();
+  assert.doesNotThrow(() => drive.restore());
+});
+
+test("#1998 a third-party beforeQueued hook that is NOT a control is left alone", () => {
+  let calls = [];
+  const node = {
+    id: 7,
+    type: "SomePack",
+    widgets: [
+      {
+        name: "populated_text",
+        value: "x",
+        options: { serialize: true },
+        beforeQueued: (o) => calls.push(o),
+        afterQueued: (o) => calls.push(o),
+      },
+    ],
+  };
+  const drive = driveControlHooksAcrossScopedBatch([node]);
+  assert.deepEqual(drive.armed, [], "only value-control combos are driven");
+  queueBatch([node], { batchCount: 2, isPartialExecution: true });
+  drive.restore();
+  assert.ok(
+    calls.every((o) => o.isPartialExecution === true),
+    "a foreign hook must still be told the truth about the run it is in",
+  );
+});
+
+test("#1998 a control detected by OPTION SHAPE is driven even when it is renamed", () => {
+  const nodes = [controlledSeedNode(42, "increment")];
+  nodes[0].widgets[1].name = "seed_behavior";
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  assert.equal(drive.armed.length, 1, "a name test would have dropped this one");
+  const seeds = queueBatch(nodes, { batchCount: 3, isPartialExecution: true });
+  drive.restore();
+  assert.deepEqual(seeds, [12345, 12346, 12347]);
+});
+
+test("#1998 observe() reports what the widget DID, not what the drive asked for", () => {
+  const nodes = [controlledSeedNode(42, "randomize"), controlledSeedNode(43, "randomize", { linkFed: true })];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  queueBatch(nodes, { batchCount: 3, isPartialExecution: true });
+  const seen = drive.observe();
+  drive.restore();
+  const byNode = Object.fromEntries(seen.map((o) => [o.node_id, o]));
+  assert.equal(byNode["42"].advanced, true);
+  assert.equal(byNode["42"].governed, "seed");
+  assert.equal(byNode["42"].governed_source, "linked");
+  assert.equal(byNode["43"].advanced, false, "a link-fed target is skipped by ComfyUI on every path");
+  assert.equal(byNode["43"].observed, true, "and we DID watch it - `observed` is not `advanced`");
+});
+
+test("#1998 the note names what advanced and warns about what did not", () => {
+  const nodes = [controlledSeedNode(42, "randomize"), controlledSeedNode(43, "increment", { linkFed: true })];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  queueBatch(nodes, { batchCount: 4, isPartialExecution: true });
+  const note = scopedBatchDriveNote(drive.observe(), 4);
+  drive.restore();
+  assert.match(note, /node 42 \(KSampler\) seed=randomize/);
+  assert.match(note, /did NOT move/);
+  assert.match(note, /node 43 \(KSampler\) seed=increment/);
+  assert.match(note, /#8774/, "the note must name the upstream behaviour it is working around");
+});
+
+test("#1998 the note is silent for a batch of one and for a graph of only fixed controls", () => {
+  const nodes = [controlledSeedNode(42, "randomize")];
+  const drive = driveControlHooksAcrossScopedBatch(nodes);
+  queueBatch(nodes, { batchCount: 1, isPartialExecution: true });
+  assert.equal(scopedBatchDriveNote(drive.observe(), 1), "");
+  drive.restore();
+  assert.equal(scopedBatchDriveNote([{ mode: "fixed", advanced: false, node_id: "1" }], 4), "");
+});
+
+test("#1998 the drive never throws on a malformed graph", () => {
+  assert.doesNotThrow(() => driveControlHooksAcrossScopedBatch(null));
+  assert.doesNotThrow(() => driveControlHooksAcrossScopedBatch([null, {}, { widgets: null }, { widgets: [null] }]));
+  assert.deepEqual(driveControlHooksAcrossScopedBatch(undefined).armed, []);
+});
+
+test("#1998 CALL SITE: the drive is installed on the SCOPED path, and restored in a finally", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  // It has to be imported to be callable - a bare reference is a ReferenceError that
+  // only a live panel would surface.
+  assert.match(
+    src,
+    /import \{[^}]*\bdriveControlHooksAcrossScopedBatch\b[^}]*\} from "\.\/lib\/scoped-batch-seed\.js"/s,
+    "driveControlHooksAcrossScopedBatch must be imported",
+  );
+  const install = src.indexOf("driveControlHooksAcrossScopedBatch(");
+  const scopedDispatch = src.indexOf("runScopeResult = await dispatchScopedRun({");
+  const unscopedDispatch = src.indexOf("await app.queuePrompt(0, batch, undefined)");
+  assert.ok(install > 0, "the drive is never installed - the fix is not wired in");
+  assert.ok(install < scopedDispatch, "it must be armed BEFORE the scoped dispatch it wraps");
+  assert.ok(
+    install > unscopedDispatch,
+    "it must sit in the SCOPED branch: the unscoped path already advances and must not be touched",
+  );
+  // The restore has to be unconditional. A throw out of dispatchScopedRun that left the
+  // hooks wrapped would keep advancing controls on the user's later single previews.
+  const tail = src.slice(scopedDispatch, scopedDispatch + 2500);
+  assert.match(tail, /\}\s*finally\s*\{[\s\S]{0,400}?controlDrive\?\.restore\(\)/, "restore must run in a finally around the dispatch");
+  // Gated on batch > 1: a scoped run of one keeps upstream #8774 behaviour.
+  const head = src.slice(Math.max(0, install - 600), install + 300);
+  assert.match(head, /batch > 1/, "the override must be gated on batch > 1");
+});
+
+test("#1998 CALL SITE: a driven batch does not also ship #988's contradictory warning", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const sites = [...src.matchAll(/const repeatingNote = ([^\n;]+)/g)].map((m) => m[1].trim());
+  assert.equal(sites.length, 1, "the #988 note is computed somewhere unexpected - re-check this gate");
+  assert.match(
+    sites[0],
+    /controlDriveObservations \?\s*""\s*:\s*scopedBatchSeedNote\(/,
+    `the "this batch WILL reuse the same values" note must be suppressed once the drive ran, got: ${sites[0]}`,
+  );
+  assert.match(src, /accept\.batch_controls_note = driveNote/, "the driven result must carry its own note");
 });

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -785,9 +785,15 @@ test("#1998 CALL SITE: the drive is installed on the SCOPED path, and restored i
   // hooks wrapped would keep advancing controls on the user's later single previews.
   const tail = src.slice(scopedDispatch, scopedDispatch + 2500);
   assert.match(tail, /\}\s*finally\s*\{[\s\S]{0,400}?controlDrive\?\.restore\(\)/, "restore must run in a finally around the dispatch");
-  // Gated on batch > 1: a scoped run of one keeps upstream #8774 behaviour.
-  const head = src.slice(Math.max(0, install - 600), install + 300);
-  assert.match(head, /batch > 1/, "the override must be gated on batch > 1");
+  // Gated on batch > 1: a scoped run of one keeps upstream #8774 behaviour. Assert on
+  // the ARGUMENT EXPRESSION, not on a window of surrounding source - a window matched
+  // the word "batch > 1" in the comment above the call and let a dropped gate survive.
+  const call = src.slice(install, src.indexOf(");", install) + 2);
+  assert.match(
+    call,
+    /batch > 1\s*\?/,
+    `the override must be gated on batch > 1, got: ${call}`,
+  );
 });
 
 test("#1998 CALL SITE: a driven batch does not also ship #988's contradictory warning", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -226,6 +226,7 @@ import {
   findRepeatingControlWidgets,
   scopedBatchSeedNote,
   driveControlHooksAcrossScopedBatch,
+  nodesInPartialExecutionScope,
   scopedBatchDriveNote,
   findRgthreeSeedNodes,
   rgthreeFixedSeedNote,
@@ -15944,6 +15945,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // Resolution is read-only, so moving it ahead changes nothing it does; it only changes
     // which refusal answers first, and "node N was not found" is the better answer to a
     // request naming node N than a report about some other node's pack.
+    // #1998 (gate P1-1) — the pre-flight's serialization, kept so the scope closure can
+    // be computed from the SAME compilation. A second `app.graphToPrompt()` would describe
+    // a graph that may have moved and is not read-only (#985). Null whenever the pre-flight
+    // did not produce one, which the closure treats as "scope unprovable".
+    let preflightPrompt = null;
     let partialTargets;
     // #699 — carried out of the resolve block so the queue-rejection summary can
     // explain a `prompt_no_outputs` refusal of a target the panel already verified
@@ -16034,6 +16040,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // the pre-flight catch as a throw, exactly as the bare await delivered it.
       if ("error" in preflightBuild) throw preflightBuild.error;
       const built = preflightBuild.value;
+      preflightPrompt = built;
       // comfyui-mcp#1582 — SERIALIZATION ITSELF CAN FAIL, and this is where that has to
       // be caught. `unrunnableNodeIds(undefined)` answers `[]` — correctly, since a
       // result that does not exist has no unrunnable entries in it — and the check below
@@ -16316,13 +16323,42 @@ const GRAPH_TOOL_EXECUTORS = {
       //
       // ONLY for batch > 1. A single scoped preview keeps #8774's behaviour exactly:
       // the user iterating on one branch does not want their seed churned.
+      //
+      // SCOPED TO THE RUN, not to the workflow (gate P1-1). Arming every node advanced
+      // controls on branches this run never executes — MEASURED: a batch scoped to node 9
+      // walked an unrelated KSampler's seed 808000 -> 808004 and reported it as advanced.
+      // That is a silent wrong-target mutation, and it contradicts the very reason for
+      // overriding #8774: the user asked for N renders OF THE SCOPE THEY NAMED.
+      //
+      // `nodesInPartialExecutionScope` returns null when the scope cannot be PROVEN, and
+      // null arms nothing: the batch then repeats exactly as ComfyUI ships it and #988's
+      // warning stands (see the skip below). Never an approximation of the node set.
       let controlDrive = null;
       try {
-        controlDrive = driveControlHooksAcrossScopedBatch(
-          batch > 1 ? collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []) : [],
-        );
+        const inScope =
+          batch > 1 ? nodesInPartialExecutionScope(rootGraph, preflightPrompt, partialTargets) : [];
+        controlDrive = driveControlHooksAcrossScopedBatch(inScope ?? []);
       } catch {
         controlDrive = null; /* the run must survive a failure to arm the drive */
+      }
+      // #988 x #1998 (gate P1-2) — SUBTRACT ONLY WHAT WAS ACTUALLY ARMED. The suppression
+      // used to key on `controlDriveObservations` being non-null, and an empty array is
+      // non-null: a control the drive could not arm (one queue hook, an older frontend's
+      // widget shape, a node outside the scope) submitted identical prompts while the
+      // reply carried NEITHER the drive note NOR the repetition warning. MEASURED: with a
+      // single-hook control on the in-scope KSampler, the four posts carried seed 707000
+      // four times and `repeating_controls_note` was absent. Absence of evidence read as
+      // evidence of success — and the empty-array check would not even have caught it,
+      // because an off-scope control had filled the array.
+      if (controlDrive?.armedWidgets?.size) {
+        try {
+          repeatingControls = findRepeatingControlWidgets(
+            collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []),
+            { skip: controlDrive.armedWidgets },
+          );
+        } catch {
+          /* keep the unfiltered scan — over-warning is the safe direction here */
+        }
       }
       try {
         runScopeResult = await dispatchScopedRun({
@@ -16566,8 +16602,11 @@ const GRAPH_TOOL_EXECUTORS = {
       accept.batch_controls = controlDriveObservations;
       accept.batch_controls_note = driveNote;
     }
-    // #988 — attach the PRE-dispatch finding.
-    const repeatingNote = controlDriveObservations ? "" : scopedBatchSeedNote(repeatingControls, batch);
+    // #988 — attach the PRE-dispatch finding, now covering exactly the controls the drive
+    // did NOT arm (gate P1-2). The subtraction happens at the arming site, before dispatch,
+    // so this keeps #988's "computed BEFORE dispatch" property; what changed is that an
+    // unarmed control keeps its warning instead of being silenced by an unrelated one.
+    const repeatingNote = scopedBatchSeedNote(repeatingControls, batch);
     if (repeatingNote) {
       accept.repeating_controls = repeatingControls;
       accept.repeating_controls_note = repeatingNote;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -225,6 +225,8 @@ import {
 import {
   findRepeatingControlWidgets,
   scopedBatchSeedNote,
+  driveControlHooksAcrossScopedBatch,
+  scopedBatchDriveNote,
   findRgthreeSeedNodes,
   rgthreeFixedSeedNote,
   repeatingRgthreeSeeds,
@@ -16152,6 +16154,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // FIXED rgthree seed is submitted verbatim for every item whether the run is scoped or
     // not. Gating it the same way would have kept it invisible for exactly the unscoped
     // batch a user reaches for when they want ten different images.
+    // #1998 - what the driven control widgets ACTUALLY did across a scoped batch.
+    // Null when no scoped batch ran, so the #988 warning stays in charge of that case.
+    let controlDriveObservations = null;
     let rgthreeSeeds = [];
     if (batch > 1) {
       try {
@@ -16188,16 +16193,54 @@ const GRAPH_TOOL_EXECUTORS = {
       // drive (#556). It marks every one of this run's posts with a queue
       // position sentinel and tags the pending queue item, so a scoped run
       // can never be confused with unrelated queue traffic.
-      runScopeResult = await dispatchScopedRun({
-        app,
-        apiTarget: api,
-        execIds: partialTargets,
-        batch,
-        toNodeId: to_node_id,
-        onRejection: captureRejection,
-        onPromptId: capturePromptId,
-        onAcceptedNodeErrors: captureAcceptedNodeErrors,
-      });
+      // #1998 - a SCOPED batch of more than one would submit N byte-identical
+      // prompts. ComfyUI refuses to advance control_after_generate on a PARTIAL
+      // execution (ComfyUI_frontend #8774: `if (params.isPartialExecution) return
+      // undefined`), so every item after the first is a cache hit that returns the
+      // FIRST output file - and panel_run reported N successes for one render.
+      //
+      // Separating the dispatches does not help: MEASURED on frontend 1.49.6, four
+      // separate `queuePrompt(0, 1, scope)` calls posted the same seed four times,
+      // exactly like one `queuePrompt(0, 4, scope)`. The refusal keys on the scope,
+      // not on the batch position. So the ONE thing that can vary the value is the
+      // flag, and that is the only thing this changes: the control widgets' OWN
+      // hooks run with `isPartialExecution: false` and ComfyUI computes every value
+      // itself - which is why `fixed` still repeats (its own `mode === "fixed"`
+      // returns undefined) and increment/decrement need no panel arithmetic.
+      //
+      // ONLY for batch > 1. A single scoped preview keeps #8774's behaviour exactly:
+      // the user iterating on one branch does not want their seed churned.
+      let controlDrive = null;
+      try {
+        controlDrive = driveControlHooksAcrossScopedBatch(
+          batch > 1 ? collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []) : [],
+        );
+      } catch {
+        controlDrive = null; /* the run must survive a failure to arm the drive */
+      }
+      try {
+        runScopeResult = await dispatchScopedRun({
+          app,
+          apiTarget: api,
+          execIds: partialTargets,
+          batch,
+          toNodeId: to_node_id,
+          onRejection: captureRejection,
+          onPromptId: capturePromptId,
+          onAcceptedNodeErrors: captureAcceptedNodeErrors,
+        });
+      } finally {
+        // ALWAYS, on every exit including a throw. A hook left wrapped would keep
+        // advancing controls on the user's later single scoped previews.
+        try {
+          controlDrive?.restore();
+        } catch {}
+      }
+      try {
+        controlDriveObservations = controlDrive ? controlDrive.observe() : null;
+      } catch {
+        controlDriveObservations = null;
+      }
     }
     // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —
     // BEFORE the rejection check. With batch>1, app.queuePrompt breaks its loop on
@@ -16316,8 +16359,18 @@ const GRAPH_TOOL_EXECUTORS = {
       // #1504 — outputs ComfyUI dropped from the prompt it queued.
       droppedOutputs: acceptedNodeErrors,
     });
+    // #1998 — when the scoped batch was DRIVEN, report what the controls actually did
+    // and do NOT also ship #988's "this batch WILL reuse the same values": that sentence
+    // is what the drive stops being true, and two contradictory statements in one result
+    // is worse than either alone. The #988 note stays in charge whenever the drive did
+    // not run (arming threw, or a frontend with no hooks to wrap).
+    const driveNote = scopedBatchDriveNote(controlDriveObservations, batch);
+    if (driveNote) {
+      accept.batch_controls = controlDriveObservations;
+      accept.batch_controls_note = driveNote;
+    }
     // #988 — attach the PRE-dispatch finding.
-    const repeatingNote = scopedBatchSeedNote(repeatingControls, batch);
+    const repeatingNote = controlDriveObservations ? "" : scopedBatchSeedNote(repeatingControls, batch);
     if (repeatingNote) {
       accept.repeating_controls = repeatingControls;
       accept.repeating_controls_note = repeatingNote;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16500,28 +16500,12 @@ const GRAPH_TOOL_EXECUTORS = {
       try {
         const inScope =
           batch > 1 ? nodesInPartialExecutionScope(rootGraph, preflightPrompt, partialTargets) : [];
-        controlDrive = driveControlHooksAcrossScopedBatch(inScope ?? []);
+        // `batchCount` is what lets the drive PROVE the hook calls it observed were its
+        // own: owning the batch means exactly 2 x batchCount invocations. Without it the
+        // drive attributes nothing, which is the fail-closed default (gate r2 P1-A).
+        controlDrive = driveControlHooksAcrossScopedBatch(inScope ?? [], { batchCount: batch });
       } catch {
         controlDrive = null; /* the run must survive a failure to arm the drive */
-      }
-      // #988 x #1998 (gate P1-2) — SUBTRACT ONLY WHAT WAS ACTUALLY ARMED. The suppression
-      // used to key on `controlDriveObservations` being non-null, and an empty array is
-      // non-null: a control the drive could not arm (one queue hook, an older frontend's
-      // widget shape, a node outside the scope) submitted identical prompts while the
-      // reply carried NEITHER the drive note NOR the repetition warning. MEASURED: with a
-      // single-hook control on the in-scope KSampler, the four posts carried seed 707000
-      // four times and `repeating_controls_note` was absent. Absence of evidence read as
-      // evidence of success — and the empty-array check would not even have caught it,
-      // because an off-scope control had filled the array.
-      if (controlDrive?.armedWidgets?.size) {
-        try {
-          repeatingControls = findRepeatingControlWidgets(
-            collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []),
-            { skip: controlDrive.armedWidgets },
-          );
-        } catch {
-          /* keep the unfiltered scan — over-warning is the safe direction here */
-        }
       }
       try {
         runScopeResult = await dispatchScopedRun({
@@ -16556,6 +16540,33 @@ const GRAPH_TOOL_EXECUTORS = {
         controlDriveObservations = controlDrive ? controlDrive.observe() : null;
       } catch {
         controlDriveObservations = null;
+      }
+      // #988 x #1998 (gate P1-2, narrowed by gate r2 P1-A) - SUBTRACT ONLY WHAT THE DRIVE
+      // CAN PROVE IT OWNED.
+      //
+      // The suppression first keyed on `controlDriveObservations` being non-null, and an
+      // empty array is non-null: a control the drive could not arm submitted identical
+      // prompts while the reply carried NEITHER the drive note NOR the warning (MEASURED:
+      // four posts of seed 707000 with `repeating_controls_note` absent). Keying it on
+      // "armed" fixed that but was still too generous - an armed control whose hook calls
+      // came from somewhere else was subtracted on the strength of another run's work. So
+      // the skip is now the ATTRIBUTED set: armed AND with exactly this batch's own
+      // invocation count behind it.
+      //
+      // RUN AFTER THE DISPATCH, and that is safe here even though #988's finding is
+      // deliberately a pre-dispatch one: this scan reads control MODES and node identity,
+      // and the drive mutates neither - it moves the GOVERNED value widget. The entries it
+      // produces are therefore the same before and after, which is pinned by a test.
+      try {
+        const attributed = controlDrive?.attributedWidgets?.() ?? null;
+        if (attributed?.size) {
+          repeatingControls = findRepeatingControlWidgets(
+            collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []),
+            { skip: attributed },
+          );
+        }
+      } catch {
+        /* keep the unfiltered scan - over-warning is the safe direction here */
       }
     }
     // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -39,6 +39,8 @@
  */
 
 import { isControlAfterGenerateWidget } from "./control-after-generate.js";
+import { upstreamClosure } from "./partial-run-prune.js";
+import { buildNodeExecutionId } from "./subgraph-scope.js";
 
 /**
  * Values of `control_after_generate` that mean "change this between runs".
@@ -90,7 +92,7 @@ function governedValueWidget(widgets, control, index) {
  * Fully defensive — a malformed node or a throwing accessor reduces what is found,
  * never throws. A warning must not be able to take down the run it is about.
  */
-export function findRepeatingControlWidgets(nodes) {
+export function findRepeatingControlWidgets(nodes, { skip = null } = {}) {
   const found = [];
   if (!Array.isArray(nodes)) return found;
   for (const node of nodes) {
@@ -100,6 +102,12 @@ export function findRepeatingControlWidgets(nodes) {
         const w = widgets[i];
         const name = typeof w?.name === "string" ? w.name : null;
         if (name !== "control_after_generate") continue;
+        // #1998 — a control the DRIVE armed is already accounted for by the drive's own
+        // observation note, and warning "this batch WILL reuse it" beside that would be
+        // the contradiction this option exists to prevent. Identity, not id: two nodes in
+        // different subgraphs can share `node.id`, so matching on ids would silence the
+        // wrong widget. Absent/empty skip ⇒ byte-identical to the shipped behaviour.
+        if (skip && skip.has(w)) continue;
         const mode = typeof w.value === "string" ? w.value : null;
         // `fixed` is the one setting that WANTS the same value every time, so a scoped
         // batch repeating it is correct and must not be warned about.
@@ -594,6 +602,7 @@ export function rgthreeFixedSeedNote(seeds, batchCount) {
  */
 export function driveControlHooksAcrossScopedBatch(nodes) {
   const armed = [];
+  const armedWidgets = new Set();
   const restores = [];
   if (Array.isArray(nodes)) {
     for (const node of nodes) {
@@ -643,6 +652,7 @@ export function driveControlHooksAcrossScopedBatch(nodes) {
             };
           w.beforeQueued = forced(before);
           w.afterQueued = forced(after);
+          armedWidgets.add(w);
           restores.push(() => {
             w.beforeQueued = before;
             w.afterQueued = after;
@@ -656,6 +666,13 @@ export function driveControlHooksAcrossScopedBatch(nodes) {
   }
   return {
     armed: armed.map((a) => ({ ...a.entry })),
+    /**
+     * The control widget OBJECTS this drive wrapped — the exact set #988's scan must
+     * skip, so a control the drive could not reach keeps its repetition warning
+     * (#1998 gate P1-2). Identity rather than ids: `node.id` is not unique across
+     * subgraphs, and silencing the wrong widget is the failure being fixed.
+     */
+    armedWidgets,
     /**
      * Put every hook back. Called from the caller's `finally`, so the override lasts
      * exactly the dispatch - a control left wrapped would keep advancing on the user's
@@ -742,4 +759,79 @@ export function scopedBatchDriveNote(observations, batchCount) {
     );
   }
   return parts.join(" ");
+}
+
+/**
+ * #1998 (gate P1-1) — the nodes a PARTIAL execution actually runs, or null when that
+ * cannot be established.
+ *
+ * WHY THIS EXISTS. The drive was armed over `collectAllGraphs(rootGraph)` — every node
+ * in the workflow. MEASURED on the rig with a two-branch graph (KSampler 3 -> SaveImage
+ * 9, KSampler 13 -> SaveImage 19, both `increment`), running
+ * `graph_run { batch_count: 4, to_node_id: 9 }`:
+ *
+ *     partial_execution_targets   ["9"] on all four posts
+ *     node 3  (in scope)  seed widget 707000 -> 707004
+ *     node 13 (OFF scope) seed widget 808000 -> 808004      <-- never executed
+ *
+ * Node 13 is not in the run. Advancing it silently rewrites a branch the user did not
+ * run, and the drive then REPORTED it as `advanced: true`. That is a wrong-target
+ * mutation of someone's workflow, and it is worse than the cache-hit this whole change
+ * exists to fix, because the cache-hit was visible in the outputs and this is not. It
+ * also inverts the justification for overriding ComfyUI_frontend #8774 in the first
+ * place: that the user asked for N distinct renders OF THE SCOPE THEY NAMED.
+ *
+ * ONE CLOSURE, NOT A SECOND OPINION. The backward walk that decides what a run-to-node
+ * executes already lives in `partial-run-prune.js` (#1511) and is what the #1871
+ * pre-flight narrows on. This imports that verdict rather than restating it — two
+ * answers to one question is two chances to disagree, and here disagreement means
+ * either mutating an off-scope node or failing to advance an in-scope one.
+ *
+ * IT WORKS ON THE PROMPT MAP, so the caller must hand over the SAME serialization the
+ * pre-flight already produced. Building a fresh one here would be a second compilation
+ * of a graph that may have moved, and `graphToPrompt` is not read-only (#985).
+ *
+ * FAIL-CLOSED, DELIBERATELY. Null is returned — and the caller then arms NOTHING —
+ * whenever the scope cannot be proven: no prompt map, roots that are not keys of it, or
+ * a node whose execution id cannot be built (a stale/ghost subgraph). Arming nothing
+ * degrades to ComfyUI's shipped behaviour (the batch repeats) AND leaves #988's warning
+ * standing, so the caller is told the truth. Arming everything is the defect above.
+ *
+ * KNOWN LIMIT, stated rather than papered over: a node that carries a control but has no
+ * entry in the prompt map — a frontend-only `PrimitiveNode` feeding a seed, a Reroute —
+ * is not in the closure and is therefore NOT armed. Its control keeps #988's repetition
+ * warning instead, which is the honest outcome; extending the closure to virtual nodes
+ * would mean a second link-walk over litegraph, which is exactly the duplicate verdict
+ * this function refuses to create.
+ */
+export function nodesInPartialExecutionScope(rootGraph, promptResult, targetIds) {
+  try {
+    if (!rootGraph) return null;
+    const map =
+      promptResult?.output && typeof promptResult.output === "object" ? promptResult.output : promptResult;
+    const closure = upstreamClosure(map, targetIds);
+    if (!closure) return null;
+    const out = [];
+    const seen = new Set();
+    const stack = [rootGraph];
+    while (stack.length) {
+      const graph = stack.pop();
+      if (!graph || seen.has(graph)) continue;
+      seen.add(graph);
+      for (const node of graph._nodes ?? []) {
+        if (!node) continue;
+        if (node.subgraph) stack.push(node.subgraph);
+        if (node.id == null) continue;
+        // The colon path ComfyUI itself keys a flattened prompt by, so `closure` (which
+        // holds prompt keys) and this are the same namespace. A node that cannot be
+        // placed makes the whole answer unprovable — see FAIL-CLOSED above.
+        const execId = buildNodeExecutionId(rootGraph, graph, node.id);
+        if (execId == null) return null;
+        if (closure.has(execId)) out.push(node);
+      }
+    }
+    return out;
+  } catch {
+    return null;
+  }
 }

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -38,6 +38,8 @@
  * preventing it.
  */
 
+import { isControlAfterGenerateWidget } from "./control-after-generate.js";
+
 /**
  * Values of `control_after_generate` that mean "change this between runs".
  *
@@ -47,6 +49,34 @@
  * is the only one that legitimately repeats.
  */
 const ADVANCING = new Set(["randomize", "increment", "decrement", "increment-wrap"]);
+
+/**
+ * The value widget a control governs, resolved the way `findRepeatingControlWidgets`
+ * resolves it — LINK first, adjacency as a labelled fallback.
+ *
+ * ONE resolver, two callers (the #988 warning and the #1998 drive), because they must
+ * never disagree about which widget a control governs: the warning names it and the
+ * drive OBSERVES it, so a divergence would report movement on one widget while
+ * describing another. Returns `{ widget, source }`, or `{ widget: null, source: null }`
+ * when neither signal identifies one — blaming the wrong value widget is worse than
+ * naming none.
+ *
+ * The link points VALUE -> CONTROL, not the other way round: ComfyUI attaches the
+ * control to the VALUE widget's `linkedWidgets`.
+ */
+function governedValueWidget(widgets, control, index) {
+  const owner = widgets.find((cand) => {
+    try {
+      return Array.isArray(cand?.linkedWidgets) && cand.linkedWidgets.includes(control);
+    } catch {
+      return false;
+    }
+  });
+  if (owner && typeof owner.name === "string") return { widget: owner, source: "linked" };
+  const prev = index > 0 ? widgets[index - 1] : null;
+  if (prev && typeof prev.name === "string") return { widget: prev, source: "adjacent" };
+  return { widget: null, source: null };
+}
 
 /**
  * Widgets whose value an unscoped batch would have advanced between items, and which
@@ -84,27 +114,11 @@ export function findRepeatingControlWidgets(nodes) {
         // attaches the control to the VALUE widget's `linkedWidgets`. Reading it off
         // the control found nothing in the ordinary core case and fell through to
         // adjacency, so the authoritative signal was never actually being used.
-        let pairedName = null;
-        let pairedSource = null;
-        const owner = widgets.find((cand) => {
-          try {
-            return Array.isArray(cand?.linkedWidgets) && cand.linkedWidgets.includes(w);
-          } catch {
-            return false;
-          }
-        });
-        const ownerName = typeof owner?.name === "string" ? owner.name : null;
-        if (ownerName) {
-          pairedName = ownerName;
-          pairedSource = "linked";
-        } else {
-          const prev = i > 0 ? widgets[i - 1] : null;
-          const adjacent = typeof prev?.name === "string" ? prev.name : null;
-          if (adjacent) {
-            pairedName = adjacent;
-            pairedSource = "adjacent";
-          }
-        }
+        // ONE resolver, shared with the #1998 drive so the widget this warning NAMES is
+        // the widget that drive OBSERVES (governedValueWidget, above).
+        const paired = governedValueWidget(widgets, w, i);
+        const pairedName = paired.widget ? paired.widget.name : null;
+        const pairedSource = paired.source;
         found.push({
           node_id: node?.id != null ? String(node.id) : null,
           node_type: node?.type ?? null,
@@ -508,4 +522,223 @@ export function rgthreeFixedSeedNote(seeds, batchCount) {
     (anyDegenerate ? `randomMin/randomMax in its node properties` : "") +
     `. This is reported, not repaired — the panel does not rewrite your seeds.`
   );
+}
+
+/**
+ * #1998 - DRIVE ComfyUI's own control hooks across the items of a SCOPED batch.
+ *
+ * THE MECHANISM, read out of the pinned frontend's own source (comfyui_frontend_package
+ * ships sourcemaps with sourcesContent, so this is the real TypeScript, not a guess).
+ * ComfyUI runs its batch loop INSIDE one `app.queuePrompt(number, batchCount, scope)`
+ * call and fires the queue-time widget hooks once per item (src/scripts/app.ts):
+ *
+ *     const isPartialExecution = !!queueNodeIds?.length
+ *     for (let i = 0; i < batchCount; i++) {
+ *       forEachNode(this.rootGraph, (node) => {
+ *         for (const widget of node.widgets ?? []) widget.beforeQueued?.({ isPartialExecution })
+ *         applyPromotedWidgetControl(node, 'beforeQueued', { isPartialExecution })
+ *       })
+ *       const p = await this.graphToPrompt(this.rootGraph)          // the body that is POSTed
+ *       const res = await api.queuePrompt(number, p, { partialExecutionTargets: queueNodeIds })
+ *       executeWidgetsCallback(queuedNodes, 'afterQueued', { isPartialExecution })
+ *     }
+ *
+ * ...and src/scripts/valueControl.ts refuses to advance anything when that flag is set:
+ *
+ *     export function nextValueForLinkedTarget(params) {
+ *       if (params.isPartialExecution) return undefined
+ *
+ * That refusal is deliberate upstream behaviour - ComfyUI_frontend PR #8774, "disable
+ * control after generate during partial execution", merged 2026-02-11, so that queueing
+ * selected output nodes while iterating does not churn the user's seed.
+ *
+ * MEASURED on ComfyUI 0.33.2 / frontend 1.49.6 by capturing the outgoing /prompt bodies
+ * behind an interceptor that answered them locally - nothing queued, no GPU time:
+ *
+ *     unscoped  queuePrompt(0, 4, undefined)   randomize -> 4 distinct seeds
+ *     unscoped  queuePrompt(0, 4, undefined)   increment -> 12345, 12346, 12347, 12348
+ *     scoped    queuePrompt(0, 4, ["9"])       randomize -> 12345, 12345, 12345, 12345
+ *     scoped    queuePrompt(0, 4, ["9"])       increment -> 12345, 12345, 12345, 12345
+ *     scoped    4x queuePrompt(0, 1, ["9"])    randomize -> 12345, 12345, 12345, 12345
+ *
+ * THE LAST LINE IS THE ONE THAT DECIDES THE FIX. "Do what the Queue button does, N
+ * times" does NOT work here: the refusal is keyed on the scope, not on the batch
+ * position, so separating the dispatches changes nothing. (That is also why the #988
+ * reporter's own loop-with-batch:1 patch failed after 114 green tests.) The only thing
+ * that can make the value vary is the flag itself.
+ *
+ * SO WE PASS THE FLAG, AND NOTHING ELSE. This wraps each control widget's OWN
+ * `beforeQueued`/`afterQueued` so they receive `isPartialExecution: false`, and the
+ * frontend then does every remaining thing: `computeNextControlledValue` picks the next
+ * value for randomize / increment / decrement / increment-wrap, honours min/max/step and
+ * a combo's filter list, and - the case that breaks a naive fix - returns `undefined`
+ * for `fixed`, so a fixed control still submits N identical prompts. There is no seed
+ * arithmetic in this module and no mode table: `fixed` is protected by ComfyUI's own
+ * `if (mode === 'fixed') return undefined`, not by a panel branch.
+ *
+ * SCOPE OF THE OVERRIDE. The caller installs this ONLY for a scoped run with
+ * `batch_count > 1` - the one case where upstream's refusal turns "give me N renders"
+ * into N byte-identical prompts that ComfyUI answers from cache while the tool reports N
+ * successes. A scoped run of ONE is left exactly as #8774 made it.
+ *
+ * WHAT IT CANNOT REACH, stated so the note can never over-claim. `app.queuePrompt` also
+ * calls `applyPromotedWidgetControl(node, phase, { isPartialExecution })` directly for a
+ * subgraph host's PROMOTED widgets - a module function, not a widget property, so there
+ * is nothing here to wrap and those still repeat. So do controls whose governed input is
+ * fed by a LINK, which the frontend skips on every path. Neither is guessed at:
+ * `observe()` reports what each governed widget ACTUALLY did across the batch, and
+ * `scopedBatchDriveNote` warns about every advancing control that did not move.
+ *
+ * Returns `{ armed, restore, observe }`. Fully defensive, like the rest of this module:
+ * an unreadable node costs its own entry, never the run.
+ */
+export function driveControlHooksAcrossScopedBatch(nodes) {
+  const armed = [];
+  const restores = [];
+  if (Array.isArray(nodes)) {
+    for (const node of nodes) {
+      try {
+        const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+        for (let i = 0; i < widgets.length; i++) {
+          const w = widgets[i];
+          // DETECTED BY OPTION SHAPE, not by name (control-after-generate.js): a node def
+          // may name its control widget anything, and a name test silently drops those.
+          // BOTH hooks must be present - that is the frontend's own `isValueControlWidget`
+          // test, and it keeps this away from third-party `beforeQueued` hooks which are
+          // not controls and never asked for our flag.
+          if (!isControlAfterGenerateWidget(w)) continue;
+          if (typeof w.beforeQueued !== "function") continue;
+          if (typeof w.afterQueued !== "function") continue;
+          const paired = governedValueWidget(widgets, w, i);
+          const target = paired.widget ?? null;
+          const entry = {
+            node_id: node?.id != null ? String(node.id) : null,
+            node_type: node?.type ?? null,
+            control: typeof w.name === "string" ? w.name : null,
+            mode: typeof w.value === "string" ? w.value : null,
+            ...(target ? { governed: target.name, governed_source: paired.source } : {}),
+          };
+          const seen = [];
+          const record = () => {
+            if (!target) return;
+            try {
+              seen.push(target.value);
+            } catch {
+              /* an unreadable value costs one sample, never the run */
+            }
+          };
+          const before = w.beforeQueued;
+          const after = w.afterQueued;
+          // Sample the governed value on BOTH sides of every hook call, so `observe()`
+          // reports the value this run actually carried rather than the change we asked
+          // for. The FIRST sample is the value the first prompt was built from.
+          const forced = (orig) =>
+            function (opts) {
+              record();
+              try {
+                return orig.call(this, { ...(opts ?? {}), isPartialExecution: false });
+              } finally {
+                record();
+              }
+            };
+          w.beforeQueued = forced(before);
+          w.afterQueued = forced(after);
+          restores.push(() => {
+            w.beforeQueued = before;
+            w.afterQueued = after;
+          });
+          armed.push({ entry, seen });
+        }
+      } catch {
+        /* one unreadable node costs its own entry, never the whole dispatch */
+      }
+    }
+  }
+  return {
+    armed: armed.map((a) => ({ ...a.entry })),
+    /**
+     * Put every hook back. Called from the caller's `finally`, so the override lasts
+     * exactly the dispatch - a control left wrapped would keep advancing on the user's
+     * own single scoped previews, which is the behaviour #8774 exists to prevent.
+     * Idempotent: the queue drains the list, so a second call restores nothing.
+     */
+    restore() {
+      for (const r of restores.splice(0).reverse()) {
+        try {
+          r();
+        } catch {
+          /* a widget that vanished with its graph needs no restoring */
+        }
+      }
+    },
+    /** What each governed widget ACTUALLY did across the batch. */
+    observe() {
+      return armed.map(({ entry, seen }) => {
+        const keys = seen.map((v) =>
+          typeof v === "object" && v !== null ? JSON.stringify(v) : `${typeof v}:${String(v)}`,
+        );
+        const distinct = new Set(keys).size;
+        return {
+          ...entry,
+          observed: seen.length > 0,
+          distinct_values: distinct,
+          advanced: distinct > 1,
+          ...(seen.length ? { from: seen[0], to: seen[seen.length - 1] } : {}),
+        };
+      });
+    },
+  };
+}
+
+/**
+ * The disclosure for a scoped batch the panel DROVE (#1998).
+ *
+ * REPLACES `scopedBatchSeedNote` on that path rather than sitting beside it: that note
+ * says the batch WILL reuse the same values, which is exactly what this drive stops
+ * being true, and shipping both would put two contradictory sentences in one result.
+ *
+ * Silent for a batch of one, and silent when no advancing control was armed - a graph
+ * carrying nothing but `fixed` controls has no surprise to report, and saying something
+ * anyway is the noise that trains people to skip the useful case.
+ */
+export function scopedBatchDriveNote(observations, batchCount) {
+  if (!Array.isArray(observations) || !(Number(batchCount) > 1)) return "";
+  const advancingMode = observations.filter((o) => o && ADVANCING.has(o.mode));
+  if (!advancingMode.length) return "";
+  const moved = advancingMode.filter((o) => o.advanced);
+  const stuck = advancingMode.filter((o) => !o.advanced);
+  const describe = (o) =>
+    `node ${o.node_id}${o.node_type ? ` (${o.node_type})` : ""} ${o.governed ?? o.control}=${o.mode}`;
+  const list = (xs) => {
+    const head = xs.slice(0, 5).map(describe).join("; ");
+    return xs.length > 5 ? `${head}, and ${xs.length - 5} more` : head;
+  };
+  const parts = [];
+  if (moved.length) {
+    parts.push(
+      `A run scoped with to_node_id is a PARTIAL execution, and ComfyUI does not advance ` +
+        `control_after_generate between the items of one (ComfyUI_frontend #8774) - so a scoped ` +
+        `batch would otherwise submit ${batchCount} byte-identical prompts and answer all but the ` +
+        `first from cache, returning the SAME output file for every one. For this batch the panel ` +
+        `ran ComfyUI's OWN control hooks once per item with the partial-execution flag cleared, ` +
+        `and these advanced exactly as they would on an unscoped run: ${list(moved)}. The values ` +
+        `are ComfyUI's: the panel does not compute seeds, it only passes the flag, so ` +
+        `increment/decrement/increment-wrap and a combo's filter list behave as they do on the ` +
+        `Queue button, and a control set to fixed still repeats on purpose (#1998).`,
+    );
+  }
+  if (stuck.length) {
+    parts.push(
+      `${moved.length ? "" : `This scoped batch was driven with ComfyUI's own control hooks (#1998), but `}` +
+        `these advancing controls did NOT move across the batch, so anything depending on them is ` +
+        `identical for every item and can come back as a cache hit on the first output: ` +
+        `${list(stuck)}. OBSERVED, not inferred - the panel read each governed widget on both ` +
+        `sides of every hook call. The usual causes are a governed input fed by a LINK (ComfyUI ` +
+        `skips the control on every path when the value comes from the link rather than the ` +
+        `widget) and a widget PROMOTED to a subgraph host, which ComfyUI advances through a ` +
+        `module function the panel cannot wrap. Set those values yourself between runs, or run ` +
+        `the branch unscoped.`,
+    );
+  }
+  return parts.join(" ");
 }

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -600,7 +600,15 @@ export function rgthreeFixedSeedNote(seeds, batchCount) {
  * Returns `{ armed, restore, observe }`. Fully defensive, like the rest of this module:
  * an unreadable node costs its own entry, never the run.
  */
-export function driveControlHooksAcrossScopedBatch(nodes) {
+
+export function driveControlHooksAcrossScopedBatch(nodes, { batchCount = null } = {}) {
+  // EXPECTED INVOCATIONS. ComfyUI fires beforeQueued and afterQueued once each per batch
+  // item, so a drive that owns the whole batch sees exactly `2 * batchCount` calls. Any
+  // other number means something we did not dispatch also ran through these hooks (or a
+  // rejected item cut the loop short), and `observe()` then refuses to claim anything —
+  // see the attribution note there. Absent batchCount attributes NOTHING, deliberately:
+  // a lenient default is how the previous version came to believe another run's work.
+  const expected = Number.isFinite(batchCount) && batchCount > 0 ? 2 * batchCount : null;
   const armed = [];
   const armedWidgets = new Set();
   const restores = [];
@@ -643,29 +651,82 @@ export function driveControlHooksAcrossScopedBatch(nodes) {
           // for. The FIRST sample is the value the first prompt was built from.
           const forced = (orig) =>
             function (opts) {
+              // NOT OUR RUN — forward it untouched and record nothing (gate r2 P1-A).
+              //
+              // Two cases, and both used to be swallowed. A retired wrapper is one this
+              // drive has already stood down from; and an invocation whose incoming flag is
+              // not `true` is not a partial execution at all, so it is provably not the run
+              // this override exists for — an unscoped queue that happened to land inside
+              // our window. EXECUTED against this module before the fix: an unrelated
+              // unscoped batch of 3 during an armed drive produced
+              // `observed: true, advanced: true, from 12345 to 12348` for a scoped batch
+              // that had not run a single item.
+              if (state.retired || opts?.isPartialExecution !== true) return orig.call(this, opts);
+              // COUNTED PER CALL, not per sample: `record()` fires on both sides of the
+              // original, so counting samples would have meant "4 per item" while the
+              // attribution check said 2. Counting the invocation itself is what the
+              // expectation below is actually about.
+              state.calls += 1;
               record();
               try {
-                return orig.call(this, { ...(opts ?? {}), isPartialExecution: false });
+                return orig.call(this, { ...opts, isPartialExecution: false });
               } finally {
                 record();
               }
             };
-          w.beforeQueued = forced(before);
-          w.afterQueued = forced(after);
+          const state = { retired: false, calls: 0 };
+          const wrappedBefore = forced(before);
+          const wrappedAfter = forced(after);
+          w.beforeQueued = wrappedBefore;
+          w.afterQueued = wrappedAfter;
           armedWidgets.add(w);
           restores.push(() => {
-            w.beforeQueued = before;
-            w.afterQueued = after;
+            // RETIRE, NEVER CLOBBER — and this pair of lines is the whole of gate r2 P1-B.
+            //
+            // Overlapping drives each captured whatever was installed when THEY armed, so
+            // the second's restore wrote the FIRST's wrapper back onto the widget and left
+            // it there, live. EXECUTED against this module before the fix:
+            //
+            //   d1 = drive(nodes); d2 = drive(nodes); d1.restore(); d2.restore();
+            //   queueBatch(nodes, { batchCount: 3, isPartialExecution: true })
+            //     -> 12345, 12346, 12347     a SCOPED run advancing: #8774 broken for good
+            //
+            // Retiring FIRST and unconditionally makes this wrapper transparent however it
+            // is later reached, so a copy left installed by someone else's restore is inert
+            // rather than live. Unhooking only when OURS is still what is installed stops us
+            // clobbering a third party who wrapped on top of us between arming and now.
+            // Together they make nesting SAFE instead of forbidden — no exclusivity latch,
+            // and therefore no way for one missed restore to disable the feature for the
+            // life of the page. (The same rule run-scope-guard.js learned for its fetch
+            // guards: a superseded guard is retired, never unhooked.) After the fix the
+            // sequence above yields 12345, 12345, 12345.
+            state.retired = true;
+            if (w.beforeQueued === wrappedBefore) w.beforeQueued = before;
+            if (w.afterQueued === wrappedAfter) w.afterQueued = after;
           });
-          armed.push({ entry, seen });
+          armed.push({ entry, seen, widget: w, state });
         }
       } catch {
         /* one unreadable node costs its own entry, never the whole dispatch */
       }
     }
   }
+  // ONE predicate. `observe()` and `attributedWidgets()` answer the same question - "are
+  // these samples this drive's own?" - and two copies of it is two chances to disagree
+  // about whether a control may be subtracted from #988's warning.
+  const isAttributable = (a) => expected != null && a.state?.calls === expected;
   return {
     armed: armed.map((a) => ({ ...a.entry })),
+    /**
+     * The armed widgets whose samples this drive can PROVE are its own — the only ones
+     * the caller may subtract from #988's scan (gate r2 P1-A). An armed but unattributed
+     * control keeps its repetition warning, because we do not know what it did.
+     */
+    attributedWidgets() {
+      const out = new Set();
+      for (const a of armed) if (isAttributable(a)) out.add(a.widget);
+      return out;
+    },
     /**
      * The control widget OBJECTS this drive wrapped — the exact set #988's scan must
      * skip, so a control the drive could not reach keeps its repetition warning
@@ -688,15 +749,32 @@ export function driveControlHooksAcrossScopedBatch(nodes) {
         }
       }
     },
-    /** What each governed widget ACTUALLY did across the batch. */
+    /**
+     * What each governed widget ACTUALLY did across the batch — and only when this drive
+     * can PROVE the samples are its own (gate r2 P1-A).
+     *
+     * ATTRIBUTION IS CHECKED, NOT ASSUMED. `2 * batchCount` invocations is exactly what
+     * owning the whole batch looks like; any other count means either something we did not
+     * dispatch ran through these hooks, or a rejected item cut ComfyUI's loop short. In
+     * both cases this reports `attributable: false` and claims NOTHING — no advancement,
+     * no repetition verdict — and the caller then leaves #988's warning in place for that
+     * control. Saying "I cannot tell" is the whole point: the previous version said
+     * "advanced" on another run's work.
+     */
     observe() {
-      return armed.map(({ entry, seen }) => {
+      return armed.map((entryRef) => {
+        const { entry, seen } = entryRef;
+        const attributable = isAttributable(entryRef);
+        if (!attributable) {
+          return { ...entry, attributable: false, observed: false, distinct_values: 0, advanced: false };
+        }
         const keys = seen.map((v) =>
           typeof v === "object" && v !== null ? JSON.stringify(v) : `${typeof v}:${String(v)}`,
         );
         const distinct = new Set(keys).size;
         return {
           ...entry,
+          attributable: true,
           observed: seen.length > 0,
           distinct_values: distinct,
           advanced: distinct > 1,
@@ -720,7 +798,12 @@ export function driveControlHooksAcrossScopedBatch(nodes) {
  */
 export function scopedBatchDriveNote(observations, batchCount) {
   if (!Array.isArray(observations) || !(Number(batchCount) > 1)) return "";
-  const advancingMode = observations.filter((o) => o && ADVANCING.has(o.mode));
+  // An UNATTRIBUTED control is described by neither half of this note: we do not know what
+  // it did, so we neither announce an advance nor warn about a repeat. #988's warning keeps
+  // it instead, because the caller does not subtract it from that scan (gate r2 P1-A).
+  const advancingMode = observations.filter(
+    (o) => o && ADVANCING.has(o.mode) && o.attributable !== false,
+  );
   if (!advancingMode.length) return "";
   const moved = advancingMode.filter((o) => o.advanced);
   const stuck = advancingMode.filter((o) => !o.advanced);

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -660,7 +660,7 @@ export function driveControlHooksAcrossScopedBatch(nodes) {
      * Put every hook back. Called from the caller's `finally`, so the override lasts
      * exactly the dispatch - a control left wrapped would keep advancing on the user's
      * own single scoped previews, which is the behaviour #8774 exists to prevent.
-     * Idempotent: the queue drains the list, so a second call restores nothing.
+     * Idempotent: the first call drains the list, so a second restores nothing.
      */
     restore() {
       for (const r of restores.splice(0).reverse()) {
@@ -735,9 +735,10 @@ export function scopedBatchDriveNote(observations, batchCount) {
         `${list(stuck)}. OBSERVED, not inferred - the panel read each governed widget on both ` +
         `sides of every hook call. The usual causes are a governed input fed by a LINK (ComfyUI ` +
         `skips the control on every path when the value comes from the link rather than the ` +
-        `widget) and a widget PROMOTED to a subgraph host, which ComfyUI advances through a ` +
-        `module function the panel cannot wrap. Set those values yourself between runs, or run ` +
-        `the branch unscoped.`,
+        `widget) and a widget PROMOTED to a subgraph host, which ComfyUI drives through ` +
+        `applyPromotedWidgetControl - a module function rather than a widget property, so the ` +
+        `cleared flag never reaches it. Set those values yourself between runs, or run the ` +
+        `branch unscoped.`,
     );
   }
   return parts.join(" ");


### PR DESCRIPTION
Fixes the panel side of **artokun/comfyui-mcp#1998** — `panel_run batch_count>1` queues identical seed snapshots so the extras cache-hit the first output.

**Review is PENDING.** Nothing here has been reviewed by anyone but its author.

---

## What the user saw

`panel_run` with `batch_count: 4` came back with `queued: true`, four `prompt_ids`, and four completions. One image was rendered. The other three were served from ComfyUI's cache and reported the *first* run's output file. The tool reported four successes for one render.

## Reproduced, by execution, on a real ComfyUI

ComfyUI 0.33.2 / frontend 1.49.6, real panel over the suite's MockBridge, real `graph_run`, real renders. `/history` for the four minted prompt ids, **with the fix removed**:

```
prompt   seed    partial_execution_targets  execution_cached                 ms     output
bc554fa3 707000  ["9"]                      []                               5584   b1998before_00001_.png
dcb1248d 707000  ["9"]                      ["3","4","5","6","7","8","9"]       2   b1998before_00001_.png
bf54dc30 707000  ["9"]                      ["3","4","5","6","7","8","9"]       2   b1998before_00001_.png
7f1f7bc6 707000  ["9"]                      ["3","4","5","6","7","8","9"]       3   b1998before_00001_.png
```

**The cache-hit claim is settled by execution, not by timing.** ComfyUI's own `execution_cached` message names every node *including the SaveImage output node 9* for prompts 2–4, and all four `/history` entries carry the same `filename`. On disk: one `b1998before_*.png`, not four. Fast and cached are different bugs; this is the cached one.

Same run **with the fix**:

```
16012abe 707000            ["9"]  ["3","4","5","6","7","8"]   12   a1998after_00001_.png
f2460058 300614720541829   ["9"]  ["4","5","6","7"]          576   a1998after_00002_.png
486d0a11 372489251625065   ["9"]  ["4","5","6","7"]          510   a1998after_00004_.png
1d54a33c 304038503665136   ["9"]  ["4","5","6","7"]          456   a1998after_00003_.png
```

Four seeds, four renders, four files, and the scope is still on every post. (Item 1's KSampler cache hit is the previous run at the same seed; it still writes its own file.)

## What the frontend actually does per queue click, and how that was established

Not inferred from the widget name. `comfyui_frontend_package` ships sourcemaps **with `sourcesContent`**, so the pinned build's original TypeScript is recoverable. From 1.49.6:

`src/scripts/app.ts` — the batch loop lives INSIDE one `queuePrompt` call and fires the hooks per item:

```ts
const isPartialExecution = !!queueNodeIds?.length
for (let i = 0; i < batchCount; i++) {
  forEachNode(this.rootGraph, (node) => {
    for (const widget of node.widgets ?? []) widget.beforeQueued?.({ isPartialExecution })
    applyPromotedWidgetControl(node, 'beforeQueued', { isPartialExecution })
  })
  const p = await this.graphToPrompt(this.rootGraph)      // the body that is POSTed
  const res = await api.queuePrompt(number, p, { partialExecutionTargets: queueNodeIds })
  executeWidgetsCallback(queuedNodes, 'afterQueued', { isPartialExecution })
}
```

`src/scripts/valueControl.ts` — and it refuses to advance anything on a partial execution:

```ts
export function nextValueForLinkedTarget(params) {
  if (params.isPartialExecution) return undefined
```

That refusal is **deliberate upstream behaviour**: ComfyUI_frontend PR **#8774**, *"disable control after generate during partial execution"*, merged 2026-02-11, so that queueing selected output nodes while iterating does not churn the user's seed.

Then measured on the rig, capturing the outgoing `/prompt` bodies behind an interceptor that answered them locally (nothing queued, no GPU):

```
unscoped  queuePrompt(0, 4, undefined)   randomize -> 4 distinct seeds
unscoped  queuePrompt(0, 4, undefined)   increment -> 12345, 12346, 12347, 12348
unscoped  queuePrompt(0, 4, undefined)   fixed     -> 12345 x4
scoped    queuePrompt(0, 4, ["9"])       randomize -> 12345 x4
scoped    queuePrompt(0, 4, ["9"])       increment -> 12345 x4
scoped    queuePrompt(0, 4, ["9"])       fixed     -> 12345 x4
scoped    4x queuePrompt(0, 1, ["9"])    randomize -> 12345 x4     <-- decides the fix
```

Two things follow.

1. **The UNSCOPED path was already correct** and is not touched. `graph_run` hands an unscoped batch to `app.queuePrompt(0, batch, undefined)` — ComfyUI's own loop, hooks and all. The reporter's steps do not mention `to_node_id`; measured on a current frontend, an unscoped `batch_count: 4` with `randomize` already posts four different seeds. The path that reproduces their exact symptom — N prompt ids, ~0 s each, same output file — is the **scoped** one, which is #988's mechanism, warned about since panel 0.11.94 and never repaired. Their reported panel version (0.11.57) predates even the warning. Called out plainly because it is the one thing in this PR I could not confirm from the report itself.

2. **"Press Queue N times" does not work here.** Four separate `queuePrompt(0, 1, scope)` calls post the same seed four times: the refusal keys on the *scope*, not on the batch position. That is also why the #988 reporter's own loop-with-`batch:1` patch failed after 114 green tests.

## The fix — Option A, and only the flag

For a **scoped** run with **`batch > 1` only**, each control widget's own `beforeQueued`/`afterQueued` is wrapped for exactly the duration of the dispatch so it receives `isPartialExecution: false`. ComfyUI then computes everything:

- no seed arithmetic and no mode table in the panel;
- `randomize` / `increment` / `decrement` / `increment-wrap`, `min`/`max`/`step2`, and a combo's filter list all behave exactly as they do on the Queue button, because they *are* the Queue button's code;
- **`fixed` still repeats**, and it is ComfyUI's own `if (mode === 'fixed') return undefined` that decides it — not a panel branch. `driveControlHooksAcrossScopedBatch` deliberately arms fixed controls too, and a unit test asserts `drive.armed.length === 1` for a `fixed` control so a future "optimisation" that skips them locally is caught. Verified by execution: `fixed`, `batch_count: 4`, scoped → one seed, one file, four cache hits. Identical jobs stay identical.

Detection is by **option shape** (`serialize:false` + `canvasOnly:true` + the mode option list), not by widget name, so a node def that renames its control is still driven; and both hooks must exist, which is the frontend's own `isValueControlWidget` test and keeps this away from third-party `beforeQueued` hooks that are not controls (they still receive the truthful flag).

A scoped run of **one** is untouched: #8774 keeps owning the case it was written for.

## What it deliberately does NOT do

- **Promoted subgraph widgets are not reached.** `app.queuePrompt` advances those through `applyPromotedWidgetControl(node, phase, { isPartialExecution })` — a module function, not a widget property, so there is nothing to wrap. They still repeat.
- **Link-fed governed inputs are not reached** — the frontend skips the control on every path when the value comes from the link.
- Neither is guessed at. The drive **observes** each governed widget on both sides of every hook call, and the result note names every advancing control that did **not** move, with the two usual causes. `observe()` reports what the widget did, not what the drive asked for; a mutation that hard-codes `advanced: true` kills two named tests.
- **#988's note is suppressed on the driven path.** "THIS BATCH WILL REUSE THE SAME VALUE" is the sentence this change stops being true; shipping both would put two contradictory statements in one result. It stays in charge whenever the drive did not run.
- **No change to what is POSTed structurally.** `partial_execution_targets` is present on all four posts before and after (asserted in the e2e), so this cannot buy distinct seeds by quietly dropping the scope and running the full graph (#556). And the #556 drift hash already excludes a non-`fixed` control's linked target, so a changing seed is not read as graph drift — confirmed live: the driven run returned `drift_coverage.uncovered_inputs: ["3 control_after_generate","3 seed"]` and dispatched normally.
- **No orchestrator change.** `panel_run` forwards the panel's result object verbatim, so `batch_controls` / `batch_controls_note` reach the caller with no MCP-side work.

## Known windows, stated rather than hidden

- The wrap lives for the dispatch only, restored in a `finally` on every exit including a throw. If `app.queuePrompt` **defers** (its processor is busy) and posts after `dispatchScopedRun` gives up, the deferred items run with the original hooks and repeat — degrading to today's behaviour, and `observe()` then reports `advanced: false`, so the note tells the truth rather than claiming a fix that did not happen.
- During that window a *user-initiated* partial-execution queue in the same tab would see the flag cleared too. Panel commands are dispatched serially and the window is sub-second, but it is a real window and it is not zero.

## Evidence

**Live, executed** — the four `/history` tables above, plus `fixed` (1 seed / 1 file) and `increment` (900100 → 900104, 4 files) both by execution, and the on-disk file counts (`b1998before` × 1 vs `a1998after` × 4).

**Unit** — 51 tests in `browser_tests/unit/scoped-batch-seed.test.mjs`, driven against a *port* of frontend 1.49.6's own hook (every branch quoted from the recovered TypeScript, and cross-checked against the live numbers above).

**e2e** — `browser_tests/scoped-batch-control.spec.ts` drives the REAL `graph_run` through the REAL bridge frame in a REAL browser and reads the seeds off the POST bodies. Nothing queued: `api.fetchApi` is wrapped before the run so the panel's own scoped guard chains on top of it.

**Mutation — the fix deleted, and named tests fail.** Full suite green at 51/51 first, and restored to 51/51 after:

| mutation | pass/fail | killed by |
|---|---|---|
| M1 drop the `isPartialExecution: false` override | 43/8 | `DRIVEN, a scoped randomize batch posts four different seeds`, `…increment batch matches the unscoped sequence exactly`, `decrement runs backwards`, `works in Comfy.WidgetControlMode 'before'`, `restore() puts #8774 back`, `detected by OPTION SHAPE … renamed`, `observe() reports what the widget DID`, `the note names what advanced` |
| M2 CALL SITE: never install the drive | 50/1 | `CALL SITE: the drive is installed on the SCOPED path, and restored in a finally` |
| M3 the panel special-cases `fixed` itself | 50/1 | `` `fixed` still repeats - and it is ComfyUI that refuses, not a panel branch `` |
| M4 CALL SITE: restore not in a `finally` | 50/1 | `CALL SITE: the drive is installed on the SCOPED path, and restored in a finally` |
| M5 CALL SITE: `batch > 1` gate dropped | 50/1 | `CALL SITE: the drive is installed on the SCOPED path, and restored in a finally` |
| M6 CALL SITE: ship #988's contradictory warning too | 50/1 | `CALL SITE: a driven batch does not also ship #988's contradictory warning` |
| M7 `observe()` claims success instead of measuring | 49/2 | `observe() reports what the widget DID`, `the note names what advanced` |

M5 **survived the first round**: the gate matched the phrase `batch > 1` in the *comment above* the call, so a dropped gate read as present. It now asserts on the argument expression. That is in this PR as a commit of its own reasoning.

**Call site, at e2e level too** — with the install removed, `scoped-batch-control.spec.ts` reports `expected four distinct seeds, got [707000,707000,707000,707000]`.

**Gates** — `npm run test:unit` (6183 pass / 0 fail, includes i18n, tool-vocabulary and the panel-scope compiler gate), `npm run typecheck` clean, and the full Playwright suite at `--workers=1` — 26 failed / 58 passed, which is this suite's known isolated state on this box; 18 of the 26 are the 8-second `openSidebar` mount budget losing to machine load, including this PR's own two, which fail BEFORE any line this PR touches and pass 3/3 in isolation. Full triage in the comments.

---

## What I deliberately did NOT do

- **I did not touch the unscoped path.** It is already correct: `graph_run` hands an unscoped batch to `app.queuePrompt(0, batch, undefined)` — ComfyUI's own loop — and randomize/increment both advance there (measured above). I drafted an observation-only watcher for it, so that an unscoped batch whose controls fail to move would say so instead of returning N silent successes, and then removed it: the only ways a control stays put on that path are a **link-fed** governed input (the user wired a constant in, so N identical renders is what they asked for) and a **promoted subgraph** widget — and promoted widgets *do* advance unscoped, because `applyPromotedWidgetControl` receives `isPartialExecution: false` there. I could not reproduce a silent unscoped failure, so I did not ship a guard for one. rgthree's fixed-seed case on an unscoped batch already has its own disclosure (#1339).

- **I did not make the panel compute any seed.** Every value in a driven batch comes from `computeNextControlledValue`. That is the difference between Option A and Option B, and it is what keeps `increment`, `decrement`, `increment-wrap`, combo filter lists and `fixed` correct without the panel knowing any of those rules.

- **I did not repair promoted subgraph widgets.** `applyPromotedWidgetControl` is a module function called directly from `app.queuePrompt`; there is no widget property to wrap and no supported seam. Patching the `window.comfyAPI` re-export would not reach app.ts's own binding. They are reported as not-advanced instead of silently repeating.

- **I did not refuse the extras.** Refusing to queue items 2..N when they look identical was considered and rejected: the #988 note already documents that another extension's queue-time hook (rgthree's `api.queuePrompt` patch) can vary a prompt the panel's scan believes is fixed, so a refusal would be wrong exactly where the panel is least able to tell.

- **I did not change the orchestrator.** `panel_run` forwards the panel's result verbatim; `batch_controls` / `batch_controls_note` arrive with no MCP-side work. No change to `partial_execution_targets` or to what is POSTed per job, so nothing collides with the partial-execution / prompt-pruning behaviour.

- **I did not run `codex-gate.mjs` or spawn codex**, per the brief.

## One thing I could not settle

The report's repro steps do not mention `to_node_id`, and on a current frontend an unscoped `batch_count: 4` already posts four different seeds. The reporter's stated panel version (0.11.57) predates even #988's warning (0.11.94), and their ComfyUI is 0.28.0, so I could not confirm which path they were on — their `/history` is long gone and the env fingerprint (RTX 5080) is a different machine from this rig. What I can say is measured: the **scoped** path reproduces their exact symptom — N prompt ids, ~0 s each, `execution_cached` covering the output node, one file on disk — and this fixes it.

---

### Where the risk is, for the reviewer

1. **Is overriding ComfyUI_frontend #8774 the right call at all?** It is deliberate upstream behaviour, and this deviates from it — narrowly, for a scoped run with `batch_count > 1` only, on the argument that `batch_count: N` is a request for N renders and that upstream's rationale (don't churn a seed while iterating on one branch) does not describe a batch. A scoped batch of one is untouched. This is the load-bearing judgement in the PR and the thing most worth disagreeing with.
2. **The wrap is a live mutation of frontend widget objects for the duration of a dispatch.** Restored in a `finally`, drained and reversed, idempotent — but if `app.queuePrompt` defers (busy processor) and posts after `dispatchScopedRun` gives up, the deferred items run unwrapped, and a *user-initiated* partial-execution queue landing inside that sub-second window would see the flag cleared too. I judged both acceptable and disclosed rather than guarded. Second opinion wanted.
3. **The detection predicate.** `isControlAfterGenerateWidget` (option shape: `serialize:false` + `canvasOnly:true` + the mode list) plus "both queue hooks are functions". Too loose and we steer a third-party hook that never asked for it; too tight and a renamed control silently keeps repeating. I chose the shipped #558 predicate rather than inventing one.
4. **`observe()` is what the note is built from.** If sampling the governed widget on both sides of every hook call does not actually capture the values the prompts carried, the note is confidently wrong in the one direction that matters. The e2e cross-checks it against the real POST bodies, and the live `/history` seeds match, but it is the claim I would attack first.
5. **`fixed`.** The whole design rests on the panel *not* deciding anything about modes, so that `fixed` stays identical because ComfyUI says so. Verified by execution (1 seed / 1 file / 4 cache hits) and pinned by a test that asserts the fixed control is still armed — but if there is a mode where handing back `isPartialExecution: false` is wrong, that is where it hides.
