### PR TITLE
fix: return refresh_nodes budget verdict before reapply (#1562)

### DIFF
--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -117,6 +117,12 @@ function busyBlock(ms) {
   while (performance.now() < end) {}
 }
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
 test("#1562: refresh_nodes answers before synchronous reapply and keeps registration single-flight", async () => {
   // Scaled 10:1 from the report: fetch finishes inside the caller's wait, but fetch plus
   // synchronous registration exceeds the relay. A retry is issued before the first run's
@@ -182,4 +188,45 @@ test("#1562: refresh_nodes answers before synchronous reapply and keeps registra
   }
   assert.equal(registrationCalls, 2, "the retry joined/queued behind the first run, then refreshed once");
   assert.equal(maxConcurrentRegistrations, 1, "registration passes must remain single-flight");
+});
+
+test("#1562: a later bounded caller upgrades an already-queued trailing run", async () => {
+  const hold = deferred();
+  let runNumber = 0;
+  let localWorkStarted = 0;
+  let inFlight = null;
+  const coalescer = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => { inFlight = p; },
+    runRegister: async (_defs, _opts, control) => {
+      const number = ++runNumber;
+      if (number === 1) await hold.promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await control.beforeLocalWork?.();
+      if (number === 2) localWorkStarted += 1;
+      busyBlock(100);
+    },
+    withTimeout,
+  });
+
+  const first = coalescer(undefined, { force: true });
+  // The unbounded download/reconnect-style force caller queues the shared
+  // trailing run without asking it to yield.
+  const unboundedTrailing = coalescer(undefined, { force: true });
+  // refresh_nodes arrives while that trailing run is still queued and upgrades
+  // it before its fetch/local-work handoff begins.
+  const bounded = coalescer(undefined, {
+    force: true,
+    joinMs: 1000,
+    abandonBeforeLocalWork: true,
+  });
+
+  hold.resolve();
+  const outcome = await bounded;
+  assert.equal(outcome, REFRESH_JOIN_ABANDONED);
+  assert.equal(localWorkStarted, 0, "the bounded caller must return before trailing local work");
+
+  await first;
+  await unboundedTrailing;
+  assert.equal(localWorkStarted, 1, "the upgraded trailing run still completes its registration");
 });

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -1,0 +1,185 @@
+// panel#1562 recurrence: a large /object_info can finish just before the refresh
+// caller's budget, then synchronous schema registration blocks the timer that should
+// produce the retryable verdict. The verdict must cross the relay before that local work,
+// while the single-flight run remains alive and owns registration until it finishes.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { fetchWholeObjectInfo, TRANSPORT_OUTCOME } from "../../web/js/lib/object-info-oracle.js";
+import { describeNodeDefRefresh, NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
+import { comboRebuildCovered } from "../../web/js/lib/asset-staleness.js";
+
+const SRC = readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
+
+function extractFunction(marker) {
+  const start = SRC.indexOf(marker);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = SRC.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") { i = SRC.indexOf("\n", i + 2); if (i < 0) break; continue; }
+    if (ch === "/" && SRC[i + 1] === "*") { i = SRC.indexOf("*/", i + 2); if (i < 0) break; i += 1; continue; }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const q = ch;
+      for (i += 1; i < SRC.length; i += 1) { if (SRC[i] === "\\") { i += 1; continue; } if (SRC[i] === q) break; }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function: ${marker}`);
+}
+
+const NODE_DEFS_NO_ANSWER = Symbol("node-defs-timeout");
+const COMBO_OK = Symbol("combo-refreshed");
+const COMBO_NO_ANSWER = Symbol("combo-timeout");
+const monotonicNow = () => performance.now();
+const nodeDefsBudgetLeft = (deadline, share = 1) => Math.max(1, Math.floor((deadline - monotonicNow()) * share));
+const cacheSpy = { invalidate: () => {}, read: async (f) => f() };
+const snapshotSpy = { clear: () => {}, record: () => true };
+const COMMAND_BUDGET = 2500;
+const RELAY = 3000;
+const FETCH_MS = 2080;
+const BLOCK_MS = 1500;
+
+function buildRun({ appValue, apiValue }) {
+  const body = extractFunction("async function registerComfyNodeDefs(");
+  const names = [
+    "app", "api", "recordObjectInfoTypes", "reapplyDefsToLiveNodes", "comboRebuildCovered",
+    "describeNodeDefRefresh", "fetchNodeDefsWithRetry", "withTimeout", "NODE_DEFS_NO_ANSWER",
+    "COMBO_OK", "COMBO_NO_ANSWER", "NODE_DEFS_FETCH_TIMEOUT_MS", "NODE_DEFS_RUN_BUDGET_MS",
+    "NODE_DEFS_FETCH_SHARE", "fetchWholeObjectInfo", "nodeDefsBudgetLeft", "monotonicNow",
+    "NODE_DEFS_RETRY_DELAYS_MS", "objectInfoCache", "objectInfoSnapshot", "backendReconnectEpoch",
+    "TRANSPORT_OUTCOME",
+  ];
+  const vals = {
+    app: appValue, api: apiValue,
+    recordObjectInfoTypes: () => ({}),
+    reapplyDefsToLiveNodes: () => {},
+    comboRebuildCovered,
+    describeNodeDefRefresh,
+    fetchNodeDefsWithRetry: (g, o) => fetchNodeDefsWithRetry(g, { ...o, sleep: async () => {} }),
+    withTimeout,
+    NODE_DEFS_NO_ANSWER, COMBO_OK, COMBO_NO_ANSWER,
+    NODE_DEFS_FETCH_TIMEOUT_MS: 10000,
+    NODE_DEFS_RUN_BUDGET_MS: 9000,
+    NODE_DEFS_FETCH_SHARE: 2 / 3,
+    fetchWholeObjectInfo,
+    nodeDefsBudgetLeft, monotonicNow,
+    NODE_DEFS_RETRY_DELAYS_MS: OBJECT_INFO_RETRY_DELAYS_MS,
+    objectInfoCache: cacheSpy,
+    objectInfoSnapshot: snapshotSpy,
+    backendReconnectEpoch: 7,
+    TRANSPORT_OUTCOME,
+  };
+  const factory = new Function(...names, `
+    const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
+      if (typeof api?.getNodeDefs !== "function") return null;
+      const settled = await withTimeout(
+        Promise.resolve().then(() => api.getNodeDefs()).then((value) => ({ value }), (err) => ({ err })),
+        ms, () => NODE_DEFS_NO_ANSWER,
+      );
+      if (settled === NODE_DEFS_NO_ANSWER) return NODE_DEFS_NO_ANSWER;
+      if ("err" in settled) throw settled.err;
+      return settled.value;
+    };
+    let nodeDefsRefreshConfirmed = false;
+    ${body}
+    return registerComfyNodeDefs;`);
+  return factory(...names.map((n) => vals[n]));
+}
+
+const refreshNodesMatch = SRC.match(/\n {2}async refresh_nodes\(\) \{[\s\S]*?\n {2}\},/);
+assert.ok(refreshNodesMatch, "refresh_nodes not found");
+
+function buildRefreshNodes({ refreshComfyNodeDefs }) {
+  const deps = {
+    refreshComfyNodeDefs,
+    REFRESH_JOIN_ABANDONED,
+    NODE_DEF_REFRESH_REASONS,
+    REFRESH_NODES_COMMAND_BUDGET_MS: COMMAND_BUDGET,
+    REFRESH_NODES_RUN_BUDGET_MS: Math.ceil(COMMAND_BUDGET / (2 / 3)),
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(...names, `const executors = {${refreshNodesMatch[0]}}; return executors.refresh_nodes;`);
+  return factory(...names.map((n) => deps[n]));
+}
+
+function busyBlock(ms) {
+  const end = performance.now() + ms;
+  // eslint-disable-next-line no-empty
+  while (performance.now() < end) {}
+}
+
+test("#1562: refresh_nodes answers before synchronous reapply and keeps registration single-flight", async () => {
+  // Scaled 10:1 from the report: fetch finishes inside the caller's wait, but fetch plus
+  // synchronous registration exceeds the relay. A retry is issued before the first run's
+  // handoff timer, so an overlapping registration would be observable.
+  const TYPES = 5635;
+  const defs = {};
+  for (let i = 0; i < TYPES; i += 1) defs[`Type${i}`] = { input: {}, output: [] };
+
+  let fetchCalls = 0;
+  let registrationCalls = 0;
+  let activeRegistrations = 0;
+  let maxConcurrentRegistrations = 0;
+  const appValue = {
+    graph: null,
+    registerNodesFromDefs: async () => {
+      registrationCalls += 1;
+      activeRegistrations += 1;
+      maxConcurrentRegistrations = Math.max(maxConcurrentRegistrations, activeRegistrations);
+      busyBlock(BLOCK_MS);
+      activeRegistrations -= 1;
+    },
+    refreshComboInNodes: async () => {},
+  };
+  const apiValue = {
+    getNodeDefs: () => {
+      const delay = fetchCalls++ === 0 ? FETCH_MS : 0;
+      return new Promise((resolve) => setTimeout(() => resolve(defs), delay));
+    },
+  };
+
+  let inFlight = null;
+  const run = buildRun({ appValue, apiValue });
+  const coalescer = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => { inFlight = p; },
+    runRegister: run,
+    withTimeout,
+  });
+  const refresh_nodes = buildRefreshNodes({ refreshComfyNodeDefs: coalescer });
+
+  const startedAt = performance.now();
+  const reply = await refresh_nodes();
+  const elapsed = performance.now() - startedAt;
+
+  assert.ok(elapsed < RELAY, `structured reply arrived at ${Math.round(elapsed)}ms, past ${RELAY}ms relay`);
+  assert.deepEqual(
+    { ok: reply.ok, refreshed: reply.refreshed, reason: reply.reason },
+    { ok: true, refreshed: false, reason: "refresh_still_running" },
+  );
+  assert.equal(
+    registrationCalls,
+    0,
+    "the caller must reply before registerNodesFromDefs/reapply can block the main thread",
+  );
+
+  // This retry sees the still-live first promise and queues one trailing forced run. Both
+  // runs may register eventually, but the coalescer must never let those passes overlap.
+  const retryReply = await refresh_nodes();
+  assert.equal(retryReply.reason, "refresh_still_running");
+  while (inFlight) {
+    const current = inFlight;
+    await current;
+  }
+  assert.equal(registrationCalls, 2, "the retry joined/queued behind the first run, then refreshed once");
+  assert.equal(maxConcurrentRegistrations, 1, "registration passes must remain single-flight");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1313,7 +1313,7 @@ const OBJECT_INFO_SEED_WAIT_MS = 8000;
 const awaitObjectInfoHistorySeed = (waitMs = OBJECT_INFO_SEED_WAIT_MS) =>
   awaitHistoryBaseline(objectInfoHistory, objectInfoHistorySeed, waitMs);
 
-async function registerComfyNodeDefs(preloadedDefs, runOpts) {
+async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // Trust the live combos for suppressing missing-asset candidates ONLY once they have
   // ACTUALLY BEEN REBUILT from an authoritative payload this run obtained. Two things can
   // do that and the trust flag accepts either (#1193): `refreshComboInNodes()` answering,
@@ -1710,6 +1710,18 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts) {
       // Rethrown here rather than at the catch, so the phase attribution, the verdict's
       // reason and its detail are untouched for the case where both routes failed.
       if (clientRouteThrew) throw clientRouteError;
+    }
+    // #1562 — hand a bounded `refresh_nodes` caller its retryable verdict before any local
+    // schema work can block the main thread. Resolving a promise is not enough here: its
+    // reaction is a microtask, while `recordObjectInfoTypes`, graph serialization,
+    // `registerNodesFromDefs` and the reapply sweep can all run synchronously before the
+    // event loop gets another turn. The coalescer therefore asks this run to announce the
+    // handoff and, for that caller only, awaits one macrotask after the announcement. The
+    // run remains in the single-flight slot throughout, so a retry joins or queues behind
+    // it and can never overlap another registration pass.
+    if (defs && typeof runControl?.beforeLocalWork === "function") {
+      const localWorkGate = runControl.beforeLocalWork();
+      if (localWorkGate) await localWorkGate;
     }
     // Record observed backend history (#458 trust root) — covers reconnect, the forced
     // refresh_nodes path, add_node payloads, and download-triggered refreshes.
@@ -11624,6 +11636,10 @@ const GRAPH_TOOL_EXECUTORS = {
     const verdict = await refreshComfyNodeDefs(undefined, {
       force: true,
       joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,
+      // #1562 — the run announces this handoff after /object_info and yields one turn
+      // before registration, so this caller can return its structured retryable verdict
+      // before synchronous schema work blocks the relay timer.
+      abandonBeforeLocalWork: true,
       // #1562 — and the RUN this command starts gets an allowance that outlasts that wait,
       // so the JOIN is what ends the command. Without this line the run gives up first and
       // the retryable `refresh_still_running` verdict below is unreachable on exactly the
@@ -11655,8 +11671,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // the second case — and it is the case a big install hits without any concurrency at
         // all. `graph_add_node`'s refusal names both for the same reason.
         detail:
-          `A node-def refresh was still running when this command's ` +
-          `${Math.round(REFRESH_NODES_COMMAND_BUDGET_MS / 1000)}s budget ran out waiting for ` +
+          `A node-def refresh was still running when this command stopped waiting for ` +
           `it — either one something else started (a ComfyUI reconnect, a finished install or ` +
           `download, this panel's own missing-asset check after an upload) or this command's ` +
           `own registration. Nothing failed and nothing was changed.`,

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -58,7 +58,8 @@
  *
  * A distinct value rather than `undefined`, because `undefined` is already what a
  * successful plain join resolves to and the two demand opposite handling — one means "the
- * defs you wanted are registered", the other means "nobody registered anything for you".
+ * defs you wanted are registered", the other means "the caller stopped waiting while the
+ * run was still responsible for registering them".
  */
 export const REFRESH_JOIN_ABANDONED = Symbol("refresh-join-abandoned");
 
@@ -105,21 +106,31 @@ async function joinBounded(current, joinMs, withTimeout) {
  *
  * A rejecting run still rejects: #608 reads the verdict a forced refresh resolves, and a
  * bound on the wait must not quietly turn that into a success. Only the abandonment is new.
+ * `abandonBeforeLocalWork` also lets a caller stop at the explicit handoff immediately
+ * before a run begins synchronous schema work; the run itself is not cancelled.
  */
-async function waitForRun(run, ms, withTimeout) {
+async function waitForRun(runHandle, ms, withTimeout, abandonBeforeLocalWork = false) {
+  const run = runHandle.promise;
   if (ms === null) return run;
   // An abandoned wait is not a reason to turn the run's failure into an unhandled rejection.
   run.catch(() => {});
   if (!(ms > 0)) return REFRESH_JOIN_ABANDONED;
+  const runOutcome = Promise.resolve(run).then(
+    (value) => ({ value }),
+    (err) => ({ err }),
+  );
   const settled = await withTimeout(
-    Promise.resolve(run).then(
-      (value) => ({ value }),
-      (err) => ({ err }),
-    ),
+    abandonBeforeLocalWork
+      ? Promise.race([
+          runOutcome,
+          runHandle.beforeLocalWork.then(() => ({ beforeLocalWork: true })),
+        ])
+      : runOutcome,
     ms,
     () => null,
   );
   if (settled === null) return REFRESH_JOIN_ABANDONED;
+  if (settled?.beforeLocalWork === true) return REFRESH_JOIN_ABANDONED;
   if ("err" in settled) throw settled.err;
   return settled.value;
 }
@@ -144,10 +155,11 @@ async function waitForRun(run, ms, withTimeout) {
 //
 //   getInFlight / setInFlight : accessors for the shared single-flight promise slot
 //                               (module-level in the panel).
-//   runRegister(preloadedDefs, runOpts) : performs the actual (idempotent) registration;
-//                                its own cleanup must NOT clear the slot — the coalescer
-//                                owns the slot lifecycle. `runOpts` is the caller's
-//                                `{ runBudgetMs }`, forwarded verbatim.
+//   runRegister(preloadedDefs, runOpts, runControl) : performs the actual (idempotent)
+//                                registration; its own cleanup must NOT clear the slot —
+//                                the coalescer owns the slot lifecycle. `runOpts` is the
+//                                caller's `{ runBudgetMs }`, forwarded verbatim. `runControl`
+//                                carries the pre-local-work handoff used by a bounded caller.
 //   withTimeout                : the repo's ONE bounding primitive (bounded-step.js),
 //                                injected rather than imported so this module stays a
 //                                pure coordinator and a test can drive the clock. Omit it
@@ -158,10 +170,30 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
   // The single queued trailing (forced, no-payload) run, or null when none is
   // pending. Coalesces any number of forced calls arriving during one in-flight run.
   let trailing = null;
-  const startRun = (preloadedDefs, runOpts) => {
+  const startRun = (preloadedDefs, runOpts, abandonBeforeLocalWork) => {
+    let announceBeforeLocalWork;
+    const beforeLocalWork = new Promise((resolve) => {
+      announceBeforeLocalWork = resolve;
+    });
+    let announced = false;
+    const runControl = {
+      beforeLocalWork: () => {
+        if (!announced) {
+          announced = true;
+          announceBeforeLocalWork();
+        }
+        // Resolving the signal alone is not enough: its reaction is a microtask, and the
+        // next synchronous registration call could block the tab before that reaction runs.
+        // The production run awaits this one macrotask when a caller asked for the early
+        // verdict, giving the caller's structured reply a chance to compose first.
+        return abandonBeforeLocalWork
+          ? new Promise((resolve) => setTimeout(resolve, 0))
+          : undefined;
+      },
+    };
     const p = (async () => {
       try {
-        return await runRegister(preloadedDefs, runOpts);
+        return await runRegister(preloadedDefs, runOpts, runControl);
       } finally {
         // Clear the slot only if it still points at THIS run (a later run may have
         // already replaced it).
@@ -169,7 +201,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       }
     })();
     setInFlight(p);
-    return p;
+    return { promise: p, beforeLocalWork };
   };
   return async function refresh(preloadedDefs, opts) {
     const force = !!(opts && opts.force);
@@ -187,6 +219,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     // #1562 — the caller's RUN allowance, forwarded to every `startRun` below. Built here,
     // once, so no branch can start a run under a different budget than its siblings.
     const runOpts = opts && Number.isFinite(opts.runBudgetMs) ? { runBudgetMs: opts.runBudgetMs } : undefined;
+    const abandonBeforeLocalWork = !!(opts && opts.abandonBeforeLocalWork);
     const remaining = () => (joinMs === null ? null : joinMs - (Date.now() - startedAt));
     const current = getInFlight();
     if (current) {
@@ -205,7 +238,12 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         // #1351 — the join settled, so starting our own run is not a stampede. What remains
         // of `joinMs` bounds the wait on THAT run. Wrapping join+run as one promise and
         // bounding it once would start the run after an abandoned join — the stampede.
-        return waitForRun(startRun(preloadedDefs, runOpts), remaining(), withTimeout);
+        return waitForRun(
+          startRun(preloadedDefs, runOpts, abandonBeforeLocalWork),
+          remaining(),
+          withTimeout,
+          abandonBeforeLocalWork,
+        );
       }
       // Forced, no payload ⇒ guarantee a fresh fetch AFTER the current run
       // settles; coalesce concurrent forced calls into ONE trailing run (#396).
@@ -217,23 +255,32 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       // The queued promise already includes the trailing `startRun`, so this one bound
       // covers join AND run — the shape #1351 brings to the payload path as well.
       if (!trailing) {
-        trailing = (async () => {
+        const queued = (async () => {
           try {
             await current;
           } catch {
             /* the in-flight refresh failed — run our own anyway */
           }
           trailing = null;
-          return startRun(undefined, runOpts);
+          return startRun(undefined, runOpts, abandonBeforeLocalWork);
         })();
+        trailing = {
+          promise: queued.then((handle) => handle.promise),
+          beforeLocalWork: queued.then((handle) => handle.beforeLocalWork),
+        };
       }
-      return waitForRun(trailing, joinMs, withTimeout);
+      return waitForRun(trailing, joinMs, withTimeout, abandonBeforeLocalWork);
     }
     // #1351 — nothing in flight, so `joinMs` has no join to bound. It still bounds THIS
     // run: the 8.0× measurement was a 2,251 ms own run against a 280 ms bound with the
     // join landing (or never starting) inside it. A bound already spent starts nothing —
     // the same as an abandoned join, and for the same `withTimeout` trap.
     if (joinMs !== null && !(joinMs > 0)) return REFRESH_JOIN_ABANDONED;
-    return waitForRun(startRun(preloadedDefs, runOpts), joinMs, withTimeout);
+    return waitForRun(
+      startRun(preloadedDefs, runOpts, abandonBeforeLocalWork),
+      joinMs,
+      withTimeout,
+      abandonBeforeLocalWork,
+    );
   };
 }

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -171,6 +171,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
   // pending. Coalesces any number of forced calls arriving during one in-flight run.
   let trailing = null;
   const startRun = (preloadedDefs, runOpts, abandonBeforeLocalWork) => {
+    let yieldBeforeLocalWork = !!abandonBeforeLocalWork;
     let announceBeforeLocalWork;
     const beforeLocalWork = new Promise((resolve) => {
       announceBeforeLocalWork = resolve;
@@ -186,7 +187,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         // next synchronous registration call could block the tab before that reaction runs.
         // The production run awaits this one macrotask when a caller asked for the early
         // verdict, giving the caller's structured reply a chance to compose first.
-        return abandonBeforeLocalWork
+        return yieldBeforeLocalWork
           ? new Promise((resolve) => setTimeout(resolve, 0))
           : undefined;
       },
@@ -200,8 +201,17 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         if (getInFlight() === p) setInFlight(null);
       }
     })();
+    // A bounded refresh_nodes caller can arrive after this run was created by
+    // an unbounded force-trigger (download/reconnect). Keep the handoff
+    // upgradeable until the run reaches it; once local synchronous work starts,
+    // no later caller can safely interrupt that JavaScript turn.
+    const requestEarlyYield = () => {
+      yieldBeforeLocalWork = true;
+    };
+    p.beforeLocalWork = beforeLocalWork;
+    p.requestEarlyYield = requestEarlyYield;
     setInFlight(p);
-    return { promise: p, beforeLocalWork };
+    return { promise: p, beforeLocalWork, requestEarlyYield };
   };
   return async function refresh(preloadedDefs, opts) {
     const force = !!(opts && opts.force);
@@ -254,7 +264,15 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       // asymmetry is deliberate: the run is #396's guarantee to whoever else is waiting.
       // The queued promise already includes the trailing `startRun`, so this one bound
       // covers join AND run — the shape #1351 brings to the payload path as well.
+      // #1562 — a bounded refresh_nodes call may arrive after an unbounded force caller
+      // already started the current run or queued the shared trailing run. Upgrade both
+      // handles before waiting so either run yields at the explicit pre-local-work handoff.
+      if (abandonBeforeLocalWork) {
+        current.requestEarlyYield?.();
+        trailing?.requestEarlyYield?.();
+      }
       if (!trailing) {
+        let earlyYieldRequested = abandonBeforeLocalWork;
         const queued = (async () => {
           try {
             await current;
@@ -262,11 +280,14 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
             /* the in-flight refresh failed — run our own anyway */
           }
           trailing = null;
-          return startRun(undefined, runOpts, abandonBeforeLocalWork);
+          return startRun(undefined, runOpts, earlyYieldRequested);
         })();
         trailing = {
           promise: queued.then((handle) => handle.promise),
           beforeLocalWork: queued.then((handle) => handle.beforeLocalWork),
+          requestEarlyYield: () => {
+            earlyYieldRequested = true;
+          },
         };
       }
       return waitForRun(trailing, joinMs, withTimeout, abandonBeforeLocalWork);


### PR DESCRIPTION
## Summary
- let a later bounded refresh_nodes caller upgrade an already-queued trailing refresh run
- return the bounded handoff verdict before synchronous node reapply can block the relay
- preserve trailing refresh completion and add regression coverage

## Validation
- node browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
- node --test browser_tests/unit/refresh-nodes-command-budget.test.mjs browser_tests/unit/node-def-refresh.test.mjs
- npm.cmd run typecheck
- npm.cmd run i18n:check
- node scripts/check-panel-scope.mjs
- git diff --check

Independent direct gate: SHIP at exact head 9700acca91235a1fa2ed6491bf61c890e4c3fdd9.