### PR TITLE
fix(477): a subgraph node's rebuilt widget list is verified by MEMBERSHIP, so a perfect rollback stops reporting a partial state

### DIFF
--- a/browser_tests/unit/promoted-rollback-widget-list.test.mjs
+++ b/browser_tests/unit/promoted-rollback-widget-list.test.mjs
@@ -1,0 +1,364 @@
+/**
+ * #477 P1's rollback read-back vs. a REAL `SubgraphNode`.
+ *
+ * The guard snapshots the outer node's widget LIST before a promoted write and, on a
+ * failed write's rollback, restores it and verifies it came back. It verified by ARRAY
+ * IDENTITY — `node.widgets === <the array we snapshotted>`.
+ *
+ * That holds only for a node that STORES its widget list. A real ComfyUI SubgraphNode
+ * does not. Read off the installed comfyui-frontend 1.49.6 (`SubgraphNode`), its
+ * constructor installs:
+ *
+ *   Object.defineProperty(this, "widgets", {
+ *     get: () => [
+ *       ...this.inputs.flatMap(i => { const w = this._projectPromotedWidget(i); return w ? [w] : [] }),
+ *       ...this._extraWidgets,
+ *     ],
+ *     set: () => {}, configurable: true, enumerable: true });
+ *
+ * and `_projectPromotedWidget` MEMOISES each proxy onto `input._widget`:
+ *
+ *   _projectPromotedWidget(input) {
+ *     if (input._widget) return input._widget;
+ *     ... input._widget = proxy; return input._widget }
+ *
+ * So the MEMBERS are stable across reads and the containing ARRAY is fresh on every
+ * read. Three consequences, all load-bearing here:
+ *
+ *   * `node.widgets !== prevOuterWidgetsRef` is ALWAYS true — the identity half of the
+ *     check could only ever fail;
+ *   * assigning the list back is swallowed by the no-op setter, and refilling the array
+ *     a read handed out mutates a throwaway — the restore was theatre;
+ *   * therefore EVERY failed promoted write on a subgraph node reported
+ *     `partialWrite: true` ("the graph may be in a partial state; re-set the widget or
+ *     undo") even when the rollback had been perfect — and `partialWrite` is
+ *     deliberately non-rewordable by callers (`set-widget.js` `refusalFrame`), so a
+ *     clean refusal reached the user as a possibly-corrupt graph.
+ *
+ * The fix compares MEMBERSHIP/ORDER by value for a projected list and keeps the
+ * identity compare for a stored one. These tests pin BOTH directions: the false alarm
+ * is gone, and a list that is genuinely replaced, reordered, extended, or whose
+ * property changes KIND mid-write is still reported.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyWidgetWrite, WidgetWriteError } from "../../web/js/lib/widget-write.js";
+
+const ROOT_GRAPH_ID = "c4a254bb-935e-4013-b380-5e36954de4b0";
+const PARTIAL_CLAUSE = /promotion host input \/ parent widget list \(node\.inputs\/widgets\)/;
+
+/**
+ * One reusable subgraph definition plus a factory for instances, in the frontend's own
+ * shape: a shared inner node, a per-widgetId value store the rail is a VIEW of, and an
+ * outer widget list that is either PROJECTED (the real SubgraphNode) or STORED (a plain
+ * node, and what #477 P1 was written against).
+ *
+ * `extras` models `_extraWidgets` — real widgets that ride in the same list without
+ * belonging to any promoted input. They give the tests a way to corrupt the LIST
+ * without also disturbing `hostInput.widget`/`_widget`, which have their own checks;
+ * that keeps each case a probe of one half of the list compare and nothing else.
+ */
+function makeSubgraph({ definitionValue = 512, widgetsMode = "projected" } = {}) {
+  const inner = {
+    id: 10,
+    type: "EmptyLatentImage",
+    widgets: [{ name: "width", type: "INT", value: definitionValue }],
+  };
+  const subgraph = {
+    id: "sg-uuid",
+    _nodes: [inner],
+    getNodeById: (id) => (String(id) === "10" ? inner : null),
+  };
+  const store = new Map();
+
+  function instance(id, { extras = [] } = {}) {
+    const widgetId = `${ROOT_GRAPH_ID}:${encodeURIComponent(String(id))}:${encodeURIComponent("width")}`;
+    if (!store.has(widgetId)) {
+      store.set(widgetId, { name: "width", type: "INT", value: inner.widgets[0].value, options: {} });
+    }
+    const rail = {
+      get name() {
+        return store.get(widgetId)?.name ?? "width";
+      },
+      get type() {
+        return store.get(widgetId)?.type ?? "INT";
+      },
+      get options() {
+        return store.get(widgetId)?.options ?? {};
+      },
+      get value() {
+        return store.get(widgetId)?.value;
+      },
+      set value(next) {
+        const state = store.get(widgetId);
+        if (state) state.value = next;
+      },
+      callback(next) {
+        const state = store.get(widgetId);
+        if (state) state.value = next;
+      },
+    };
+    Object.defineProperty(rail, "widgetId", { value: widgetId, enumerable: false, configurable: true });
+    // `_projectPromotedWidget` caches the proxy here, which is why per-member identity
+    // stays stable even though the containing array does not.
+    const input = {
+      name: "width",
+      widgetId,
+      _widget: rail,
+      widget: { name: "width" },
+      _subgraphSlot: { name: "width" },
+    };
+    const extraWidgets = extras.slice();
+    const node = { id, type: "SubgraphNode", subgraph, inputs: [input] };
+    const project = () => [...node.inputs.flatMap((i) => (i._widget ? [i._widget] : [])), ...extraWidgets];
+    if (widgetsMode === "projected") {
+      // Verbatim shape of the real constructor: fresh array per read, setter ignored.
+      Object.defineProperty(node, "widgets", {
+        get: project,
+        set: () => {},
+        configurable: true,
+        enumerable: true,
+      });
+    } else if (widgetsMode === "accessor") {
+      // An ACCESSOR that keeps ONE array. Descriptor-wise this is indistinguishable
+      // from the projected shape; behaviourally it is a stored list, and its identity
+      // is as meaningful as any data property's.
+      let kept = project();
+      Object.defineProperty(node, "widgets", {
+        get: () => kept,
+        set: (next) => {
+          kept = next;
+        },
+        configurable: true,
+        enumerable: true,
+      });
+    } else {
+      node.widgets = project();
+    }
+    return { node, rail, input, widgetId, extraWidgets };
+  }
+
+  const queuedValue = (inst) => store.get(inst.widgetId)?.value;
+  const definition = () => inner.widgets[0].value;
+  return { inner, store, instance, queuedValue, definition };
+}
+
+const resolveSource = (_node, subgraphInput) =>
+  subgraphInput?.name === "width" ? { sourceNodeId: "10", sourceWidgetName: "width" } : null;
+
+/**
+ * A store entry that silently swallows writes, so the write fails its read-back.
+ *
+ * The refusal is planted on the STORE, not on the rail proxy: in the real frontend the
+ * rail's `set value` AND its `callback` both funnel into `store.setValue(widgetId, v)`,
+ * so a rail that "does not take the value" is a store that does not take it. Overriding
+ * the proxy's accessor instead would leave the callback writing the store behind a
+ * getter that lies about it — a fixture that leaks the requested value into the very
+ * place queue compilation reads.
+ */
+function makeStoreRefuse(sg, target) {
+  const entry = sg.store.get(target.widgetId);
+  const held = entry.value;
+  Object.defineProperty(entry, "value", { get: () => held, set: () => {}, configurable: true });
+  return held;
+}
+
+const extraWidget = (name) => ({ name, type: "INT", value: 1 });
+
+/**
+ * Run a failing promoted write, corrupting the outer widget list from an `afterChange`
+ * hook on the chosen invocation. The hook fires TWICE: once closing the write envelope,
+ * once closing the ROLLBACK envelope. Corrupting on 2 is the case #477 P1 names — a
+ * stateful hook that re-adds a replacement AFTER the restore ran — and is the only way
+ * to corrupt a STORED list durably, since the restore refills it.
+ */
+function failingWrite(target, { corrupt, corruptOn = 1 } = {}) {
+  let calls = 0;
+  return () =>
+    applyWidgetWrite(target.node, "width", 1024, {
+      resolveSource,
+      afterChange() {
+        calls += 1;
+        if (corrupt && calls === corruptOn) corrupt();
+      },
+    });
+}
+
+// ---------------------------------------------- the false alarm this fixes
+
+test("#477 P1 x subgraph projection: a failed promoted write on a getter-backed `widgets` refuses CLEANLY, not as a partial state", () => {
+  const sg = makeSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293, { extras: [extraWidget("seed")] });
+  // Two reads of the REAL shape are never the same array — the premise of the defect.
+  assert.notEqual(target.node.widgets, target.node.widgets);
+  assert.equal(target.node.widgets[0], target.node.widgets[0]);
+
+  const before = makeStoreRefuse(sg, target);
+
+  assert.throws(failingWrite(target), (err) => {
+    assert.ok(err instanceof WidgetWriteError);
+    assert.equal(err.partialWrite, false, `should not claim a partial state:\n${err.message}`);
+    assert.doesNotMatch(err.message, PARTIAL_CLAUSE);
+    assert.doesNotMatch(err.message, /may be in a partial state/);
+    return true;
+  });
+
+  // ...and the rollback really WAS perfect, so the clean refusal is the honest report
+  // and not a disarmed guard covering for a mess.
+  assert.equal(sg.queuedValue(target), before);
+  assert.equal(sg.definition(), 512);
+  assert.deepEqual(
+    target.node.widgets.map((w) => w.name),
+    ["width", "seed"],
+  );
+});
+
+// ---------------------------------------------- the guard still bites
+
+test("#477 P1 x subgraph projection: an EXTRA widget left in the projected list is still a partial state", () => {
+  const sg = makeSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293, { extras: [extraWidget("seed")] });
+  makeStoreRefuse(sg, target);
+
+  assert.throws(
+    failingWrite(target, { corrupt: () => target.extraWidgets.push(extraWidget("decoy")) }),
+    (err) => err instanceof WidgetWriteError && err.partialWrite === true && PARTIAL_CLAUSE.test(err.message),
+  );
+});
+
+test("#477 P1 x subgraph projection: a REPLACED member of the projected list is still a partial state", () => {
+  const sg = makeSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293, { extras: [extraWidget("seed")] });
+  makeStoreRefuse(sg, target);
+
+  assert.throws(
+    // Same name, same length, same position — a DIFFERENT object. Membership is by
+    // identity precisely because that is what authenticates a rail/proxy.
+    failingWrite(target, { corrupt: () => (target.extraWidgets[0] = extraWidget("seed")) }),
+    (err) => err instanceof WidgetWriteError && err.partialWrite === true && PARTIAL_CLAUSE.test(err.message),
+  );
+});
+
+test("#477 P1 x subgraph projection: a REORDERED projected list is still a partial state", () => {
+  const sg = makeSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293, { extras: [extraWidget("seed"), extraWidget("batch_size")] });
+  makeStoreRefuse(sg, target);
+
+  assert.throws(
+    // Identical membership, different order — only the per-index compare can see this.
+    failingWrite(target, { corrupt: () => target.extraWidgets.reverse() }),
+    (err) => err instanceof WidgetWriteError && err.partialWrite === true && PARTIAL_CLAUSE.test(err.message),
+  );
+});
+
+test("#477 P1 x subgraph projection: a DROPPED member of the projected list is still a partial state", () => {
+  const sg = makeSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293, { extras: [extraWidget("seed")] });
+  makeStoreRefuse(sg, target);
+
+  assert.throws(
+    // A SHORTER list is the one corruption the per-index compare cannot see on its own
+    // — it walks the LIVE list, so a list missing its tail has nothing left to disagree
+    // about. The length compare is what catches a detached rail/proxy.
+    failingWrite(target, { corrupt: () => target.extraWidgets.pop() }),
+    (err) => err instanceof WidgetWriteError && err.partialWrite === true && PARTIAL_CLAUSE.test(err.message),
+  );
+});
+
+test("#477 P1 x subgraph projection: an UNREADABLE `widgets` is a partial state, and does not swallow the write's own error", () => {
+  const sg = makeSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293, { extras: [extraWidget("seed")] });
+  makeStoreRefuse(sg, target);
+
+  assert.throws(
+    failingWrite(target, {
+      corrupt: () => {
+        Object.defineProperty(target.node, "widgets", {
+          get() {
+            throw new TypeError("widgets is gone");
+          },
+          configurable: true,
+        });
+      },
+      corruptOn: 2,
+    }),
+    // The partial state itself is reported either way (the live-input recheck cannot
+    // resolve through a throwing getter either). What the guarded read buys is the
+    // `instanceof`: unguarded, the getter's raw TypeError escapes `applyWidgetWrite`
+    // and REPLACES the WidgetWriteError that says what failed and what was restored.
+    (err) => err instanceof WidgetWriteError && err.partialWrite === true && PARTIAL_CLAUSE.test(err.message),
+  );
+});
+
+// ---------------------------------------------- a STORED list is unchanged
+
+test("#477 P1: a STORED `widgets` re-pointed after the rollback is still a partial state, on IDENTITY alone", () => {
+  const sg = makeSubgraph({ definitionValue: 512, widgetsMode: "stored" });
+  const target = sg.instance(293, { extras: [extraWidget("seed")] });
+  makeStoreRefuse(sg, target);
+
+  assert.throws(
+    failingWrite(target, {
+      // A NEW array holding the SAME members in the SAME order: membership/order say
+      // nothing, identity is the only witness — and for a stored list it is a real one,
+      // because a re-pointed array is what detaches a captured proxy.
+      corrupt: () => {
+        target.node.widgets = target.node.widgets.slice();
+      },
+      corruptOn: 2,
+    }),
+    (err) => err instanceof WidgetWriteError && err.partialWrite === true && PARTIAL_CLAUSE.test(err.message),
+  );
+});
+
+test("#477 P1: a projected `widgets` FROZEN into a stored array mid-write is itself a partial state", () => {
+  const sg = makeSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293, { extras: [extraWidget("seed")] });
+  makeStoreRefuse(sg, target);
+
+  assert.throws(
+    failingWrite(target, {
+      // The one direction nothing else sees. Going the other way — a stored array
+      // swapped for a getter — is already caught by the identity compare, because the
+      // snapshot was of a stored list and a getter can never hand that array back. But
+      // a PROJECTION replaced by a plain array of the same members passes membership,
+      // passes order, and is exempt from the identity compare by the very relaxation
+      // this fix introduces. It is real corruption: the list no longer tracks
+      // `node.inputs`, so it is a stale copy that outlives the next promotion change.
+      // Only comparing the property's KIND across the write catches it.
+      corrupt: () => {
+        Object.defineProperty(target.node, "widgets", {
+          value: target.node.widgets.slice(),
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
+      },
+      corruptOn: 2,
+    }),
+    (err) => err instanceof WidgetWriteError && err.partialWrite === true && PARTIAL_CLAUSE.test(err.message),
+  );
+});
+
+test("#477 P1: an ACCESSOR that keeps ONE array is a stored list, and its identity is still enforced", () => {
+  const sg = makeSubgraph({ definitionValue: 512, widgetsMode: "accessor" });
+  const target = sg.instance(293, { extras: [extraWidget("seed")] });
+  makeStoreRefuse(sg, target);
+  // Two reads agree — which is the whole difference from the projected shape, and it is
+  // not visible in the property descriptor, only in what the property DOES.
+  assert.equal(target.node.widgets, target.node.widgets);
+
+  assert.throws(
+    failingWrite(target, {
+      // Equal membership, equal order, different array. Classifying every accessor as a
+      // rebuilt list would exempt this from the identity compare and let a re-pointed
+      // list through — so the classifier has to ASK the property, not read its shape.
+      corrupt: () => {
+        target.node.widgets = target.node.widgets.slice();
+      },
+      corruptOn: 2,
+    }),
+    (err) => err instanceof WidgetWriteError && err.partialWrite === true && PARTIAL_CLAUSE.test(err.message),
+  );
+});

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -296,6 +296,49 @@ function restoreFiniteNumberIfUnstored(widget, expected) {
   }
 }
 
