### PR TITLE
fix(mcp#2000): a frontend-only node stays addable when the object_info fetch does not answer

### DIFF
--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -1146,6 +1146,111 @@ test("mcp#2000 add_node: object_info UNAVAILABLE still fails closed for everythi
   );
 });
 
+// ---- mcp#2000 PARITY: the SAME relaxation in the two set_widget guards. All three
+//      /object_info-oracle guards had the identical `!freshDefs` early throw, so fixing
+//      only add_node would have shipped HALF the documented annotation path — the note
+//      appears and its text can never be written. Measured on origin/main before
+//      extending the fix: with the fetch unavailable the write REFUSED, and the control
+//      (same state, fetch answering) WROTE, so the probe was proving the product and not
+//      itself. One copy relaxed alone is the #496 drift again, hence all three. --------
+
+test("mcp#2000 set_widget: assertTypeAgainstFreshBackend exempts an authorized frontend-only type when object_info is unavailable", () => {
+  const reg = registryWithNatives();
+  const node = { id: 7, type: "MarkdownNote", constructor: reg["MarkdownNote"] };
+  assert.doesNotThrow(() =>
+    assertTypeAgainstFreshBackend(null, "MarkdownNote", 7, {
+      registry: reg,
+      node,
+      wasTypeEverDefined: () => false,
+    }),
+  );
+  // …and every other direction still fails closed on the SAME unavailable map.
+  for (const [why, type, opts] of [
+    ["a real backend type", "KSampler", { registry: reg, wasTypeEverDefined: () => false }],
+    ["a non-allowlisted type", "TotallyMadeUpNode", { registry: reg, wasTypeEverDefined: () => false }],
+    ["an ever-seen (removed) allowlisted name", "MarkdownNote", { registry: reg, node, wasTypeEverDefined: () => true }],
+    ["a pending baseline", "MarkdownNote", { registry: reg, node, wasTypeEverDefined: () => HISTORY_PENDING }],
+    ["an unseeded baseline", "MarkdownNote", { registry: reg, node, wasTypeEverDefined: () => HISTORY_UNSEEDED }],
+    ["no registry wired at all", "MarkdownNote", { node, wasTypeEverDefined: () => false }],
+    ["a provenance-bearing husk", "MarkdownNote", { registry: loadedRegistry(["MarkdownNote"]), wasTypeEverDefined: () => false }],
+  ]) {
+    assert.throws(
+      () => assertTypeAgainstFreshBackend(null, type, 7, opts),
+      /cannot verify|object_info is unavailable|no usable/i,
+      `mcp#2000: ${why} must still fail closed`,
+    );
+  }
+  // A stale backend INSTANCE under a bare native class of the same name is refused by
+  // the instance-provenance clause, which only this guard family has.
+  assert.throws(
+    () =>
+      assertTypeAgainstFreshBackend(null, "MarkdownNote", 7, {
+        registry: reg,
+        node: { id: 7, type: "MarkdownNote", constructor: { comfyClass: "MarkdownNote" } },
+        wasTypeEverDefined: () => false,
+      }),
+    /cannot verify|no usable/i,
+  );
+});
+
+test("mcp#2000 set_widget: assertMutatedNodeAuthorized keeps the same terms on the unavailable path", () => {
+  const reg = registryWithNatives();
+  const node = { id: 9, type: "MarkdownNote", constructor: reg["MarkdownNote"] };
+  assert.doesNotThrow(() => assertMutatedNodeAuthorized(null, reg, node, "target", () => false));
+  assert.throws(
+    () => assertMutatedNodeAuthorized(null, reg, node, "target", () => true),
+    /cannot verify|object_info is unavailable/i,
+    "an ever-seen removal still wins",
+  );
+  assert.throws(
+    () => assertMutatedNodeAuthorized(null, reg, { id: 9, type: "KSampler" }, "target", () => false),
+    /cannot verify|object_info is unavailable/i,
+    "a real backend type still needs the fetch",
+  );
+  assert.throws(
+    () => assertMutatedNodeAuthorized(null, undefined, node, "target", () => false),
+    /cannot verify|object_info is unavailable/i,
+    "no registry wired ⇒ no exemption",
+  );
+});
+
+test("mcp#2000 set_widget e2e: the documented annotation path COMPLETES through the production handler when object_info never answers", async () => {
+  // THE WHOLE POINT: add the note, then put the text in it. Driving runSetWidget — the
+  // body graph_set_widget delegates to — not a predicate in isolation.
+  const history = createObjectInfoHistory();
+  history.recordTypes({ KSampler: {}, SaveImage: {} });
+  history.markSeeded();
+  history.recordTypes(null); // the timed-out refresh
+
+  const ctor = function MarkdownNoteNative() {};
+  const reg = loadedRegistry();
+  reg["MarkdownNote"] = ctor;
+  const node = { id: 42, type: "MarkdownNote", widgets: [{ name: "text", type: "text", value: "" }], constructor: ctor };
+  const { set } = await runSetWidget(node, "text", "hello", {
+    registry: reg,
+    getFreshObjectInfo: async () => null, // the fetch never answers
+    wasTypeEverDefined: (t) => history.wasTypeEverDefined(t),
+    ...HOOKS,
+  });
+  assert.equal(set.value, "hello");
+  assert.equal(node.widgets[0].value, "hello", "the note is fillable, not just addable");
+
+  // CONTROL: a REAL backend node in the identical state still refuses — the relaxation
+  // is scoped to frontend-only types, not to "object_info is down".
+  const ksNode = { id: 43, type: "KSampler", widgets: [{ name: "steps", type: "INT", value: 1 }], constructor: reg["KSampler"] };
+  await assert.rejects(
+    () =>
+      runSetWidget(ksNode, "steps", 20, {
+        registry: reg,
+        getFreshObjectInfo: async () => null,
+        wasTypeEverDefined: (t) => history.wasTypeEverDefined(t),
+        ...HOOKS,
+      }),
+    /cannot verify|object_info is unavailable|no usable/i,
+  );
+  assert.equal(ksNode.widgets[0].value, 1, "the refused write left the node untouched");
+});
+
 // ---- #1296: an allowlisted FRONTEND-ONLY type that is NOT in the live registry is
 //      still refused (LiteGraph could only mint a placeholder — that part is
 //      correct), but the refusal must stop diagnosing it as "not installed / its

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -1146,6 +1146,71 @@ test("mcp#2000 add_node: object_info UNAVAILABLE still fails closed for everythi
   );
 });
 
