### PR TITLE
fix(1575): reopening a closed tab loads the workflow ComfyUI's store-level open skipped

### DIFF
--- a/browser_tests/reopen-closed-workflow.spec.ts
+++ b/browser_tests/reopen-closed-workflow.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * #1575 — reopening a saved workflow after `panel_close_workflow` closed its tab.
+ *
+ * THE REPORT. The reopen came back with "workflow_open could not rebind the active
+ * canvas because this frontend did not expose a complete workflow state for a safe
+ * repaint" — an unknown partial outcome — and `panel_list_workflows` could then show
+ * an inconsistent active/open state.
+ *
+ * THE CAUSE. `app.extensionManager.workflow` is ComfyUI's workflow STORE, not the
+ * workflow service, so this pack's close and open are the store's primitives and they
+ * do not pair up: `closeWorkflow` unloads the tab and leaves `activeWorkflow` pointing
+ * at it, and `openWorkflow` begins `if (isActive(workflow)) return workflow` where
+ * `isActive` compares BY PATH. The reopen therefore early-returns on the stale pointer,
+ * loads nothing, and never puts the tab back in the open list — and the panel's repaint
+ * finds no state to paint from.
+ *
+ * Driven over the bridge rather than asserted at source: the defect is an interaction
+ * between the panel's command and two of ComfyUI's store methods, and it only appears
+ * when the real store runs. `browser_tests/unit/settle-open-target.test.mjs` pins the
+ * decision; this pins that the reported CALL now works.
+ */
+import { test, expect, deleteSavedWorkflow } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+test('a saved workflow reopens after its tab was closed', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  await claimFreshCanvas(page, mockBridge)
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    ;(app?.canvas?.graph ?? app?.graph).add(LG.createNode('EmptyLatentImage'))
+  })
+  await settleCanvas(page)
+
+  // #907 — the try opens BEFORE the save, so a save that lands and then fails an
+  // assertion is still cleaned up.
+  let savedName = ''
+  try {
+    const e2eName = `cmcp-e2e-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    const saved = await mockBridge.command('workflow_save_as', { name: e2eName })
+    expect(saved.ok, 'the save must succeed so the tab is clean enough to close').toBe(true)
+    savedName = String(saved.result?.workflow || '')
+    expect(savedName, 'the save must report a name, or cleanup has nothing to remove').toBeTruthy()
+
+    const listed = await mockBridge.command('workflow_list', {})
+    const active = listed.result?.active
+    // The PATH, not the routing key: after the close this workflow is no longer an open
+    // tab, and the on-disk path is the selector the reporter used.
+    const savedPath = String(active?.path || '')
+    expect(savedPath, 'the saved workflow must report an on-disk path').toBeTruthy()
+    const stamp = active?.workflow_uuid
+    expect(stamp, 'workflow_list must report the active workflow uuid').toBeTruthy()
+
+    // Closing the ACTIVE workflow is fenced, so stamp it (see #882's spec).
+    const closed = await mockBridge.command('workflow_close', {
+      path: active?.routing_key || active?.key || savedPath,
+      workflow_uuid: stamp
+    })
+    expect(closed.ok, `the close must succeed: ${JSON.stringify(closed)}`).toBe(true)
+
+    // THE REPORTED CALL. Before the fix this refused, because ComfyUI's store still
+    // named the just-closed tab as active and its `openWorkflow` early-returned.
+    const reopened = await mockBridge.command('workflow_open', { path: savedPath })
+    expect(
+      JSON.stringify(reopened),
+      'the reopen must not refuse with the #1575 rebind failure'
+    ).not.toContain('did not expose a complete workflow state')
+    expect(reopened.ok, `the reopen must succeed: ${JSON.stringify(reopened)}`).toBe(true)
+
+    // The canvas must actually be this workflow's graph, not an empty or stale one.
+    const onCanvas = await page.evaluate(() => {
+      const w = window as any
+      const app = w.comfyAPI?.app?.app || w.app
+      const graph = app?.canvas?.graph ?? app?.graph
+      return (graph?.nodes || []).map((n: any) => n.type)
+    })
+    expect(onCanvas, 'the reopened canvas must carry the saved graph').toContain(
+      'EmptyLatentImage'
+    )
+
+    // …and the active/open state must agree again — the second half of the report.
+    const after = await mockBridge.command('workflow_list', {})
+    expect(after.result?.active?.path, 'the reopened workflow must be active').toBe(savedPath)
+    const openPaths = (after.result?.open || after.result?.workflows || []).map((x: any) =>
+      String(x?.path || '')
+    )
+    expect(openPaths, 'and it must be listed as OPEN, not active-but-closed').toContain(
+      savedPath
+    )
+  } finally {
+    await deleteSavedWorkflow(page, savedName)
+  }
+})

--- a/browser_tests/unit/frontend-contract.test.mjs
+++ b/browser_tests/unit/frontend-contract.test.mjs
@@ -71,7 +71,12 @@ const SAVE_AS_ROUTES = [
 // `removeWorkflow` is a best-effort orphan-copy cleanup on a failed 1.47 persist
 // (#309) — only called when the store exposes it (else it falls back to closeWorkflow
 // or splicing the open-tabs array), so it is optional, not required.
-const OPTIONAL_METHODS = ['syncWorkflows', 'removeWorkflow']
+// `openWorkflowsInBackground` returns a tab to `openWorkflowPaths` after the store's
+// own `openWorkflow` early-returned on a stale active pointer and skipped that push
+// (#1575). Only called behind a `typeof … === "function"` guard: a frontend without it
+// still gets the loaded canvas, it just cannot have its tab list corrected, which the
+// reply discloses.
+const OPTIONAL_METHODS = ['syncWorkflows', 'removeWorkflow', 'openWorkflowsInBackground']
 
 // Reactive store PROPERTIES the panel reads off the service.
 const STORE_PROPS = ['activeWorkflow', 'workflows', 'openWorkflows']

--- a/browser_tests/unit/settle-open-target.test.mjs
+++ b/browser_tests/unit/settle-open-target.test.mjs
@@ -1,0 +1,478 @@
+/**
+ * #1575 — reopening a saved workflow whose tab was closed with panel_close_workflow.
+ *
+ * THE REPORT. `panel_open_workflow` refused with "workflow_open could not rebind the
+ * active canvas because this frontend did not expose a complete workflow state for a
+ * safe repaint", and `panel_list_workflows` showed an inconsistent active/open state.
+ *
+ * THE CAUSE, read out of the ComfyUI frontend's own source and then MEASURED in a
+ * browser against a live ComfyUI. `app.extensionManager.workflow` is the workflow
+ * STORE (`workspaceStore` binds it as `computed(() => useWorkflowStore())`), so the
+ * panel's close and open are the store's primitives — and they do not pair up:
+ *
+ *   closeWorkflow(wf)  drops the path from `openWorkflowPaths`, calls `wf.unload()`
+ *                      (nulling `changeTracker`), and LEAVES `activeWorkflow` on wf.
+ *   openWorkflow(wf)   begins `if (isActive(workflow)) return workflow`, and
+ *                      `isActive` is `activeWorkflow.path === workflow.path`.
+ *
+ * So the open early-returns on the stale pointer, loads nothing, never pushes the
+ * path back, and resolves as though it worked. The panel then reads
+ * `changeTracker?.activeState ?? activeState` and gets null — the refusal.
+ *
+ * `FakeWorkflowStore` below is a transcription of those two methods (and `unload`,
+ * and the derived `activeState` getter) from the frontend source, so the state these
+ * tests drive the helper against is the state the frontend really produces. The
+ * measured browser run agreed with it exactly:
+ *
+ *   after store.closeWorkflow   activeIsSameObject:true  hasTracker:false  inOpenList:false
+ *   after store.openWorkflow    activeIsSameObject:true  hasTracker:false  inOpenList:false
+ *   panel repaint-state read    null
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  settleOpenedWorkflowTarget,
+  hasCompleteRepaintState,
+  workflowRepaintState,
+} from "../../web/js/lib/settle-open-target.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const clone = (v) => JSON.parse(JSON.stringify(v));
+const DISK_STATE = { nodes: [{ id: 1, type: "CheckpointLoaderSimple" }, { id: 2, type: "KSampler" }], links: [] };
+
+/** ComfyWorkflow, as far as this bug is concerned. `activeState` is a DERIVED
+ *  getter over `changeTracker` — verified against the frontend source, and it is
+ *  why unloading takes the flat fallback away too. */
+class FakeWorkflow {
+  constructor(path, diskState) {
+    this.path = path;
+    this.filename = path.split("/").pop();
+    this.isPersisted = true;
+    this.isTemporary = false;
+    this.isModified = false;
+    this.changeTracker = null;
+    this._disk = diskState;
+    this.loadCalls = 0;
+  }
+  get key() {
+    return this.path.replace(/^workflows\//, "");
+  }
+  get activeState() {
+    return this.changeTracker?.activeState ?? null;
+  }
+  get isLoaded() {
+    return this.changeTracker !== null;
+  }
+  async load() {
+    this.loadCalls += 1;
+    if (this.isLoaded) return this;
+    this.originalContent = JSON.stringify(this._disk);
+    this.changeTracker = { activeState: clone(this._disk) };
+    return this;
+  }
+  unload() {
+    this.changeTracker = null;
+  }
+}
+
+/** The two store methods, transcribed. */
+class FakeWorkflowStore {
+  /** Starts with the workflow LISTED but not open and not active — the state a
+   *  freshly-synced store is in before anyone opens anything. */
+  constructor(workflow) {
+    this.lookup = { [workflow.path]: workflow };
+    this.openWorkflowPaths = [];
+    this.activeWorkflow = null;
+    this.backgroundCalls = [];
+  }
+  get workflows() {
+    return Object.values(this.lookup);
+  }
+  get openWorkflows() {
+    return this.openWorkflowPaths.map((p) => this.lookup[p]);
+  }
+  /** BY PATH — this is the comparison that makes `openWorkflow` early-return. */
+  isActive(wf) {
+    return this.activeWorkflow?.path === wf.path;
+  }
+  async closeWorkflow(wf) {
+    this.openWorkflowPaths = this.openWorkflowPaths.filter((p) => p !== wf.path);
+    if (wf.isTemporary) delete this.lookup[wf.path];
+    else wf.unload();
+    // NOTE: `activeWorkflow` is deliberately NOT moved. The frontend's SERVICE does
+    // that, and the panel cannot reach the service.
+  }
+  async openWorkflow(wf) {
+    if (this.isActive(wf)) return wf; // <- the early return
+    if (!this.openWorkflowPaths.includes(wf.path)) this.openWorkflowPaths.push(wf.path);
+    const loaded = await wf.load();
+    this.activeWorkflow = loaded;
+    return loaded;
+  }
+  openWorkflowsInBackground({ right = [] } = {}) {
+    this.backgroundCalls.push(right);
+    for (const p of right) {
+      if (p in this.lookup && !this.openWorkflowPaths.includes(p)) this.openWorkflowPaths.push(p);
+    }
+  }
+}
+
+/** Reproduce the reported sequence and hand back the state workflow_open sees. */
+async function strandedByCloseThenOpen() {
+  const wf = new FakeWorkflow("workflows/report-1575.json", DISK_STATE);
+  const store = new FakeWorkflowStore(wf);
+  await store.openWorkflow(wf); // step 1: it is open, saved and active
+  assert.equal(wf.isLoaded, true, "precondition: the tab starts loaded");
+
+  await store.closeWorkflow(wf); // step 2: panel_close_workflow
+  wf.loadCalls = 0; // count only what the REOPEN does
+
+  // step 3: panel_open_workflow — the panel's own find(), then the store's open.
+  const target = store.lookup["workflows/report-1575.json"];
+  const wasOpen = !!target.changeTracker;
+  await store.openWorkflow(target);
+  return { store, target, wasOpen };
+}
+
+const sameWorkflowObject = (a, b) => a === b;
+const matchesSelector = (w, sel) => w?.path === sel || w?.key === sel || w?.filename === sel;
+
+function settleArgs(store, target, wasOpen, overrides = {}) {
+  return {
+    wasOpen,
+    target,
+    selector: target.path,
+    activeAfterOpen: store.activeWorkflow,
+    openWorkflows: store.openWorkflows,
+    sameWorkflowObject,
+    matchesSelector,
+    loadWorkflowContent: (wf) => (typeof wf.load === "function" ? wf.load() : undefined),
+    reopenTabInBackground: (p) => store.openWorkflowsInBackground({ right: [p] }),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The bug, and the fix
+// ---------------------------------------------------------------------------
+
+test("#1575: the reported state — close then open leaves the store naming an UNLOADED tab active", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  assert.equal(wasOpen, false, "the closed tab has no change tracker");
+  assert.equal(store.activeWorkflow, target, "the store still names the closed tab as active");
+  assert.equal(target.changeTracker, null, "and the store's open loaded nothing");
+  assert.equal(
+    store.openWorkflows.some((w) => w?.path === target.path),
+    false,
+    "and never pushed the path back into the open list",
+  );
+  assert.equal(target.loadCalls, 0, "the early return means load() was never reached");
+});
+
+test("#1575: WITHOUT the fix, the panel's repaint read is null — that is the refusal", async () => {
+  const { target } = await strandedByCloseThenOpen();
+  // The exact expression workflow_open uses, and the exact condition it refuses on.
+  const st = target.changeTracker?.activeState ?? target.activeState;
+  assert.equal(st, null);
+  assert.equal(!st || !Array.isArray(st.nodes), true, "this is what emits 'did not expose a complete workflow state'");
+});
+
+test("#1575: the fix loads the content the store's early return skipped", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(settleArgs(store, target, wasOpen));
+
+  assert.equal(result.reason, "loaded-after-noop-open");
+  assert.equal(result.loaded, true);
+  assert.equal(result.target, target, "the object is repaired in place, not swapped");
+  assert.equal(target.loadCalls, 1, "exactly one load");
+
+  const st = workflowRepaintState(result.target);
+  assert.ok(Array.isArray(st?.nodes), "the repaint now has a state to read");
+  assert.equal(st.nodes.length, 2);
+  assert.equal(hasCompleteRepaintState(result.target), true, "workflow_open no longer refuses");
+});
+
+test("#1575: the fix also returns the tab to the open list (the inconsistent active/open state)", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(settleArgs(store, target, wasOpen));
+
+  assert.equal(result.reopened, true);
+  assert.deepEqual(store.backgroundCalls, [[target.path]], "through openWorkflowsInBackground, once");
+  assert.equal(
+    store.openWorkflows.some((w) => w?.path === target.path),
+    true,
+    "panel_list_workflows now agrees with the active pointer",
+  );
+});
+
+test("#1575: the loaded state is the SAVED file, and the tab is not marked dirty by the repair", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  await settleOpenedWorkflowTarget(settleArgs(store, target, wasOpen));
+  assert.deepEqual(workflowRepaintState(target), DISK_STATE);
+  assert.equal(target.isModified, false, "a repair is not an edit");
+});
+
+// ---------------------------------------------------------------------------
+// The patch proposed in the issue does NOT fix this state
+// ---------------------------------------------------------------------------
+
+test("#1575: reacquiring activeWorkflowRef() alone is INERT here — the active object IS the target", async () => {
+  const { store, target } = await strandedByCloseThenOpen();
+  // The issue's proposal, transcribed: adopt the post-open active workflow when it
+  // matches the requested selector.
+  const activeAfterOpen = store.activeWorkflow;
+  const adopted =
+    activeAfterOpen && matchesSelector(activeAfterOpen, target.path) ? activeAfterOpen : target;
+  assert.equal(adopted, target, "it is the same object — ComfyWorkflow.load() returns `this`");
+  const st = adopted.changeTracker?.activeState ?? adopted.activeState;
+  assert.equal(st, null, "so the open still refuses; adoption alone cannot repair this");
+});
+
+// ---------------------------------------------------------------------------
+// Non-regression: the healthy paths must not be touched
+// ---------------------------------------------------------------------------
+
+test("#1575: a normal first-time open (state present) returns untouched — nothing is loaded or re-listed", async () => {
+  const wf = new FakeWorkflow("workflows/normal.json", DISK_STATE);
+  const store = new FakeWorkflowStore(wf);
+  await store.openWorkflow(wf); // a real open: not active, so it loads
+  const loadsAfterOpen = wf.loadCalls;
+
+  const result = await settleOpenedWorkflowTarget(settleArgs(store, wf, false));
+  assert.equal(result.reason, "loaded");
+  assert.equal(result.loaded, false);
+  assert.equal(result.adopted, false);
+  assert.equal(result.target, wf);
+  assert.equal(wf.loadCalls, loadsAfterOpen, "no extra load");
+  assert.deepEqual(store.backgroundCalls, [], "the open list is not touched");
+});
+
+test("#1575: an ALREADY-OPEN tab is never touched — that path owns the #442 disk comparison", async () => {
+  const wf = new FakeWorkflow("workflows/already.json", DISK_STATE);
+  const store = new FakeWorkflowStore(wf);
+  await store.openWorkflow(wf);
+  const result = await settleOpenedWorkflowTarget(settleArgs(store, wf, true));
+  assert.equal(result.reason, "already-open");
+  assert.equal(result.loaded, false);
+  assert.deepEqual(store.backgroundCalls, []);
+});
+
+test("#1575: a target the frontend does NOT name as active is left to the existing refusal", async () => {
+  const wf = new FakeWorkflow("workflows/other.json", DISK_STATE);
+  const store = new FakeWorkflowStore(wf);
+  const someoneElse = new FakeWorkflow("workflows/elsewhere.json", DISK_STATE);
+  await someoneElse.load();
+  wf.unload();
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, wf, false, { activeAfterOpen: someoneElse }),
+  );
+  // someoneElse HAS a state but does not answer to wf's selector, so it is not adopted
+  // either — adopting it would repaint and stamp under another tab's identity.
+  assert.equal(result.reason, "not-active-after-open");
+  assert.equal(result.target, wf);
+  assert.equal(wf.loadCalls, 0);
+});
+
+// ---------------------------------------------------------------------------
+// The adopt arm (a frontend that DOES hand back a different instance)
+// ---------------------------------------------------------------------------
+
+test("#1575: a DIFFERENT live object answering the selector with a state IS adopted", async () => {
+  const stale = new FakeWorkflow("workflows/swapped.json", DISK_STATE);
+  const live = new FakeWorkflow("workflows/swapped.json", DISK_STATE);
+  await live.load();
+  const store = new FakeWorkflowStore(stale);
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, stale, false, { activeAfterOpen: live, selector: "workflows/swapped.json" }),
+  );
+  assert.equal(result.reason, "adopted-live-object");
+  assert.equal(result.adopted, true);
+  assert.equal(result.target, live);
+  assert.equal(stale.loadCalls, 0, "adoption does not also load the stale object");
+});
+
+test("#1575: a live object that does NOT answer the selector is never adopted", async () => {
+  const stale = new FakeWorkflow("workflows/mine.json", DISK_STATE);
+  const foreign = new FakeWorkflow("workflows/theirs.json", DISK_STATE);
+  await foreign.load();
+  const store = new FakeWorkflowStore(stale);
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, stale, false, { activeAfterOpen: foreign, selector: "workflows/mine.json" }),
+  );
+  assert.notEqual(result.target, foreign, "repainting and stamping a foreign tab is the #1089 hazard");
+  assert.equal(result.adopted, false);
+});
+
+test("#1575: a throwing selector oracle refuses the adoption rather than guessing", async () => {
+  const stale = new FakeWorkflow("workflows/x.json", DISK_STATE);
+  const live = new FakeWorkflow("workflows/x.json", DISK_STATE);
+  await live.load();
+  const store = new FakeWorkflowStore(stale);
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, stale, false, {
+      activeAfterOpen: live,
+      matchesSelector: () => {
+        throw new Error("selector oracle exploded");
+      },
+    }),
+  );
+  assert.equal(result.adopted, false);
+});
+
+// ---------------------------------------------------------------------------
+// Best-effort: nothing here may turn a refusal into a throw
+// ---------------------------------------------------------------------------
+
+test("#1575: a throwing load() falls back to the existing refusal, it does not escape", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, target, wasOpen, {
+      loadWorkflowContent: () => {
+        throw new Error("userdata unreachable");
+      },
+    }),
+  );
+  assert.match(result.reason, /^load-failed: /);
+  assert.equal(result.loaded, false);
+  assert.equal(result.target, target);
+  assert.deepEqual(store.backgroundCalls, [], "a failed load must not re-list the tab");
+});
+
+test("#1575: a REJECTING load() is awaited and contained", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, target, wasOpen, {
+      loadWorkflowContent: async () => {
+        throw new Error("fetch failed");
+      },
+    }),
+  );
+  assert.match(result.reason, /^load-failed: /);
+  assert.equal(store.backgroundCalls.length, 0);
+});
+
+test("#1575: a load that produces no state is reported, not claimed as repaired", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, target, wasOpen, { loadWorkflowContent: () => undefined }),
+  );
+  assert.equal(result.reason, "load-produced-no-state");
+  assert.equal(result.loaded, false);
+});
+
+test("#1575: a frontend without openWorkflowsInBackground still gets the loaded canvas", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, target, wasOpen, { reopenTabInBackground: undefined }),
+  );
+  assert.equal(result.loaded, true, "the load is what unblocks the repaint");
+  assert.equal(result.reopened, false, "and the un-fixed tab list is disclosed, not hidden");
+});
+
+test("#1575: a throwing openWorkflowsInBackground still yields a loaded target", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, target, wasOpen, {
+      reopenTabInBackground: () => {
+        throw new Error("store refused");
+      },
+    }),
+  );
+  assert.equal(result.loaded, true);
+  assert.equal(result.reopened, false);
+});
+
+test("#1575: a frontend without load() degrades to today's refusal", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, target, wasOpen, { loadWorkflowContent: undefined }),
+  );
+  assert.equal(result.reason, "load-unavailable");
+  assert.equal(hasCompleteRepaintState(result.target), false);
+});
+
+test("#1575: null / garbage input is a no-op, never a throw", async () => {
+  assert.equal((await settleOpenedWorkflowTarget()).reason, "no-target");
+  assert.equal((await settleOpenedWorkflowTarget({ target: null })).reason, "no-target");
+  assert.equal((await settleOpenedWorkflowTarget({ target: 42 })).reason, "no-target");
+});
+
+// ---------------------------------------------------------------------------
+// The state predicate must mean the same thing the call site means
+// ---------------------------------------------------------------------------
+
+test("#1575: hasCompleteRepaintState mirrors workflow_open's own refusal condition", () => {
+  assert.equal(hasCompleteRepaintState({ changeTracker: { activeState: { nodes: [] } } }), true, "zero nodes is complete");
+  assert.equal(hasCompleteRepaintState({ activeState: { nodes: [{ id: 1 }] } }), true, "the flat shape counts (#721)");
+  assert.equal(hasCompleteRepaintState({ changeTracker: { activeState: { nodes: "bad" } } }), false);
+  assert.equal(hasCompleteRepaintState({ changeTracker: { activeState: null } }), false);
+  assert.equal(hasCompleteRepaintState({}), false);
+  assert.equal(hasCompleteRepaintState(null), false);
+});
+
+// ---------------------------------------------------------------------------
+// Wiring — deleting the call in workflow_open must fail these
+// ---------------------------------------------------------------------------
+
+test("#1575: workflow_open settles the target AFTER openWorkflow and BEFORE it reads the state", () => {
+  assert.match(
+    SRC,
+    /import \{\s*settleOpenedWorkflowTarget\s*\} from "\.\/lib\/settle-open-target\.js"/,
+    "the shipped helper must be imported, not inlined",
+  );
+
+  const openAt = SRC.indexOf("await s.openWorkflow(target);");
+  const settleAt = SRC.indexOf("openSettled = await settleOpenedWorkflowTarget({");
+  const stAt = SRC.indexOf("const st = target.changeTracker?.activeState ?? target.activeState;");
+  assert.notEqual(openAt, -1, "the store-level open must still be what moves the pointer");
+  assert.notEqual(settleAt, -1, "the settle call must exist");
+  assert.notEqual(stAt, -1, "the repaint-state read must still be there (#721)");
+  assert.ok(openAt < settleAt, "settling before the open would have nothing to settle");
+  assert.ok(settleAt < stAt, "settling after the state read would be too late to prevent the refusal");
+
+  const call = SRC.slice(settleAt, SRC.indexOf("});", settleAt) + 3);
+  assert.match(call, /selector:\s*path/, "the adopt arm must be pinned to the REQUESTED selector");
+  assert.match(call, /activeAfterOpen:\s*activeWorkflowRef\(\)/, "read the pointer AFTER the open");
+  assert.match(call, /matchesSelector:\s*workflowRecordMatchesSelector/, "the panel's own selector rule");
+  assert.match(call, /sameWorkflowObject/, "identity is proxy-safe, not `===` (#558 r2)");
+  assert.match(call, /loadWorkflowContent:/, "the load the store's early return skipped");
+  assert.match(call, /openWorkflowsInBackground/, "and the tab-list half of it");
+  assert.match(call, /wasOpen,/, "an already-open tab must be excluded");
+});
+
+test("#1575: the repaired target REPLACES the local one, or every later step reads the stale object", () => {
+  const settleAt = SRC.indexOf("openSettled = await settleOpenedWorkflowTarget({");
+  const after = SRC.slice(settleAt, settleAt + 2000);
+  assert.match(
+    after,
+    /if \(openSettled\.target && openSettled\.target !== target\) target = openSettled\.target;/,
+    "the adopt arm is worthless if the result is discarded",
+  );
+});
+
+test("#1575: a state just read off DISK is not overwritten by the still-mounted canvas (#1215/#874)", () => {
+  const gateAt = SRC.indexOf("const captureBinding = describeLiveCanvasBinding(target);");
+  assert.notEqual(gateAt, -1);
+  const gate = SRC.slice(gateAt, SRC.indexOf("await target.changeTracker?.checkState?.()", gateAt));
+  assert.match(
+    gate,
+    /openSettled\?\.loaded !== true/,
+    "capturing the closed tab's canvas over the freshly-loaded file is the #1215 poison",
+  );
+  // #1295's own pins must survive this change.
+  assert.match(gate, /captureBinding === "bound"/);
+  assert.match(gate, /captureBinding !== "foreign" && !pointerMovedThisOpen/);
+});
+
+test("#1575: a repaired open DISCLOSES that the canvas is the on-disk copy", () => {
+  assert.match(SRC, /openSettled\?\.loaded === true\s*\?\s*\{\s*reopened_from_disk:/, "the reply must say what happened");
+  const at = SRC.indexOf("reopened_from_disk:");
+  const note = SRC.slice(at, at + 1600);
+  assert.match(note, /ON-DISK copy/, "the caller must be told which graph they are looking at");
+  assert.match(note, /#874/, "and that node-written values are not in it");
+});

--- a/browser_tests/unit/settle-open-target.test.mjs
+++ b/browser_tests/unit/settle-open-target.test.mjs
@@ -308,6 +308,24 @@ test("#1575: a live object that does NOT answer the selector is never adopted", 
   assert.equal(result.adopted, false);
 });
 
+test("#1575: a live object at a DIFFERENT path is not adopted even when the selector matches it", async () => {
+  // A bare filename is a valid selector and two directories can hold the same one.
+  // Adopting on the name alone would repaint and stamp another workflow's tab (#1089).
+  const stale = new FakeWorkflow("workflows/a/shared.json", DISK_STATE);
+  const otherDir = new FakeWorkflow("workflows/b/shared.json", DISK_STATE);
+  await otherDir.load();
+  const store = new FakeWorkflowStore(stale);
+  const result = await settleOpenedWorkflowTarget(
+    settleArgs(store, stale, false, {
+      activeAfterOpen: otherDir,
+      selector: "shared.json",
+      matchesSelector: (w, sel) => w?.filename === sel, // both answer to it
+    }),
+  );
+  assert.equal(result.adopted, false, "same NAME is not same WORKFLOW");
+  assert.notEqual(result.target, otherDir);
+});
+
 test("#1575: a throwing selector oracle refuses the adoption rather than guessing", async () => {
   const stale = new FakeWorkflow("workflows/x.json", DISK_STATE);
   const live = new FakeWorkflow("workflows/x.json", DISK_STATE);

--- a/browser_tests/unit/settle-open-target.test.mjs
+++ b/browser_tests/unit/settle-open-target.test.mjs
@@ -151,8 +151,16 @@ function settleArgs(store, target, wasOpen, overrides = {}) {
     openWorkflows: store.openWorkflows,
     sameWorkflowObject,
     matchesSelector,
+    // The collaborators are built EXACTLY as workflow_open builds them — capability
+    // ternaries and all. An earlier version of these tests injected `undefined` or a
+    // throwing stub for `reopenTabInBackground`, two shapes the call site can never
+    // produce, and that blindness let a false `reopened:true` ship (review P1).
+    readOpenWorkflows: () => store.openWorkflows,
     loadWorkflowContent: (wf) => (typeof wf.load === "function" ? wf.load() : undefined),
-    reopenTabInBackground: (p) => store.openWorkflowsInBackground({ right: [p] }),
+    reopenTabInBackground: (p) =>
+      typeof store.openWorkflowsInBackground === "function"
+        ? store.openWorkflowsInBackground({ right: [p] })
+        : undefined,
     ...overrides,
   };
 }
@@ -383,26 +391,53 @@ test("#1575: a load that produces no state is reported, not claimed as repaired"
   assert.equal(result.loaded, false);
 });
 
-test("#1575: a frontend without openWorkflowsInBackground still gets the loaded canvas", async () => {
+test("#1575: a store with NO openWorkflowsInBackground reports reopened:false — through the REAL lambda", async () => {
+  // review P1. The call site always passes a FUNCTION; on a frontend lacking the store
+  // method that function returns `undefined` without throwing. Inferring success from
+  // "it did not throw" made this claim the tab was restored while the open list was
+  // untouched — and suppressed the disclosure that says otherwise.
   const { store, target, wasOpen } = await strandedByCloseThenOpen();
-  const result = await settleOpenedWorkflowTarget(
-    settleArgs(store, target, wasOpen, { reopenTabInBackground: undefined }),
-  );
+  store.openWorkflowsInBackground = undefined; // the frontend simply does not have it
+  const result = await settleOpenedWorkflowTarget(settleArgs(store, target, wasOpen));
+
   assert.equal(result.loaded, true, "the load is what unblocks the repaint");
-  assert.equal(result.reopened, false, "and the un-fixed tab list is disclosed, not hidden");
+  assert.equal(result.reopened, false, "an un-restored tab must NOT be reported as restored");
+  assert.equal(
+    store.openWorkflows.some((w) => w?.path === target.path),
+    false,
+    "ground truth: the tab really is still absent from the open list",
+  );
 });
 
-test("#1575: a throwing openWorkflowsInBackground still yields a loaded target", async () => {
+test("#1575: a store whose openWorkflowsInBackground SILENTLY does nothing reports reopened:false", async () => {
+  // The other shape of the same class: the method exists, accepts the call, and the tab
+  // still does not appear. Only an observation of the list can tell these apart.
   const { store, target, wasOpen } = await strandedByCloseThenOpen();
-  const result = await settleOpenedWorkflowTarget(
-    settleArgs(store, target, wasOpen, {
-      reopenTabInBackground: () => {
-        throw new Error("store refused");
-      },
-    }),
-  );
+  store.openWorkflowsInBackground = () => {}; // accepts, does nothing
+  const result = await settleOpenedWorkflowTarget(settleArgs(store, target, wasOpen));
+  assert.equal(result.loaded, true);
+  assert.equal(result.reopened, false, "reopened must be READ from the open list, not assumed");
+});
+
+test("#1575: a throwing openWorkflowsInBackground still yields a loaded target, reopened:false", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  store.openWorkflowsInBackground = () => {
+    throw new Error("store refused");
+  };
+  const result = await settleOpenedWorkflowTarget(settleArgs(store, target, wasOpen));
   assert.equal(result.loaded, true);
   assert.equal(result.reopened, false);
+});
+
+test("#1575: reopened:true is only ever claimed when the tab is OBSERVED in the open list", async () => {
+  const { store, target, wasOpen } = await strandedByCloseThenOpen();
+  const result = await settleOpenedWorkflowTarget(settleArgs(store, target, wasOpen));
+  assert.equal(result.reopened, true);
+  assert.equal(
+    store.openWorkflows.some((w) => w?.path === target.path),
+    true,
+    "the claim and the store must agree",
+  );
 });
 
 test("#1575: a frontend without load() degrades to today's refusal", async () => {
@@ -461,6 +496,35 @@ test("#1575: workflow_open settles the target AFTER openWorkflow and BEFORE it r
   assert.match(call, /loadWorkflowContent:/, "the load the store's early return skipped");
   assert.match(call, /openWorkflowsInBackground/, "and the tab-list half of it");
   assert.match(call, /wasOpen,/, "an already-open tab must be excluded");
+  // review P1 — a READER, so `reopened` can be re-read after the call. A snapshot array
+  // cannot show whether the store did anything.
+  assert.match(
+    call,
+    /readOpenWorkflows:\s*\(\)\s*=>\s*s\.openWorkflows/,
+    "the open list must be re-readable, not captured once",
+  );
+  assert.doesNotMatch(call, /openWorkflows:\s*s\.openWorkflows/, "a snapshot cannot observe an effect");
+});
+
+test("#1575: the settle's await is held INSIDE a reload step, or the fence ages out mid-load", () => {
+  // review P1 — `target.load()` is an unbounded /userdata fetch. Between steps the guard
+  // sits at pending === 0, where activeWorkflowReloadGuard() expires it after
+  // WORKFLOW_RELOAD_GUARD_MAX_MS; a stalled read would drop the fence, let a concurrent
+  // graph_* command through, and the repaint would then overwrite it from disk.
+  const settleAt = SRC.indexOf("openSettled = await settleOpenedWorkflowTarget({");
+  assert.notEqual(settleAt, -1);
+  const before = SRC.slice(Math.max(0, settleAt - 900), settleAt);
+  const after = SRC.slice(settleAt, settleAt + 2200);
+  assert.match(
+    before,
+    /beginWorkflowReloadStep\(reloadGuardToken\);\s*\r?\n\s*try \{\s*\r?\n\s*$/,
+    "the settle must open a reload step immediately before it",
+  );
+  assert.match(
+    after,
+    /\} finally \{\s*\r?\n\s*endWorkflowReloadStep\(reloadGuardToken\);/,
+    "and release it in a finally, so a throwing settle cannot hold the fence forever",
+  );
 });
 
 test("#1575: the repaired target REPLACES the local one, or every later step reads the stale object", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -487,6 +487,7 @@ import {
   trackerCaptureSuppressed,
 } from "./lib/change-tracker-snapshot.js";
 import { flushSourceCanvasBeforeSwitch } from "./lib/flush-source-before-switch.js";
+import { settleOpenedWorkflowTarget } from "./lib/settle-open-target.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext, stripAgentDirectedBlocks } from "./lib/chat-serialize.js";
 import {
   applyCurrentDefWidgetValues,
@@ -18022,6 +18023,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // tag-based classification answers "unknown" for it, which warns nobody —
     // and that is the configuration the wrong-canvas reports arrived in.
     let sourceUnproven = false;
+    // #1575 — what `settleOpenedWorkflowTarget` had to do after ComfyUI's
+    // store-level open resolved without loading anything. Null on every open that
+    // needed nothing, which is every open that works today. Drives the #874
+    // capture gate (a state we just read off disk must not be overwritten by the
+    // still-mounted canvas) and the reply's disclosure.
+    let openSettled = null;
     let reloaded = false;
     let reloadError = null;
     let openFailed = null;
@@ -18095,6 +18102,44 @@ const GRAPH_TOOL_EXECUTORS = {
         endWorkflowReloadStep(reloadGuardToken);
       }
       if (!openFailed) {
+        // #1575 — `s.openWorkflow(target)` RESOLVING is not proof it loaded anything.
+        //
+        // `app.extensionManager.workflow` is the workflow STORE (workspaceStore binds it
+        // as `computed(() => useWorkflowStore())`), so this command's close and open are
+        // the store's primitives, and they do not pair up the way the SERVICE's do:
+        // `closeWorkflow` unloads the tab and leaves `activeWorkflow` pointing at it,
+        // while `openWorkflow` opens with `if (isActive(workflow)) return workflow` and
+        // `isActive` compares BY PATH. So the tab this command just closed is still named
+        // as active, this open early-returns on that stale pointer, and nothing loads.
+        // Measured on a live frontend: hasTracker false and inOpenList false both before
+        // AND after the open, which makes the `st` read below null and this command refuse
+        // with "this frontend did not expose a complete workflow state" — blaming the
+        // frontend for a state that is one `load()` away on the object already in hand.
+        //
+        // Runs BEFORE the capture gate and the repaint so every later step — the identity
+        // stamp, the proof, the fence, the reply — reads the object that actually holds
+        // the workflow. Returns untouched (`reason: "loaded"`) whenever the open produced
+        // a usable state, which is every open that works today.
+        openSettled = await settleOpenedWorkflowTarget({
+          wasOpen,
+          target,
+          selector: path,
+          activeAfterOpen: activeWorkflowRef(),
+          openWorkflows: s.openWorkflows,
+          sameWorkflowObject,
+          matchesSelector: workflowRecordMatchesSelector,
+          // The exact call the store's own `openWorkflow` skipped. Guarded, so a
+          // frontend without it degrades to today's refusal rather than throwing.
+          loadWorkflowContent: (wf) => (typeof wf.load === "function" ? wf.load() : undefined),
+          // The store's own "add paths without loading them or changing the active
+          // workflow" entry point — the missing half of the early-returned open, and
+          // what clears the active-but-not-open state the report also named.
+          reopenTabInBackground: (p) =>
+            typeof s.openWorkflowsInBackground === "function"
+              ? s.openWorkflowsInBackground({ right: [p] })
+              : undefined,
+        });
+        if (openSettled.target && openSettled.target !== target) target = openSettled.target;
       // We deliberately do NOT auto-reload the canvas from disk here: switching to an
       // already-open tab must not silently discard the user's in-memory graph, and a
       // re-read could race a concurrent canvas edit and clobber it. Instead the staleness
@@ -18242,8 +18287,14 @@ const GRAPH_TOOL_EXECUTORS = {
           const captureBinding = describeLiveCanvasBinding(target);
           pointerMovedThisOpen = !sameWorkflowObject(activeBefore, target);
           if (
-            captureBinding === "bound" ||
-            (captureBinding !== "foreign" && !pointerMovedThisOpen)
+            // #1575 — a state THIS command just read off disk is authoritative, and the
+            // canvas mounted behind it is whatever the closed tab left there. Serializing
+            // that over the fresh state is the #1215/#968 poisoning through a new entry
+            // point, and it can preserve nothing: nothing has run against a just-loaded
+            // tracker, so it holds no node-written values (#874) for the capture to save.
+            openSettled?.loaded !== true &&
+            (captureBinding === "bound" ||
+              (captureBinding !== "foreign" && !pointerMovedThisOpen))
           ) {
             try {
               // AWAITED (codex). A frontend whose tracker captures asynchronously would
@@ -19139,6 +19190,32 @@ const GRAPH_TOOL_EXECUTORS = {
       // passing. The two read identically now, so this discloses instead of
       // claiming. Its own key, like the foreign one: a caller can hit it with
       // neither `stale` nor `canvas_file_divergence` firing.
+      //
+      // #1575 — the open SUCCEEDED, and it succeeded because this command repaired a
+      // frontend state the frontend does not repair for itself. Say so rather than
+      // report a bland success: the canvas now shows the SAVED file, so any node-written
+      // value that only ever lived on the canvas of the tab that was closed is gone —
+      // and that is a real difference the caller may be about to build on.
+      ...(openSettled?.loaded === true
+        ? {
+            reopened_from_disk:
+              "This workflow's tab was closed while it was still the frontend's ACTIVE " +
+              "workflow, which leaves ComfyUI's workflow store naming it active with no " +
+              "content loaded and its tab absent from the open list. The store's own open " +
+              "returns early in that state (it matches the active workflow BY PATH), so it " +
+              "loaded nothing and this command loaded the saved file itself" +
+              (openSettled.reopened ? " and restored the tab to the open list" : "") +
+              ". The canvas therefore shows the ON-DISK copy: anything a NODE wrote and " +
+              "nobody saved — a populated wildcard, a rolled seed (#874) — is not in it. " +
+              "Re-read the graph (panel_graph_outline / panel_query_graph) before relying " +
+              "on values you generated before the close." +
+              (openSettled.reopened
+                ? ""
+                : " The tab could NOT be returned to the open list, so panel_list_workflows " +
+                  "may still show this workflow as active-but-not-open; reload the panel to " +
+                  "clear that."),
+          }
+        : {}),
       ...(sourceUnproven
         ? {
             unproven_source_state:

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18120,25 +18120,39 @@ const GRAPH_TOOL_EXECUTORS = {
         // stamp, the proof, the fence, the reply — reads the object that actually holds
         // the workflow. Returns untouched (`reason: "loaded"`) whenever the open produced
         // a usable state, which is every open that works today.
-        openSettled = await settleOpenedWorkflowTarget({
-          wasOpen,
-          target,
-          selector: path,
-          activeAfterOpen: activeWorkflowRef(),
-          openWorkflows: s.openWorkflows,
-          sameWorkflowObject,
-          matchesSelector: workflowRecordMatchesSelector,
-          // The exact call the store's own `openWorkflow` skipped. Guarded, so a
-          // frontend without it degrades to today's refusal rather than throwing.
-          loadWorkflowContent: (wf) => (typeof wf.load === "function" ? wf.load() : undefined),
-          // The store's own "add paths without loading them or changing the active
-          // workflow" entry point — the missing half of the early-returned open, and
-          // what clears the active-but-not-open state the report also named.
-          reopenTabInBackground: (p) =>
-            typeof s.openWorkflowsInBackground === "function"
-              ? s.openWorkflowsInBackground({ right: [p] })
-              : undefined,
-        });
+        // INSIDE a reload STEP (review P1). `target.load()` is a `/userdata` fetch with
+        // no deadline of its own, and between steps the guard sits at `pending === 0`,
+        // where `activeWorkflowReloadGuard()` expires it after WORKFLOW_RELOAD_GUARD_MAX_MS.
+        // A stalled read would therefore drop the fence mid-load, let a concurrent
+        // graph_* command through and acknowledge it, and the repaint below would then
+        // overwrite it from the disk state — the data-loss shape the guard exists to
+        // prevent. A step keeps `pending > 0`, which is never expired.
+        beginWorkflowReloadStep(reloadGuardToken);
+        try {
+          openSettled = await settleOpenedWorkflowTarget({
+            wasOpen,
+            target,
+            selector: path,
+            activeAfterOpen: activeWorkflowRef(),
+            // A READER, not a snapshot: the helper re-reads it after the re-list to
+            // report what the store DID rather than that the call returned (review P1).
+            readOpenWorkflows: () => s.openWorkflows,
+            sameWorkflowObject,
+            matchesSelector: workflowRecordMatchesSelector,
+            // The exact call the store's own `openWorkflow` skipped. Guarded, so a
+            // frontend without it degrades to today's refusal rather than throwing.
+            loadWorkflowContent: (wf) => (typeof wf.load === "function" ? wf.load() : undefined),
+            // The store's own "add paths without loading them or changing the active
+            // workflow" entry point — the missing half of the early-returned open, and
+            // what clears the active-but-not-open state the report also named.
+            reopenTabInBackground: (p) =>
+              typeof s.openWorkflowsInBackground === "function"
+                ? s.openWorkflowsInBackground({ right: [p] })
+                : undefined,
+          });
+        } finally {
+          endWorkflowReloadStep(reloadGuardToken);
+        }
         if (openSettled.target && openSettled.target !== target) target = openSettled.target;
       // We deliberately do NOT auto-reload the canvas from disk here: switching to an
       // already-open tab must not silently discard the user's in-memory graph, and a

--- a/web/js/lib/settle-open-target.js
+++ b/web/js/lib/settle-open-target.js
@@ -1,0 +1,221 @@
+/**
+ * #1575 — after ComfyUI's store-level `openWorkflow` resolves, make sure the panel
+ * is holding a LOADED workflow object for the workflow the caller asked for.
+ *
+ * THE REPORT. `panel_open_workflow` on a saved workflow whose tab had just been
+ * closed with `panel_close_workflow` came back with
+ *
+ *   "workflow_open could not rebind the active canvas because this frontend did
+ *    not expose a complete workflow state for a safe repaint."
+ *
+ * — an unknown partial outcome, and `panel_list_workflows` showing an
+ * inconsistent active/open state.
+ *
+ * THE CAUSE, measured in a browser against a live ComfyUI (frontend source read
+ * at 1.47.2; probe run against the installed frontend on 2026-08-21).
+ *
+ * `app.extensionManager.workflow` is the workflow STORE, not the workflow
+ * service — `workspaceStore` binds it as `computed(() => useWorkflowStore())`.
+ * The panel therefore calls the store's two primitives, and they do not pair up
+ * the way the service's do:
+ *
+ *   store.closeWorkflow(wf)  removes the path from `openWorkflowPaths` and calls
+ *                            `wf.unload()` (which nulls `changeTracker`), and
+ *                            LEAVES `activeWorkflow` pointing at wf. Moving the
+ *                            pointer is the SERVICE's job, and the service is a
+ *                            Vue composable the panel cannot reach.
+ *
+ *   store.openWorkflow(wf)   begins `if (isActive(workflow)) return workflow`,
+ *                            and `isActive` compares `activeWorkflow.path` to
+ *                            `workflow.path` — BY PATH, not by identity.
+ *
+ * So after a panel-driven close of the active tab the store is left in a state
+ * its own types forbid — `activeWorkflow` is a `LoadedComfyWorkflow` whose
+ * `changeTracker` is null, and whose path is not in the open list — and the next
+ * `openWorkflow` for that path early-returns on the stale pointer. Nothing is
+ * loaded, the path is never pushed back into `openWorkflowPaths`, and the await
+ * resolves as though the open had succeeded.
+ *
+ * MEASURED, in that order, on the real frontend:
+ *
+ *   after store.closeWorkflow   activeIsSameObject:true  hasTracker:false  inOpenList:false
+ *   after store.openWorkflow    activeIsSameObject:true  hasTracker:false  inOpenList:false
+ *   panel repaint-state read    changeTracker?.activeState ?? activeState  ===  null
+ *
+ * `null` is exactly what makes `workflow_open` refuse — and the refusal blames
+ * the FRONTEND for not exposing a complete state, which is untrue: the state is
+ * one `load()` away, on the very object the panel is already holding.
+ *
+ * WHY THE PATCH IN THE ISSUE DOES NOT FIX IT. It proposed re-reading
+ * `activeWorkflowRef()` after the open and adopting it when it matches the
+ * selector, on the theory that the frontend had replaced the catalog entry with
+ * a new live tab object. It does not: `ComfyWorkflow.load()` returns `this`, and
+ * the probe shows `activeWorkflow` IS the object the panel already held
+ * (`activeIsSameObject: true`), so that adoption is a no-op and the open still
+ * refuses. The adopt arm is kept here anyway — it is cheap, and it is the right
+ * repair IF a frontend ever does hand back a different instance. It is simply not
+ * the arm that fixes the reported bug.
+ *
+ * WHAT THIS DOES, only when the open left us with NO usable state:
+ *
+ *   1. ADOPT — a DIFFERENT live object is active for the requested selector and
+ *      it has a complete state. Take it.
+ *   2. LOAD  — the frontend still names our target as active by the same rule its
+ *      own `openWorkflow` used to early-return (path equality), yet it is
+ *      unloaded. That combination is the store contradicting itself, so load the
+ *      content the early return skipped, then put the tab back in the open list.
+ *
+ * The open-list repair goes through `openWorkflowsInBackground`, the store's own
+ * "add paths without loading them or changing the active workflow" entry point.
+ * It is the missing half of the early-returned open, and it is what clears the
+ * inconsistent active/open state the report also named.
+ *
+ * NON-REGRESSION, by construction: an open that already produced a complete state
+ * returns at `reason: "loaded"` before anything is touched. Every open that works
+ * today takes that exit.
+ *
+ * ORDER: load FIRST, re-list the tab only once the load succeeded, so a repair
+ * that fails leaves the store exactly as it was found.
+ *
+ * Best-effort throughout. Nothing here may turn a working open into a throw; on
+ * any failure the caller keeps the object it had and the pre-existing refusal
+ * stands unchanged. Callers inject the collaborators so the decision is
+ * unit-testable without a DOM.
+ */
+
+/** The state `workflow_open` repaints FROM. Mirrors the call site's `st` read,
+ *  which accepts both the tracker-owned and the flat shape (#721). */
+export function workflowRepaintState(wf) {
+  return wf?.changeTracker?.activeState ?? wf?.activeState;
+}
+
+/** Is that state complete enough to repaint from? The call site's
+ *  `!st || !Array.isArray(st.nodes)` refusal, inverted. */
+export function hasCompleteRepaintState(wf) {
+  const st = workflowRepaintState(wf);
+  return !!st && typeof st === "object" && Array.isArray(st.nodes);
+}
+
+/** The frontend's OWN activity test, which is what decided the early return:
+ *  `activeWorkflow.path === workflow.path`. Object identity counts too, because a
+ *  proxy/raw pair is one tab and `sameWorkflowObject` is the panel's proxy-safe
+ *  answer to that (#558 r2). */
+function frontendConsidersActive(active, target, sameWorkflowObject) {
+  if (!active || typeof active !== "object" || !target) return false;
+  try {
+    if (typeof sameWorkflowObject === "function" && sameWorkflowObject(active, target)) return true;
+  } catch {
+    // A throwing identity oracle must not decide this; fall through to the path test.
+  }
+  return typeof active.path === "string" && !!active.path && active.path === target.path;
+}
+
+/**
+ * @param {{
+ *   wasOpen?: boolean,
+ *   target?: object | null,
+ *   selector?: string,
+ *   activeAfterOpen?: object | null,
+ *   openWorkflows?: unknown,
+ *   sameWorkflowObject?: (a: unknown, b: unknown) => boolean,
+ *   matchesSelector?: (wf: object, sel: string) => boolean,
+ *   loadWorkflowContent?: (wf: object) => unknown,
+ *   reopenTabInBackground?: (path: string) => unknown,
+ * }} [input]
+ * @returns {Promise<{ target: object | null, adopted: boolean, loaded: boolean,
+ *   reopened: boolean, reason: string }>}
+ */
+export async function settleOpenedWorkflowTarget({
+  wasOpen,
+  target,
+  selector,
+  activeAfterOpen,
+  openWorkflows,
+  sameWorkflowObject,
+  matchesSelector,
+  loadWorkflowContent,
+  reopenTabInBackground,
+} = {}) {
+  const keep = (reason) => ({ target, adopted: false, loaded: false, reopened: false, reason });
+  try {
+    if (!target || typeof target !== "object") return keep("no-target");
+    // An already-loaded tab cannot be in this state: `wasOpen` IS
+    // `!!target.changeTracker`, and the store's early return only ever strands an
+    // UNLOADED workflow. Leaving the already-open path untouched also keeps the
+    // #442 disk-staleness comparison reading the object it baselined.
+    if (wasOpen) return keep("already-open");
+    // THE NON-REGRESSION EXIT. Every open that works today lands here.
+    if (hasCompleteRepaintState(target)) return keep("loaded");
+
+    // 1. ADOPT — a different live object answers for this selector and has state.
+    if (activeAfterOpen && typeof activeAfterOpen === "object" && hasCompleteRepaintState(activeAfterOpen)) {
+      let sameObject;
+      try {
+        sameObject =
+          typeof sameWorkflowObject === "function"
+            ? sameWorkflowObject(activeAfterOpen, target)
+            : activeAfterOpen === target;
+      } catch {
+        sameObject = activeAfterOpen === target;
+      }
+      let selectorOk = false;
+      try {
+        selectorOk =
+          typeof matchesSelector === "function" && typeof selector === "string" && !!selector
+            ? !!matchesSelector(activeAfterOpen, selector)
+            : false;
+      } catch {
+        // An unreadable selector answer is NOT a match: adopting the active
+        // workflow without proving it is the requested one would repaint, stamp
+        // and report under someone else's tab.
+        selectorOk = false;
+      }
+      if (!sameObject && selectorOk) {
+        return {
+          target: activeAfterOpen,
+          adopted: true,
+          loaded: false,
+          reopened: false,
+          reason: "adopted-live-object",
+        };
+      }
+    }
+
+    // 2. LOAD — the store early-returned on a stale active pointer.
+    if (!frontendConsidersActive(activeAfterOpen, target, sameWorkflowObject)) {
+      return keep("not-active-after-open");
+    }
+    if (typeof loadWorkflowContent !== "function") return keep("load-unavailable");
+    try {
+      await loadWorkflowContent(target);
+    } catch (err) {
+      return keep(`load-failed: ${err?.message ?? err}`);
+    }
+    if (!hasCompleteRepaintState(target)) return keep("load-produced-no-state");
+
+    // The other half of the early-returned open: the tab itself. Best-effort, and
+    // strictly after the load, so a failure here leaves a loaded tab rather than
+    // an empty one.
+    let reopened = false;
+    const path = typeof target.path === "string" ? target.path : "";
+    const alreadyListed = Array.isArray(openWorkflows) && openWorkflows.some((w) => w?.path === path);
+    if (path && !alreadyListed && typeof reopenTabInBackground === "function") {
+      try {
+        reopenTabInBackground(path);
+        reopened = true;
+      } catch {
+        // A tab that is active but absent from the open list is recoverable, and is
+        // disclosed on the reply; failing the whole open over it would not be.
+      }
+    }
+    return {
+      target,
+      adopted: false,
+      loaded: true,
+      reopened: reopened || alreadyListed,
+      reason: "loaded-after-noop-open",
+    };
+  } catch (err) {
+    return keep(`failed: ${err?.message ?? err}`);
+  }
+}

--- a/web/js/lib/settle-open-target.js
+++ b/web/js/lib/settle-open-target.js
@@ -170,7 +170,20 @@ export async function settleOpenedWorkflowTarget({
         // and report under someone else's tab.
         selectorOk = false;
       }
-      if (!sameObject && selectorOk) {
+      // …and it must be the SAME WORKFLOW FILE, not merely something the selector
+      // answers to. `workflowRecordMatchesSelector` accepts a bare filename, and two
+      // workflows in different directories can share one — so on a path where the
+      // store's open failed for a reason OTHER than the early return, the active tab
+      // could be a DIFFERENT workflow that answers the same bare name. Adopting it
+      // would repaint it, stamp this command's uuid onto it, and report success under
+      // its identity: the #1089 hazard, manufactured by the repair. This arm exists for
+      // "a different OBJECT for the same workflow", so requiring the path to agree costs
+      // it nothing, and falling through leaves today's refusal rather than a wrong tab.
+      const samePath =
+        typeof activeAfterOpen.path === "string" &&
+        !!activeAfterOpen.path &&
+        activeAfterOpen.path === target.path;
+      if (!sameObject && selectorOk && samePath) {
         return {
           target: activeAfterOpen,
           adopted: true,

--- a/web/js/lib/settle-open-target.js
+++ b/web/js/lib/settle-open-target.js
@@ -116,7 +116,7 @@ function frontendConsidersActive(active, target, sameWorkflowObject) {
  *   target?: object | null,
  *   selector?: string,
  *   activeAfterOpen?: object | null,
- *   openWorkflows?: unknown,
+ *   readOpenWorkflows?: () => unknown[],
  *   sameWorkflowObject?: (a: unknown, b: unknown) => boolean,
  *   matchesSelector?: (wf: object, sel: string) => boolean,
  *   loadWorkflowContent?: (wf: object) => unknown,
@@ -130,7 +130,7 @@ export async function settleOpenedWorkflowTarget({
   target,
   selector,
   activeAfterOpen,
-  openWorkflows,
+  readOpenWorkflows,
   sameWorkflowObject,
   matchesSelector,
   loadWorkflowContent,
@@ -209,13 +209,29 @@ export async function settleOpenedWorkflowTarget({
     // The other half of the early-returned open: the tab itself. Best-effort, and
     // strictly after the load, so a failure here leaves a loaded tab rather than
     // an empty one.
-    let reopened = false;
+    //
+    // `reopened` is an OBSERVATION of the open list, never "the call did not throw"
+    // (review, P1). The call site reaches `openWorkflowsInBackground` through a
+    // capability-guarded lambda, so on a frontend that lacks it the call returns
+    // `undefined` silently — and inferring success from the absence of an exception
+    // made "this store has no such API" and "the tab was restored" the same value.
+    // The reply then asserted it had restored the tab AND suppressed the disclosure
+    // saying it could not, which is the inconsistent active/open state this fix
+    // exists to repair being reported as repaired while untouched.
     const path = typeof target.path === "string" ? target.path : "";
-    const alreadyListed = Array.isArray(openWorkflows) && openWorkflows.some((w) => w?.path === path);
+    const listedNow = () => {
+      if (typeof readOpenWorkflows !== "function" || !path) return false;
+      try {
+        const list = readOpenWorkflows();
+        return Array.isArray(list) && list.some((w) => w?.path === path);
+      } catch {
+        return false;
+      }
+    };
+    const alreadyListed = listedNow();
     if (path && !alreadyListed && typeof reopenTabInBackground === "function") {
       try {
         reopenTabInBackground(path);
-        reopened = true;
       } catch {
         // A tab that is active but absent from the open list is recoverable, and is
         // disclosed on the reply; failing the whole open over it would not be.
@@ -225,7 +241,8 @@ export async function settleOpenedWorkflowTarget({
       target,
       adopted: false,
       loaded: true,
-      reopened: reopened || alreadyListed,
+      // Re-read, so this reports what the store DID, not what it was asked to do.
+      reopened: alreadyListed || listedNow(),
       reason: "loaded-after-noop-open",
     };
   } catch (err) {


### PR DESCRIPTION
Fixes #1575

## The report

`panel_open_workflow` on a saved workflow whose tab had just been closed with
`panel_close_workflow` returned an unknown partial outcome:

> workflow_open could not rebind the active canvas because this frontend did not expose
> a complete workflow state for a safe repaint. The open may have switched the active
> workflow; inspect panel_list_workflows, then reload the panel before graph edits.

…and `panel_list_workflows` could then show an inconsistent active/open state.

## The cause — and it is NOT the one in the issue body

The issue proposed that "ComfyUI frontend can replace the saved-workflow catalog entry
passed to `openWorkflow()` with a new live tab object", with a patch that re-reads
`activeWorkflowRef()` after the open and adopts it. **That mechanism is not what
happens, and that patch is inert against this bug.** `ComfyWorkflow.load()` returns
`this`, and a live browser probe shows the post-open active workflow *is* the object the
panel already held (`activeIsSameObject: true`), so the adoption is a no-op.

The real cause is that `app.extensionManager.workflow` is ComfyUI's workflow **store**,
not the workflow **service** — `workspaceStore` binds it as
`computed(() => useWorkflowStore())`. So this pack's close and open are the store's
primitives, and they do not pair up the way the service's do:

| call | what it does |
| --- | --- |
| `store.closeWorkflow(wf)` | drops the path from `openWorkflowPaths`, calls `wf.unload()` (nulling `changeTracker`), and **leaves `activeWorkflow` pointing at wf**. Moving the pointer is the SERVICE's job, and the service is a Vue composable the panel cannot reach. |
| `store.openWorkflow(wf)` | begins `if (isActive(workflow)) return workflow`, and `isActive` is `activeWorkflow.path === workflow.path` — **by path, not identity**. |

So a panel-driven close of the active tab leaves the store in a state its own types
forbid: `activeWorkflow` is a `LoadedComfyWorkflow` whose `changeTracker` is null and
whose path is not in the open list. The next `openWorkflow` for that path early-returns
on that stale pointer, loads nothing, never pushes the path back, and **resolves as
though it worked**. `workflow_open` then reads
`target.changeTracker?.activeState ?? target.activeState`, gets `null`, and refuses —
blaming the frontend for a state that was one `load()` away on the object already in hand.

### Measured in a browser, against the reporter's own frontend (ComfyUI 0.33.2 / frontend 1.49.6)

```
after store.closeWorkflow   activeIsSameObject:true  hasTracker:false  inOpenList:false
after store.openWorkflow    activeIsSameObject:true  hasTracker:false  inOpenList:false
panel repaint-state read    changeTracker?.activeState ?? activeState  ===  null   -> wouldRefuse:true
```

and the repair, measured in the same probe:

```
openWorkflowsInBackground({right:[path]})  -> inOpenList:true
wf.load()                                  -> hasTracker:true, nodes:10, isModified:false
app.loadGraphData(state,true,true,wf)      -> canvasNodes:10, active:wf, inOpenList:true
```

## The fix

New `web/js/lib/settle-open-target.js`, called from `workflow_open` immediately after
`s.openWorkflow(target)` and before the state read. It does nothing unless the open left
us with no usable state; then:

1. **ADOPT** — a *different* live object is active for the requested selector and has a
   complete state. Take it. (This is the issue's proposal. It is kept because it is cheap
   and correct *if* a frontend ever does hand back a different instance — it is simply not
   the arm that fixes this report.)
2. **LOAD** — the frontend still names our target as active by the same rule its own
   `openWorkflow` used to early-return, yet it is unloaded. Load the content the early
   return skipped, then return the tab to the open list via `openWorkflowsInBackground`
   (the store's own "add paths without loading them or changing the active workflow"
   entry point) — which is what clears the inconsistent active/open state the report also
   named.

Two supporting changes:

- **The #874 capture gate now skips when we just loaded from disk.** Serializing the
  still-mounted canvas (the closed tab's) over a state read fresh off disk would be the
  #1215/#968 poisoning through a new entry point, and it can preserve nothing — nothing
  has run against a just-loaded tracker.
- **The reply discloses it** (`reopened_from_disk`): the canvas now shows the *on-disk*
  copy, so any node-written value that only lived on the closed tab's canvas (#874) is not
  in it. A bland success would have hidden a real difference.

Non-regression is structural: an open that already produced a complete state returns at
`reason: "loaded"` before anything is touched — that is every open that works today.

## Evidence

**Mutation-verified** — the fix deleted, the named test goes red:

| mutation | result |
| --- | --- |
| remove the LOAD arm from the helper | 9 named unit tests fail, incl. *"the fix loads the content the store's early return skipped"* |
| delete the `settleOpenedWorkflowTarget` call site | 2 wiring pins fail |
| remove the capture-gate guard | *"a state just read off DISK is not overwritten by the still-mounted canvas"* fails |
| delete the call site, then run the **e2e** spec | reproduces the reporter's error **verbatim**: `workflow_open could not rebind the active canvas because this frontend did not expose a complete workflow state for a safe repaint.` |

**Tests**

- `browser_tests/unit/settle-open-target.test.mjs` — 24 tests. Drives the shipped helper
  against `FakeWorkflowStore`, a transcription of the frontend's real `openWorkflow` /
  `closeWorkflow` / `unload` / derived `activeState` getter, so the state under test is
  the state the frontend really produces. Includes an explicit test that the issue's own
  patch is inert here.
- `browser_tests/reopen-closed-workflow.spec.ts` — drives the reported sequence
  (save → close → reopen) through real panel commands against a real ComfyUI.
- `npm run test:unit`: **6271 passed, 0 failed**. (The `#671 manager-install` wall-clock
  flake fired once under load in an earlier run and is green in isolation: 125/125.)
- `npx tsc --noEmit`: clean.
- Full Playwright suite at `--workers=1`: running; result posted in a comment below.

`browser_tests/unit/frontend-contract.test.mjs` gains `openWorkflowsInBackground` as an
OPTIONAL member — always called behind a `typeof … === "function"` guard, so a frontend
without it still gets the loaded canvas and the reply says the tab list could not be
corrected.

## What I deliberately did not do

- **I did not change `workflow_close`.** The true origin is that the panel calls the
  store's `closeWorkflow`, which does not move the active pointer the way the service's
  does. Fixing it there would mean the panel picking a next-active workflow — replicating
  service logic and changing close behaviour — and it would leave already-stranded
  sessions broken. The repair belongs where the failure is observed. Worth a follow-up
  issue; not this PR, under the freeze.
- **I did not act on the issue's patch as written.** Applying it would have shipped a
  no-op. The reporter's live verification was done *after a frontend reload*, which on its
  own explains the recovery — so their evidence does not isolate their patch.
- I did not touch the already-open path (`wasOpen`), which owns the #442 disk-staleness
  comparison.

## Review

**Review is PENDING.** This change is not gated, and I have not merged it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
