### PR TITLE
fix(comfyui-mcp#828): free_vram classifies what answered instead of pasting the proxy's error page

### DIFF
--- a/browser_tests/unit/http-failure.test.mjs
+++ b/browser_tests/unit/http-failure.test.mjs
@@ -1,0 +1,366 @@
+// comfyui-mcp#828 (recurrence 2026-08-21) — a panel executor must never paste a
+// response body into the agent's tool result, and `free_vram` must report the
+// backend-socket fact the panel already knows.
+//
+// The report: on a remote target behind Cloudflare, immediately after a ComfyUI
+// restart while the tab's backend socket was reconnecting, `panel_free_vram`
+// surfaced the ENTIRE Cloudflare 502 error document. In the same state
+// `panel_graph_outline` reported `backend_socket:"reconnecting"` — because a
+// `graph_*` command reaches the dispatcher branch that consults
+// `comfyBackendIsDown()`, and `free_vram` does not.
+//
+// What is locked here:
+//   1. The classifier NAMES what answered and never ships the document.
+//   2. It never asserts the socket state it was not told (the #796
+//      unknown-collapse discipline: an unpassed fact stays unsaid).
+//   3. It never claims the operation did or did not run.
+//   4. ADOPTION IS COUNTED, not spot-checked. Every site in the shipped bundle
+//      that captures a response body is enumerated, and none of them may
+//      interpolate that body into an Error unless it goes through
+//      `describeHttpFailure`. A per-site test passes while a NEW bypass ships;
+//      the count is what fails. The scanner is itself verified against the
+//      pre-fix `free_vram` source, so a scanner that silently stopped matching
+//      cannot report a clean sweep.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  classifyHttpFailure,
+  describeHttpFailure,
+  describeHttpStatus,
+  httpBodyPrefix,
+  scrubSecretShapedText,
+  HTTP_FAILURE_BODY_PREFIX_CAP,
+} from "../../web/js/lib/http-failure.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** The reported document, in the shape Cloudflare actually serves it. */
+const CLOUDFLARE_502 = `<!DOCTYPE html>
+<html class="no-js" lang="en-US">
+<head>
+<title>comfy.example.net | 502: Bad gateway</title>
+<meta charset="UTF-8" />
+<meta name="robots" content="noindex, nofollow" />
+<link rel="stylesheet" id="cf_styles-css" href="/cdn-cgi/styles/main.css" />
+<style>body{font-family:system-ui}.cf-error-details{padding:0}</style>
+<script>window.__CF$cv$params={r:'9c7fd0a1e4b23f10',t:'MTc2NzIyMzYwMC4wMDAwMDA='};</script>
+</head>
+<body>
+<div id="cf-wrapper"><div id="cf-error-details">
+<h1><span>Bad gateway</span><span class="code-label">Error code 502</span></h1>
+<div>Visit <a href="https://www.cloudflare.com/5xx-error-landing">cloudflare.com</a> for more information.</div>
+<p><span>Cloudflare Ray ID: <strong>9c7fd0a1e4b23f10</strong></span>
+<span id="cf-footer-item-ip">Your IP: 203.0.113.42</span>
+<span>Performance &amp; security by <a href="https://www.cloudflare.com/">Cloudflare</a></span></p>
+</div></div>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
+// 1. The classification
+// ---------------------------------------------------------------------------
+
+test("a Cloudflare 502 page is classified as a proxy error, not as ComfyUI", () => {
+  assert.equal(
+    classifyHttpFailure({ status: 502, contentType: "text/html; charset=UTF-8", body: CLOUDFLARE_502 }),
+    "proxy-error",
+  );
+});
+
+test("body evidence outranks status: a gateway page that links a sign-in stays a proxy error", () => {
+  const nginxWithLoginFooter = `<!DOCTYPE html><html><head><title>502 Bad Gateway</title></head>
+    <body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx/1.24.0</center>
+    <p>Need access? <a href="/login">Sign in</a></p></body></html>`;
+  assert.equal(classifyHttpFailure({ status: 502, body: nginxWithLoginFooter }), "proxy-error");
+});
+
+test("a sign-in page on a 200 is a login gate", () => {
+  const sso = `<!DOCTYPE html><html><head><title>Sign in</title></head><body>
+    <form action="/login"><input type="password" name="password"></form></body></html>`;
+  assert.equal(classifyHttpFailure({ status: 200, body: sso }), "login");
+});
+
+test("a plain-text 500 is NOT blamed on a proxy — it can be ComfyUI itself", () => {
+  const kind = classifyHttpFailure({ status: 500, contentType: "text/plain", body: "CUDA out of memory" });
+  assert.equal(kind, "not-json");
+  const msg = describeHttpFailure({
+    what: "free VRAM",
+    route: "POST /free",
+    status: 500,
+    contentType: "text/plain",
+    body: "CUDA out of memory",
+  });
+  assert.doesNotMatch(msg, /did not come from ComfyUI/);
+  assert.match(msg, /CUDA out of memory/);
+});
+
+// codex gate round 1, both P1s: this helper runs on ANY not-ok response, unlike
+// the orchestrator's json-guard which only runs after a JSON parse has already
+// failed. A JSON body must therefore end the question before any status rule.
+
+test("a ComfyUI 503 with a JSON body is NOT blamed on a gateway", () => {
+  const body = '{"error":"busy"}';
+  assert.equal(classifyHttpFailure({ status: 503, body }), "json-error");
+  const msg = describeHttpFailure({
+    what: "free VRAM",
+    route: "POST /free",
+    status: 503,
+    contentType: "application/json",
+    body,
+  });
+  assert.doesNotMatch(msg, /did not come from ComfyUI/i);
+  assert.doesNotMatch(msg, /reverse proxy|gateway-class/i);
+  assert.match(msg, /JSON error document saying: busy/);
+});
+
+test("a ComfyUI 401 with a JSON body is NOT blamed on an identity proxy", () => {
+  const body = '{"error":"Unauthorized"}';
+  assert.equal(classifyHttpFailure({ status: 401, body }), "json-error");
+  const msg = describeHttpFailure({ what: "free VRAM", route: "POST /free", status: 401, body });
+  assert.doesNotMatch(msg, /did not come from ComfyUI/i);
+  assert.doesNotMatch(msg, /identity proxy|sign-in|SSO/i);
+  assert.match(msg, /Unauthorized/);
+});
+
+test("a status-only verdict asserts nothing about WHO answered", () => {
+  // A bare 502 with no page is equally consistent with ComfyUI crashing
+  // mid-response; a bare 403 with no page is equally consistent with ComfyUI
+  // behind the operator's own auth layer.
+  for (const status of [502, 403]) {
+    const msg = describeHttpFailure({ what: "free VRAM", route: "POST /free", status, body: "" });
+    assert.doesNotMatch(
+      msg,
+      /did not come from ComfyUI/i,
+      `status ${status} with no body must not name a responder`,
+    );
+    assert.match(msg, new RegExp(String(status)));
+  }
+  // …while a page that CARRIES the markers still does.
+  assert.match(cloudflareMessage(), /did not come from ComfyUI/i);
+});
+
+test("a declared text/html that is not markup does not become an HTML verdict", () => {
+  assert.equal(
+    classifyHttpFailure({ status: 500, contentType: "text/html", body: "boom" }),
+    "not-json",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2. The message: honest, bounded, and free of the document
+// ---------------------------------------------------------------------------
+
+function cloudflareMessage(extra = {}) {
+  return describeHttpFailure({
+    what: "free VRAM",
+    route: "POST /free",
+    status: 502,
+    statusText: "Bad Gateway",
+    contentType: "text/html; charset=UTF-8",
+    body: CLOUDFLARE_502,
+    outcomeUnknownNote:
+      "Nothing in this response shows models were unloaded, and nothing in it shows they were not — the outcome is genuinely UNKNOWN, so the safe working assumption is that the unload did not happen. /free is idempotent, so re-issuing it once ComfyUI answers again cannot double-apply anything and is the right next step.",
+    ...extra,
+  });
+}
+
+test("the proxy document never reaches the caller", () => {
+  const msg = cloudflareMessage();
+  assert.doesNotMatch(msg, /<!DOCTYPE/i, "the document leaked");
+  assert.doesNotMatch(msg, /<\/?(html|head|body|div|span|script|style|link|meta)\b/i, "markup leaked");
+  assert.doesNotMatch(msg, /203\.0\.113\.42/, "the client IP leaked");
+});
+
+test("the message length does not grow with the body — a 500 KB page is not a context bomb", () => {
+  // The invariant is INDEPENDENCE, not "shorter than this fixture": a real
+  // Cloudflare page is kilobytes and an SPA index.html can be megabytes, so
+  // comparing against one small sample would pass while the body still rode along.
+  const huge = CLOUDFLARE_502.replace("</body>", `<p>${"padding ".repeat(80000)}</p></body>`);
+  assert.ok(huge.length > 500_000, "fixture must actually be large");
+  const small = cloudflareMessage({ backendReconnecting: true });
+  const large = cloudflareMessage({ body: huge, backendReconnecting: true });
+  // Bounded ABSOLUTELY: fixed prose + one capped prefix, whatever the body was.
+  assert.ok(large.length < 2000, `message was ${large.length} chars for a ${huge.length}-char body`);
+  // And bounded RELATIVELY: 500 KB of extra body may move the message by at most
+  // the ellipsis the cap adds, never by the padding itself.
+  assert.ok(
+    Math.abs(large.length - small.length) <= 4,
+    `500 KB of body moved the message by ${large.length - small.length} chars`,
+  );
+  assert.doesNotMatch(large, /padding padding/);
+});
+
+test("the failure is NAMED, not swallowed", () => {
+  const msg = cloudflareMessage();
+  assert.match(msg, /Failed to free VRAM/);
+  assert.match(msg, /POST \/free/);
+  assert.match(msg, /\b502\b/);
+  assert.match(msg, /reverse proxy or gateway/i);
+  // A prefix of the page is still carried — it is what lets a human recognise
+  // the page that answered.
+  assert.match(msg, /Body starts:/);
+  assert.match(msg, /502: Bad gateway|Bad gateway/i);
+});
+
+test("it never claims the free ran, or that it did not", () => {
+  const msg = cloudflareMessage();
+  assert.doesNotMatch(msg, /\bfreed\b/i, "it must not report a success it did not observe");
+  assert.match(msg, /the outcome is genuinely UNKNOWN/);
+  assert.match(msg, /whether the request reached ComfyUI at all is not established/i);
+  assert.match(msg, /idempotent/);
+});
+
+test("the reconnecting state is stated only when it was OBSERVED", () => {
+  const unknown = cloudflareMessage(); // backendReconnecting omitted
+  assert.doesNotMatch(
+    unknown,
+    /reconnect/i,
+    "an unpassed socket fact must stay unsaid — inferring it from a 502 is the same wrong diagnosis, reversed",
+  );
+
+  const down = cloudflareMessage({ backendReconnecting: true });
+  assert.match(down, /backend socket is ALSO down/i);
+  assert.match(down, /backend_socket:"reconnecting"/);
+
+  const up = cloudflareMessage({ backendReconnecting: false });
+  assert.match(up, /backend socket is currently OPEN/i);
+  assert.doesNotMatch(up, /ALSO down/i);
+});
+
+test("an empty body is its own observation, not a generic parse complaint", () => {
+  const msg = describeHttpFailure({ what: "free VRAM", route: "POST /free", status: 504, body: "" });
+  assert.match(msg, /Body starts: \(empty\)/);
+  assert.match(msg, /\b504\b/);
+});
+
+test("the body prefix is bounded and single-line", () => {
+  const prefix = httpBodyPrefix(CLOUDFLARE_502);
+  assert.ok(prefix.length <= HTTP_FAILURE_BODY_PREFIX_CAP + 1, `prefix was ${prefix.length} chars`);
+  assert.doesNotMatch(prefix, /[\r\n]/);
+  // <script>/<style> contents are dropped whole, not tag-stripped.
+  assert.doesNotMatch(prefix, /font-family|__CF\$cv\$params/);
+});
+
+test("credential-shaped text in a reflecting gateway's page is scrubbed", () => {
+  const reflected =
+    "<html><body>Invalid request: Authorization: Bearer sk-live-8fbc21aa77de4931b0c5e6f1a2d3 rejected " +
+    "for token=Zm9vYmFyYmF6cXV1eGNvcmdlZ3JhdWx0Z2FybHk=</body></html>";
+  const prefix = httpBodyPrefix(reflected);
+  assert.doesNotMatch(prefix, /sk-live-8fbc21aa77de4931b0c5e6f1a2d3/);
+  assert.doesNotMatch(prefix, /Zm9vYmFyYmF6cXV1eGNvcmdlZ3JhdWx0Z2FybHk=/);
+  assert.match(prefix, /«redacted»/);
+  assert.doesNotMatch(scrubSecretShapedText("api_key=abc123def456"), /abc123def456/);
+});
+
+test("a standard reason phrase is dropped, a custom one is kept", () => {
+  assert.equal(describeHttpStatus(502, "Bad Gateway"), "502");
+  assert.equal(describeHttpStatus(503, "Origin warming up"), "503 Origin warming up");
+  assert.equal(describeHttpStatus(502, ""), "502");
+});
+
+// ---------------------------------------------------------------------------
+// 3. ADOPTION, COUNTED
+// ---------------------------------------------------------------------------
+
+/**
+ * Every site in a source file that captures an HTTP response body, and whether
+ * that captured value is interpolated into an `Error` message WITHOUT going
+ * through `describeHttpFailure`.
+ *
+ * Deliberately a source scan and not a set of per-site unit tests: the defect
+ * class here is a call site that never adopted the canonical mechanism, and a
+ * per-site test cannot see a site nobody wrote a test for.
+ */
+export function scanBodyCaptureSites(src) {
+  const sites = [];
+  const CAPTURE = /(\w+)\s*=\s*await\s+[\w.?]+\.text\(\)/g;
+  let m;
+  while ((m = CAPTURE.exec(src)) !== null) {
+    const ident = m[1];
+    const line = src.slice(0, m.index).split("\n").length;
+    // The reporting that follows a capture lives within a few statements of it.
+    const window = src.slice(m.index, m.index + 1200);
+    const errors = [...window.matchAll(/new Error\(/g)];
+    let leaks = false;
+    for (const e of errors) {
+      // The Error's argument list, bounded by the same window.
+      const arg = window.slice(e.index, e.index + 900);
+      const interpolated = new RegExp(`\\$\\{[^}]*\\b${ident}\\b`).test(arg);
+      if (interpolated && !/describeHttpFailure\(/.test(arg)) leaks = true;
+    }
+    sites.push({ ident, line, leaks, adopts: /describeHttpFailure\(/.test(window) });
+  }
+  return sites;
+}
+
+// The scanner's own known-positive: the pre-fix `free_vram`, verbatim. A scanner
+// that stopped matching would otherwise report a clean sweep forever.
+const PRE_FIX_FREE_VRAM = `
+  async free_vram() {
+    const res = await api.fetchApi("/free", { method: "POST" });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(\`Failed to free VRAM: \${res.status} \${res.statusText}\${text ? \` — \${text}\` : ""}\`);
+    }
+    return { freed: true };
+  },
+`;
+
+test("the scanner detects the defect it exists to detect", () => {
+  const found = scanBodyCaptureSites(PRE_FIX_FREE_VRAM);
+  assert.equal(found.length, 1, "the pre-fix capture must be seen");
+  assert.equal(found[0].leaks, true, "the pre-fix raw-body interpolation must be flagged");
+});
+
+test("no shipped panel site interpolates a raw response body into an Error", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const sites = scanBodyCaptureSites(src);
+  const leaking = sites.filter((s) => s.leaks);
+  assert.deepEqual(
+    leaking.map((s) => `line ${s.line} (${s.ident})`),
+    [],
+    "a response body reached an Error message raw — route it through describeHttpFailure()",
+  );
+
+  // The COUNT is the point. If this number moved, a site that reads a failed
+  // response body was added or removed: decide whether it reports to the agent,
+  // adopt describeHttpFailure() if it does, and update this number deliberately.
+  assert.equal(
+    sites.length,
+    8,
+    `body-capture sites moved from 8 to ${sites.length}:\n` +
+      sites.map((s) => `  line ${s.line} — ${s.ident}${s.adopts ? " [adopts]" : ""}`).join("\n"),
+  );
+
+  const adopters = sites.filter((s) => s.adopts);
+  assert.equal(adopters.length, 1, "exactly the free_vram failure path adopts the classifier today");
+});
+
+test("free_vram's CALL SITE adopts the classifier", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /import \{ describeHttpFailure \} from "\.\/lib\/http-failure\.js";/,
+    "the shipped bundle must import the classifier",
+  );
+  const start = src.indexOf("async free_vram()");
+  assert.ok(start > 0, "free_vram executor not found");
+  const body = src.slice(start, src.indexOf("\n  },", start));
+  assert.match(body, /describeHttpFailure\(/, "free_vram must route its failure through the classifier");
+  assert.match(
+    body,
+    /backendReconnecting:\s*comfyBackendIsDown\(\)/,
+    "free_vram must pass the SAME live socket predicate the graph_* branch consults — that asymmetry is issue #828",
+  );
+  assert.doesNotMatch(
+    body,
+    /\$\{text\}/,
+    "the raw body must not be interpolated anywhere in free_vram",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -306,6 +306,7 @@ import {
   classifyBackendStatusEvent,
   describeGraphMutationReadiness,
 } from "./lib/reconnect-recovery.js";
+import { describeHttpFailure } from "./lib/http-failure.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
 import { todoItemGlyph } from "./lib/plan-glyph.js";
 import {
@@ -22349,8 +22350,35 @@ const GRAPH_TOOL_EXECUTORS = {
       body: JSON.stringify({ unload_models: true, free_memory: true }),
     });
     if (!res.ok) {
+      // comfyui-mcp#828 — this used to interpolate `await res.text()` RAW, and on
+      // a target behind Cloudflare that pasted the whole 502 error document into
+      // the agent's tool result. `describeHttpFailure` is the one place a panel
+      // executor turns a not-ok Response into agent-visible text; it classifies
+      // what answered and carries a bounded, scrubbed prefix instead of the page.
+      //
+      // `comfyBackendIsDown()` is the SAME live predicate the graph_* dispatcher
+      // branch and `backendSocketReplyFields` consult — the fact that made
+      // panel_graph_outline say backend_socket:"reconnecting" in the very moment
+      // this call leaked HTML. `free_vram` does not start with `graph_`, so it
+      // never enters that branch; reading the predicate here is what closes the
+      // asymmetry. It is passed as an OBSERVED boolean, never inferred from the
+      // status — a 502 on its own says nothing about this tab's socket.
       const text = await res.text().catch(() => "");
-      throw new Error(`Failed to free VRAM: ${res.status} ${res.statusText}${text ? ` — ${text}` : ""}`);
+      throw new Error(
+        describeHttpFailure({
+          what: "free VRAM",
+          route: "POST /free",
+          status: res.status,
+          statusText: res.statusText,
+          contentType: res.headers?.get?.("content-type") ?? "",
+          body: text,
+          // /free is idempotent (the orchestrator's own #1249 direct re-issue
+          // rests on that), so a retry cannot double-apply anything.
+          outcomeUnknownNote:
+            "Nothing in this response shows models were unloaded, and nothing in it shows they were not — the outcome is genuinely UNKNOWN, so the safe working assumption is that the unload did not happen. /free is idempotent, so re-issuing it once ComfyUI answers again cannot double-apply anything and is the right next step.",
+          backendReconnecting: comfyBackendIsDown(),
+        }),
+      );
     }
     return { freed: true, unload_models: true, free_memory: true };
   },

--- a/web/js/lib/http-failure.js
+++ b/web/js/lib/http-failure.js
@@ -1,0 +1,335 @@
+// comfyui-mcp#828 (recurrence, 2026-08-21) — describe a ComfyUI HTTP route that
+// answered NOT-OK, without pasting what answered into the agent's tool result.
+//
+// The report: on a remote target behind Cloudflare, immediately after a ComfyUI
+// restart while the tab's backend socket was reconnecting, `panel_free_vram`
+// surfaced the ENTIRE Cloudflare 502 error document — markup, Ray ID, client IP
+// and all — because `free_vram` built its failure message as
+//
+//     `Failed to free VRAM: ${res.status} ${res.statusText} — ${await res.text()}`
+//
+// In the very same state `panel_graph_outline` reported `backend_socket:
+// "reconnecting"`, because a `graph_*` command reaches the dispatcher branch that
+// consults `comfyBackendIsDown()` (reconnect-recovery.js) and annotates its reply
+// via `backendSocketReplyFields`. `free_vram` does not start with `graph_`, so it
+// never enters that branch: it neither consults the socket fact the panel already
+// knows nor has anything that looks at the response body. Two calls, one moment,
+// one honest and one relaying a proxy's error page.
+//
+// ## What this module is, and is not
+//
+// It is the panel-side sibling of the orchestrator's `src/comfyui/json-guard.ts`
+// (#1178), deliberately using the SAME classification vocabulary — `proxy-error`,
+// `login`, `not-found`, `html-page`, `not-json` — so the two runtimes name the
+// same situation with the same word. It is NOT a second copy for its own sake:
+// json-guard is Node/TypeScript inside the orchestrator process and cannot be
+// reached from a browser executor, which is the only place that ever holds this
+// `Response`. Anything added here should be added to json-guard's vocabulary too,
+// and vice versa — one classification, two runtimes.
+//
+// ## The rules it follows
+//
+//   1. NEVER paste the body. A bounded, markup-stripped, secret-scrubbed prefix
+//      is a diagnostic; the document is a context bomb and a credential risk
+//      (json-guard's `bodyPrefixOf` records a gateway that REFLECTS the request
+//      putting our own ComfyUI credential in the page it answers with).
+//   2. NEVER swallow the failure. An HTML body where JSON was promised is
+//      information: something other than ComfyUI's API answered.
+//   3. NEVER assert a cause the response does not carry. A status alone does not
+//      prove who produced it, and the backend-socket state is stated only when
+//      the caller passes the fact it observed — `undefined` says nothing.
+//   4. NEVER claim the operation did or did not run. A response that did not come
+//      from ComfyUI reports on the proxy, not on the request.
+
+/** Cap on the body prefix carried into a message. Diagnostic, not a document. */
+export const HTTP_FAILURE_BODY_PREFIX_CAP = 200;
+
+/** Reason phrases that add nothing beside the code they belong to. Mirrors
+ *  json-guard's `describeStatus`: a CUSTOM phrase ("Origin warming up",
+ *  "Backend read timeout") is often the most useful token in the response, a
+ *  standard one is noise. */
+const STANDARD_REASON_PHRASES = new Set([
+  "ok",
+  "bad request",
+  "unauthorized",
+  "forbidden",
+  "not found",
+  "method not allowed",
+  "request timeout",
+  "conflict",
+  "payload too large",
+  "unprocessable entity",
+  "too many requests",
+  "internal server error",
+  "not implemented",
+  "bad gateway",
+  "service unavailable",
+  "gateway timeout",
+]);
+
+/** `502` or `503 Origin warming up` — the code, plus a reason phrase worth reading. */
+export function describeHttpStatus(status, statusText) {
+  const text = String(statusText ?? "").trim();
+  if (!text) return String(status);
+  if (STANDARD_REASON_PHRASES.has(text.toLowerCase())) return String(status);
+  // A phrase is a short label, not a document; a long one is a body that escaped
+  // into the status line. Scrubbed like the body — a hostile proxy writes this too.
+  const clipped = text.length > 80 ? `${text.slice(0, 80)}…` : text;
+  return `${status} ${scrubSecretShapedText(clipped)}`;
+}
+
+const REDACTED = "«redacted»";
+
+/**
+ * Redact credential-shaped text by SHAPE, not by known value.
+ *
+ * The panel does not hold the orchestrator's credential list, and a proxy can
+ * percent-encode, case-fold or line-wrap whatever it echoes, so a blocklist of
+ * known values would miss the reflected form anyway. Two passes:
+ *
+ *   - a labelled secret (`token=…`, `Authorization: Bearer …`), where the LABEL
+ *     is the evidence and the value goes whatever it looks like;
+ *   - a long opaque run (32+ chars of a base64/hex/JWT alphabet), which is what
+ *     an unlabelled key or session id looks like. 32 is deliberately above the
+ *     length of the identifiers an error page legitimately prints (a Cloudflare
+ *     Ray ID is 16–20) so a useful diagnostic is not redacted into uselessness.
+ *
+ * The label list also covers the CDN convention of printing the VIEWER'S OWN
+ * ADDRESS on an error page ("Your IP: …", which the reported Cloudflare 502
+ * carries). That is not a credential, but this text is what a user pastes into a
+ * public bug report, so the labelled form goes. A BARE address is deliberately
+ * left alone: an nginx 502 body's `upstream: http://127.0.0.1:8188` is often the
+ * single most useful token on the page, and redacting by shape here would remove
+ * the diagnosis along with the PII.
+ *
+ * A DELIMITER (`:` or `=`) is required for the labelled rule. Allowing a bare
+ * space would turn "Authorization required" into "Authorization: «redacted»" and
+ * "auth failed" into "auth: «redacted»" — destroying the diagnosis in the name of
+ * protecting it. The one unlabelled-but-unambiguous form, `Bearer <token>`, gets
+ * its own rule; the scheme is consumed as part of the labelled value so a
+ * `Authorization: Bearer sk-…` redacts the TOKEN and not just the word "Bearer".
+ *
+ * `/` is excluded from the opaque-run alphabet so an ordinary URL on the page
+ * survives: with it in, `//www.cloudflare.com/5xx-error-landing` is a 38-char run
+ * and collapses to a redaction marker. Real credentials still have a 32+ run of
+ * the remaining alphabet between any slashes.
+ */
+export function scrubSecretShapedText(text) {
+  return String(text ?? "")
+    .replace(
+      /\b(authorization|auth|bearer|token|access[-_]?token|api[-_]?key|apikey|secret|password|passwd|pwd|session[-_]?id|sessionid|cookie|your ip|client ip|remote ip|remote addr|x-forwarded-for)\b\s*[:=]\s*(?:bearer\s+|basic\s+|token\s+)?("[^"]*"|'[^']*'|\S+)/gi,
+      (_m, label) => `${label}: ${REDACTED}`,
+    )
+    .replace(/\b(bearer|basic)\s+[A-Za-z0-9._\-+/=]{8,}/gi, (_m, scheme) => `${scheme} ${REDACTED}`)
+    .replace(/[A-Za-z0-9_\-+=.]{32,}/g, REDACTED);
+}
+
+/**
+ * A short, single-line, markup-free, secret-scrubbed prefix of a response body.
+ *
+ * `<script>`/`<style>` contents are dropped whole rather than tag-stripped: their
+ * text is code, not a message, and a minified bundle would eat the entire cap
+ * before the page said anything.
+ */
+export function httpBodyPrefix(body) {
+  const raw = String(body ?? "");
+  if (raw.trim() === "") return "(empty)";
+  const text = scrubSecretShapedText(
+    raw
+      .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, " ")
+      .replace(/<!--[\s\S]*?-->/g, " ")
+      .replace(/<[^>]*>/g, " ")
+      .replace(/&(?:nbsp|bull|middot);/gi, " ")
+      .replace(/&amp;/gi, "&")
+      .replace(/&lt;/gi, "<")
+      .replace(/&gt;/gi, ">")
+      .replace(/&quot;/gi, '"')
+      .replace(/&#0*39;|&apos;/gi, "'"),
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+  if (text === "") return "(no readable text)";
+  return text.length > HTTP_FAILURE_BODY_PREFIX_CAP
+    ? `${text.slice(0, HTTP_FAILURE_BODY_PREFIX_CAP)}…`
+    : text;
+}
+
+const PROXY_MARKERS =
+  /\b(cloudflare|cf-ray|nginx|openresty|traefik|envoy|haproxy|varnish|squid|apache\b|gunicorn|amazon cloudfront|akamai|error code 5\d\d|bad gateway|gateway time-?out)\b/i;
+const LOGIN_MARKERS =
+  /(<input[^>]+type=["']?password|name=["']?password|\bsign[ -]?in\b|\blog[ -]?in\b|\bsso\b|cloudflare access|okta|auth0|keycloak)/i;
+
+function looksLikeHtml(body) {
+  const head = String(body ?? "").trimStart().slice(0, 512).toLowerCase();
+  return head.startsWith("<!doctype html") || head.startsWith("<html") || /<(html|head|body|div|title)\b/.test(head);
+}
+
+/** The body parsed as a JSON document, or null. */
+function parsedJsonBody(body) {
+  const text = String(body ?? "").trim();
+  if (text === "" || !/^[[{"]/.test(text)) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/** The message a JSON error document carries, under any of the keys this
+ *  codebase's servers actually use. Bounded and scrubbed like any other body
+ *  text — a JSON envelope is not a promise that the value is safe to print. */
+function jsonErrorMessage(parsed) {
+  if (parsed == null || typeof parsed !== "object") return "";
+  for (const key of ["error", "message", "detail", "reason"]) {
+    const v = parsed[key];
+    if (typeof v === "string" && v.trim()) return httpBodyPrefix(v);
+    if (v && typeof v === "object" && typeof v.message === "string" && v.message.trim()) {
+      return httpBodyPrefix(v.message);
+    }
+  }
+  return "";
+}
+
+/**
+ * What answered instead of the ComfyUI HTTP API.
+ *
+ * A PARSING JSON BODY IS CHECKED FIRST, and it ends the question (codex gate,
+ * round 1, both P1s). The orchestrator's `json-guard` only ever runs AFTER a
+ * JSON parse has already failed; this helper is called on ANY not-ok response,
+ * so it sees inputs json-guard never does. Without this branch a ComfyUI `503
+ * {"error":"busy"}` or a `401 {"error":"Unauthorized"}` from ComfyUI's own auth
+ * layer was classified by STATUS alone as a gateway page or an identity proxy,
+ * and told the caller the answer "did not come from ComfyUI". Blaming a proxy
+ * that is not there is the same wrong-diagnosis failure this issue is about.
+ *
+ * After that: BODY EVIDENCE OUTRANKS STATUS, and a confirmed proxy page outranks
+ * a status-only auth guess — the same precedence json-guard settled on, for the
+ * same reason: an nginx 502 whose footer links to a login page is the proxy
+ * failure it is, not an auth gate.
+ *
+ * @returns {"json-error"|"proxy-error"|"login"|"not-found"|"html-page"|"not-json"}
+ */
+export function classifyHttpFailure({ status, body = "" } = {}) {
+  // `contentType` is deliberately NOT read here. A declared type is a CLAIM; only
+  // the body is evidence. The disagreement between the two is reported by
+  // `causeOf`, which is where a claim belongs — as a remark, not a verdict.
+  if (parsedJsonBody(body) !== null) return "json-error";
+  const html = looksLikeHtml(body);
+  const proxyPage = html && PROXY_MARKERS.test(body);
+  const loginPage = html && LOGIN_MARKERS.test(body);
+  const gatewayStatus = status === 502 || status === 503 || status === 504;
+  if (proxyPage || (gatewayStatus && !loginPage)) return "proxy-error";
+  if (loginPage || status === 401 || status === 403) return "login";
+  if (status === 404 && html) return "not-found";
+  if (html) return "html-page";
+  return "not-json";
+}
+
+/**
+ * True only when the BODY carries evidence that something other than ComfyUI's
+ * HTTP API produced this response.
+ *
+ * Keyed on the evidence, never on the kind (codex gate, round 1). A status-only
+ * `proxy-error` — a bare 502 with an empty body — is equally consistent with
+ * ComfyUI crashing mid-response, and a status-only `login` is equally consistent
+ * with ComfyUI behind the operator's own auth layer. Those cases still say what
+ * they saw; they must not say where it came from.
+ */
+function answeredBySomethingElse(kind, body) {
+  if (kind === "json-error" || kind === "not-json") return false;
+  const html = looksLikeHtml(body);
+  if (!html) return false; // status-only verdicts assert nothing about the responder
+  return kind === "proxy-error" || kind === "login" || kind === "not-found" || kind === "html-page";
+}
+
+function causeOf(kind, status, body, contentType = "") {
+  const claimsHtml = /\b(text\/html|application\/xhtml\+xml)\b/i.test(String(contentType));
+  switch (kind) {
+    case "json-error": {
+      // The route answered with a JSON document, which is what the ComfyUI API
+      // does when it rejects a request. Report the status and what it said; do
+      // not speculate about who sent it.
+      const said = jsonErrorMessage(parsedJsonBody(body));
+      return said
+        ? `the route answered with a JSON error document saying: ${said}`
+        : "the route answered with a JSON document rather than the success this call expects; the status is what it is reporting";
+    }
+    case "proxy-error":
+      return PROXY_MARKERS.test(String(body ?? ""))
+        ? "a reverse proxy or gateway in front of ComfyUI returned its OWN error page (its markers are in the body) — the proxy is reachable but could not get an answer out of ComfyUI"
+        : `a gateway-class status (${status}) came back without a page identifying who sent it. A reverse proxy typically answers this way when ComfyUI has crashed, is restarting, or is otherwise unreachable — but ComfyUI itself can answer a ${status} too, and nothing in this response distinguishes them`;
+    case "login":
+      return LOGIN_MARKERS.test(String(body ?? ""))
+        ? "an authentication gate answered with a SIGN-IN PAGE rather than letting the request through — typically an identity proxy such as Cloudflare Access or an SSO portal"
+        : `the request was rejected with ${status} and the body is not JSON; that is most often an identity proxy or sign-in gate in front of ComfyUI, though ComfyUI behind your own auth layer can return it too, and this response does not distinguish them`;
+    case "not-found":
+      return "whatever is answering this host does not serve that route at all — the usual candidates are a reverse proxy that forwards the ComfyUI UI but not its API routes, and a base URL pointing somewhere other than the ComfyUI API root";
+    case "html-page":
+      return "some HTTP responder other than the ComfyUI API answered this route with a web page; this body alone does not identify which. The usual candidates are the ComfyUI frontend's catch-all, a reverse proxy that forwards the UI but not the API, and a maintenance or WAF page";
+    default:
+      return String(body ?? "").trim() === ""
+        ? `NOTHING was sent back — the response carried no body at all, so the ${status} status is the entire message, and it does not identify what produced it`
+        : "the body is not markup and is not the JSON this route promises" +
+            (claimsHtml
+              ? ", although the response DECLARES itself text/html — the declaration and the body disagree, so neither settles what answered"
+              : "") +
+            "; it is consistent with ComfyUI itself answering an error, with a truncated response, and with a responder that is not the ComfyUI API, and nothing here distinguishes them";
+  }
+}
+
+/**
+ * The one place a panel executor turns a not-ok `Response` into agent-visible text.
+ *
+ * @param {{
+ *   what: string,                  // what the caller was doing, e.g. "free VRAM"
+ *   route: string,                 // e.g. "POST /free"
+ *   status: number,
+ *   statusText?: string,
+ *   contentType?: string,
+ *   body?: string,
+ *   outcomeUnknownNote?: string,   // what the caller can say about its own operation
+ *   backendReconnecting?: boolean, // ONLY pass the fact you observed; omit if unknown
+ * }} o
+ */
+export function describeHttpFailure({
+  what,
+  route,
+  status,
+  statusText,
+  contentType = "",
+  body = "",
+  outcomeUnknownNote = "",
+  backendReconnecting,
+} = {}) {
+  const kind = classifyHttpFailure({ status, body });
+  const parts = [
+    `Failed to ${what}: ${route} answered ${describeHttpStatus(status, statusText)} — ${causeOf(kind, status, body, contentType)}.`,
+  ];
+  if (answeredBySomethingElse(kind, body)) {
+    parts.push(
+      `This answer did not come from ComfyUI, so it reports on whatever produced it and NOT on the request: ` +
+        `whether the request reached ComfyUI at all is not established here.`,
+    );
+  }
+  if (outcomeUnknownNote) parts.push(outcomeUnknownNote);
+  // #3 — state the socket only when the caller passed the fact it observed.
+  // `undefined` is unknown and stays unsaid; inferring "reconnecting" from a 502
+  // would be exactly the diagnosis this issue is about, pointed the other way.
+  if (backendReconnecting === true) {
+    parts.push(
+      `This tab's ComfyUI backend socket is ALSO down right now (a restart or reconnect is in ` +
+        `progress) — the same fact panel_graph_outline reports as backend_socket:"reconnecting". ` +
+        `Wait for it to reconnect, then retry.`,
+    );
+  } else if (backendReconnecting === false) {
+    parts.push(
+      `This tab's ComfyUI backend socket is currently OPEN, so a restart/reconnect window does not ` +
+        `explain this — look at whatever sits between this browser and ComfyUI.`,
+    );
+  }
+  parts.push(
+    `Content-Type: ${contentType ? scrubSecretShapedText(String(contentType)) : "(none)"}. ` +
+      `Body starts: ${httpBodyPrefix(body)}`,
+  );
+  return parts.join(" ");
+}


### PR DESCRIPTION
Fixes the 2026-08-21 recurrence on **artokun/comfyui-mcp#828** (comfyui-mcp 0.52.45 / panel 0.15.32, remote Linux target behind Cloudflare). Cross-repo reference, so it will not auto-close — the issue is closed by hand on merge.

> immediately after a ComfyUI restart while the backend was reconnecting, `panel_free_vram` surfaced the full Cloudflare 502 HTML document from `/free`. In the same state, `panel_graph_outline` correctly reported `backend_socket=reconnecting`.

## The asymmetry is the whole defect

Two calls, one moment, one backend state. One is honest, one pastes a proxy error page at the caller. That is not a missing HTML check — it is one path not reaching a mechanism the other path uses.

Established by execution, not by reading:

| | `panel_graph_outline` | `panel_free_vram` |
|---|---|---|
| dispatcher branch | `msg.cmd.startsWith("graph_")` → consults `comfyBackendIsDown()` (line ~23694) | not a `graph_` command — **skips the whole branch** |
| socket fact in the reply | `backendSocketReplyFields()` → `describeGraphMutationReadiness()` (`lib/reconnect-recovery.js`) | **nothing** |
| body handling | n/a (reads local canvas) | `` `… — ${await res.text()}` `` — raw, unbounded |

`backendSocketReplyFields()` has exactly three adopters in the bundle (`graph_outline`, `workflow_list`, `workflow_open`/`set_workflow_target`). `free_vram` is none of them, which is why one call could say `reconnecting` and the other could not.

## Reproduction — SYNTHESISED, not live

A local HTTP server answering `POST /free` with a real-shaped Cloudflare 502 document (`Server: cloudflare`, `CF-RAY`, Ray ID, `Your IP:`). No Cloudflare and no remote target involved; the panel's `free_vram` body was run **verbatim from `origin/main`** against it over a real HTTP round trip, and `describeGraphMutationReadiness` was called with the reconnecting state in the same script.

```
BEFORE (origin/main)
Failed to free VRAM: 502 Bad Gateway — <!DOCTYPE html>
<html class="no-js" lang="en-US">
… 976 chars of markup, Ray ID and the client IP …
--- <!DOCTYPE: true | markup: true | client IP: true | names reconnect: false

same moment, graph path:
{ "backend_socket": "reconnecting", "mutations_ready": false, "graph_binding": "reconnecting", … }
```

```
AFTER (this branch)
Failed to free VRAM: POST /free answered 502 — a reverse proxy or gateway in front of ComfyUI
returned its OWN error page (its markers are in the body) — the proxy is reachable but could not
get an answer out of ComfyUI. This answer did not come from ComfyUI, so it reports on whatever
produced it and NOT on the request: whether the request reached ComfyUI at all is not established
here. Nothing in this response shows models were unloaded, and nothing in it shows they were not —
the outcome is genuinely UNKNOWN, so the safe working assumption is that the unload did not happen.
/free is idempotent, so re-issuing it once ComfyUI answers again cannot double-apply anything and
is the right next step. This tab's ComfyUI backend socket is ALSO down right now (a restart or
reconnect is in progress) — the same fact panel_graph_outline reports as
backend_socket:"reconnecting". Wait for it to reconnect, then retry.
Content-Type: text/html; charset=UTF-8. Body starts: comfy.example.net | 502: Bad gateway Bad
gateway Error code 502 Visit cloudflare.com for more information. Cloudflare Ray ID:
9c7fd0a1e4b23f10 Your IP: «redacted» Performance & security by Cloudflare
--- <!DOCTYPE: false | markup: false | client IP: false | names reconnect: true
```

The failure is **not swallowed**: the status, the responder and a recognisable prefix of the page are all still there. It is classified instead of pasted.

## Why a new module and not a second HTML check

`describeHttpFailure` in `web/js/lib/http-failure.js` is the browser-side sibling of the orchestrator's `src/comfyui/json-guard.ts` (comfyui-mcp#1178) and uses the **same classification vocabulary** — `proxy-error` / `login` / `not-found` / `html-page` / `not-json` — with the same precedence rule (body evidence outranks status; a confirmed proxy page outranks a status-only auth guess). It is a second *runtime*, not a second *check*: json-guard is Node/TypeScript inside the orchestrator process and is unreachable from the browser executor that is the only thing holding this `Response`. Anything added to one vocabulary belongs in the other.

## Where the load-bearing claims are — please look here

1. **`scrubSecretShapedText`'s label rule requires a `:` or `=` delimiter.** An earlier draft allowed a bare space and turned `Authorization required` into `Authorization: «redacted»`. Checked against six real page fragments; the nginx `upstream: http://127.0.0.1:8188/free` line and a plain `https://…` URL survive intact, which is the whole point of a diagnostic prefix.
2. **`/` is excluded from the 32+ opaque-run alphabet.** With it in, `//www.cloudflare.com/5xx-error-landing` is a 38-char run and collapses to a redaction marker.
3. **The `Your IP:` redaction is deliberate and narrow.** A CDN error page prints the viewer's own address, and this text is what a user pastes into a public issue. Only the *labelled* form goes; a bare address is left alone.
4. **`backendReconnecting` is passed, never inferred.** `undefined` says nothing at all. Inferring "reconnecting" from a 502 would be the same wrong diagnosis as the original bug, pointed the other way — there is a mutation below that proves the test catches it.
5. **The pinned count `sites.length === 8`** will fail on any PR that adds or removes a response-body capture in the bundle. That is intended: it forces a decision about adoption rather than letting a new bypass ship green.

## Verification

- `npm run test:unit` — **6264 pass / 0 fail** (baseline `origin/main` in a clean worktree: 6263 / 0). `check-tool-vocabulary` OK, `check-panel-scope` OK ("every name in `comfyui-mcp-panel.js` resolves" — the compiler gate that catches a name resolving in a sibling function).
- `npm run typecheck` — clean.
- `http-failure.js` imported and called in Node: loads as an ES module, exports resolve.

### Mutation evidence — deleted the fix, watched named tests fail

Two of the five mutate the **CALL SITE**, not just the helper.

| mutation | tests killed |
|---|---|
| **call site** reverted to the raw-body throw | `no shipped panel site interpolates a raw response body into an Error`, `free_vram's CALL SITE adopts the classifier` |
| **call site** stops passing `comfyBackendIsDown()` | `free_vram's CALL SITE adopts the classifier` |
| helper stops bounding/stripping the body | `the proxy document never reaches the caller`, `the message length does not grow with the body`, `the body prefix is bounded and single-line`, `credential-shaped text … is scrubbed` |
| helper stops recognising a proxy error page | `a Cloudflare 502 page is classified as a proxy error`, `body evidence outranks status`, `the failure is NAMED, not swallowed` |
| helper **infers** `reconnecting` from a 502 it never observed | `the reconnecting state is stated only when it was OBSERVED` |

The adoption scanner is itself verified against the pre-fix `free_vram` source inside the test (`the scanner detects the defect it exists to detect`), so a scanner that silently stopped matching cannot report a clean sweep.

## Other call sites with the same pattern

Swept every response-body capture in the bundle. `free_vram` was the **only** one interpolating a raw body into an agent-visible error. The Manager paths (`managerV2` / `managerCall`) already refuse to: on `!res.ok` they build `Manager <route>: HTTP <status>` and use a body value only when it parses as JSON with a `.message`. `comfy_reboot` reports status only. They are thin rather than wrong, so they are left alone; the counting test now covers all 8 sites, so a regression at any of them fails.

One neighbouring observation, **not fixed here**, filed with evidence on the issue instead: the orchestrator's own direct `/free` (`src/orchestrator/panel-tools.ts` `freeVramDirect`, the #1249 frozen-tab settle path) reports `POST <base>/free answered HTTP <status>` — no leak, but no classification either, so a Cloudflare 502 there reads as though ComfyUI answered 502. It has `classifyNonJson` available in-process and does not use it. Different repo, different release train, and it is honest-but-thin rather than misleading, so it is not folded in.

## Browser verification — what was and was not run

`npx playwright test` was **not** run for this change, and I am not implying coverage I do not have. There is no e2e spec touching `free_vram` anywhere in `browser_tests/` (checked), and reaching this branch needs a proxy that answers `/free` with a 502 — no spec sets that up, so the suite would only re-measure its ~26 known failures on a shared rig. What was run instead is the evidence that actually bears on a bundle change: `check-panel-scope` (compiler-verified name resolution over the whole bundle, which is what catches a `ReferenceError` at a new call site), `typecheck`, the full 6264-test unit suite, and a real HTTP round trip through the shipped module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