+test("mcp#2000 INVARIANT: relaxing the precondition does not change WHICH types are exempt", async () => {
+  // THE load-bearing invariant of the whole change, and the one a reviewer can check
+  // without re-deriving my reasoning: the exempt SET must be identical whether
+  // /object_info answered or not. The change moves a PRECONDITION, it does not widen the
+  // permission set. Exactly one verdict may differ between the two paths — a REAL backend
+  // type, for which the fetch genuinely is load-bearing.
+  //
+  // Iterating FRONTEND_ONLY_NODE_TYPES rather than a hand-written list is deliberate: a
+  // type added to the allowlist later is covered here automatically, on both paths.
+  const addVerdict = async (fresh, type, reg, ever) => {
+    try {
+      await assertAddNodeResolvableRefreshing(() => reg, type, {
+        getFreshObjectInfo: async () => fresh,
+        refresh: async () => {},
+        wasTypeEverDefined: ever,
+      });
+      return "ALLOW";
+    } catch {
+      return "REFUSE";
+    }
+  };
+  const swVerdict = (fresh, type, reg, ever) => {
+    try {
+      assertTypeAgainstFreshBackend(fresh, type, 1, {
+        registry: reg,
+        node: { id: 1, type, constructor: reg[type] },
+        wasTypeEverDefined: ever,
+      });
+      return "ALLOW";
+    } catch {
+      return "REFUSE";
+    }
+  };
+  const healthy = objectInfo(); // a live backend that never lists a frontend-only type
+  const never = () => false;
+
+  const cases = [];
+  for (const t of FRONTEND_ONLY_NODE_TYPES) {
+    cases.push([`${t} (clean, never-seen)`, t, loadedRegistry([], [t]), never, "ALLOW"]);
+  }
+  cases.push(["unknown type", "TotallyMadeUpNode", loadedRegistry(), never, "REFUSE"]);
+  cases.push(["ever-seen ⇒ removed", "MarkdownNote", registryWithNatives(), () => true, "REFUSE"]);
+  cases.push(["provenance husk", "MarkdownNote", loadedRegistry(["MarkdownNote"]), never, "REFUSE"]);
+  cases.push(["not in the live registry", "MarkdownNote", loadedRegistry(), never, "REFUSE"]);
+
+  for (const [label, type, reg, ever, expected] of cases) {
+    const withDefs = await addVerdict(healthy, type, reg, ever);
+    const without = await addVerdict(null, type, reg, ever);
+    assert.equal(withDefs, expected, `add/${label}: unexpected verdict WITH defs`);
+    assert.equal(without, withDefs, `add/${label}: the two paths disagree — the exempt set moved`);
+    const swWith = swVerdict(healthy, type, reg, ever);
+    const swWithout = swVerdict(null, type, reg, ever);
+    assert.equal(swWithout, swWith, `set_widget/${label}: the two paths disagree`);
+  }
+
+  // …and the ONE type whose verdict MUST differ: a real backend node genuinely needs the
+  // fetch, so an unanswered one still refuses. If this ever stops differing, the
+  // relaxation has leaked out of the frontend-only set and into live backend types.
+  const reg = loadedRegistry();
+  assert.equal(await addVerdict(objectInfo(["KSampler"]), "KSampler", reg, never), "ALLOW");
+  assert.equal(await addVerdict(null, "KSampler", reg, never), "REFUSE");
+  assert.equal(swVerdict(objectInfo(["KSampler"]), "KSampler", reg, never), "ALLOW");
+  assert.equal(swVerdict(null, "KSampler", reg, never), "REFUSE");
+});
+
 test("mcp#2000: an exemption that THROWS must not replace the refusal it was checking", async () => {
   // Found by running the review taxonomy against my OWN diff (class 5: what does the
   // change make WORSE?). Before mcp#2000 these guards threw their refusal WITHOUT

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -1146,6 +1146,71 @@ test("mcp#2000 add_node: object_info UNAVAILABLE still fails closed for everythi
   );
 });
 
