### PR TITLE
fix(1283): a benign load-time rewrite INSIDE a subgraph definition stops refusing the open

### DIFF
--- a/browser_tests/unit/definitions-renumber.test.mjs
+++ b/browser_tests/unit/definitions-renumber.test.mjs
@@ -123,7 +123,14 @@ test("#886 WIRING: the content proof consults it for a definitions surface", () 
   // The predicate is inert unless the proof calls it, and the behavioural tests
   // above cannot see the call site.
   const src = readFileSync(join(ROOT, "web/js/lib/graph-binding.js"), "utf8");
-  assert.match(src, /import \{ definitionsDifferOnlyByRenumber \} from "\.\/definitions-renumber\.js";/);
+  // panel#1283 (the 2026-08-21 recurrence) added a SECOND import from this module, so the
+  // statement became a braced multi-line one. Pin what the assertion is FOR — that
+  // graph-binding pulls THIS symbol from THAT module — rather than one spelling of the
+  // statement, which a formatter or a sibling import re-breaks while the wiring is fine.
+  assert.match(
+    src,
+    /import\s*\{[^}]*\bdefinitionsDifferOnlyByRenumber\b[^}]*\}\s*from\s*"\.\/definitions-renumber\.js";/,
+  );
   // comfyui-mcp#1706 — BOTH call sites must pass the payload's ROOT nodes. The node-id
   // account is granted only to a caller that supplies them (a call without the argument
   // answers the pre-#1706 question and refuses), so a call site that dropped it would

--- a/browser_tests/unit/open-content-proof.test.mjs
+++ b/browser_tests/unit/open-content-proof.test.mjs
@@ -104,6 +104,10 @@ test("#1001 a byte-identical repaint is still reported as exact", () => {
     // consult would misattribute the proof.
     normalizedOnly: false,
     normalizedFields: [],
+    // panel#1283 (the 2026-08-21 recurrence) — nor the DEFINITIONS arm of that ground.
+    // Same rule: an account the proof never consulted must not be reported as one it
+    // used, or the reply discloses a subgraph difference that did not decide anything.
+    definitionsNormalized: false,
   });
 });
 
@@ -244,6 +248,7 @@ test("#1001 an unreadable root proves nothing — absence of comparison is not e
       // unreadable root would prove an open off a comparison that never happened.
       normalizedOnly: false,
       normalizedFields: [],
+      definitionsNormalized: false,
     });
   }
   assert.equal(graphRootReproducesStateContent({ rootGraph: rootOf(state), state: null }).proven, false);

