### PR TITLE
fix: bound silent schema probes with a fresh snapshot (#1582)

### DIFF
--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -277,6 +277,23 @@ test("#1223 the reported case: silent probes on an unbroken connection authorize
   assert.ok(Object.prototype.hasOwnProperty.call(defs, "H3Keyframes"), "and the reported node type is in it");
 });
 
+test("#1582 a same-connection snapshot can shorten the live probe budget", () => {
+  const snap = createObjectInfoSnapshot();
+  assert.equal(stored(snap, SCHEMA, 3), true);
+  assert.equal(snap.isReusable({ epoch: 3, socketDown: false }), true);
+});
+
+test("#1582 snapshot budget shortening keeps the reconnect and socket-down fences", () => {
+  const empty = createObjectInfoSnapshot();
+  assert.equal(empty.isReusable({ epoch: 3, socketDown: false }), false, "nothing observed cannot shorten a probe");
+
+  const snap = createObjectInfoSnapshot();
+  stored(snap, SCHEMA, 3);
+  assert.equal(snap.isReusable({ epoch: 3, socketDown: true }), false, "a down socket may be restarting");
+  assert.equal(snap.isReusable({ epoch: 4, socketDown: false }), false, "a new epoch may define different types");
+  assert.equal(snap.isReusable({ epoch: 3, socketDown: false }), true, "the original connection is reusable");
+});
+
 test("#1223 what is stored is DETACHED — registration hooks mutate defs in place", () => {
   // `registerNodesFromDefs` runs `beforeRegisterNodeDef` hooks that mutate the definitions
   // in place (Comfy's own upload hook adds an input the backend never declared). Retaining
@@ -463,9 +480,9 @@ const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", impo
 function extractSetWidgetOracle() {
   const anchor = PANEL_SRC.indexOf("// #716 — READ THROUGH THE BURST CACHE.");
   assert.notEqual(anchor, -1, "the set_widget oracle's marker comment moved");
-  const start = PANEL_SRC.lastIndexOf("readObjectInfo: async (readThroughCache) => {", anchor);
+  const start = PANEL_SRC.lastIndexOf("readObjectInfo: async (readThroughCache, { reuseSnapshot = true } = {}) => {", anchor);
   assert.notEqual(start, -1, "readObjectInfo not found above its own marker");
-  const open = PANEL_SRC.indexOf("{", start);
+  const open = PANEL_SRC.indexOf("=> {", start) + 3;
   let depth = 0;
   for (let i = open; i < PANEL_SRC.length; i += 1) {
     const ch = PANEL_SRC[i];
@@ -498,7 +515,7 @@ function extractSetWidgetOracle() {
  * `epochDuringFetch` lets a test move the connection epoch WHILE the read is in flight —
  * the reconnect-mid-fetch hazard, which cannot be exercised any other way.
  */
-function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epochDuringFetch = null }) {
+function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epochDuringFetch = null, onFetch = null }) {
   const body = extractSetWidgetOracle();
   const factory = new Function(
     "api",
@@ -511,7 +528,9 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     "comfyBackendSocketDown",
     "objectInfoOracleFailureNote",
     "OBJECT_INFO_DEADLINE_MS",
+    "OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS",
     "makeCommandBudget",
+    "onFetch",
     // #1560 — the shipped body decides the type-scoped route's silence licence beside the
     // snapshot's own verdict, so this sandbox has to supply the same predicate. A name the
     // body closes over and the harness does not provide is a harness that models a panel
@@ -538,6 +557,7 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
      // Declared HERE so it closes over the mutable epoch above and can move it the moment
      // the read is issued — the panel's real hazard is a reconnect landing mid-fetch.
      const fetchWholeObjectInfo = (opts) => {
+       onFetch?.(opts);
        const pending = realFetchWholeObjectInfo({ ...opts, deadlineMs: 20 });
        if (epochDuringFetch !== null) backendReconnectEpoch = epochDuringFetch;
        return pending;
@@ -545,11 +565,14 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
      // The shipped body now takes the cache entry point, so the ordinary read and the
      // last-resort forced reread share it. Driving it the way graph_set_widget's own
      // getFreshObjectInfo does keeps this exercising production wiring, not a paraphrase.
-     const readObjectInfo = async (readThroughCache) => ${body};
+     const readObjectInfo = async (readThroughCache, { reuseSnapshot = true } = {}) => ${body};
      const getFreshObjectInfo = async () =>
        readObjectInfo((loader, opts) => objectInfoCache.readWithProvenance(loader, opts));
+     const refetchObjectInfoLive = async () =>
+       readObjectInfo((loader, opts) => objectInfoCache.readFresh(loader, opts), { reuseSnapshot: false });
      return {
        getFreshObjectInfo,
+       refetchObjectInfoLive,
        setEpoch: (n) => { backendReconnectEpoch = n; },
        readNote: () => setWidgetSchemaFromSnapshot,
        readIneligibility: () => snapshotIneligibility,
@@ -569,7 +592,9 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     socketDown,
     objectInfoOracleFailureNote,
     OBJECT_INFO_DEADLINE_MS,
+    2000,
     makeCommandBudget,
+    onFetch,
     noBackendAnswerEstablished,
   );
 }
@@ -622,13 +647,54 @@ test("#1223 SHIPPED: a CACHE HIT is never filed as evidence — it can predate a
   );
 });
 
-test("#1223 SHIPPED: the reported case — hung probes fall back and disclose", async () => {
+test("#1582 SHIPPED: the reported case — a held snapshot shortens hung probes", async () => {
   const snapshot = createObjectInfoSnapshot();
   stored(snapshot, SCHEMA, 5);
-  const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5, socketDown: false });
+  let clientCalls = 0;
+  let httpCalls = 0;
+  const deadlines = [];
+  const o = buildShippedOracle({
+    api: {
+      getNodeDefs: () => {
+        clientCalls += 1;
+        return new Promise(() => {});
+      },
+      fetchApi: () => {
+        httpCalls += 1;
+        return new Promise(() => {});
+      },
+    },
+    snapshot,
+    epoch: 5,
+    socketDown: false,
+    onFetch: (opts) => deadlines.push(opts.deadlineMs),
+  });
   const defs = await o.getFreshObjectInfo();
   assert.ok(defs && Object.prototype.hasOwnProperty.call(defs, "H3Keyframes"), "the edit is no longer refused");
-  assert.match(o.readNote(), /did not answer/, "and the reply can say which routes went silent");
+  assert.equal(clientCalls, 1, "the client route is still probed so an answered error can refuse");
+  assert.equal(httpCalls, 1, "the raw route is still probed so the fallback transport can answer");
+  assert.deepEqual(deadlines, [2000], "the reusable snapshot caps the serial oracle before the 15s stall");
+  assert.match(o.readNote(), /did not answer/);
+  assert.equal(o.readFailures().length, 2, "the fallback still discloses both silent routes");
+});
+
+test("#1582 the forced live reread does not take the snapshot shortcut", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  stored(snapshot, SCHEMA, 5);
+  let clientCalls = 0;
+  const o = buildShippedOracle({
+    api: {
+      getNodeDefs: async () => {
+        clientCalls += 1;
+        return SCHEMA;
+      },
+    },
+    snapshot,
+    epoch: 5,
+  });
+  assert.equal(await o.refetchObjectInfoLive(), SCHEMA);
+  assert.equal(clientCalls, 1, "the blind-write recovery still forces a live schema read");
+  assert.equal(o.readNote(), null, "a live reread does not disclose snapshot authorization");
 });
 
 test("#1223 SHIPPED: a snapshot re-read is NOT recorded as a new backend observation", async () => {

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -430,6 +430,30 @@ test("#1223 × #1126 wiring: graph_set_widget THREADS the schema provenance into
   );
 });
 
+test("#1582 wiring: a reusable snapshot shortens only the ordinary schema probe", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.search(/async graph_set_widget\(\{[^}]*\}\)/);
+  const end = src.indexOf("\n  async graph_remove_widget(", start);
+  assert.notEqual(start, -1, "graph_set_widget executor must exist");
+  assert.notEqual(end, -1, "graph_set_widget executor boundary must exist");
+  const body = src.slice(start, end);
+  assert.match(
+    body,
+    /readObjectInfo: async \(readThroughCache, \{ reuseSnapshot = true \} = \{\}\)/,
+    "the shared oracle must know whether the caller is an ordinary read or a forced reread",
+  );
+  assert.match(
+    body,
+    /reuseSnapshot &&[\s\S]{0,260}objectInfoSnapshot\.isReusable\([\s\S]{0,180}OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS/,
+    "a current-connection snapshot must cap the ordinary serial probe",
+  );
+  assert.match(
+    body,
+    /objectInfoCache\.readFresh\([\s\S]{0,120}\{ reuseSnapshot: false \}/,
+    "the forced live recovery must bypass that cap",
+  );
+});
+
 test("#458 set_widget: REMOVED type (stale registry positive, absent from fresh object_info) ⇒ FAIL CLOSED, no mutation", async () => {
   // GoneNode's pack was uninstalled + ComfyUI restarted WITHOUT a tab reload: the
   // registry still holds it (with a def) AND the instance is genuinely-resolved, so
@@ -554,6 +578,35 @@ test("#458 set_widget: LIVE VALID type (in fresh object_info + registry) ⇒ sti
   assert.equal(res.set.value, 30);
   assert.equal(node.widgets[0].value, 30);
   assert.equal(objectInfoFetches, 1, "hot path fetches fresh object_info exactly once");
+});
+
+test("#1582 set_widget: snapshot authorization still validates a combo value", async () => {
+  const reg = loadedRegistry(["UNETLoader"]);
+  const widget = {
+    name: "unet_name",
+    type: "combo",
+    options: { values: ["model.safetensors"] },
+    value: "old.safetensors",
+  };
+  const node = regNode("UNETLoader", [widget]);
+  const snapshotDefs = { UNETLoader: {} }; // #1223's detached, membership-only shape
+  const opts = {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => snapshotDefs,
+    schemaProvenance: () => "snapshot",
+    ...HOOKS,
+  };
+
+  const accepted = await runSetWidget(node, "unet_name", "model.safetensors", opts);
+  assert.equal(accepted.set.value, "model.safetensors", "a current combo option still writes");
+
+  await assert.rejects(
+    () => runSetWidget(node, "unet_name", "not-listed.safetensors", opts),
+    /not a valid option/i,
+    "the snapshot must not turn a combo write into an unchecked write",
+  );
+  assert.equal(widget.value, "model.safetensors", "an off-list value is still refused without mutation");
 });
 
 test("#458 set_widget: stale-combo refresh retry STILL works with the fresh oracle wired (#338)", async () => {

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -562,7 +562,7 @@ test("#1418 the seed wait and the oracle read are capped by the command budget",
   );
   assert.match(
     body,
-    /deadlineMs: budget\.bounded\(OBJECT_INFO_DEADLINE_MS\)/,
+    /deadlineMs:\s*budget\.bounded\([\s\S]{0,260}OBJECT_INFO_DEADLINE_MS/,
     "the flat 20000ms oracle deadline is capped by what the command has left",
   );
   assert.match(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1030,6 +1030,15 @@ function noteOpenAttempt({ cmd, rid, requested, resolved, applied, error }) {
 const NODE_DEFS_FETCH_TIMEOUT_MS = 10000;
 
 /**
+ * #1582 — when a same-connection whole-schema snapshot is already held, do not spend the
+ * full serial 10s client share plus 5s raw-route share proving that both routes are silent.
+ * Two seconds still leaves roughly four times the measured warm whole-schema read while
+ * keeping the existing fail-closed outcome distinction: an answered bad response refuses,
+ * and only actual silence licenses the last-observed snapshot.
+ */
+const OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS = 2000;
+
+/**
  * #1180 — ONE budget for a whole `registerComfyNodeDefs` run, shared by its phases.
  *
  * PER-PHASE BOUNDS DO NOT COMPOSE, and three review rounds on this issue were spent
@@ -14827,7 +14836,13 @@ const GRAPH_TOOL_EXECUTORS = {
       // path. Sharing the body is what keeps the snapshot fallback, the failure-route
       // bookkeeping and the provenance handling identical between them — a second hand-rolled
       // copy of this for the recovery path is how the two would drift.
-      readObjectInfo: async (readThroughCache) => {
+      readObjectInfo: async (readThroughCache, { reuseSnapshot = true } = {}) => {
+        // #1582 — a whole schema observed on this SAME backend connection makes silence
+        // recoverable, but it must not suppress a route that answers with an unusable schema.
+        // When that snapshot is reusable, shorten the serial oracle budget so the panel spends
+        // at most two seconds discovering silence before the existing snapshot authorization.
+        // A forced reread keeps the normal budget: its purpose is to obtain a live answer for
+        // the blind-write recovery and it must not be shortened by the old snapshot.
         // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
         // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
         // Still the WHOLE payload, so no question this fence asks changes scope —
@@ -14879,7 +14894,16 @@ const GRAPH_TOOL_EXECUTORS = {
             return fetchWholeObjectInfo({
               getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
               fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
-              deadlineMs: budget.bounded(OBJECT_INFO_DEADLINE_MS),
+              deadlineMs: budget.bounded(
+                reuseSnapshot &&
+                  typeof objectInfoSnapshot.isReusable === "function" &&
+                  objectInfoSnapshot.isReusable({
+                    epoch: backendReconnectEpoch,
+                    socketDown: comfyBackendIsDown(),
+                  })
+                  ? OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS
+                  : OBJECT_INFO_DEADLINE_MS,
+              ),
             });
           },
           { stamp: () => backendReconnectEpoch },
@@ -14953,7 +14977,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // invalidating — which used to retire the other's just-issued request and refuse a write
       // that was perfectly valid.
       refetchObjectInfoLive: async () =>
-        setWidgetOpts.readObjectInfo((loader, opts) => objectInfoCache.readFresh(loader, opts)),
+        setWidgetOpts.readObjectInfo((loader, opts) => objectInfoCache.readFresh(loader, opts), { reuseSnapshot: false }),
       // #1560 — the THIRD route, and the only one that is TYPE-SCOPED.
       //
       // On a ~1023-model install neither whole-schema route ever lands inside its share of
@@ -15106,7 +15130,13 @@ const GRAPH_TOOL_EXECUTORS = {
         // always the target's own type — which is how a payload can be present and
         // still be the wrong one.
         const keyType = concreteType ?? target?.type ?? target?.comfyClass;
-        if (defs && keyType && Object.prototype.hasOwnProperty.call(defs, keyType)) {
+        // #1582/#1223 — a snapshot deliberately carries TYPE NAMES ONLY. Treating its
+        // empty placeholder as a usable definition would make this callback silently skip
+        // the authoritative refresh and then validate a newly-downloaded combo against the
+        // stale live list. Reuse is safe for membership, not for option lists.
+        const snapshotOnlySchema =
+          typeof setWidgetSchemaProvenance === "function" && setWidgetSchemaProvenance() === "snapshot";
+        if (!snapshotOnlySchema && defs && keyType && Object.prototype.hasOwnProperty.call(defs, keyType)) {
           // Key the combo options on the ULTIMATE CONCRETE type (resolved through the
           // promotion chain), not the intermediate virtual node's type, and bridge a
           // RENAMED nested promotion via nameMap, so a nested promoted combo is refreshed

--- a/web/js/lib/object-info-snapshot.js
+++ b/web/js/lib/object-info-snapshot.js
@@ -244,6 +244,23 @@ export function createObjectInfoSnapshot() {
       return { defs, reason: "" };
     },
 
+    /**
+     * Is this snapshot current enough to shorten the next probe budget?
+     *
+     * This does not authorize anything and does not expose the names-only map. The actual
+     * `authorize` call still requires the transport outcome to establish silence, preserving
+     * the distinction between a busy backend and one that answered with an unusable schema.
+     * The same socket/epoch fence is used so a reconnect cannot inherit the shorter budget.
+     */
+    isReusable({ epoch: currentEpoch, socketDown } = {}) {
+      return (
+        defs !== null &&
+        !socketDown &&
+        Number.isFinite(currentEpoch) &&
+        currentEpoch === epoch
+      );
+    },
+
     /** Drop it — for anything that knows, or merely suspects, the schema moved. */
     clear() {
       defs = null;


### PR DESCRIPTION
Recovered abandoned issue #1582. The implementation agent committed and pushed the narrow snapshot/probe timeout fix with focused coverage. Please review against current main.