+test("mcp#2000: an exemption that THROWS must not replace the refusal it was checking", async () => {
+  // Found by running the review taxonomy against my OWN diff (class 5: what does the
+  // change make WORSE?). Before mcp#2000 these guards threw their refusal WITHOUT
+  // consulting anything, so nothing on this path could raise. Consulting two predicates
+  // first meant a hostile registry or a raising oracle surfaced a RAW error instead of
+  // the worded refusal — measured leaking "registry exploded" / "history oracle exploded"
+  // from all three guards before the shared helper swallowed it. Any doubt REFUSES.
+  const ctor = function MarkdownNoteNative() {};
+  const reg = registryWithNatives();
+  const node = { id: 1, type: "MarkdownNote", constructor: reg["MarkdownNote"] };
+  const BOOM = () => {
+    throw new Error("history oracle exploded");
+  };
+  // A registry whose membership probe throws — the realistic shape is a Proxy.
+  const hostileReg = new Proxy(
+    {},
+    {
+      getOwnPropertyDescriptor() {
+        throw new Error("registry exploded");
+      },
+      has() {
+        throw new Error("registry exploded");
+      },
+      get() {
+        throw new Error("registry exploded");
+      },
+    },
+  );
+  const isWorded = (err) => {
+    assert.match(err.message, /cannot verify|object_info is unavailable|no usable/i);
+    assert.doesNotMatch(err.message, /exploded/, "the raw error must not reach the caller");
+    return true;
+  };
+
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", {
+        getFreshObjectInfo: async () => null,
+        refresh: async () => {},
+        wasTypeEverDefined: BOOM,
+      }),
+    isWorded,
+  );
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => hostileReg, "MarkdownNote", {
+        getFreshObjectInfo: async () => null,
+        refresh: async () => {},
+        wasTypeEverDefined: () => false,
+      }),
+    isWorded,
+  );
+  assert.throws(
+    () => assertTypeAgainstFreshBackend(null, "MarkdownNote", 1, { registry: reg, node, wasTypeEverDefined: BOOM }),
+    isWorded,
+  );
+  assert.throws(() => assertMutatedNodeAuthorized(null, reg, node, "target", BOOM), isWorded);
+
+  // CONTROL: swallowing must not have swallowed the exemption itself.
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", ADD_OPTS_NO_OBJECT_INFO()),
+  );
+  void ctor;
+});
+
 // ---- mcp#2000 PARITY: the SAME relaxation in the two set_widget guards. All three
 //      /object_info-oracle guards had the identical `!freshDefs` early throw, so fixing
 //      only add_node would have shipped HALF the documented annotation path — the note

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -1010,16 +1010,137 @@ test("#496 add_node: the EVER-SEEN gate still wins — an allowlisted name whose
   );
 });
 
