### PR TITLE
fix: accept wildcard producers for custom sockets (#1584)

### DIFF
--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -120,7 +120,7 @@ function wildcardDictObjectInfo() {
     JsonParseNode: {
       name: "JsonParseNode",
       input: { required: {} },
-      output: ["*"],
+      output: ["*,IMAGE"],
     },
     DictGetNode: {
       name: "DictGetNode",

--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -115,7 +115,22 @@ function backendObjectInfo() {
   };
 }
 
-function makeComfy() {
+function wildcardDictObjectInfo() {
+  return {
+    JsonParseNode: {
+      name: "JsonParseNode",
+      input: { required: {} },
+      output: ["*"],
+    },
+    DictGetNode: {
+      name: "DictGetNode",
+      input: { required: { py_dict: ["DICT", {}] } },
+      output: ["DICT_VALUE"],
+    },
+  };
+}
+
+function makeComfy(defs = backendObjectInfo()) {
   const widgets = {
     COMBO(node, name, spec) {
       return { widget: node.addWidget("combo", name, spec[0][0], null, { values: spec[0] }) };
@@ -172,7 +187,7 @@ function makeComfy() {
 
   // Step 4 of the report: the tab was NOT reloaded, but the panel reconnected and the
   // pack's three classes are registered. That is precisely what arms the #780 fast path.
-  void app.registerNodesFromDefs(backendObjectInfo());
+  void app.registerNodesFromDefs(defs);
 
   const graph = {
     _nodes: [],
@@ -390,6 +405,34 @@ test("#821: refusal is not merely deferred — it does not spend the wait window
     Date.now() - startedAt < 150,
     `add should not consume the registration wait window (took ${Date.now() - startedAt}ms)`,
   );
+});
+
+test("#1584: a live wildcard producer makes a custom dict input addable", async () => {
+  const comfy = makeComfy(wildcardDictObjectInfo());
+  const { graph_add_node } = realGraphAddNode(comfy, {
+    api: {
+      async getNodeDefs() {
+        return wildcardDictObjectInfo();
+      },
+      async fetchApi(route) {
+        const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+        const defs = wildcardDictObjectInfo();
+        const body = Object.prototype.hasOwnProperty.call(defs, classType)
+          ? { [classType]: defs[classType] }
+          : {};
+        return { status: 200, json: async () => body };
+      },
+    },
+  });
+
+  const producer = await graph_add_node({ class_type: "JsonParseNode" });
+  assert.equal(producer.added.type, "JsonParseNode");
+  assert.equal(comfy.graph._nodes[0].type, "JsonParseNode", "the wildcard producer is live");
+
+  const consumer = await graph_add_node({ class_type: "DictGetNode" });
+  assert.equal(consumer.added.type, "DictGetNode");
+  assert.deepEqual(consumer.added.inputs, ["py_dict"]);
+  assert.equal(comfy.graph._nodes.length, 2);
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -353,6 +353,31 @@ test("registeredSocketTypes derives link datatypes from fresh /object_info outpu
   assert.equal(types.size, 5);
 });
 
+test("#1584: registeredSocketTypes recognizes wildcard output segments", () => {
+  for (const output of ["*", "*,IMAGE", "IMAGE,*", " IMAGE , * "]) {
+    const types = registeredSocketTypes({ Producer: { output: [output] } });
+    assert.equal(types.has("*"), true, `${JSON.stringify(output)} proves wildcard output`);
+  }
+
+  for (const output of ["**", "*IMAGE", "IMAGE, MASK"]) {
+    const types = registeredSocketTypes({ Producer: { output: [output] } });
+    assert.equal(types.has("*"), false, `${JSON.stringify(output)} is not a wildcard segment`);
+  }
+});
+
+test("#1584: a wildcard output segment clears a custom socket wait without waiving widgets", () => {
+  const known = registeredSocketTypes({ Producer: { output: ["*,IMAGE"] } });
+  const socket = { input: { required: { value: ["DICT", {}] } } };
+  const widget = { input: { required: { value: ["DICT", { default: {} }] } } };
+
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(socket, {}, known, socket), []);
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(widget, {}, known, widget),
+    ["DICT"],
+    "wildcard output proof must not waive a value-bearing custom widget",
+  );
+});
+
 // ---- #626 P0-1: output-type compatibility is not proof an input is LINK-ONLY -------
 //
 // `knownSocketTypes` waived registration for any input whose type appears as SOME fresh

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -193,6 +193,14 @@ export function unavailableRequiredWidgetReport(
   for (const type of widgetDeclared) socketDeclared.delete(type);
   for (const type of nonNativeDeclared) nativeWidgetDeclared.delete(type);
 
+  // #1584 — `*` is ComfyUI's wildcard output type, not a literal datatype. A live
+  // wildcard producer such as JsonParseNode can feed a custom input like DICT, so an
+  // exact membership test would still misclassify that socket as a widget waiting for
+  // registration. This only widens the OUTPUT-side proof; the input-level
+  // `socketDeclared` check below remains required so a value-bearing custom widget is
+  // never waived merely because some node emits a wildcard.
+  const wildcardOutputProven = knownSocketTypes?.has?.("*") === true;
+
   const report = [];
   for (const [type, inputs] of inputsByType) {
     // The registry is keyed by the DECLARED type exactly as written — including
@@ -217,7 +225,8 @@ export function unavailableRequiredWidgetReport(
       (member) =>
         SAFE_SOCKET_TYPES.has(member) ||
         isCore3dFileType(member) ||
-        knownSocketTypes?.has?.(member) === true,
+        knownSocketTypes?.has?.(member) === true ||
+        wildcardOutputProven,
     );
     // A SINGLE built-in connection datatype is waived on the type alone. Unchanged from
     // before this fix, and sound for the same reason it was then: ComfyUI registers no

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -605,7 +605,12 @@ export function registeredSocketTypes(objectInfoDefs) {
     const outputs = def?.output;
     if (!Array.isArray(outputs)) continue;
     for (const out of outputs) {
-      if (typeof out === "string" && out) types.add(out);
+      if (typeof out !== "string" || !out) continue;
+      types.add(out);
+      // ComfyUI's `*` wildcard can be one segment of a comma-joined output type
+      // (for example `*,IMAGE`). Keep the existing whole-output proof, and add the
+      // same wildcard sentinel used by the report's output-side check.
+      if (out.split(",").some((segment) => segment.trim() === "*")) types.add("*");
     }
   }
   return types;


### PR DESCRIPTION
## Summary\n- Fix custom socket producer matching for wildcard producers from issue #1584.\n- Add focused regression coverage.\n\nRecovered abandoned issue lane; implementation agent committed and pushed this branch. Please review against current main.