### PR TITLE
fix: publish workflow identity on graph reads (#1973)

### DIFF
--- a/browser_tests/unit/graph-view-identity.test.mjs
+++ b/browser_tests/unit/graph-view-identity.test.mjs
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 
 import { withWorkflowUuid } from "../../web/js/lib/graph-view-identity.js";
+
+const PANEL_SRC = fs.readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
 
 test("graph read identity carries the live root workflow uuid", () => {
   const root = { extra: { comfyui_mcp: { workflow_uuid: "workflow-a" } } };
@@ -27,4 +30,28 @@ test("missing or malformed identity stays omitted", () => {
     withWorkflowUuid({ scope: "root" }, { extra: { comfyui_mcp: { workflow_uuid: "" } } }),
     { scope: "root" },
   );
+});
+
+test("an explicit live identity wins over a stale root tag", () => {
+  const root = { extra: { comfyui_mcp: { workflow_uuid: "workflow-old" } } };
+  assert.deepEqual(withWorkflowUuid({ scope: "root" }, root, "workflow-new"), {
+    scope: "root",
+    workflow_uuid: "workflow-new",
+  });
+  assert.deepEqual(withWorkflowUuid({ scope: "root" }, root, null), { scope: "root" });
+});
+
+test("production graph read callers publish the live viewing identity", () => {
+  assert.match(PANEL_SRC, /const workflow = activeWorkflowRef\(\);/);
+  assert.match(PANEL_SRC, /const withLiveIdentity = \(viewing\) => withWorkflowUuid\(viewing, root, workflowUuid\);/);
+
+  const subgraphStart = PANEL_SRC.indexOf("graph_get_subgraph({ node_id }) {");
+  const subgraphEnd = PANEL_SRC.indexOf("async graph_add_node", subgraphStart);
+  assert.ok(subgraphStart >= 0 && subgraphEnd > subgraphStart);
+  assert.match(PANEL_SRC.slice(subgraphStart, subgraphEnd), /viewing: describeActiveGraph\(graph\)/);
+
+  const queryStart = PANEL_SRC.indexOf("graph_query({");
+  const queryEnd = PANEL_SRC.indexOf("graph_find_nodes({", queryStart);
+  assert.ok(queryStart >= 0 && queryEnd > queryStart);
+  assert.match(PANEL_SRC.slice(queryStart, queryEnd), /viewing: describeActiveGraph\(graph\)/);
 });

--- a/browser_tests/unit/graph-view-identity.test.mjs
+++ b/browser_tests/unit/graph-view-identity.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { withWorkflowUuid } from "../../web/js/lib/graph-view-identity.js";
+
+test("graph read identity carries the live root workflow uuid", () => {
+  const root = { extra: { comfyui_mcp: { workflow_uuid: "workflow-a" } } };
+  assert.deepEqual(withWorkflowUuid({ scope: "root" }, root), {
+    scope: "root",
+    workflow_uuid: "workflow-a",
+  });
+});
+
+test("subgraph replies retain the root workflow uuid", () => {
+  const root = { extra: { comfyui_mcp: { workflow_uuid: "workflow-a" } } };
+  assert.deepEqual(withWorkflowUuid({ scope: "subgraph", owner_node_id: 7, title: "Detail" }, root), {
+    scope: "subgraph",
+    owner_node_id: 7,
+    title: "Detail",
+    workflow_uuid: "workflow-a",
+  });
+});
+
+test("missing or malformed identity stays omitted", () => {
+  assert.deepEqual(withWorkflowUuid({ scope: "root" }, {}), { scope: "root" });
+  assert.deepEqual(
+    withWorkflowUuid({ scope: "root" }, { extra: { comfyui_mcp: { workflow_uuid: "" } } }),
+    { scope: "root" },
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -197,6 +197,7 @@ import {
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
+import { withWorkflowUuid } from "./lib/graph-view-identity.js";
 import { saveReplyIdentity, shouldEstablishIdentityAfterSave } from "./lib/save-reply-identity.js";
 import { describeOpenActiveBinding } from "./lib/open-active-binding.js";
 import { compareVersions, releasesSince, summarizeReleases, updateAnnouncement } from "./lib/changelog-delta.js";
@@ -8757,25 +8758,28 @@ function refreshPromotedParents(parents, canvas) {
  *  lockstep (#220/#308). */
 function describeActiveGraph(graph) {
   const root = app?.graph;
-  if (!root || !graph || graph === root) return { scope: "root" };
+  if (!root || !graph || graph === root) return withWorkflowUuid({ scope: "root" }, root);
   const owner = findSubgraphOwner(root, graph);
   if (owner) {
-    return {
+    return withWorkflowUuid({
       scope: "subgraph",
       owner_node_id: owner.id ?? null,
       title: owner.title ?? graph?.name ?? "subgraph",
-    };
+    }, root);
   }
   // Ownerless but authoritatively part of the root via its subgraphs registry — a
   // valid registry-owned subgraph, exactly what resolveScope keeps (NOT stale). Must
   // report "subgraph" here too, else `viewing` would say root while reads/edits act
   // on the subgraph — reintroducing the #308/#220 divergence.
   if (isSubgraphInRoot(root, graph)) {
-    return { scope: "subgraph", owner_node_id: null, title: graph?.name ?? "subgraph" };
+    return withWorkflowUuid(
+      { scope: "subgraph", owner_node_id: null, title: graph?.name ?? "subgraph" },
+      root,
+    );
   }
   // Neither owned nor registered — a stale reference; report root to match
   // getGraphCtx()'s reconciliation (read + edit stay in lockstep).
-  return { scope: "root" };
+  return withWorkflowUuid({ scope: "root" }, root);
 }
 
 // ---- per-turn graph snapshots (rollback foundation, #44) -------------------

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8758,28 +8758,38 @@ function refreshPromotedParents(parents, canvas) {
  *  lockstep (#220/#308). */
 function describeActiveGraph(graph) {
   const root = app?.graph;
-  if (!root || !graph || graph === root) return withWorkflowUuid({ scope: "root" }, root);
+  // Reads may pass the #995 stale-tag bypass without rewriting root.extra. Use
+  // the live workflow object's canonical identity for replies, never a possibly
+  // historical root tag. If the active workflow cannot be read, omit identity.
+  let workflowUuid = null;
+  try {
+    const workflow = activeWorkflowRef();
+    if (workflow) workflowUuid = workflowObjectUuid(workflow) || workflowStableUuid(workflow);
+  } catch {
+    workflowUuid = null;
+  }
+  const withLiveIdentity = (viewing) => withWorkflowUuid(viewing, root, workflowUuid);
+  if (!root || !graph || graph === root) return withLiveIdentity({ scope: "root" });
   const owner = findSubgraphOwner(root, graph);
   if (owner) {
-    return withWorkflowUuid({
+    return withLiveIdentity({
       scope: "subgraph",
       owner_node_id: owner.id ?? null,
       title: owner.title ?? graph?.name ?? "subgraph",
-    }, root);
+    });
   }
   // Ownerless but authoritatively part of the root via its subgraphs registry — a
   // valid registry-owned subgraph, exactly what resolveScope keeps (NOT stale). Must
   // report "subgraph" here too, else `viewing` would say root while reads/edits act
   // on the subgraph — reintroducing the #308/#220 divergence.
   if (isSubgraphInRoot(root, graph)) {
-    return withWorkflowUuid(
+    return withLiveIdentity(
       { scope: "subgraph", owner_node_id: null, title: graph?.name ?? "subgraph" },
-      root,
     );
   }
   // Neither owned nor registered — a stale reference; report root to match
   // getGraphCtx()'s reconciliation (read + edit stay in lockstep).
-  return withWorkflowUuid({ scope: "root" }, root);
+  return withLiveIdentity({ scope: "root" });
 }
 
 // ---- per-turn graph snapshots (rollback foundation, #44) -------------------
@@ -12546,12 +12556,12 @@ const GRAPH_TOOL_EXECUTORS = {
     };
     if (upstream_of != null) {
       const seed = String(upstream_of);
-      if (!byId.has(seed)) return { total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `upstream_of node ${clipDiag(seed)} not found (${total} nodes in view).` };
+      if (!byId.has(seed)) return { viewing: describeActiveGraph(graph), total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `upstream_of node ${clipDiag(seed)} not found (${total} nodes in view).` };
       scope = closure(up, seed, maxDepth);
     }
     if (downstream_of != null) {
       const seed = String(downstream_of);
-      if (!byId.has(seed)) return { total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `downstream_of node ${clipDiag(seed)} not found (${total} nodes in view).` };
+      if (!byId.has(seed)) return { viewing: describeActiveGraph(graph), total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `downstream_of node ${clipDiag(seed)} not found (${total} nodes in view).` };
       const d = closure(down, seed, maxDepth);
       scope = scope ? new Set([...scope].filter((x) => d.has(x))) : d;
     }
@@ -13236,6 +13246,7 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!sub) throw new Error(`Node ${node.id} (${node.type}) is not a subgraph`);
     const inner = [...(sub._nodes ?? sub.nodes ?? [])];
     return {
+      viewing: describeActiveGraph(graph),
       subgraph_of: { node_id: node.id, title: node.title },
       // #636 — the inner nodes below are the DEFINITION's; the parent instance's
       // promoted widgets can override them. Carry both, labelled, so a legitimate
@@ -21569,7 +21580,7 @@ const GRAPH_TOOL_EXECUTORS = {
   // only exists inside the skipped parent and navigated nowhere useful (#412).
   async graph_exit_subgraph() {
     const { app: comfyApp, graph, canvas, rootGraph } = getGraphCtx();
-    if (graph === rootGraph) return { viewing: { scope: "root" }, note: tr("panel.already_at_root", "already at root") };
+    if (graph === rootGraph) return { viewing: describeActiveGraph(graph), note: tr("panel.already_at_root", "already at root") };
     if (typeof canvas.setGraph !== "function") {
       throw new Error("subgraph navigation unavailable on this frontend");
     }

--- a/web/js/lib/graph-view-identity.js
+++ b/web/js/lib/graph-view-identity.js
@@ -1,0 +1,11 @@
+/**
+ * Stable identity attached to graph read replies. A scope descriptor alone is
+ * not enough: two root workflows (or two subgraphs with the same owner/title)
+ * can legitimately report the same scope shape after a tab switch.
+ */
+export function withWorkflowUuid(viewing, rootGraph) {
+  const uuid = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
+  return typeof uuid === "string" && uuid.length > 0
+    ? { ...viewing, workflow_uuid: uuid }
+    : viewing;
+}

--- a/web/js/lib/graph-view-identity.js
+++ b/web/js/lib/graph-view-identity.js
@@ -3,8 +3,14 @@
  * not enough: two root workflows (or two subgraphs with the same owner/title)
  * can legitimately report the same scope shape after a tab switch.
  */
-export function withWorkflowUuid(viewing, rootGraph) {
-  const uuid = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
+export function withWorkflowUuid(viewing, rootGraph, workflowUuid) {
+  // A read-only stale-tag bypass can deliberately leave rootGraph.extra carrying
+  // the previous workflow's UUID. Callers that resolved the live workflow must
+  // pass that canonical identity explicitly; the root fallback remains for
+  // standalone callers and older integrations.
+  const uuid = workflowUuid !== undefined
+    ? workflowUuid
+    : rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
   return typeof uuid === "string" && uuid.length > 0
     ? { ...viewing, workflow_uuid: uuid }
     : viewing;


### PR DESCRIPTION
## Summary
- Attach the live root workflow UUID to graph read descriptors, including subgraph reads.
- Keep malformed or missing identity omitted.
- Add focused unit coverage.

This is the paired panel support for MCP #1973 / PR #2033, which now requires workflow identity before completing a budgeted get_errors audit. Focused test: node --test browser_tests/unit/graph-view-identity.test.mjs (3/3).