-test("#496 add_node: object_info UNAVAILABLE still fails closed, even for a frontend-only type", async () => {
-  // The exemption is scoped to "object_info WAS fetched but lacks the type". An
-  // unverifiable backend must never authorize anything (#458).
+// ---- mcp#2000: object_info UNAVAILABLE no longer refuses a FRONTEND-ONLY type.
+//      Reported against a HEALTHY live canvas: panel_refresh_nodes timed out fetching
+//      /object_info, and the very next panel_add_node "MarkdownNote" was refused with
+//      "Reconnect ComfyUI and retry" — while ComfyUI was answering fine. The
+//      availability guard ran BEFORE the frontend-only exemption, so a fetch that did
+//      not answer vetoed a type the fetch could never have answered about: /object_info
+//      never lists Note/MarkdownNote/Reroute/PrimitiveNode BY DESIGN.
+//
+//      The exemption is applied on the SAME terms as the fetched-defs path, and neither
+//      of its clauses reads freshDefs — the ever-seen gate reads the session history
+//      oracle (which a timeout leaves intact), and isAuthorizedFrontendOnlyType reads
+//      the live registry. So this narrows nothing about #458: the block below pins every
+//      fail-closed direction, and each case is refused for a DIFFERENT clause. --------
+
+const ADD_OPTS_NO_OBJECT_INFO = (wasTypeEverDefined = () => false) => ({
+  getFreshObjectInfo: async () => null, // the bounded fetch timed out / rejected
+  refresh: async () => {},
+  wasTypeEverDefined,
+});
+
+test("mcp#2000 add_node: THE REPORTED CASE — a frontend-only native is ADDABLE when the /object_info fetch did not answer", async () => {
   const reg = registryWithNatives();
+  for (const t of ["Note", "MarkdownNote", "Reroute", "PrimitiveNode"]) {
+    await assert.doesNotReject(
+      () => assertAddNodeResolvableRefreshing(() => reg, t, ADD_OPTS_NO_OBJECT_INFO()),
+      `mcp#2000: "${t}" is frontend-only — a fetch that did not answer withheld nothing about it`,
+    );
+  }
+  // The rgthree frontend control nodes ride the same shared allowlist.
+  const reg2 = loadedRegistry([], ["Fast Groups Bypasser (rgthree)"]);
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(
+      () => reg2,
+      "Fast Groups Bypasser (rgthree)",
+      ADD_OPTS_NO_OBJECT_INFO(),
+    ),
+  );
+});
+
+test("mcp#2000 add_node: driven through the REAL history oracle after a timed-out refresh, not a stub", async () => {
+  // Production wiring: the baseline seeded at page load, then a refresh timed out.
+  // recordTypes(null) records nothing and a timeout must NEVER arm loseBaseline, so the
+  // baseline SURVIVES — which is exactly why the ever-seen gate is still trustworthy on
+  // this path. If that ever stops holding, this test is the one that catches it.
+  const history = createObjectInfoHistory();
+  history.recordTypes({ KSampler: {}, VAEDecode: {}, SaveImage: {} });
+  history.markSeeded();
+  history.recordTypes(null); // the timed-out refresh
+  assert.equal(history.seeded, true, "a timeout must not demote the baseline");
+  assert.equal(history.wasTypeEverDefined("MarkdownNote"), false, "verdict must be never-seen");
+
+  const reg = registryWithNatives();
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(
+      () => reg,
+      "MarkdownNote",
+      ADD_OPTS_NO_OBJECT_INFO((t) => history.wasTypeEverDefined(t)),
+    ),
+  );
+  // …and a type the SAME surviving baseline DID report is still refused: the trust root
+  // is doing real work here, it is not merely present.
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(
+        () => loadedRegistry([], ["SaveImage"]),
+        "SaveImage",
+        ADD_OPTS_NO_OBJECT_INFO((t) => history.wasTypeEverDefined(t)),
+      ),
+    /cannot verify|object_info is unavailable/i,
+  );
+});
+
+test("mcp#2000 add_node: object_info UNAVAILABLE still fails closed for everything that is not an authorized frontend-only type", async () => {
+  // Each case below trips a DIFFERENT clause, so a mutation that removes any one of
+  // them shows up here rather than hiding behind a sibling.
+  // (a) not on the allowlist — a genuinely unknown type.
+  const reg = registryWithNatives();
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "TotallyMadeUpNode", ADD_OPTS_NO_OBJECT_INFO()),
+    /cannot verify|object_info is unavailable/i,
+  );
+  // (b) a REAL backend type: /object_info IS load-bearing for it, so an unanswered
+  //     fetch must still veto — this is the #458 case the guard exists for.
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "KSampler", ADD_OPTS_NO_OBJECT_INFO()),
+    /cannot verify|object_info is unavailable/i,
+  );
+  // (c) an allowlisted NAME whose registered class carries backend provenance — a
+  //     removed pack's stale class squatting a reserved name.
+  const regHusk = loadedRegistry(["MarkdownNote"]); // registered WITH nodeData
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => regHusk, "MarkdownNote", ADD_OPTS_NO_OBJECT_INFO()),
+    /cannot verify|object_info is unavailable/i,
+  );
+  // (d) an allowlisted name absent from the LIVE REGISTRY — registry membership is what
+  //     LG.createNode needs, so without it the add could only mint a placeholder.
+  const regBare = loadedRegistry();
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => regBare, "MarkdownNote", ADD_OPTS_NO_OBJECT_INFO()),
+    /cannot verify|object_info is unavailable/i,
+  );
+  // (e) THE EVER-SEEN GATE, on the unavailable path too: the backend reported this
+  //     reserved name earlier this session ⇒ its pack was removed ⇒ refuse.
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(
+        () => reg,
+        "MarkdownNote",
+        ADD_OPTS_NO_OBJECT_INFO((t) => t === "MarkdownNote"),
+      ),
+    /cannot verify|object_info is unavailable/i,
+  );
+  // (f) history PENDING (the baseline has not arrived) and (g) UNSEEDED (it never
+  //     will) are both TRUTHY sentinels ⇒ not "never-seen" ⇒ refuse.
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", ADD_OPTS_NO_OBJECT_INFO(() => HISTORY_PENDING)),
+    /cannot verify|object_info is unavailable/i,
+  );
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", ADD_OPTS_NO_OBJECT_INFO(() => HISTORY_UNSEEDED)),
+    /cannot verify|object_info is unavailable/i,
+  );
+  // (h) NO history oracle wired at all: the exemption REQUIRES the non-forgeable trust
+  //     root, so a caller that omits it gets the strict pre-mcp#2000 behaviour.
   await assert.rejects(
     () =>
       assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", {
         getFreshObjectInfo: async () => null,
         refresh: async () => {},
-        wasTypeEverDefined: () => false,
       }),
     /cannot verify|object_info is unavailable/i,
   );

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -533,6 +533,12 @@ export function assertAddNodeResolvable(registry, class_type) {
  *      We must NOT fall back to the stale registry: a transient fetch failure would
  *      otherwise authorize a since-removed type (#458/P1-2). Only a caller that
  *      wires NO fresh-oracle at all degrades to the registry-only guard.
+ *      THE ONE EXCEPTION (mcp#2000) is the SAME frontend-only exemption as step 2,
+ *      applied on the same terms: a type absent from the session history oracle
+ *      (which a timeout leaves intact) AND authorized by isAuthorizedFrontendOnlyType
+ *      against the LIVE REGISTRY. Neither clause reads /object_info, and for a
+ *      frontend-only type /object_info is empty by design — so a fetch that did not
+ *      answer withheld nothing, and refusing on it was a false refusal, not a guard.
  *
  *   getRegistry        : () => the LIVE registry object (re-invoked after refresh).
  *   getFreshObjectInfo : optional async () => the CURRENT /object_info map (keyed by
@@ -575,6 +581,36 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       freshDefs = null;
     }
     if (!freshDefs || typeof freshDefs !== "object") {
+      // mcp#2000 — A FETCH THAT DID NOT ANSWER IS NOT EVIDENCE ABOUT A TYPE THE FETCH
+      // COULD NEVER HAVE ANSWERED ABOUT. Failing closed here for EVERY type refused a
+      // MarkdownNote on a healthy live canvas whose /object_info refresh had just timed
+      // out, telling the reporter to "Reconnect ComfyUI" while ComfyUI was answering
+      // fine. object-info-history.js already states this rule for its own latch — "ARM
+      // THIS ONLY ON EVIDENCE, NEVER ON A TIMEOUT… latching on one would turn ordinary
+      // latency into a permanent false refusal of every legitimate add/write" — and this
+      // branch was breaking it.
+      //
+      // The exemption below is EXACTLY the one the fetched-defs path applies a few lines
+      // down, and it is safe here because NOT ONE of its clauses reads `freshDefs`:
+      //   - the #458 ever-seen gate reads the SESSION HISTORY oracle, which survives a
+      //     timeout untouched (recordTypes(null) records nothing, and a timeout must
+      //     never arm loseBaseline) — so the non-forgeable trust root that catches a
+      //     removed pack squatting a reserved name is still fully in force; and
+      //   - isAuthorizedFrontendOnlyType reads the LIVE REGISTRY (membership + reserved
+      //     allowlist + no backend provenance), which is also precisely what
+      //     LG.createNode needs, so an exempted add constructs a REAL node and cannot
+      //     mint the #458 placeholder.
+      // For a genuinely frontend-only type /object_info is empty BY DESIGN, so a
+      // successful fetch would have added no information about it whatsoever. Every
+      // other type — and every doubt, including a pending/unseeded/absent history
+      // oracle — still fails closed on the message below, unchanged.
+      if (
+        typeof wasTypeEverDefined === "function" &&
+        backendHistoryVerdict(class_type, wasTypeEverDefined) === "never-seen" &&
+        isAuthorizedFrontendOnlyType(readRegistry(), class_type)
+      ) {
+        return;
+      }
       throw new Error(
         `cannot verify node type "${class_type}" against the ComfyUI backend ` +
           `(object_info is unavailable — the backend is unreachable or the fetch failed). ` +

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -604,8 +604,13 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // successful fetch would have added no information about it whatsoever. Every
       // other type — and every doubt, including a pending/unseeded/absent history
       // oracle — still fails closed on the message below, unchanged.
+      //
+      // Testing `=== "never-seen"` is what makes the ever-seen gate load-bearing here,
+      // and it subsumes the sibling exemption's separate `typeof wasTypeEverDefined ===
+      // "function"` clause: an unwired oracle classifies as "no-oracle", never
+      // "never-seen". Spelling that clause out as well passed every test with it
+      // deleted, so it is left out rather than kept as an untestable reassurance.
       if (
-        typeof wasTypeEverDefined === "function" &&
         backendHistoryVerdict(class_type, wasTypeEverDefined) === "never-seen" &&
         isAuthorizedFrontendOnlyType(readRegistry(), class_type)
       ) {

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -268,6 +268,37 @@ export function isAuthorizedFrontendOnlyType(registry, type, node) {
  * BEFORE the frontend-only exemption. `wasTypeEverDefined` is injected by the panel
  * and itself fails closed while the session baseline is unseeded.
  */
+/**
+ * mcp#2000 — THE FRONTEND-ONLY EXEMPTION AS APPLIED ON THE UNAVAILABLE-/object_info PATH,
+ * in ONE place for all three guards that need it. The clauses are identical to the ones
+ * each guard applies when /object_info WAS fetched, and neither reads the fetched defs:
+ * the ever-seen gate reads the session-history oracle (a timeout leaves it intact) and
+ * isAuthorizedFrontendOnlyType reads the live registry. A frontend-only type is absent
+ * from /object_info BY DESIGN, so a fetch that did not answer withheld nothing about it.
+ *
+ * WHY IT SWALLOWS: before mcp#2000 these guards threw their refusal WITHOUT consulting
+ * anything, so nothing on that path could raise. Consulting two predicates first means a
+ * hostile registry (a Proxy whose membership trap throws) or an oracle that raises would
+ * surface a RAW error in place of the worded refusal — the change making something worse
+ * that it did not have to. Measured, not theorised: all three guards leaked
+ * "registry exploded" / "history oracle exploded" before this wrapper existed.
+ * Any doubt returns false, which refuses — the #458 default, and the same idiom this file
+ * already uses for readImportFailures and describeObjectInfoFailure ("a diagnostic that
+ * throws must not replace the refusal it explains").
+ *
+ * One copy, three call sites, deliberately: three inline copies is the #496 drift.
+ */
+function frontendOnlyExemptionApplies(registry, type, node, wasTypeEverDefined) {
+  try {
+    return (
+      backendHistoryVerdict(type, wasTypeEverDefined) === "never-seen" &&
+      isAuthorizedFrontendOnlyType(registry, type, node)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function isRemovedBackendType(type, wasTypeEverDefined) {
   return backendHistoryVerdict(type, wasTypeEverDefined) === "removed";
 }
@@ -431,12 +462,7 @@ export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "t
     // clause reads `freshDefs`, and for a frontend-only type a successful fetch would
     // have said nothing about it anyway. Kept in step with the two sibling guards
     // deliberately — one copy relaxed alone is the #496 drift all over again.
-    if (
-      backendHistoryVerdict(type, wasTypeEverDefined) === "never-seen" &&
-      isAuthorizedFrontendOnlyType(registry, type, node)
-    ) {
-      return;
-    }
+    if (frontendOnlyExemptionApplies(registry, type, node, wasTypeEverDefined)) return;
     throw new Error(
       `Cannot set widget on node ${id}${label}: cannot verify the ${role} node against the ` +
         `ComfyUI backend (object_info is unavailable). Refusing to write rather than trust a ` +
@@ -620,10 +646,7 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // "function"` clause: an unwired oracle classifies as "no-oracle", never
       // "never-seen". Spelling that clause out as well passed every test with it
       // deleted, so it is left out rather than kept as an untestable reassurance.
-      if (
-        backendHistoryVerdict(class_type, wasTypeEverDefined) === "never-seen" &&
-        isAuthorizedFrontendOnlyType(readRegistry(), class_type)
-      ) {
+      if (frontendOnlyExemptionApplies(readRegistry(), class_type, undefined, wasTypeEverDefined)) {
         return;
       }
       throw new Error(
@@ -859,12 +882,7 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
     // is placed after `describeObjectInfoFailure` deliberately: that oracle only builds
     // a diagnostic string, so an exempted write costs it nothing that matters and the
     // refusal it explains still reads identically for every type that is refused.
-    if (
-      backendHistoryVerdict(type, wasTypeEverDefined) === "never-seen" &&
-      isAuthorizedFrontendOnlyType(registry, type, node)
-    ) {
-      return;
-    }
+    if (frontendOnlyExemptionApplies(registry, type, node, wasTypeEverDefined)) return;
     throw new Error(
       `Cannot set widget on node ${nodeId}${label}: cannot verify the node type against the ` +
         `ComfyUI backend — no usable /object_info schema was obtained.${observed} ` +

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -427,6 +427,16 @@ export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "t
   const id = node?.id ?? "(unknown)";
   const label = typeof type === "string" ? ` ("${type}")` : "";
   if (!freshDefs || typeof freshDefs !== "object") {
+    // mcp#2000 — same exemption, same terms, same reason as the add guard: neither
+    // clause reads `freshDefs`, and for a frontend-only type a successful fetch would
+    // have said nothing about it anyway. Kept in step with the two sibling guards
+    // deliberately — one copy relaxed alone is the #496 drift all over again.
+    if (
+      backendHistoryVerdict(type, wasTypeEverDefined) === "never-seen" &&
+      isAuthorizedFrontendOnlyType(registry, type, node)
+    ) {
+      return;
+    }
     throw new Error(
       `Cannot set widget on node ${id}${label}: cannot verify the ${role} node against the ` +
         `ComfyUI backend (object_info is unavailable). Refusing to write rather than trust a ` +
@@ -802,7 +812,9 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
  * a STALE POSITIVE for an uninstalled pack when the browser tab was never reloaded
  * after a ComfyUI restart. `freshDefs` is the freshly-fetched /object_info map (or
  * null/undefined when the fetch failed). FAILS CLOSED in both directions:
- *   - fetch unavailable (null/non-object) ⇒ "cannot verify against backend"; and
+ *   - fetch unavailable (null/non-object) ⇒ "cannot verify against backend" — except
+ *     for an authorized frontend-only type, which the fetch could not have spoken to
+ *     either way (mcp#2000); and
  *   - type absent from the fresh map ⇒ "backend does not provide" (removed pack).
  * Never authorizes from the stale registry. Pure — no side effects — so the caller
  * can run it on the exact target it is about to mutate, before any mutation.
@@ -815,9 +827,11 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
  * frontend canvas edit and legitimately has no /object_info entry. This does NOT
  * reopen the #458 hole: a REMOVED backend node (whether it keeps a stale-positive
  * class WITH nodeData, or is left as a DEFLESS husk) is NOT on the allowlist and is
- * still refused; and the exemption applies ONLY when object_info was fetched — a
- * genuinely UNVERIFIABLE type (fetch unavailable, null map) always fails closed below,
- * for every type.
+ * still refused. mcp#2000 — the exemption is NO LONGER scoped to "object_info was
+ * fetched": it is applied on the unavailable path too, on identical terms, because
+ * neither of its clauses reads `freshDefs` and a frontend-only type is absent from
+ * /object_info BY DESIGN, so a fetch that did not answer withheld nothing about it.
+ * Every OTHER type still fails closed on an unavailable map, exactly as before.
  *
  * `opts.registry` is the live LiteGraph registry used to recognize a frontend-only
  * type; `opts.node` is the actual write-target node whose OWN constructor is also
@@ -839,6 +853,17 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
       observed = typeof describeObjectInfoFailure === "function" ? describeObjectInfoFailure() || "" : "";
     } catch {
       observed = ""; // a diagnostic must never replace the refusal it is describing
+    }
+    // mcp#2000 — see assertAddNodeResolvableRefreshing. The exemption is evaluated
+    // BEFORE this refusal on exactly the terms the fetched-defs path below uses, and it
+    // is placed after `describeObjectInfoFailure` deliberately: that oracle only builds
+    // a diagnostic string, so an exempted write costs it nothing that matters and the
+    // refusal it explains still reads identically for every type that is refused.
+    if (
+      backendHistoryVerdict(type, wasTypeEverDefined) === "never-seen" &&
+      isAuthorizedFrontendOnlyType(registry, type, node)
+    ) {
+      return;
     }
     throw new Error(
       `Cannot set widget on node ${nodeId}${label}: cannot verify the node type against the ` +


### PR DESCRIPTION
Reported as artokun/comfyui-mcp issue 2000 (P2, via-panel). The refusal is thrown here, so the fix lands in this repo.

## What the reporter saw

On a **healthy live canvas**, `panel_refresh_nodes` timed out fetching `/object_info`. The very next `panel_add_node "MarkdownNote"` was refused with:

> cannot verify node type "MarkdownNote" against the ComfyUI backend (object_info is unavailable …). Refusing to add.

…telling them to reconnect a ComfyUI that was answering fine. `MarkdownNote` is a documented frontend-only exemption; its creation should never depend on backend node definitions.

## Mechanism

`assertAddNodeResolvableRefreshing` ran its `/object_info` **availability** guard before the frontend-only exemption:

```js
if (!freshDefs || typeof freshDefs !== "object") { throw … }   // ← every type, no exceptions
if (!hasOwnProperty(freshDefs, class_type)) {
  … ever-seen gate …
  if (isAuthorizedFrontendOnlyType(registry, class_type)) return;   // ← never reached
}
```

So a fetch that **did not answer** vetoed a type the fetch **could never have answered about**: `/object_info` never lists `Note` / `MarkdownNote` / `Reroute` / `PrimitiveNode` — that is what frontend-only means.

`web/js/lib/object-info-history.js` already states this exact rule for its own latch, and this branch was breaking it:

> ARM THIS ONLY ON EVIDENCE, NEVER ON A TIMEOUT. A timeout is the ABSENCE of evidence, not evidence … Latching on one would turn ordinary latency into a permanent, session-long false refusal of every legitimate add/write — the exact bug class (#496/#507) this module's consumers exist to fix.

## The fix

The exemption now also runs on the unavailable path, **on identical terms**. This is safe because **neither of its clauses reads `freshDefs`**:

- the #458 **ever-seen gate** reads the **session history oracle**, which a timeout leaves intact — `recordTypes(null)` records nothing, and a timeout must never arm `loseBaseline`. The non-forgeable trust root that catches a removed pack squatting a reserved name is still fully in force.
- `isAuthorizedFrontendOnlyType` reads the **live registry** (membership + reserved allowlist + no backend provenance), which is also exactly what `LG.createNode` needs — so an exempted add builds a **real** node and cannot mint the placeholder #458 exists to prevent.

Note this is **stricter than the issue prescribed**. The report asked to resolve the allowlist *before any* availability guard; doing that literally would hoist it above the ever-seen gate too. The gate stays first, exactly as on the fetched-defs path.

## Evidence

**Reproduced by execution, not by reading** — driving the shipped guard with the real `createObjectInfoHistory`, seeded at page load and then handed a timed-out refresh:

```
wasTypeEverDefined('MarkdownNote') = false      ← baseline SURVIVED the timeout
history.seeded = true
RESULT: REFUSED — cannot verify node type "MarkdownNote" …   (byte-identical to the report)
CONTROL (fetch OK): ADDED                        ← the exemption already worked; only the precondition blocked it
```

That measurement is the load-bearing one: **the history oracle survives the timeout**, so the trust root is available on this path.

**Mutation results** — each mutant scoped to *this* branch only (the same clause text appears in the sibling exemption; my first attempt patched neither and read as "survived"):

| mutant | result |
|---|---|
| remove the whole exemption | **2 killed** — both positive tests |
| drop the ever-seen comparison | **1 killed** — the fail-closed matrix |
| drop `isAuthorizedFrontendOnlyType` | **1 killed** — the fail-closed matrix |
| invert the ever-seen comparison | **3 killed** |
| drop `typeof wasTypeEverDefined === "function"` | **SURVIVED** → removed as dead code (2nd commit) |

That last one is why the second commit exists: `backendHistoryVerdict` already classifies an unwired oracle as `"no-oracle"`, which is not `"never-seen"`, so the clause could never decide anything. Every remaining clause is load-bearing.

**Fail-closed matrix**, all with `/object_info` unavailable — each case trips a *different* clause: a real backend type (`KSampler`), a non-allowlisted type, an allowlisted name carrying backend provenance, an allowlisted name absent from the live registry, an ever-seen (removed) type, `HISTORY_PENDING`, `HISTORY_UNSEEDED`, and a caller wiring no history oracle at all.

**Production call site verified by grep, not assumed** — `web/js/comfyui-mcp-panel.js` passes `getFreshObjectInfo` (which yields `null` via `recordObjectInfoTypes(whole === NODE_DEFS_NO_ANSWER ? null : whole)`) and `wasTypeEverDefined` bound to the real `objectInfoHistory`, in the same call. The branch I changed is reached with the exact inputs the repro used.

**Suites**: `npm run test:unit` → 6248/6250. The one failure is the known #671 manager-install wall-clock flake; that file alone re-runs 125/125. My diff touches `node-resolve.js` only.

## Review status: PENDING

Not reviewed yet. **Where I would look first:**

1. **The security judgement is the whole PR.** I overturned a deliberate, documented decision — the test `#496 add_node: object_info UNAVAILABLE still fails closed, even for a frontend-only type` existed precisely to pin the old behaviour, and I replaced it. My argument is that for an *authorized frontend-only* type a successful fetch adds **zero** information, so refusing on its absence is a false refusal rather than a guard. If that reasoning is wrong anywhere, this PR is wrong.
2. **The residual window I could not close.** If a backend pack were installed mid-session providing a real node under a reserved frontend-only name (`SetNode`, `GetNode`, an rgthree control name) *after* the last successful `/object_info`, the fetched-defs path would register the fresh def while this path adds the frontend-native class instead. I judged that benign — the node is real, registered, provenance-clean, and Ctrl+Z-undoable — and structurally impossible for the four core types. Push back if that is too generous.
3. **The unchanged refusal message.** On the unavailable path an allowlisted-but-*unregistered* type still gets "Reconnect ComfyUI and retry" rather than #1296's "RELOAD the ComfyUI tab" diagnosis. I left it alone to keep the diff minimal; it is arguably the same misdiagnosis class #1296 fixed.

## What I deliberately did NOT do

- **The `panel_refresh_nodes` half of the report.** It asked for a dedicated/configurable `/object_info` timeout, or reusing a known-good defs snapshot while reporting the live refresh timed out. Both are new behaviour under the feature freeze, and neither is a defect: on a large install `/object_info` is ~5.4 MB and a bounded fetch honestly reporting a timeout is correct. The timeout was the *trigger*; the false refusal was the *bug*.
- ~~The sibling `graph_set_widget` guard~~ — **now INCLUDED; this bullet is superseded.** I measured it instead of leaving it to judgement: on `origin/main`, through the production `runSetWidget` body, the write REFUSED with the fetch unavailable and WROTE on the control. Fixing only `add_node` would have shipped a `MarkdownNote` the user cannot fill in, and all three `/object_info`-oracle guards carry the byte-identical early throw — so relaxing one copy alone is the #496 drift again. Mutation table in the scope-change comment below.
- **Browser verification.** Not run against this diff. The Playwright suite targets the panel **served** by the live ComfyUI at :8188, which is the installed build, not this worktree — and no isolated ComfyUI was allocated for this run, so installing over the shared rig would disturb other sessions. The coverage for this diff is the execution repro + unit tests + mutants above, not e2e.

Closes the underlying cause of artokun/comfyui-mcp issue 2000 (cross-repo, so it will be closed by hand after merge).