--- a/browser_tests/unit/open-definitions-normalized.test.mjs
+++ b/browser_tests/unit/open-definitions-normalized.test.mjs
@@ -1,0 +1,328 @@
+// panel#1283, the 2026-08-21 recurrence — `panel_open_workflow` on an already-open
+// unsaved `tmp:` tab was refused again, on a release (v0.15.32) that already carried
+// every fix the earlier reports produced (#1358's completed-load ground, #1387's
+// entered guard, #1477's definitions-only path).
+//
+// REPRODUCED IN A REAL BROWSER, ComfyUI 0.33.2 / frontend 1.49.6, the reporter's own
+// configuration: claim a fresh canvas, add eight nodes, convert two of them into a
+// subgraph, reopen the tab that is already active. The open bound, every root node
+// came back with the same id and type, nothing extra appeared — `ok: false`, no
+// `workflow_uuid`, refused on `nodes, definitions`.
+//
+// TWO independent causes, and BOTH are load-bearing: with either one reverted the
+// browser reproduction goes back to `ok: false` (measured, one at a time).
+//
+// -- 1. `undefined` counted as a difference -----------------------------------------
+// The definition fields that "differed" were `inputNode`, `outputNode` and `inputs`,
+// whose JSON is byte-identical. What differed was keys the LIVE serializer emits with
+// the value `undefined` and `JSON.stringify` drops:
+//
+//     inputNode / outputNode   pinned
+//     inputs[]                 localized_name, label, dir, shape, color_off, color_on
+//
+// The payload side of this comparison is `JSON.parse(JSON.stringify(state))`, and the
+// file side is a parsed `.json`, so NEITHER can ever carry such a key. Counting them
+// made #886's and #1706's renumber accounts inert on this frontend — every subgraph
+// workflow's `definitions` went unaccounted, whatever else was true of it.
+//
+// -- 2. no account for a per-node rewrite inside a definition ------------------------
+// With that repaired the surface still refused, on a real difference: an installed
+// pack (cg-use-everywhere) stamps `properties.ue_properties.version` onto every node
+// during `configure`.
+//
+//     payload  "ue_properties": { "widget_ue_connectable": {}, "input_ue_unconnectable": {} }
+//     live     "ue_properties": { "widget_ue_connectable": {}, "input_ue_unconnectable": {},
+//                                 "version": "7.8" }
+//
+// It does the same to the ROOT nodes — and THERE it is already accounted for, by
+// #1358's completed-load ground, which admits any NAMED per-node difference once the
+// panel has watched the restore run to completion. The identical rewrite, on the same
+// nodes, one level down had no account at all.
+//
+// A renumber account cannot grow to cover it: it is field-level by construction, and
+// admitting `properties` would license a renumbering to rewrite arbitrary node
+// content. So the question is asked at the level #1358 moved it to — did this restore
+// stop early? — and the answer is an observation of the load, not a judgement about a
+// field name.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  definitionsDifferOnlyByCompletedLoadNormalization,
+  definitionsDifferOnlyByRenumber,
+} from "../../web/js/lib/definitions-renumber.js";
+import { graphRootReproducesStateContent } from "../../web/js/lib/graph-binding.js";
+
+/** The definition the browser produced, payload side. */
+const payloadDef = (over = {}) => ({
+  id: "57bb0646-920b-4076-8215-2477fab7de9d",
+  version: 1,
+  state: { lastGroupId: 0, lastNodeId: 9, lastLinkId: 2, lastRerouteId: 0 },
+  revision: 0,
+  config: {},
+  name: "New Subgraph",
+  inputNode: { id: -10, bounding: [-178, 71, 128, 48] },
+  outputNode: { id: -20, bounding: [470, 71, 128, 48] },
+  inputs: [{ id: "8874cc1f", name: "text", type: "STRING", linkIds: [1], pos: [0, 0] }],
+  outputs: [],
+  widgets: [],
+  nodes: [
+    {
+      id: 2,
+      type: "CLIPTextEncode",
+      pos: [10, 10],
+      size: [400, 200],
+      order: 0,
+      mode: 0,
+      properties: {
+        cnr_id: "comfy-core",
+        ver: "0.33.2",
+        ue_properties: { widget_ue_connectable: {}, input_ue_unconnectable: {} },
+        "Node name for S&R": "CLIPTextEncode",
+      },
+      widgets_values: [""],
+    },
+  ],
+  links: [{ id: 1, origin_id: -10, origin_slot: 0, target_id: 2, target_slot: 1, type: "STRING" }],
+  groups: [],
+  extra: {},
+  ...over,
+});
+
+/** The same definition as the LIVE serializer emits it after the load. */
+const liveDef = (over = {}) => {
+  const d = payloadDef();
+  // The measured `undefined` keys. Written explicitly because that is the point: a
+  // `JSON.parse(JSON.stringify(...))` fixture would erase the very thing under test.
+  d.inputNode = { id: -10, bounding: [-178, 71, 128, 48], pinned: undefined };
+  d.outputNode = { id: -20, bounding: [470, 71, 128, 48], pinned: undefined };
+  d.inputs = [
+    {
+      id: "8874cc1f",
+      name: "text",
+      type: "STRING",
+      linkIds: [1],
+      localized_name: undefined,
+      label: undefined,
+      dir: undefined,
+      shape: undefined,
+      color_off: undefined,
+      color_on: undefined,
+      pos: [0, 0],
+    },
+  ];
+  // ...and the pack's version stamp.
+  d.nodes = [
+    {
+      ...d.nodes[0],
+      properties: {
+        ...d.nodes[0].properties,
+        ue_properties: { widget_ue_connectable: {}, input_ue_unconnectable: {}, version: "7.8" },
+      },
+    },
+  ];
+  return { ...d, ...over };
+};
+
+const payload = (over) => ({ subgraphs: [payloadDef(over)] });
+const live = (over) => ({ subgraphs: [liveDef(over)] });
+const completed = { loadRanToCompletion: true };
+
+// -- the `undefined` rule, on the ACCOUNT THAT ALREADY SHIPPED -----------------------
+//
+// This is the half that is invisible from the new predicate: #886's renumber account
+// is what a plain link-renumbering open depends on, and the `undefined` keys made it
+// answer false on any frontend that emits them. Pinned on
+// `definitionsDifferOnlyByRenumber` so a revert of the `deepEqual` rule fails HERE,
+// not only on the new ground.
+
+test("#1283 the renumber account survives the keys the live serializer emits as `undefined`", () => {
+  const before = { subgraphs: [payloadDef()] };
+  const after = {
+    subgraphs: [{ ...payloadDef(), inputNode: { id: -10, bounding: [-178, 71, 128, 48], pinned: undefined } }],
+  };
+  assert.equal(definitionsDifferOnlyByRenumber(before, after, { rootNodes: [] }), true);
+});
+
+test("#1283 `null` is still a real difference — only `undefined` is absent", () => {
+  const before = { subgraphs: [payloadDef()] };
+  const after = {
+    subgraphs: [{ ...payloadDef(), inputNode: { id: -10, bounding: [-178, 71, 128, 48], pinned: null } }],
+  };
+  assert.equal(definitionsDifferOnlyByRenumber(before, after, { rootNodes: [] }), false);
+  assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(before, after, completed), false);
+});
+
+test("#1283 a field the payload HAS and the live side lost is still a difference", () => {
+  const before = { subgraphs: [payloadDef({ name: "New Subgraph" })] };
+  const after = { subgraphs: [{ ...payloadDef(), name: undefined }] };
+  assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(before, after, completed), false);
+  assert.equal(definitionsDifferOnlyByRenumber(before, after, { rootNodes: [] }), false);
+});
+
+// -- the completed-load ground, one level down ---------------------------------------
+
+test("#1283 the MEASURED per-node rewrite inside a definition is accounted for", () => {
+  assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(payload(), live(), completed), true);
+  // ...and the renumber account still refuses it, so the new ground is what carries it.
+  assert.equal(definitionsDifferOnlyByRenumber(payload(), live(), { rootNodes: [] }), false);
+});
+
+test("#1283 the licence is the OBSERVATION: unwatched and aborted both refuse", () => {
+  for (const loadRanToCompletion of [false, null, undefined, "true", 1]) {
+    assert.equal(
+      definitionsDifferOnlyByCompletedLoadNormalization(payload(), live(), { loadRanToCompletion }),
+      false,
+      `loadRanToCompletion=${String(loadRanToCompletion)} must not license anything`,
+    );
+  }
+  assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(payload(), live(), undefined), false);
+});
+
+test("#1283 a node ADDED, RETYPED, RELABELED or REORDERED inside a definition still refuses", () => {
+  const extra = liveDef();
+  extra.nodes = [...extra.nodes, { id: 3, type: "CLIPTextEncode", properties: {} }];
+  assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(payload(), { subgraphs: [extra] }, completed), false);
+
+  const retyped = liveDef();
+  retyped.nodes = [{ ...retyped.nodes[0], type: "CLIPTextEncodeSDXL" }];
+  assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(payload(), { subgraphs: [retyped] }, completed), false);
+
+  // #1706's relabeling is deliberately NOT admitted here: a definition node id that
+  // moves is referenced from outside this surface (a root node's `proxyWidgets`), and
+  // pinning the id is what makes that hazard unreachable rather than merely guarded.
+  const relabeled = liveDef();
+  relabeled.nodes = [{ ...relabeled.nodes[0], id: 182 }];
+  assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(payload(), { subgraphs: [relabeled] }, completed), false);
+
+  const two = { ...payloadDef(), nodes: [payloadDef().nodes[0], { id: 3, type: "PreviewImage" }] };
+  const swapped = { ...payloadDef(), nodes: [{ id: 3, type: "PreviewImage" }, payloadDef().nodes[0]] };
+  assert.equal(
+    definitionsDifferOnlyByCompletedLoadNormalization({ subgraphs: [two] }, { subgraphs: [swapped] }, completed),
+    false,
+  );
+});
+
+test("#1283 anything but the node array moving still refuses — no rewire rides in on this", () => {
+  for (const over of [
+    { links: [{ id: 1, origin_id: -10, origin_slot: 0, target_id: 2, target_slot: 0, type: "STRING" }] },
+    { state: { lastGroupId: 0, lastNodeId: 14, lastLinkId: 2, lastRerouteId: 0 } },
+    { widgets: [{ id: 2, name: "text" }] },
+    { name: "Renamed Subgraph" },
+    { groups: [{ id: 1, title: "g" }] },
+    { outputs: [{ id: "x", name: "out", type: "STRING", linkIds: [] }] },
+    { extra: { note: "hi" } },
+  ]) {
+    assert.equal(
+      definitionsDifferOnlyByCompletedLoadNormalization(payload(), live(over), completed),
+      false,
+      `a change to ${Object.keys(over)[0]} must refuse`,
+    );
+  }
+});
+
+test("#1283 a definition ADDED, DROPPED or rekeyed, and an unreadable shape, all refuse", () => {
+  assert.equal(
+    definitionsDifferOnlyByCompletedLoadNormalization(payload(), { subgraphs: [liveDef(), liveDef()] }, completed),
+    false,
+  );
+  assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(payload(), { subgraphs: [] }, completed), false);
+  assert.equal(
+    definitionsDifferOnlyByCompletedLoadNormalization(
+      { subgraphs: { a: payloadDef() } },
+      { subgraphs: { b: liveDef() } },
+      completed,
+    ),
+    false,
+  );
+  assert.equal(
+    definitionsDifferOnlyByCompletedLoadNormalization(payload(), { subgraphs: [liveDef()], other: 1 }, completed),
+    false,
+  );
+  for (const bad of [null, undefined, 7, "x", []]) {
+    assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(bad, live(), completed), false);
+    assert.equal(definitionsDifferOnlyByCompletedLoadNormalization(payload(), bad, completed), false);
+  }
+});
+
+test("#1283 a cyclic definition is NOT proven — it fails closed rather than throwing", () => {
+  const cyclic = liveDef();
+  cyclic.extra = {};
+  cyclic.extra.self = cyclic.extra;
+  assert.equal(
+    definitionsDifferOnlyByCompletedLoadNormalization(payload(), { subgraphs: [cyclic] }, completed),
+    false,
+  );
+});
+
+// -- THE WIRING, on the verdict the reply is taken from -------------------------------
+//
+// The predicate above is only half a fix: it changes nothing unless
+// `graphRootReproducesStateContent` subtracts `definitions` from the surface list the
+// completed-load ground reads. These drive the REAL function, so deleting the lines
+// that call it fails here.
+
+/** The reporter's shape: root nodes rewritten by the same pack, plus the subgraph. */
+const rootNode = (props) => ({
+  id: 1,
+  type: "CheckpointLoaderSimple",
+  pos: [10, 10],
+  size: [270, 98],
+  order: 0,
+  mode: 0,
+  properties: props,
+  widgets_values: ["sd_xl.safetensors"],
+});
+const PAYLOAD_PROPS = { cnr_id: "comfy-core", ue_properties: { widget_ue_connectable: {} } };
+const LIVE_PROPS = { cnr_id: "comfy-core", ue_properties: { widget_ue_connectable: {}, version: "7.8" } };
+
+const openState = { nodes: [rootNode(PAYLOAD_PROPS)], links: [], definitions: payload() };
+const openRoot = { serialize: () => ({ nodes: [rootNode(LIVE_PROPS)], links: [], definitions: live() }) };
+
+test("#1283 the open verdict admits `nodes, definitions` on a WATCHED, completed load", () => {
+  const proof = graphRootReproducesStateContent({
+    rootGraph: openRoot,
+    state: openState,
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.proven, false, "the strict proof does not reach a properties difference");
+  assert.equal(proof.normalizedOnly, true, "the completed-load ground must carry this open");
+  assert.deepEqual(proof.normalizedFields, ["properties"]);
+  assert.equal(proof.definitionsNormalized, true, "the reply must be able to disclose the subgraph difference");
+});
+
+test("#1283 the same difference on an UNWATCHED load is still refused", () => {
+  for (const loadRanToCompletion of [null, false, undefined]) {
+    const proof = graphRootReproducesStateContent({ rootGraph: openRoot, state: openState, loadRanToCompletion });
+    assert.equal(proof.normalizedOnly, false, `loadRanToCompletion=${String(loadRanToCompletion)}`);
+    assert.equal(proof.definitionsNormalized, false);
+    assert.equal(proof.presentationOnly, false);
+  }
+});
+
+test("#1283 `definitionsNormalized` is an account that was USED, never one that merely applied", () => {
+  // The definitions are exactly the accountable shape, but a LINK was lost at the root —
+  // so the verdict refuses, and the reply must not announce a subgraph account it never
+  // rested on.
+  const proof = graphRootReproducesStateContent({
+    rootGraph: openRoot,
+    state: { ...openState, links: [[1, 1, 0, 2, 0, "MODEL"]] },
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.normalizedOnly, false, "a lost link must still refuse");
+  assert.equal(proof.definitionsNormalized, false, "and the disclosure flag must not be set");
+});
+
+test("#1283 a definitions difference the ground CANNOT account for still refuses the open", () => {
+  const rewired = liveDef();
+  rewired.links = [{ id: 1, origin_id: -10, origin_slot: 0, target_id: 2, target_slot: 0, type: "STRING" }];
+  const proof = graphRootReproducesStateContent({
+    rootGraph: {
+      serialize: () => ({ nodes: [rootNode(LIVE_PROPS)], links: [], definitions: { subgraphs: [rewired] } }),
+    },
+    state: openState,
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.normalizedOnly, false);
+  assert.equal(proof.definitionsNormalized, false);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18508,6 +18508,15 @@ const GRAPH_TOOL_EXECUTORS = {
               if (contentProof.normalizedOnly && !contentProof.presentationOnly) {
                 openContentNormalized = contentProof.normalizedFields;
               }
+              // panel#1283 (the 2026-08-21 recurrence) — the completed-load ground carried
+              // this open over a `definitions` difference as well as a `nodes` one, so the
+              // reply says so. `content_normalized` names ROOT node fields and would leave
+              // the subgraph difference unmentioned; #1477's key already exists for exactly
+              // that sentence, and its note points at the same recovery. A reply that
+              // succeeded partly on the subgraph account must not be silent about it.
+              if (contentProof.definitionsNormalized) {
+                openDefinitionsUnverified = true;
+              }
               const verdict = resolveOpenRebindVerdict({
                 instanceStillTarget,
                 markerMatches,

--- a/web/js/lib/definitions-renumber.js
+++ b/web/js/lib/definitions-renumber.js
@@ -133,8 +133,31 @@ function deepEqual(a, b, seen = new Set(), depth = 0) {
       if (a.length !== b.length) return false;
       return a.every((v, i) => deepEqual(v, b[i], seen, depth + 1));
     }
-    const ka = Object.keys(a);
-    const kb = Object.keys(b);
+    // A KEY WHOSE VALUE IS `undefined` IS ABSENT — the repo's own rule (#1001, stated and
+    // measured on `classifyNodeDifference`), applied here because this comparison has the
+    // same two sides: a JSON payload against a LIVE `serialize()`.
+    //
+    // MEASURED on ComfyUI 0.33.2 / frontend 1.49.6, reopening a subgraph workflow, payload
+    // vs live, for one `New Subgraph` definition:
+    //
+    //   inputNode / outputNode   live carries `pinned: undefined`
+    //   inputs[]                 live carries `localized_name`, `label`, `dir`, `shape`,
+    //                            `color_off`, `color_on` — every one of them `undefined`
+    //
+    // `JSON.stringify` drops such a key, so no saved workflow and no `JSON.parse(JSON
+    // .stringify(...))` payload can ever carry one. Counting them made three definition
+    // fields "differ" whose JSON is byte-identical, which refused the whole `definitions`
+    // account — i.e. #886's and #1706's renumber grounds were INERT on that frontend, and
+    // a faithful open of any subgraph workflow was reported unverified. That is the bug
+    // panel#1283 keeps being reported for.
+    //
+    // `null` STAYS SIGNIFICANT, deliberately: JSON carries null, so present-as-null and
+    // absent are genuinely different states of a saved file. Only `undefined` is dropped,
+    // and only on OBJECT keys — an array element is left alone, because a hole and a
+    // shorter array are a length difference, which is the safe direction.
+    const definedKeys = (o) => Object.keys(o).filter((k) => o[k] !== undefined);
+    const ka = definedKeys(a);
+    const kb = definedKeys(b);
     if (ka.length !== kb.length) return false;
     return ka.every(
       (k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k], seen, depth + 1),
@@ -594,4 +617,127 @@ function compareDefinitions(a, b, options) {
   }
   if (!anyRelabel) return true;
   return !rootNodesReferenceRemappedId(options?.rootNodes, remappedFrom);
+}
+
+/**
+ * panel#1283 (the 2026-08-21 recurrence) — the THIRD thing a load does to this surface,
+ * and the first one no field-level account can name.
+ *
+ * ## What was measured
+ *
+ * Reproduced in a real browser on ComfyUI 0.33.2 / frontend 1.49.6 (v0.15.32, the current
+ * release): `workflow_open` on an already-open unsaved `tmp:` tab whose graph contains a
+ * subgraph. The open bound correctly, every root node came back with the same id and
+ * type, nothing extra appeared — and it was refused, `no workflow_uuid`, because the
+ * surfaces that differed were `nodes, definitions`. The whole `definitions` difference,
+ * byte for byte, was one key appearing inside a definition node's `properties`:
+ *
+ *     payload:  "ue_properties": { "widget_ue_connectable": {}, "input_ue_unconnectable": {} }
+ *     live:     "ue_properties": { "widget_ue_connectable": {}, "input_ue_unconnectable": {},
+ *                                  "version": "7.8" }
+ *
+ * i.e. an installed pack (cg-use-everywhere) stamping its version onto every node it sees
+ * during `configure`. It does the same to the ROOT nodes — and there it is already
+ * accounted for: `openContentDifferenceIsCompletedLoadNormalization` admits ANY named
+ * per-node difference once the panel has WATCHED the restore run to completion. The same
+ * rewrite, on the same nodes, one level down, had no account at all.
+ *
+ * ## Why a renumber account cannot reach it
+ *
+ * `definitionsDifferOnlyByRenumber` is field-level by construction: it enumerates which
+ * fields a renumbering may touch and requires every other one to be deep-equal. A pack
+ * that writes a key nobody has enumerated is exactly the case that enumeration cannot
+ * answer, and adding `properties` to it would license a renumber to rewrite arbitrary
+ * node content. That is the treadmill #1358's own header describes — the next pack
+ * invents the next field.
+ *
+ * ## So this asks the question at the level #1358 moved it to
+ *
+ * The refusal exists for ONE hypothesis: a restore that stopped part-way leaves a
+ * complete node set over nodes that lost their values. `loadRanToCompletion === true`
+ * refutes that hypothesis BY OBSERVATION for this load — and the observation covers the
+ * definitions, not just the root: `installNodeConfigureIsolation` wraps
+ * `LGraphNode.prototype.configure`, which is what a definition's nodes resolve
+ * `configure` through, and `installGraphConfigureWatch` wraps `LGraph.prototype.configure`,
+ * which `Subgraph` extends.
+ *
+ * ## What it therefore requires, and every one of these fails closed
+ *
+ *  - `loadRanToCompletion === true`. STRICTLY. `null` is "nobody watched" and `false` is
+ *    "something threw"; both refuse. This is the whole licence, so it is checked first.
+ *  - The two blocks pair: same container shape, same count, same keys, and every
+ *    top-level key other than `subgraphs` deep-equal.
+ *  - Inside each definition, EVERY field but `nodes` deep-equal — `links`, `state`,
+ *    `widgets`, `inputs`, `outputs`, `groups`, `config`, `inputNode`, `outputNode`,
+ *    `name`, `id`, `extra`. So no re-wiring, no promoted-widget change, no counter
+ *    movement, and no definition added, dropped or renamed rides in on this.
+ *  - Inside `nodes`, the same array length, and at each position the SAME `id` and the
+ *    SAME `type`. Nothing was added, dropped, retyped or reordered.
+ *
+ * That last requirement also closes #1706's cross-surface hazard structurally rather
+ * than by a guard: a definition node id here can never move, so `patchProxyWidgets`
+ * cannot have run, so a root node's `properties.proxyWidgets` cannot be pointing at a
+ * node this account relabeled. `rootNodesReferenceRemappedId` has nothing to refuse
+ * because no remapping is admitted in the first place.
+ *
+ * ## What it does NOT claim
+ *
+ * Not that the values inside the definitions are the file's values — the same limit
+ * `content_normalized` states for the root. The caller is told the definitions differ
+ * (`definitions_unverified`) and pointed at `panel_graph_outline`.
+ */
+export function definitionsDifferOnlyByCompletedLoadNormalization(a, b, options) {
+  // Same boundary guard as its sibling, for the same reason: nothing in here may throw,
+  // because an exception on this path takes out the verdict rather than answering "not
+  // proven". A throwing `ownKeys` trap on a Proxy is the measured shape.
+  try {
+    if (options?.loadRanToCompletion !== true) return false;
+    return compareDefinitionsUnderCompletedLoad(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/** Same id and same type, at the same position — the node SET and its order, pinned. */
+function definitionNodesAreTheSameSet(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const na = a[i];
+    const nb = b[i];
+    if (!isObj(na) || !isObj(nb)) return false;
+    // Stringified, because a serialized id legitimately arrives as a number on one side
+    // and a numeric string on the other across frontend versions — and a `!==` on the raw
+    // values would refuse a faithful load for a dialect difference. `String` on a value
+    // with a throwing `toString` is caught by the boundary guard above.
+    if (String(na.id) !== String(nb.id)) return false;
+    if (String(na.type) !== String(nb.type)) return false;
+  }
+  return true;
+}
+
+function compareDefinitionsUnderCompletedLoad(a, b) {
+  // Shape FIRST, and no `a === b` shortcut before it: two sides we cannot read must fail
+  // closed rather than compare equal (the same order its sibling takes, for that reason).
+  if (!isObj(a) || !isObj(b)) return false;
+  if (a === b) return true;
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  let pairs = [];
+  for (const k of keys) {
+    if (k !== "subgraphs") {
+      if (!deepEqual(a[k], b[k])) return false;
+      continue;
+    }
+    const paired = pairDefinitions(a.subgraphs, b.subgraphs);
+    if (paired === null) return false;
+    pairs = paired;
+  }
+  for (const [defA, defB] of pairs) {
+    if (!isObj(defA) || !isObj(defB)) return false;
+    // Everything EXCEPT the node array must be identical. `differsOnlyIn` also pins the
+    // key sets, so a definition that gained or lost a field is refused here.
+    if (!differsOnlyIn(defA, defB, new Set(["nodes"]))) return false;
+    if (!definitionNodesAreTheSameSet(defA.nodes ?? [], defB.nodes ?? [])) return false;
+  }
+  return true;
 }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1,4 +1,7 @@
-import { definitionsDifferOnlyByRenumber } from "./definitions-renumber.js";
+import {
+  definitionsDifferOnlyByCompletedLoadNormalization,
+  definitionsDifferOnlyByRenumber,
+} from "./definitions-renumber.js";
 import { nodeInputsDifferOnlyByDefinitionRebuild } from "./node-inputs-rebuild.js";
 import {
   isEmptyBaselineMismatch,
@@ -1104,6 +1107,7 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
     presentationOnly: false,
     normalizedOnly: false,
     normalizedFields: [],
+    definitionsNormalized: false,
   };
   try {
     // ONE SNAPSHOT, and every check below reads it (codex r3). Serializing separately
@@ -1122,6 +1126,7 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
         presentationOnly: false,
         normalizedOnly: false,
         normalizedFields: [],
+        definitionsNormalized: false,
       };
     }
     const diff = describeGraphStateDifference({ rootGraph: frozen, state });
@@ -1182,9 +1187,35 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
     // refusal rests on did not happen here. Weaker than `presentationOnly` about the
     // fields (it names them rather than vouching for them) and stronger about the LOAD
     // (it is an observation of this restore, not a judgement about a field name).
+    //
+    // panel#1283 (the 2026-08-21 recurrence) — AND THE SAME GROUND ONE LEVEL DOWN.
+    //
+    // `definitions` is subtracted from `unexplainedSurfaces` above only by
+    // `definitionsDifferOnlyByRenumber`, which is FIELD-LEVEL: it enumerates what a
+    // renumbering may touch and requires every other field to be deep-equal. Measured in
+    // a real browser on v0.15.32 / ComfyUI 0.33.2 / frontend 1.49.6, an installed pack
+    // stamps a key into every node's `properties` during `configure`. On the ROOT nodes
+    // that is already accounted for — by the completed-load ground immediately below,
+    // which admits any NAMED per-node difference once the panel has watched the restore
+    // run to completion. The identical rewrite, on the same nodes, inside a subgraph
+    // definition had no account at all, so a faithful open of any subgraph workflow on
+    // that machine was refused on `nodes, definitions`, published no `workflow_uuid`, and
+    // sent the caller through the multi-call recovery this whole cluster is about.
+    //
+    // So the completed-load ground reads the surface list with that account applied too.
+    // Deliberately NOT applied to `presentationOnly`: that ground claims "nothing
+    // AUTHORED was lost", and this admits an arbitrary per-node field inside a definition
+    // — a claim only the weaker, observation-licensed ground may make.
+    const definitionsNormalized =
+      unexplainedSurfaces.includes("definitions") &&
+      definitionsDifferOnlyByCompletedLoadNormalization(state?.definitions, actualState?.definitions, {
+        loadRanToCompletion,
+      });
     const normalizedOnly = openContentDifferenceIsCompletedLoadNormalization({
       comparable: true,
-      surfaces: unexplainedSurfaces,
+      surfaces: definitionsNormalized
+        ? unexplainedSurfaces.filter((surface) => surface !== "definitions")
+        : unexplainedSurfaces,
       nodeDifference: diff.nodeDifference,
       loadRanToCompletion,
     });
@@ -1203,6 +1234,11 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
       // the strict proof, so a fix that only populated this on the success path would be
       // wired into a branch its own bug reports cannot reach.
       normalizedFields: normalizedOnly && Array.isArray(diff.nodeDifference?.fields) ? diff.nodeDifference.fields : [],
+      // Only when it actually CARRIED the verdict. The caller turns this into the
+      // `definitions_unverified` disclosure, and a reply may not announce a subgraph
+      // difference the verdict never rested on — this is an account that was USED, not
+      // one that would have applied had some other refusal not fired first.
+      definitionsNormalized: normalizedOnly && definitionsNormalized,
     };
     const surfaces = Array.isArray(diff.surfaces) ? diff.surfaces : [];
     // ONE surface, and it must be `nodes`. A group or a link that disagrees is
@@ -1251,7 +1287,15 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
     // A definitions-only difference is fully accounted for once the renumber check
     // passes: there is no node difference to classify.
     if (!unique.includes("nodes")) {
-      return { proven: true, exact: false, fields: [], presentationOnly: false, normalizedOnly: false, normalizedFields: [] };
+      return {
+        proven: true,
+        exact: false,
+        fields: [],
+        presentationOnly: false,
+        normalizedOnly: false,
+        normalizedFields: [],
+        definitionsNormalized: false,
+      };
     }
     const nodes = diff.nodeDifference;
     // THE NEXT TWO CHECKS DELIBERATELY OVERLAP, and neither can be killed alone by
@@ -1297,7 +1341,15 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
     // nobody can point at is exactly the fabricated all-clear to avoid.
     if (!fields.length) return notProven;
     if (!fields.every((field) => RECOMPUTED_NODE_FIELDS.has(field))) return notProven;
-    return { proven: true, exact: false, fields, presentationOnly: false, normalizedOnly: false, normalizedFields: [] };
+    return {
+      proven: true,
+      exact: false,
+      fields,
+      presentationOnly: false,
+      normalizedOnly: false,
+      normalizedFields: [],
+      definitionsNormalized: false,
+    };
   } catch {
     return NOT_PROVEN;
   }


### PR DESCRIPTION
Closes #1283.

**Review is PENDING.** Nothing here has been reviewed by anyone but its author. The evidence below is mine.

## What was reported, and why the last fix did not end it

#1283 has been reported five times and fixed twice (#1274, then #1358 + #1387 + #1477). The 2026-08-21 comment reports it again on panel **0.15.25** — a release that already carries every one of those fixes. So this is not a stale reporter; something the earlier grounds cannot reach was still refusing.

## Reproduced, on the current release, before writing any code

ComfyUI 0.33.2 / frontend 1.49.6, real browser, `origin/main` at v0.15.32 served to the page. The reporter's configuration: an already-open **unsaved `tmp:` tab**, reopened via `workflow_open`.

* 8 plain nodes, no subgraph → `ok: true`, `workflow_uuid` published, `content_normalized: ["properties"]`. **Does not reproduce.**
* the same tab with two nodes converted into a **subgraph** → `ok: false`, no `workflow_uuid`, refused on `nodes, definitions`, with the panel's own reply saying *"every node that was loaded IS on the canvas with the same id and type and nothing extra appeared, so no node was lost"*.

That is the recurrence, and the subgraph is what the earlier reports did not isolate. (LTX-2.5, which the reporter names, is a subgraph template.)

## Two causes, measured, both load-bearing

### 1. `deepEqual` counted a key whose value is `undefined` as a difference

The definition fields that "differed" were `inputNode`, `outputNode` and `inputs` — whose JSON is byte-identical. Dumped from the browser, what actually differed was keys the LIVE serializer emits with the value `undefined`:

```
inputNode / outputNode   pinned
inputs[]                 localized_name, label, dir, shape, color_off, color_on
```

`JSON.stringify` drops such a key. The payload side of this comparison is `JSON.parse(JSON.stringify(state))` and the file side is a parsed `.json`, so **neither side can ever carry one**. This is the identical hazard `classifyNodeDifference` already documents and handles for root nodes (#1001, `showAdvanced: undefined`) — `definitions-renumber.js` never got the rule.

The consequence is bigger than this ticket: **#886's and #1706's renumber accounts were inert on this frontend.** Every subgraph workflow's `definitions` surface went unaccounted no matter what was true of it. `undefined` is now absent; `null` stays significant, deliberately, because JSON carries null and present-as-null is a real state of a saved file.

### 2. A per-node rewrite inside a definition had no account at all

With that repaired the surface still refused, on a genuine difference. An installed pack (cg-use-everywhere) stamps its version onto every node it sees during `configure`:

```
payload  "ue_properties": { "widget_ue_connectable": {}, "input_ue_unconnectable": {} }
live     "ue_properties": { "widget_ue_connectable": {}, "input_ue_unconnectable": {}, "version": "7.8" }
```

It does exactly this to the **root** nodes too — and there it is already accounted for, by #1358's completed-load ground, which admits any *named* per-node difference once the panel has WATCHED the restore run to completion. The same rewrite, on the same nodes, one level down had nothing.

A renumber account cannot grow to cover it. It is field-level by construction, and admitting `properties` would license a renumbering to rewrite arbitrary node content — the treadmill #1358's own header describes. So `definitionsDifferOnlyByCompletedLoadNormalization` asks #1358's question one level down: *did this restore stop early?* Measured this run: `LGraphNode.prototype.configure` entered 10×, `LGraph.prototype.configure` 2×, **zero throws** on either.

It requires, and each fails closed:

* `loadRanToCompletion === true`, strictly — `null` ("nobody watched") and `false` ("something threw") both refuse;
* the blocks pair, and every top-level key but `subgraphs` is deep-equal;
* inside each definition, **every field but `nodes`** is deep-equal — `links`, `state`, `widgets`, `inputs`, `outputs`, `groups`, `config`, `inputNode`, `outputNode`, `name`, `id`, `extra`. No rewire, no promoted-widget change, no counter movement, no definition added or dropped;
* inside `nodes`, the same length and the same `id` **and** `type` at each position.

That last one closes #1706's cross-surface hazard **structurally** rather than by a guard: a definition node id can never move here, so `patchProxyWidgets` cannot have run, so a root node's `properties.proxyWidgets` cannot point at anything this account relabeled.

It is applied to `normalizedOnly` only, **not** to `presentationOnly`. `presentationOnly` claims "nothing AUTHORED was lost"; this admits an arbitrary per-node field inside a definition, which is a claim only the weaker, observation-licensed ground may make.

## What the reply now says

`ok: true`, `workflow_uuid` published, and **both** disclosures:

* `content_normalized: ["properties"]` — the root fields that moved,
* `definitions_unverified: true` — #1477's existing key, now riding the success path, because an open carried partly on the subgraph account must not be silent about it. It is set only when the account actually **carried** the verdict, never when it merely would have applied.

## Evidence

**Browser, mutation-verified one change at a time** (the reproduction above, re-run after each edit):

| state | result |
| --- | --- |
| main | `ok: false` |
| both fixes | `ok: true` + uuid + both disclosures |
| revert the `deepEqual` rule only | `ok: false` |
| disable the definitions ground only | `ok: false` |

Neither half fixes it alone.

**Unit**, `browser_tests/unit/open-definitions-normalized.test.mjs`, 13 tests. They drive the real `graphRootReproducesStateContent`, not only the predicates, because the predicate is inert unless the verdict subtracts the surface. Mutation-verified:

| mutation | fails |
| --- | --- |
| revert the `deepEqual` `undefined` rule | 3 named tests, including one on `definitionsDifferOnlyByRenumber` |
| `definitionsNormalized = false && …` | the WIRING test |
| report an account that merely applied | the USED-not-applied test |
| `!options?.loadRanToCompletion` instead of `!== true` | the OBSERVATION test |

**Suites.** `npm run test:unit`: 6177/6179, the one failure being the known `#671 verifyInstalled` wall-clock flake, which passes 125/125 when its file is run alone. Playwright `--workers=1`: **still running as this body is posted** — the result is reported in a comment below, pass or fail. It is run with the panel sources served **from this branch** (the repo's own `worktreeSource` route), not from ComfyUI's `custom_nodes` junction, which points at a checkout 64 commits behind `main` — a run without that override would report green for code it never loaded.

## What I deliberately did not do

* **Did not widen `RECOMPUTED_NODE_FIELDS` or `COSMETIC_NODE_FIELDS`.** Both are field-name allowlists and `ue_properties` is precisely the field a pack invents next.
* **Did not touch `presentationOnly`.** See above.
* **Did not extend the account to a definitions difference that is BOTH a renumber and a per-node rewrite.** Each account handles its own case; a load that did both would still refuse. No reporter has produced that shape, and combining them means admitting a relabeling and an arbitrary field change at once, which is where #1706's hazard lives.
* **Did not chase the `stale: "unknown"` on the reply.** It is honest for an unsaved `tmp:` tab and unrelated.

## Where I am least sure — please aim here

1. **The `deepEqual` change is the widest blast radius in this PR.** It is shared by every path in `definitions-renumber.js`, including #886's and #1706's shipped accounts, and it makes them *more* permissive. It reaches one consumer outside the open: `graphRootAgreesWithActiveState` (#1477) reads `proof.proven`, whose `definitions` arm is the renumber account — so the content-only binding seal is granted in cases it previously refused. I believe that is the same false refusal being repaired rather than a widening, because the keys in question carry nothing, but it is a *binding* decision and deserves its own look. My argument that it cannot admit anything real: a saved workflow is JSON, so a payload key can never hold `undefined`; a key the payload has with a real value and the live side lacks still differs; `null` vs `undefined` still differs. If there is a way for the LIVE side to lose something and have that read as `undefined`, this is where it gets through.
2. **"Everything but `nodes` deep-equal" may be the wrong cut.** I chose it because it makes the account structural rather than field-level, but it means a benign rewrite anywhere else in a definition still refuses — i.e. this ticket may come back a sixth time with a different field. Is the right shape instead "the definition's node SET is intact and the load completed", with links/state compared through the renumber account?
3. **The `definitions_unverified` reuse.** I reused #1477's key rather than minting one, so the note is written for a *definitions-only* difference and now also appears alongside `content_normalized`. Does that pair read coherently, or does the reply now say two things about one graph?
4. **Positional pairing of definition nodes.** A reordered node array inside a definition refuses. That matches `nodesDifferOnlyInLinkRefs`, but if the frontend ever reorders them the account goes inert exactly the way cause (1) did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