+/**
+ * Does `node.widgets` have a STABLE IDENTITY — is it one array the node keeps, so that
+ * comparing the array OBJECT says something and re-pointing it restores something — or
+ * is it rebuilt on every read?
+ *
+ * Answered by OBSERVATION (two reads), not by the property descriptor, because the
+ * descriptor does not settle it: an accessor that memoises one array is every bit as
+ * identity-stable as a plain data property, and it is only a getter that BUILDS A NEW
+ * ARRAY per read that makes an identity compare meaningless. Classifying by descriptor
+ * kind would relax the check for memoising accessors that never needed relaxing.
+ *
+ * A real ComfyUI SubgraphNode is the rebuilding kind. Read off the installed
+ * comfyui-frontend 1.49.6, its constructor installs
+ *
+ *   Object.defineProperty(this, "widgets", {
+ *     get: () => [...this.inputs.flatMap(i => project(i) ?? []), ...this._extraWidgets],
+ *     set: () => {}, configurable: true, enumerable: true });
+ *
+ * — a fresh array every read, behind a setter that swallows assignment. The MEMBERS are
+ * stable (`_projectPromotedWidget` memoises each proxy onto `input._widget`); only the
+ * containing array is not.
+ *
+ * The one place this matters is #477 P1's rollback read-back, which compared the outer
+ * widget list by ARRAY IDENTITY. On a rebuilt list that compare can only ever fail, so
+ * every failed promoted write on a subgraph node reported a partial state for a
+ * rollback that had been perfect. The caller gets `false` there and compares
+ * MEMBERSHIP/ORDER instead — still by per-widget identity, which is what authenticates
+ * a rail, and which the memoised projection preserves.
+ */
+function widgetsListHasStableIdentity(node) {
+  let first;
+  let second;
+  try {
+    first = node.widgets;
+    second = node.widgets;
+  } catch {
+    // Unreadable: identity can say nothing. Answering the other way would hand the
+    // identity compare a verdict it has no basis for.
+    return false;
+  }
+  return first === second;
+}
+
 export function isBooleanWidget(widget) {
   const t = String(widget?.type ?? "").toLowerCase();
   return t === "toggle" || t === "boolean";
@@ -1664,9 +1707,15 @@ export function applyWidgetWrite(
   // node.widgets (natural cleanup when substituting a live proxy) detaches a captured
   // proxy while leaving a replacement live. Restoring only the host refs would leave
   // node.widgets corrupt yet pass read-back. Snapshot the array REFERENCE + its contents
-  // so rollback re-points and refills it, and read-back verifies membership/order.
+  // so rollback can re-point and refill it — where the node KEEPS one array — and
+  // read-back verifies membership/order either way.
   const prevOuterWidgetsRef = promotedFrom && Array.isArray(node.widgets) ? node.widgets : null;
   const prevOuterWidgets = prevOuterWidgetsRef ? prevOuterWidgetsRef.slice() : null;
+  // Whether that list KEEPS its identity or is rebuilt per read decides how the
+  // rollback restores it and how the read-back verifies it — see the helper. Read
+  // BEFORE the write, so the recheck can also notice the list changing from one kind
+  // to the other mid-write, which would otherwise slip past the identity compare.
+  const prevOuterWidgetsIdentityStable = prevOuterWidgetsRef ? widgetsListHasStableIdentity(node) : false;
 
   // The undo hooks are BOOKKEEPING (litegraph history). Invoke them exception-SAFE
   // so a throwing hook can never bypass our verification/rollback and leave a silent
@@ -2156,8 +2205,14 @@ export function applyWidgetWrite(
       // replacement/reorder a callback did, so a detached captured proxy is re-attached
       // and a swapped-in replacement is dropped. ONLY when the original host input is
       // still wired (else a wholesale-replaced promotion is left for partial-state
-      // reporting rather than masked).
-      if (prevOuterWidgetsRef && hostStillWired) {
+      // reporting rather than masked) — and only when the node KEEPS one array.
+      //
+      // On a real SubgraphNode the list is rebuilt per read from `node.inputs`:
+      // refilling the array a read handed out mutates a throwaway, and the assignment
+      // is swallowed by a no-op setter, so this would be theatre. Its members follow
+      // `inputs` / `hostInput.widget` / `hostInput._widget`, which the block above has
+      // already restored; the by-value read-back below judges whether that landed.
+      if (prevOuterWidgetsRef && prevOuterWidgetsIdentityStable && hostStillWired) {
         try {
           prevOuterWidgetsRef.length = 0;
           for (const wd of prevOuterWidgets) prevOuterWidgetsRef.push(wd);
@@ -2273,12 +2328,39 @@ export function applyWidgetWrite(
     // different widgetId — serializes differently). This holds whether or not the gated
     // restore above ran.
     if (promotedFrom) {
+      // Read the list ONCE: a projected `widgets` rebuilds on every access, so four
+      // reads would compare four different arrays.
+      let liveOuterWidgets;
+      let outerWidgetsReadable = true;
+      try {
+        liveOuterWidgets = node.widgets;
+      } catch {
+        // A list we cannot read is a list we cannot clear. Report the partial state —
+        // and, just as importantly, keep the throw from escaping and replacing the
+        // WidgetWriteError that explains why the write failed with a bare TypeError.
+        outerWidgetsReadable = false;
+      }
       const listExact =
         prevOuterWidgets == null ||
-        (node.widgets === prevOuterWidgetsRef &&
-          Array.isArray(node.widgets) &&
-          node.widgets.length === prevOuterWidgets.length &&
-          node.widgets.every((wd, i) => wd === prevOuterWidgets[i]));
+        (outerWidgetsReadable &&
+          // A `widgets` that swapped KIND between snapshot and read-back has been cut
+          // off from what feeds it — a rebuilt list frozen into a plain array no
+          // longer tracks `node.inputs`. That is outer-topology drift in its own
+          // right, and catching it is what stops the relaxed identity rule below from
+          // being a door: a list cannot buy its exemption after the fact.
+          widgetsListHasStableIdentity(node) === prevOuterWidgetsIdentityStable &&
+          Array.isArray(liveOuterWidgets) &&
+          // Array identity is evidence only for a list the node KEEPS. A rebuilt one
+          // hands out a FRESH array per read, so this compare could only ever fail —
+          // which is how a PERFECT rollback on a subgraph node came to be reported as
+          // a partial state. Membership/order below is the real #477 P1 check: a
+          // replaced or reordered list, an added proxy, or a dropped rail all still
+          // fail it, because each member is compared by the same object identity that
+          // authenticates a rail (and the frontend memoises each projected proxy onto
+          // `input._widget`, so those identities are stable across reads).
+          (!prevOuterWidgetsIdentityStable || liveOuterWidgets === prevOuterWidgetsRef) &&
+          liveOuterWidgets.length === prevOuterWidgets.length &&
+          liveOuterWidgets.every((wd, i) => wd === prevOuterWidgets[i]));
       let liveInput = undefined;
       try {
         const live = resolvePromotedInnerTarget(node, widgetName, resolveSource);


### PR DESCRIPTION
## The defect

`applyWidgetWrite`'s #477 P1 rollback read-back asked whether `node.widgets` was still the **same array** it had snapshotted before the write:

```js
const prevOuterWidgetsRef = promotedFrom && Array.isArray(node.widgets) ? node.widgets : null;
// ...on a failed write's rollback:
if (node.widgets !== prevOuterWidgetsRef) node.widgets = prevOuterWidgetsRef;
// ...then:
const listExact = node.widgets === prevOuterWidgetsRef && /* contents */;
```

That question only has an answer on a node that **keeps** one array. A real ComfyUI `SubgraphNode` does not. Read off the installed `comfyui_frontend_package` 1.49.6:

```js
Object.defineProperty(this, "widgets", {
  get: () => [
    ...this.inputs.flatMap(e => { let t = this._projectPromotedWidget(e); return t ? [t] : [] }),
    ...this._extraWidgets,
  ],
  set: () => {}, configurable: true, enumerable: true });
```

A getter that **builds a new array on every read**, behind a setter that swallows assignment. So:

* `node.widgets !== prevOuterWidgetsRef` is **always** true — the identity compare could only ever fail;
* the restore that preceded it was refilling a throwaway array and assigning into a no-op setter;
* therefore **every** failed promoted write on a subgraph node reported `partialWrite: true` — *"the graph may be in a partial state; re-set the widget or undo"* — even when the rollback had been perfect.

`WidgetWriteError.partialWrite` is deliberately non-rewordable by callers (`lib/set-widget.js`'s `refusalFrame`), so a clean refusal reached the user as a possibly-corrupt graph.

Measured on the existing `promoted-value-scope.test.mjs` fixture (`#1707: an instance key does NOT license the claim`), before → after:

```
- ...Rolled back rather than report an instance-scoped write that was not one (comfyui-mcp#1707).
-   Rollback of the promotion host input / parent widget list (node.inputs/widgets) did not take
-   effect (a value setter or history hook rejected/overrode it) — the graph may be in a partial
-   state; re-set the widget or undo.          partialWrite = true
+ ...Rolled back rather than report an instance-scoped write that was not one (comfyui-mcp#1707).
+                                              partialWrite = false
```

The genuine refusal reason survives verbatim; only the false partial-state clause goes.

## The fix

The list is classified **once, before the write**, by **observation** — two reads, same array or not — not by property descriptor. Descriptor kind does not settle it: an accessor that memoises one array is as identity-stable as a plain data property and never needed relaxing.

* **Rebuilt per read** → skip the inert restore, drop the identity half of the compare, keep membership/order.
* **Kept** → unchanged from today, identity and all.
* **Swapped kind between snapshot and read-back** → reported, so the relaxation cannot be claimed after the fact.

Membership is still compared by **per-widget object identity**, which is what `resolveHostPromotedWidgets` uses to authenticate a rail — and `_projectPromotedWidget` memoises each proxy onto `input._widget`, so those identities are stable across reads even though the array is not. A replaced, reordered, extended, or shortened list all still fail.

The read-back also reads the list **once**, through a guard: previously a getter that threw mid-write let a bare `TypeError` escape and **replace** the `WidgetWriteError` that says what failed and what was restored.

## Verification

`browser_tests/unit/promoted-rollback-widget-list.test.mjs` — 9 pins over a fixture built to the frontend's own shape (rebuilt list, memoised member proxies, per-`widgetId` value store the rail is a view of).

Against **pre-fix** `widget-write.js`, 2 of the 9 fail: the clean-refusal pin, and the unreadable-`widgets` pin (which fails with the raw `TypeError: widgets is gone`, the `WidgetWriteError` gone).

Mutation matrix, run against the fixed tree (`A/clean` is the regression pin; every other case is a guard-still-bites pin):

| mutation | outcome |
|---|---|
| drop the whole list compare | killed by B,C,D,E,F,G,I |
| drop the KIND check | killed by F |
| drop identity for a kept list | killed by E,I |
| classify EVERY list as rebuilt | killed by E,F,I |
| **classify by DESCRIPTOR KIND instead of by observation** | killed by I |
| drop the per-member compare | killed by C,D |
| drop the length compare | killed by G |
| **re-tighten: identity for EVERY list (the pre-fix rule)** | killed by **A** |

`A/clean` survives every *disarming* mutation and dies only under the pre-fix rule — it is a control for over-tightening, not a passenger. Gating the (inert) restore is the one change nothing kills, correctly: on a rebuilt list that restore was theatre either way, so the gate removes pointless work rather than changing behaviour.

Full unit suite: 6175 tests, 0 failures related to this change. One pre-existing concurrency flake in `manager-install.test.mjs` (`#671 verifyInstalled ... fast-draining install`, `unverified` vs `installed`, 7.4s) — passes in isolation, untouched by this diff. Gates green: `check-panel-scope`, `check-tool-vocabulary`, `i18n-check`, `i18n-render-check`, `tsc --noEmit`.

## Scope

Found while working comfyui-mcp#1707 and deliberately left out of that PR's scope (#1427). `grep` confirms `web/js/lib/widget-write.js:2218` was the only site in `web/js/` comparing a widget list by array identity — no sibling call site to keep in parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
