### PR TITLE
fix(1485): the video completion stops waiting on work the agent never sees

### DIFF
--- a/browser_tests/unit/run-completion-video-segment.test.mjs
+++ b/browser_tests/unit/run-completion-video-segment.test.mjs
@@ -126,8 +126,10 @@ test("#1485: the note describes the frames actually PAINTED, not the grid's capa
     !/20-frame storyboard/.test(frame.note),
     `a 3-frame sheet must not be announced as 20 frames\n${frame.note}`,
   );
-  assert.match(frame.note, /3 sampled frames/, "the count that was drawn is the count that is stated");
-  assert.match(frame.note, /17 could not be captured and are BLANK/, "and the blanks are disclosed, not implied");
+  assert.match(frame.note, /Only 3 of its 20 cells hold a sampled frame/, "the count that was drawn is the count that is stated");
+  assert.match(frame.note, /the other 17 are BLANK/, "and the blanks are disclosed, not implied");
+  assert.match(frame.note, /📽️ 20-cell storyboard \(contact sheet\) of the FINAL saved video/,
+    "the head names the sheet and flows into the file — the caveat is its own sentence");
 });
 
 test("#1485: a FULL sheet still reads as a plain N-frame storyboard", async () => {
@@ -152,9 +154,35 @@ test("#1485: exactly ONE sampled frame is described in the singular, with the bl
   const { deps } = makeDeps({ buildVideoStoryboard: async () => sheetBlob({ paintedFrames: 1 }) });
   const frame = await composeRunCompletionFrame(videoPayload(), deps);
 
-  assert.match(frame.note, /holding 1 sampled frame —/, "one frame is one frame, not '1 sampled frames'");
-  assert.match(frame.note, /19 could not be captured and are BLANK/);
+  assert.match(frame.note, /Only 1 of its 20 cells hold/, "one frame is one frame");
+  assert.match(frame.note, /the other 19 are BLANK, so judge nothing from them/);
   assert.ok(!/20-frame storyboard/.test(frame.note), `\n${frame.note}`);
+});
+
+test("#1485: cells-minus-one reads 'is BLANK', not 'are BLANK' (gate non-finding)", async () => {
+  // The boundary the plural rule actually gets wrong: 19 of 20 painted leaves
+  // exactly one blank cell. Caught by the review gate reading the generated
+  // string rather than the branch, which is why it is pinned by the string.
+  const { deps } = makeDeps({ buildVideoStoryboard: async () => sheetBlob({ paintedFrames: 19 }) });
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+
+  assert.match(frame.note, /the other 1 is BLANK, so judge nothing from it/, `
+${frame.note}`);
+  assert.ok(!/the other 1 are BLANK/.test(frame.note), "one blank cell is 'is', not 'are'");
+});
+
+test("#1485: a count over capacity is CLAMPED, never announced as more than the grid holds", async () => {
+  // paintedFrames is an expando the builder sets; a caller must not be able to
+  // claim 25 samples from a 20-cell sheet. Clamped to the capacity, which then
+  // reads as a full sheet with no blanks — the honest description of 20 cells
+  // that all hold a frame.
+  const { deps } = makeDeps({ buildVideoStoryboard: async () => sheetBlob({ paintedFrames: 25 }) });
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+
+  assert.ok(!/25/.test(frame.note), `a count above the capacity must never be printed
+${frame.note}`);
+  assert.match(frame.note, /📽️ 20-frame storyboard \(contact sheet\)/);
+  assert.ok(!/BLANK/.test(frame.note), "a clamped-full sheet has no blanks to disclose");
 });
 
 test("#1485: an UNKNOWN sampled count claims no count at all — never the capacity, never 'null'", async () => {

--- a/browser_tests/unit/run-completion-video-segment.test.mjs
+++ b/browser_tests/unit/run-completion-video-segment.test.mjs
@@ -145,6 +145,46 @@ test("#1485: a FULL sheet still reads as a plain N-frame storyboard", async () =
   );
 });
 
+test("#1485: exactly ONE sampled frame is described in the singular, with the blanks named", async () => {
+  // The reported shape of a barely-decodable video: the builder paints one cell
+  // and leaves nineteen blank. This is the case the capacity claim was worst
+  // for, so the wording is pinned rather than assumed to fall out of the plural.
+  const { deps } = makeDeps({ buildVideoStoryboard: async () => sheetBlob({ paintedFrames: 1 }) });
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+
+  assert.match(frame.note, /holding 1 sampled frame —/, "one frame is one frame, not '1 sampled frames'");
+  assert.match(frame.note, /19 could not be captured and are BLANK/);
+  assert.ok(!/20-frame storyboard/.test(frame.note), `\n${frame.note}`);
+});
+
+test("#1485: an UNKNOWN sampled count claims no count at all — never the capacity, never 'null'", async () => {
+  // `paintedFrames` is best-effort: buildVideoStoryboard sets it on the blob and
+  // its own comment allows a Blob implementation that refuses extra properties,
+  // "which callers must treat as unknown — never as the capacity". Unlike
+  // show_media's produceSheet, this path does NOT withhold the sheet for an
+  // unknown count — it is the run's ONE completion and the sheet is the only
+  // thing that shows the agent the video — so it must describe it without one.
+  //
+  // The second half is the trap: `metaSuffix`'s storyboard clause is a plain
+  // truthiness guard, so passing an unknown count through as a number-shaped
+  // nothing would print "null-frame storyboard" on the metadata line.
+  const { deps, calls } = makeDeps({ buildVideoStoryboard: async () => sheetBlob({}) });
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+
+  assert.equal(frame.images.length, 1, "the sheet still ships — an unknown count is not a reason to withhold it");
+  assert.match(frame.note, /📽️ storyboard \(contact sheet\)/, "described, but not counted");
+  assert.ok(!/20-frame|20-cell/.test(frame.note), `the capacity must not stand in for the count\n${frame.note}`);
+  assert.ok(
+    !/null|undefined|NaN/.test(frame.note),
+    `an unknown count must never reach the note as a value\n${frame.note}`,
+  );
+  assert.deepEqual(
+    calls.painted.map((p) => p.caption),
+    ["Storyboard"],
+    "and the user's caption drops the count too, rather than inventing one",
+  );
+});
+
 test("#1485: the completion frame does not wait for the card's poster", async () => {
   // THE LATENCY FIX. The poster decorates the USER's video card; the agent never
   // receives it and no part of the note depends on it. It used to be awaited —

--- a/browser_tests/unit/run-completion-video-segment.test.mjs
+++ b/browser_tests/unit/run-completion-video-segment.test.mjs
@@ -1,0 +1,252 @@
+// panel#1485 — the video completion the panel PROMISED, and what it spends
+// getting there.
+//
+// THE REPORT. `panel_run` on a graph that writes an .mp4 finished successfully
+// and the panel's completion event never showed up; ~5 s later the orchestrator
+// synthesised a success notice of its own, and that notice carried no output —
+// the agent had to go and find the file with list_outputs and panel_show_media.
+// The first filing of this issue saw the same thing at ~45 s.
+//
+// WHY 45 s BECAME 5 s, AND WHY THAT MATTERS HERE. The orchestrator's
+// `DEFAULT_SYNTHESIS_GRACE_MS` was cut from 45 000 to 5 000, on a stated
+// assumption: "the normal path lands within a second or two; that is the only
+// race the grace has to win." For a STILL that is true. For a VIDEO the panel's
+// single completion frame is not sent until it has sampled the clip in a hidden
+// <video>, encoded a contact sheet, uploaded it, encoded a poster, uploaded THAT
+// and taken a HEAD of the video — measured on this repo's rig (headless and
+// headed Chromium, a 4.84 s and a 19.36 s 960×544 h264 mp4, ComfyUI on
+// localhost): 1.0–9.7 s end to end, and bounded at 25 s by design. And when the
+// orchestrator wins that race, the notice it synthesises cannot carry the video
+// at all — an .mp4 is deliberately named-but-not-attached (comfyui-mcp#1861), so
+// the storyboard is the ONLY thing that ever shows the agent this render.
+//
+// So the panel's half of the fix is: take off that path everything that is not
+// needed to tell the agent the run finished. The tests below pin the three
+// things that came off it, plus two claims the same function was making that
+// were not true.
+//
+// These drive the REAL composeRunCompletionFrame with injected deps rather than
+// asserting on source text: every one of them fails when its fix is reverted
+// (verified by reverting each in turn), which a source-regex pin cannot promise.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+
+/** A stand-in for the sheet Blob: what every consumer actually tests for is a
+ *  numeric `size`, so that is what the double carries. */
+function sheetBlob({ size = 4096, paintedFrames, posterBlob } = {}) {
+  const b = { size };
+  if (paintedFrames !== undefined) b.paintedFrames = paintedFrames;
+  if (posterBlob !== undefined) b.posterBlob = posterBlob;
+  return b;
+}
+
+function videoPayload() {
+  return {
+    promptId: "p-1485",
+    images: [],
+    videos: [{ m: { filename: "clip_00001_.mp4", subfolder: "", type: "output", format: "video/h264-mp4" }, nodeId: 128 }],
+    durationMs: 28_770,
+  };
+}
+
+/**
+ * Deps wired to succeed. `overrides` replaces individual helpers; `calls`
+ * records what the pipeline reached out to and in what order.
+ */
+function makeDeps(overrides = {}) {
+  const calls = { uploads: [], painted: [], posters: [], sizeHeads: [], frames: [] };
+  const deps = {
+    sendFrame: (frame) => {
+      calls.frames.push(frame);
+      return true;
+    },
+    coerceMessageText: (v) => (typeof v === "string" ? v : v == null ? "" : String(v)),
+    formatDuration: (ms) => `${Math.round(ms / 1000)}s`,
+    formatClock: () => "7:45:29 AM",
+    imageViewUrl: (ref) => `/view?filename=${ref?.filename ?? ""}`,
+    fetchImageBytes: async (url) => {
+      calls.sizeHeads.push(url);
+      return 1_177_013;
+    },
+    fetchImageDimensions: async () => null,
+    humanizeBytes: (n) => (n == null ? null : `${n} B`),
+    buildVideoStoryboard: async () => sheetBlob({ paintedFrames: 20 }),
+    uploadBlobToInput: async (blob, name) => {
+      calls.uploads.push({ name, blob });
+      return { filename: name, subfolder: "", type: "temp" };
+    },
+    storyboardFrameCount: () => 20,
+    paintImage: (url, caption) => calls.painted.push({ url, caption }),
+    applyVideoPoster: (videoUrl, posterUrl) => calls.posters.push({ videoUrl, posterUrl }),
+    videoStoryboardEnabled: true,
+    agentReceivesImages: () => true,
+    warn: () => {},
+    // Real timers, so a segment that is genuinely awaiting something never
+    // silently "completes" because a fake clock advanced past it.
+    videoStoryboardTimeoutMs: 25_000,
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+test("#1485: a storyboard FAILURE object is never uploaded as if it were a sheet", async () => {
+  // buildVideoStoryboard answers a codec it cannot decode with
+  // storyboardFailure({reason}) — which is TRUTHY. The old `if (!blob)` test
+  // sailed past it and handed the plain object to uploadBlobToInput, which
+  // appends it to a FormData as "[object Object]" and uploads that under a .png
+  // name; the agent was then shown a "20-frame storyboard" that is not an image
+  // and asked to review its motion and sharpness.
+  const reason =
+    "the browser reported no usable duration for it (its codec may not be decodable here — VP9/AV1 .webm is the usual case)";
+  const { deps, calls } = makeDeps({ buildVideoStoryboard: async () => ({ reason }) });
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+
+  assert.deepEqual(calls.uploads, [], "a failure object must never reach uploadBlobToInput");
+  assert.ok(frame, "the completion frame is still sent — a failed storyboard is not a failed run");
+  assert.deepEqual(frame.images, [], "and it carries no sheet, because none was built");
+  assert.ok(
+    !/storyboard \(contact sheet\)|-frame storyboard \(contact sheet\)/.test(frame.note),
+    "the note must not describe a contact sheet that does not exist",
+  );
+  // #1493 built the reason precisely so the panel could stop saying "the panel is
+  // not told which". Saying it is the whole point of carrying it.
+  assert.ok(frame.note.includes(reason), `the note must name the cause the builder supplied\n${frame.note}`);
+});
+
+test("#1485: the note describes the frames actually PAINTED, not the grid's capacity", async () => {
+  // #648 put the real count on the blob and told callers to use it. This one used
+  // storyboardFrameCount() — the CAPACITY — so a sheet holding one frame and
+  // nineteen blank cells was announced to the agent as twenty samples.
+  const { deps } = makeDeps({ buildVideoStoryboard: async () => sheetBlob({ paintedFrames: 3 }) });
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+
+  assert.ok(
+    !/20-frame storyboard/.test(frame.note),
+    `a 3-frame sheet must not be announced as 20 frames\n${frame.note}`,
+  );
+  assert.match(frame.note, /3 sampled frames/, "the count that was drawn is the count that is stated");
+  assert.match(frame.note, /17 could not be captured and are BLANK/, "and the blanks are disclosed, not implied");
+});
+
+test("#1485: a FULL sheet still reads as a plain N-frame storyboard", async () => {
+  // The disclosure above is for the degraded case only — a sheet whose every
+  // planned cell filled must not acquire a caveat it does not need.
+  const { deps, calls } = makeDeps();
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+
+  assert.match(frame.note, /📽️ 20-frame storyboard \(contact sheet\)/);
+  assert.ok(!/BLANK/.test(frame.note), "nothing was blank, so nothing is disclosed as blank");
+  assert.deepEqual(
+    calls.painted.map((p) => p.caption),
+    ["Storyboard · 20 frames"],
+    "the user's caption counts the same frames the agent's note does",
+  );
+});
+
+test("#1485: the completion frame does not wait for the card's poster", async () => {
+  // THE LATENCY FIX. The poster decorates the USER's video card; the agent never
+  // receives it and no part of the note depends on it. It used to be awaited —
+  // a full-resolution PNG encode plus a second POST /upload/image between the
+  // run finishing and the agent being told it finished.
+  //
+  // Modelled as the worst case that is not a crash: an upload that never
+  // settles. Before the fix this test hangs until the 25 s segment timeout and
+  // then reports a "storyboard preview timed out" with NO sheet; after it, the
+  // frame is sent immediately with the sheet intact.
+  let posterUploadStarted = false;
+  const { deps, calls } = makeDeps({
+    buildVideoStoryboard: async () => sheetBlob({ paintedFrames: 20, posterBlob: { size: 718_372 } }),
+    uploadBlobToInput: async (blob, name) => {
+      calls.uploads.push({ name, blob });
+      if (name.startsWith("poster_")) {
+        posterUploadStarted = true;
+        return new Promise(() => {}); // never settles
+      }
+      return { filename: name, subfolder: "", type: "temp" };
+    },
+  });
+
+  const frame = await Promise.race([
+    composeRunCompletionFrame(videoPayload(), deps),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("completion frame waited on the poster")), 2000)),
+  ]);
+
+  assert.ok(frame, "the completion frame is sent");
+  assert.equal(frame.images.length, 1, "and it carries the storyboard the agent needs");
+  assert.match(frame.note, /📽️ 20-frame storyboard/, "not the timed-out fallback");
+  assert.ok(posterUploadStarted, "the poster is still uploaded — it is detached, not dropped");
+  assert.equal(calls.posters.length, 0, "it simply has not landed yet, and the card back-fills when it does");
+});
+
+test("#1485: the poster still reaches the card when its upload resolves", async () => {
+  // Detached must not mean abandoned: the card's back-fill is the entire reason
+  // the poster is produced, and #1280's behaviour has to survive this change.
+  let resolvePoster;
+  const { deps, calls } = makeDeps({
+    buildVideoStoryboard: async () => sheetBlob({ paintedFrames: 20, posterBlob: { size: 718_372 } }),
+    uploadBlobToInput: async (blob, name) => {
+      calls.uploads.push({ name, blob });
+      if (name.startsWith("poster_")) {
+        return new Promise((res) => {
+          resolvePoster = () => res({ filename: name, subfolder: "", type: "temp" });
+        });
+      }
+      return { filename: name, subfolder: "", type: "temp" };
+    },
+  });
+
+  await composeRunCompletionFrame(videoPayload(), deps);
+  assert.equal(calls.posters.length, 0, "the frame did not wait for it");
+  resolvePoster();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(calls.posters, [
+    { videoUrl: "/view?filename=clip_00001_.mp4", posterUrl: "/view?filename=poster_clip_00001_.png" },
+  ], "and the card is back-filled by video URL exactly as before");
+});
+
+test("#1485: the video's size HEAD overlaps the sampling instead of following the upload", async () => {
+  // fetchImageBytes is bounded at 8 s inside the panel, and it used to run AFTER
+  // the sheet upload — so on a remote target it was a whole round trip added to
+  // the completion's critical path for a metadata line. Started before the
+  // sampling pass, it costs nothing the decode was not already spending.
+  const order = [];
+  const { deps } = makeDeps({
+    fetchImageBytes: async () => {
+      order.push("head:start");
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("head:end");
+      return 1_177_013;
+    },
+    buildVideoStoryboard: async () => {
+      order.push("sample:start");
+      await new Promise((r) => setTimeout(r, 30));
+      order.push("sample:end");
+      return sheetBlob({ paintedFrames: 20 });
+    },
+  });
+
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+  assert.equal(order[0], "head:start", "the HEAD is issued first");
+  assert.ok(
+    order.indexOf("head:end") < order.indexOf("sample:end"),
+    `the HEAD must finish while the decode is still running, not after it\n${order.join(" → ")}`,
+  );
+  // Overlapping it must not cost the note the value it was fetched for.
+  assert.match(frame.note, /1177013 B/, "the size still reaches the metadata line");
+});
+
+test("#1485: a HEAD that throws degrades the metadata line, never the completion", async () => {
+  // The old code awaited fetchImageBytes inline, so a throw fell into the
+  // segment's catch and cost the agent the whole storyboard. Detaching it makes
+  // that reachable in a new way, so it is pinned rather than assumed.
+  const { deps } = makeDeps({
+    fetchImageBytes: async () => {
+      throw new Error("HEAD refused");
+    },
+  });
+  const frame = await composeRunCompletionFrame(videoPayload(), deps);
+  assert.match(frame.note, /📽️ 20-frame storyboard/, "the sheet survives a failed size lookup");
+  assert.equal(frame.images.length, 1);
+});

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -312,7 +312,15 @@ function makeFrameDeps(overrides = {}) {
     fetchImageBytes: async () => 2048,
     fetchImageDimensions: async () => ({ w: 512, h: 512 }),
     humanizeBytes: (n) => (n == null ? null : `${n} B`),
-    buildVideoStoryboard: async () => ({ fake: "blob" }),
+    // #1485 — this double used to be `{ fake: "blob" }`, and that is the exact
+    // shape the composer must REFUSE: `storyboardFailure({reason})` is a truthy
+    // plain object too, so a double that is truthy-but-not-a-Blob made the old
+    // `if (!blob)` test look correct while production was uploading an
+    // explanation to ComfyUI as `storyboard_<name>.png`. A sheet is the thing
+    // with a numeric `size` (the test every consumer now applies), and
+    // `paintedFrames` is what #648 requires a caller to describe it by — so the
+    // double carries both, and the assertions below are unchanged.
+    buildVideoStoryboard: async () => ({ size: 4096, paintedFrames: 20 }),
     uploadBlobToInput: async (_blob, name, opts) => {
       uploadCalls.push({ name, opts });
       return { filename: name, type: opts?.type || "input" };
@@ -574,7 +582,8 @@ test("#609: ONE decision per frame — parallel segments can never disagree with
     // fast.mp4's storyboard resolves immediately; slow.mp4's takes a real 20ms.
     buildVideoStoryboard: async (url) => {
       if (/slow/.test(url)) await new Promise((r) => setTimeout(r, 20));
-      return { fake: "blob" };
+      return { size: 4096, paintedFrames: 20 }; // #1485 — a Blob-shaped sheet, see makeFrameDeps
+
     },
     // Blind flips ON during slow.mp4's upload — AFTER fast.mp4's whole segment
     // (including its note) was already built.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7781,9 +7781,17 @@ function awaitMediaEvent(el, name, timeoutMs) {
  *
  * THIS IS TRUTHY, so a caller must test `.reason` BEFORE treating the result as
  * a sheet — `if (!sheet)` alone would sail past it and try to upload a plain
- * object. `produceSheet` is the only consumer and does exactly that. Said
- * plainly because the tempting summary — "existing checks keep working" — is
- * false, and a wrong reassurance in a comment outlives the person who wrote it.
+ * object. Said plainly because the tempting summary — "existing checks keep
+ * working" — is false, and a wrong reassurance in a comment outlives the person
+ * who wrote it.
+ *
+ * There are TWO consumers, counted rather than remembered (#1485): `produceSheet`
+ * in lib/media-preview.js (show_media) and `buildVideoSegment` in
+ * lib/run-completion-frame.js (the run's completion frame). This comment used to
+ * say produceSheet was the only one — and the second consumer was, for that whole
+ * time, the one testing `!blob` and uploading the failure object as if it were a
+ * PNG. A comment that names its callers has to be re-counted when it is edited,
+ * or it becomes the reason nobody looks.
  *
  * What it DOES preserve is the meaning of `null`: a builder that returns nothing
  * still reports nothing, so a test double of `async () => null` keeps meaning

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -539,12 +539,72 @@ async function buildVideoSegment(v, deps) {
   // UNBOUNDED step (uploadBlobToInput does a fetch with no timeout). Bound the
   // whole pipeline: on timeout, degrade to the note-only fallback so a stalled
   // upload can never suppress the run's single completion frame.
+  //
+  // #1485 — AND KEEP THE PIPELINE SHORT, because everything on it is time the
+  // agent spends being told nothing. The run's single completion frame is not
+  // sent until this resolves, and the orchestrator now gives the panel a 5 s
+  // grace before it synthesises a completion of its own from ComfyUI history
+  // (comfyui-mcp `DEFAULT_SYNTHESIS_GRACE_MS`, cut from 45 s on the stated
+  // assumption that "the normal path lands within a second or two"). For a
+  // VIDEO that assumption does not hold: measured on this repo's rig, sampling
+  // alone is ~1–2 s for a 5–20 s 960×544 h264 clip, and the two PNG encodes
+  // stall into the seconds often enough to have been caught in a three-run
+  // sample. When the orchestrator wins that race the notice it synthesises
+  // CANNOT carry the video — an .mp4 is deliberately named-but-not-attached
+  // (comfyui-mcp#1861) — so the storyboard is the only thing that ever shows
+  // the agent this render, and it arrives late or not at all. Hence: nothing
+  // that only the USER's card needs may be awaited here, and every round trip
+  // that can overlap the decode does.
   const produce = async () => {
     try {
-      const blob = await buildVideoStoryboard(imageViewUrl(m));
+      // The video's own byte size is wanted only for the note's metadata line.
+      // Start its HEAD (bounded at 8 s inside fetchImageBytes) BEFORE the
+      // sampling pass so the round trip overlaps the decode instead of being
+      // serialised behind the sheet upload. On a remote target (a pod) that is a
+      // whole network round trip taken off the completion's critical path; the
+      // note is identical either way.
+      // Called directly, not behind a `Promise.resolve().then(…)` hop: the point
+      // is that the request is IN FLIGHT while the decode runs, and a microtask
+      // hop would let the sampling pass start first. The try/catch covers a
+      // helper that throws synchronously; the `.catch` covers a rejection, which
+      // must cost the note its size line and nothing else — inline, the same
+      // rejection fell into the segment's catch and cost the agent the sheet.
+      let sizeBytes;
+      try {
+        sizeBytes = Promise.resolve(fetchImageBytes(imageViewUrl(m))).catch(() => null);
+      } catch {
+        sizeBytes = Promise.resolve(null);
+      }
+      const produced = await buildVideoStoryboard(imageViewUrl(m));
+      // #1493 — the builder hands back `storyboardFailure({reason})` when it
+      // could not sample the video, and that object is TRUTHY: a bare `!blob`
+      // test sails straight past it and hands a plain object to
+      // uploadBlobToInput, which appends it to a FormData as the string
+      // "[object Object]" and uploads THAT as `storyboard_<name>.png`. The agent
+      // is then shown a "20-frame storyboard" that is not an image and asked to
+      // review its motion and sharpness.
+      //
+      // The builder's own comment says "produceSheet is the only consumer and
+      // does exactly that". It was not the only consumer — this is the second
+      // one, and it was the one that did not check, which is why the warning was
+      // worth nothing here. Recognise SUCCESS positively, on the same test
+      // produceSheet uses: a sheet is the thing with a numeric `size`. Anything
+      // else — `{reason}`, `{}`, `[]`, a string — is a failure, and the reason it
+      // carries is said out loud instead of being thrown away for the second
+      // time.
+      const asObject = produced != null && typeof produced === "object" ? produced : null;
+      const named = asObject && typeof asObject.reason === "string" ? asObject.reason : null;
+      const blob = asObject && typeof asObject.size === "number" && !named ? produced : null;
       if (!blob) {
-        warn("[cmcp] storyboard: could not sample frames from", m?.filename);
-        return { ref: null, note: noteOnly("couldn't sample a storyboard from it") };
+        warn("[cmcp] storyboard: could not sample frames from", m?.filename, named ?? "");
+        return {
+          ref: null,
+          note: noteOnly(
+            named
+              ? `couldn't sample a storyboard from it: ${named}`
+              : "couldn't sample a storyboard from it",
+          ),
+        };
       }
       const base = (coerceMessageText(m?.filename) || "video").replace(/\.[^.]+$/, "");
       // #209 — the storyboard contact sheet is a PANEL-GENERATED preview, not a
@@ -557,8 +617,32 @@ async function buildVideoSegment(v, deps) {
         warn("[cmcp] storyboard: upload failed for", m?.filename);
         return { ref: null, note: noteOnly("couldn't upload its storyboard") };
       }
-      const n = storyboardFrameCount();
-      const sizeStr = humanizeBytes(await fetchImageBytes(imageViewUrl(m)));
+      // THE GRID'S CAPACITY, which is NOT the number of frames that were
+      // sampled. #648 put the real count on the blob and said, in the builder,
+      // that "callers that describe the sheet must use THIS" — and then this
+      // caller described the sheet with `storyboardFrameCount()` anyway. A video
+      // whose frames refuse to seek paints fewer and leaves the rest BLANK, so
+      // the agent was told it was looking at 20 samples while it was looking at
+      // one sample and nineteen empty cells, and asked to judge motion and
+      // temporal consistency across them.
+      const cells = storyboardFrameCount();
+      const drawn = Number.isFinite(blob.paintedFrames) ? blob.paintedFrames : null;
+      const frames = drawn != null && drawn > 0 ? Math.min(drawn, cells) : null;
+      // Unlike show_media's produceSheet, an unknown count does NOT withhold the
+      // sheet here: this is the run's ONE completion, and dropping the only
+      // viewable representation of the video to avoid an imprecise sentence would
+      // cost the agent far more than the imprecision does. It is described
+      // without a count instead — never with the capacity, which is the claim
+      // that was actually false.
+      const sheetDesc =
+        frames == null
+          ? "storyboard (contact sheet)"
+          : frames < cells
+            ? `${cells}-cell storyboard (contact sheet) holding ${frames} sampled ` +
+              `frame${frames === 1 ? "" : "s"} — the other ${cells - frames} could not be captured and are ` +
+              `BLANK, so judge nothing from them, and the frames that did survive may be clustered ` +
+              `rather than spread across the video`
+            : `${frames}-frame storyboard (contact sheet)`;
       // THE POSTER rides along on the sheet blob (see buildVideoStoryboard), from
       // the same decode. Upload it beside the sheet and hand it back to the card,
       // which has already been painted by the time we get here — the card cannot
@@ -567,16 +651,32 @@ async function buildVideoSegment(v, deps) {
       // Entirely best-effort: a card with no poster keeps the metadata
       // placeholder and the guessed ratio, which is exactly the behaviour before
       // this existed. Nothing below may fail the storyboard for it.
+      //
+      // #1485 — AND IT IS DETACHED, deliberately. The poster is for the USER's
+      // video card; the agent never receives it and no part of this note depends
+      // on it. Awaiting it put a full-resolution PNG encode and a second
+      // `POST /upload/image` (718 KB on the clip measured here, against the
+      // sheet's own 1.7 MB) between the run finishing and the agent being told
+      // it finished. The card is back-filled BY URL — that is the whole reason
+      // this is a back-fill and not an argument — so it lands exactly as it does
+      // today, just without the completion frame waiting behind it. The catch is
+      // what keeps a detached rejection from surfacing as an unhandled one.
       if (blob.posterBlob && typeof applyVideoPoster === "function") {
-        try {
-          const posterRef = await uploadBlobToInput(blob.posterBlob, `poster_${base}.png`, { type: "temp" });
-          if (posterRef) applyVideoPoster(imageViewUrl(m), imageViewUrl(posterRef));
-        } catch (err) {
-          warn("[cmcp] storyboard: poster upload failed:", err);
-        }
+        void Promise.resolve()
+          .then(async () => {
+            const posterRef = await uploadBlobToInput(blob.posterBlob, `poster_${base}.png`, { type: "temp" });
+            if (posterRef) applyVideoPoster(imageViewUrl(m), imageViewUrl(posterRef));
+          })
+          .catch((err) => {
+            warn("[cmcp] storyboard: poster upload failed:", err);
+          });
       }
+      const sizeStr = humanizeBytes(await sizeBytes);
       // Show the user the contact sheet next to the <video> player.
-      paintImage(imageViewUrl(ref), `Storyboard · ${n} frames`);
+      paintImage(
+        imageViewUrl(ref),
+        frames == null ? "Storyboard" : `Storyboard · ${frames} frames`,
+      );
       // #609 — the review request is lawful ONLY when the storyboard pixels
       // actually reach the agent. Blind mode strips them at the sendFrame gate;
       // asking for a visual verdict on a withheld sheet makes a vision-capable
@@ -586,17 +686,17 @@ async function buildVideoSegment(v, deps) {
       // variant says so AFFIRMATIVELY (an explicit prohibition is reliable; a
       // merely-absent request is not) — the sheet is still painted for the user
       // above, so only the agent is blind.
-      const header = `📽️ ${n}-frame storyboard (contact sheet) of ${videoKind} — `;
+      const header = `📽️ ${sheetDesc} of ${videoKind} — `;
       const note =
         header +
         `frames run top-left→bottom-right = start→end. ` +
         `Review motion, sharpness, and temporal consistency.` +
-        metaSuffix(sizeStr, n);
+        metaSuffix(sizeStr, frames);
       const noteWhenBlind =
         header +
         `Blind mode is ON, so the storyboard was NOT sent to you (it is shown to the user). ` +
         `Do not comment on motion, sharpness, or visual quality — acknowledge completion and the metadata below only.` +
-        metaSuffix(sizeStr, n);
+        metaSuffix(sizeStr, frames);
       return { ref, note, noteWhenBlind };
     } catch (err) {
       warn("[cmcp] storyboard pipeline failed:", err);

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -634,15 +634,24 @@ async function buildVideoSegment(v, deps) {
       // cost the agent far more than the imprecision does. It is described
       // without a count instead — never with the capacity, which is the claim
       // that was actually false.
-      const sheetDesc =
+      // The head names the sheet; the disclosure is a SEPARATE sentence. Folding
+      // the blank-cell caveat into the head produced "…spread across the video of
+      // the FINAL saved video (file x.mp4…)", because the head is followed by
+      // `of ${videoKind}` — a garbled sentence in the one place this change exists
+      // to make legible (gate non-finding, fixed rather than shipped).
+      const sheetHead =
         frames == null
           ? "storyboard (contact sheet)"
           : frames < cells
-            ? `${cells}-cell storyboard (contact sheet) holding ${frames} sampled ` +
-              `frame${frames === 1 ? "" : "s"} — the other ${cells - frames} could not be captured and are ` +
-              `BLANK, so judge nothing from them, and the frames that did survive may be clustered ` +
-              `rather than spread across the video`
+            ? `${cells}-cell storyboard (contact sheet)`
             : `${frames}-frame storyboard (contact sheet)`;
+      const blanks = frames == null ? 0 : cells - frames;
+      const blankClause =
+        blanks > 0
+          ? `Only ${frames} of its ${cells} cells hold a sampled frame — the other ${blanks} ` +
+            `${blanks === 1 ? "is" : "are"} BLANK, so judge nothing from ${blanks === 1 ? "it" : "them"}, ` +
+            `and the frames that did survive may be CLUSTERED rather than spread across the video. `
+          : "";
       // THE POSTER rides along on the sheet blob (see buildVideoStoryboard), from
       // the same decode. Upload it beside the sheet and hand it back to the card,
       // which has already been painted by the time we get here — the card cannot
@@ -686,10 +695,11 @@ async function buildVideoSegment(v, deps) {
       // variant says so AFFIRMATIVELY (an explicit prohibition is reliable; a
       // merely-absent request is not) — the sheet is still painted for the user
       // above, so only the agent is blind.
-      const header = `📽️ ${sheetDesc} of ${videoKind} — `;
+      const header = `📽️ ${sheetHead} of ${videoKind} — `;
       const note =
         header +
         `frames run top-left→bottom-right = start→end. ` +
+        blankClause +
         `Review motion, sharpness, and temporal consistency.` +
         metaSuffix(sizeStr, frames);
       const noteWhenBlind =


### PR DESCRIPTION
Fixes #1485.

## What was reported

A `panel_run` that renders an .mp4 (`to_node_id=128`) finished successfully and the panel's completion event never arrived. ~5 s later the orchestrator synthesised a success notice from ComfyUI history — **with no output attached** — so the agent had to recover the file with `list_outputs` + `panel_show_media`. The first filing of this issue saw the same shape at ~45 s, on three prompts.

The issue was closed on 2026-08-20 as already-fixed by #1403/#1739 (a re-pended completion re-arming the reconcile sweep, v0.15.5). It then **recurred on panel 0.15.25**, which contains that fix. So it is not the #1739 loss window.

## What it actually is

Two things that were each individually reasonable and are wrong together.

**1. The orchestrator's grace was cut to 5 s on an assumption that does not hold for video.** `DEFAULT_SYNTHESIS_GRACE_MS` in `comfyui-mcp` went from `45_000` to `5_000`, and the comment justifying it says:

> The normal path lands within a second or two; that is the only race the grace has to win.

For a still, true. For a **video**, the run's single completion frame is not sent until the panel has: sampled the clip in a hidden `<video>`, encoded a contact sheet, uploaded it, encoded a full-resolution poster, uploaded **that**, and taken a HEAD of the video. Measured on this rig (Playwright Chromium, headless *and* headed, ComfyUI on localhost, a real 4.84 s and a 19.36 s 960x544 h264 mp4):

| stage | 4.84 s clip | notes |
|---|---|---|
| `loadedmetadata` | 9-25 ms | |
| sample 20 frames | 1 292-3 220 ms | each seek decodes from the preceding keyframe |
| sheet to PNG | 24 / 33 / **6 711** ms | 1.71 MB; the stall reproduced once in three runs |
| sheet upload | ~7-11 ms | localhost only; 1.71 MB on the wire |
| video size HEAD | 1-2 ms | localhost only; bounded at 8 s in `fetchImageBytes` |
| poster to PNG | 11 / 15 / **1 018** ms | 718 KB |
| poster upload | 3-5 ms | localhost only; 718 KB on the wire |
| **end to end** | **1 352 / 3 296 / 9 706 ms** | three consecutive runs |

Bounded at 25 s by design (`videoStoryboardTimeoutMs`). "A second or two" is not the shape of this path.

**2. When the orchestrator wins that race, its notice cannot carry the video.** comfyui-mcp#1861 made `partitionAttachableMedia` fail **closed**: an `.mp4` from `/history` is *named, never attached*, precisely because the panel's own video ref is normally an uploaded `storyboard_<base>.png`. So for a video run the panel's storyboard is the **only** thing that ever shows the agent the render — and it is the thing arriving late.

That is the reported symptom exactly: successful run, no panel completion, a synthesised notice ~5 s later with no output attached.

## What this PR changes

Everything on that path that is not needed to tell the agent the run finished comes off it, plus two claims the same function was making that were not true.

**The poster is detached.** It decorates the **user's** video card (#1280); the agent never receives it and no part of the note depends on it. Awaiting it put a full-resolution PNG encode plus a second `POST /upload/image` between the run finishing and the agent being told. The card is back-filled *by URL* — that is why it is a back-fill and not an argument — so it lands exactly as it does today, just not in front of the completion.

**The video's size HEAD is issued before the sampling pass**, not after the sheet upload, so its round trip overlaps the decode. On a remote target (a pod) that is a whole network round trip off the critical path, for one metadata line. Called directly rather than behind a `Promise.resolve().then(...)` hop, because a microtask hop lets sampling start first — the test asserts the ordering.

**`storyboardFailure({reason})` is handled.** It is **truthy**, so `if (!blob)` sailed straight past it and handed a plain object to `uploadBlobToInput`, which appends it to a `FormData` as the string `"[object Object]"` and uploads *that* as `storyboard_<name>.png`. The agent was then shown a "20-frame storyboard" that is not an image and asked to review its motion and sharpness. Success is now recognised **positively**, on the same test `produceSheet` already uses (a sheet is the thing with a numeric `size`), and the reason #1493 built is said out loud instead of discarded a second time.

The builder's own comment said *"`produceSheet` is the only consumer and does exactly that."* It was not the only consumer. `buildVideoSegment` is the second, and it was the one that did not check. The comment now counts its callers instead of remembering them.

**The note describes the frames that PAINTED, not the grid's capacity.** #648 put the real count on the blob and told callers to use it; this caller used `storyboardFrameCount()`, so a sheet holding one frame and nineteen blank cells was announced to the agent as twenty samples. A degraded sheet now discloses how many cells are blank and that the survivors may be clustered; a full sheet reads exactly as before.

## The existing suite was pinning the first defect

`makeFrameDeps`' storyboard double was `{ fake: "blob" }` — truthy, **not** a Blob, i.e. the failure shape — and four tests asserted that it got uploaded and described as a sheet. The double now models a Blob (`{ size, paintedFrames }`); every assertion around it is unchanged. No assertion was loosened.

## Evidence

- `browser_tests/unit/run-completion-video-segment.test.mjs` — 7 tests driving the **real** `composeRunCompletionFrame` with injected deps, not source-regex pins.
- **Mutation-verified.** Each fix reverted in turn; the test that names it went red:
  - revert the `size`/`reason` test: *"a storyboard FAILURE object is never uploaded as if it were a sheet"* fails
  - revert `paintedFrames`: *"the note describes the frames actually PAINTED"* fails
  - re-`await` the poster: *"the completion frame does not wait for the card's poster"* fails **by hanging to the 25 s segment timeout** (run under `--test-timeout 20000`, or it hangs silently)
  - re-inline the HEAD: both HEAD tests fail
- Full unit suite: **6172 pass, 0 fail** (`node --test browser_tests/unit/*.test.mjs`), plus i18n, i18n-render, tool-vocabulary and panel-scope gates all OK.

## Browser gate — RUN, against this branch's exact bytes

**Correction to an earlier revision of this body, which said the suite could not be run.** That was true of the route I first tried and false in general, and the difference matters, so both are recorded:

- The shared ComfyUI on `:8188` resolves the `custom_nodes` **junction at startup**. I re-pointed it at this worktree and the server still served the main checkout's file (28 317 bytes, no `1485` marker) — verified over HTTP with a cache-buster. Junction restored to its original target. That route needs a ComfyUI restart, which would break another agent's run mid-flight.
- The route that works: the `ap-1` slot on `:8211` mounts the pack as a real **git worktree**, so `git checkout --detach <sha>` swaps the served files with no restart. Confirmed the served file was this branch's exact bytes before running (34 747 bytes, `1485` marker present) and that it reverted when checked back to main. The slot was restored to its original HEAD (`adf23a05`, clean tree) afterwards.

| run | code under test | result |
|---|---|---|
| full suite, 81 specs | this branch (`f720c377`) | **63 passed, 18 failed** (9.3 m) |
| the 7 affected spec files, 21 tests | `origin/main` (`869362ec`), same slot | **3 passed, 18 failed** (5.1 m) |

The two failure sets are **identical** — same 18 test IDs, `comm -23` between them is empty. Nothing fails on this branch that does not already fail on `main`. All 18 are MockBridge/session specs (`conversation-persistence`, `chat-history-v2`, `workflow-chat-identity`, `streaming-render`, `hidden-tab`, `pending-queue`, `external-orchestrator`) and none of them touch the completion composer. A separate `main` baseline captured earlier today by another session lists the same set plus one (`agent-drive.spec.ts:113:7`), which passed in my run.

Worth stating: the suite has **no coverage of this path** — zero of the 81 specs mention `storyboard`, `composeRunCompletionFrame`, `paintVideo` or `.mp4`. So this run is a no-regression result, not evidence for the fix. The evidence for the fix is the unit tests and their mutations.

The latency measurements in the table above are from real Chromium (Playwright, headless *and* headed) against a real ComfyUI output file — they measure the pipeline, not the panel's wiring.

## What this deliberately does NOT do

- **It does not guarantee the panel wins a 5 s grace.** Sampling alone is ~1-2 s before any of the above. This removes an encode, an upload and a round trip from the critical path and stops two false claims; it does not make a browser-side video decode fast.
- **It does not touch the sampling loop.** A single forward decode pass (`requestVideoFrameCallback` at `playbackRate` 16) measured 1.22 s vs 1.76-1.96 s of seeking on the 19.36 s clip, and 0.37 s vs 1.05-1.76 s on the 4.84 s clip — a real but bimodal 1.4x-3x win that also fills only 18-19 of 20 cells at that rate and depends on a background tab presenting frames. That is a rewrite of the DOM closure justified only by a variable measurement, so it is written down here rather than shipped on the back of this fix.
- **It does not change the sheet's codec.** WebP encoded the same canvas in 57-68 ms at 147 KB vs PNG's 1.71 MB — but with renderer throttling disabled PNG was usually 24-35 ms, so the win is an intermittent stall, not a reliable cost. Not shipping a wire-format change on a bimodal measurement.
- **It does not touch the orchestrator.** The other half of this is `comfyui-mcp`'s: either the grace accounts for a video completion, or the synthesised notice attaches something viewable for an `.mp4`. Written up on the issue.

## Review

**grok was asked first** (PR comment above, naming the risky parts) and did not answer within ~1 h 20 m. Rather than stall, I ran the repo's own adversarial gate.

### `claude-gate.mjs` — verdict: **SHIP**

**SUBSTITUTED REVIEW — disclose this on the PR** (the gate prints that line itself; this is that disclosure). It is not codex and not grok. It spawns a fresh session that has never seen the implementation, hands it the diff plus the repo's `review-taxonomy.md`, and tells it to refute and to RUN the code. It reads more and executes less than codex would. It is a fallback, not an equal.

What it did:

- Independently re-counted the builder's consumers (`media-preview.js:875`, `run-completion-frame.js:578`) and confirmed the corrected comment.
- **Ran 5 mutations, all killed**: bare `!blob`, capacity-for-painted, re-awaited poster, inlined HEAD, always-plural.
- **A/B'd `HEAD~2` vs `HEAD` over 25 hostile inputs.** Every divergence is old-worse: the old code uploaded `[]`, `{}`, `"oops"` and `{reason:{...}}` as `[object Object]` PNGs, and dropped the entire sheet whenever `fetchImageBytes` threw, rejected, or was absent. **Nothing regressed.** No unhandled rejections in any case, including a rejecting detached poster upload and a throwing `applyVideoPoster`.
- Confirmed the detached poster keys `_videoPosters` by video URL and prunes `!holder.isConnected`, and that the late-resolve case back-fills the correct URL pair — my question 1.
- Confirmed `produceSheet` uses the identical numeric-`size` test, and that `fetchImageBytes` really is bounded at 8 s — my questions 2 and 4.
- Confirmed production reachability at `comfyui-mcp-panel.js:34529-34539` against a real `Blob`.

**It also found two prose defects and filed them as non-findings** — by reading the *generated string* rather than the branch:

1. at `frames === cells - 1` the note read "the other 1 **are** BLANK";
2. the degraded head ran into the filename as "...spread across the video **of the FINAL saved video** (file clip.mp4 ...)".

Both were grammar and both still stated the correct fact, so the gate was right not to block on them. **I fixed them anyway** (`8e99ff1c`): this PR exists to stop the completion note making garbled or false claims to the agent, so shipping a garbled one would be the wrong lesson. The head now names the sheet and flows into the file; the caveat is its own sentence. Two further tests pin the boundaries the plural rule and the clamp actually get wrong (`cells - 1`, and a `paintedFrames` above capacity).

The gate was then **re-run on the rebased head**, so the verdict names the SHA that merges rather than an earlier one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

