### PR TITLE
fix: ignore stale graph output links in audits (#1590)

### DIFF
--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { liveLinkTargetInput } from "../../web/js/lib/graph-read.js";
+import { readStoredLink } from "../../web/js/lib/connect-verify.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -292,8 +293,39 @@ function renderOutgoing({ node, links, nodes }) {
   assert.equal(body.lastIndexOf("const outs = [];"), start, "one outgoing render block only");
   const block = body.slice(start, end);
   // eslint-disable-next-line no-new-func -- running the real source IS the assertion
-  const run = new Function("n", "links", "byId", "liveLinkTargetInput", block + " return outs;");
-  return run(node, links, new Map(nodes.map((x) => [x.id, x])), liveLinkTargetInput);
+  const run = new Function(
+    "n",
+    "links",
+    "byId",
+    "liveLinkTargetInput",
+    "readStoredLink",
+    "graph",
+    block + " return outs;",
+  );
+  return run(
+    node,
+    links,
+    new Map(nodes.map((x) => [x.id, x])),
+    liveLinkTargetInput,
+    readStoredLink,
+    { links },
+  );
+}
+
+/** The graph_query adjacency block, taken VERBATIM from the handler and run against a
+ * synthetic graph. Keeping this at the production-source boundary covers traversal,
+ * rather than only the outline's formatting branch. */
+function queryAdjacency({ nodes, links }) {
+  const body = handlerBody(readFileSync(PANEL_JS, "utf8"), "graph_query({");
+  assert.ok(body, "graph_query({ … }) handler must exist");
+  const start = body.indexOf("const up = new Map();");
+  const end = body.indexOf("const closure =", start);
+  assert.notEqual(start, -1, "the graph-query adjacency block must be locatable");
+  assert.ok(end > start, "the graph-query adjacency block must terminate at the closure");
+  const block = body.slice(start, end);
+  // eslint-disable-next-line no-new-func -- running the real source IS the assertion
+  const run = new Function("nodes", "graph", "links", "readStoredLink", `${block}\nreturn { up, down };`);
+  return run(nodes, { links }, links, readStoredLink);
 }
 
 test("#342 an ORPHANED outgoing link renders NOTHING, not the slot that took its index", () => {
@@ -363,6 +395,45 @@ test("#342 an ordinary, uncompacted link still renders exactly as before", () =>
     links: { 4: { id: 4, origin_id: 1, origin_slot: 0, target_id: 3, target_slot: 0 } },
   });
   assert.deepEqual(outs, ["3.model"]);
+});
+
+test("#1590 a stale source output backlink cannot fabricate downstream consumers", () => {
+  // The live target backlink and link record say 4 → 8. Node 17's output cache still
+  // carries that link id, which used to make the outline say 17 → 8 while detail and
+  // downstream_of followed the stored origin and said 4 → 8.
+  const target = {
+    id: 8,
+    type: "KSampler",
+    inputs: [{ name: "model", type: "MODEL", link: 40 }],
+  };
+  const staleSource = { id: 17, type: "NC04 LoRA", outputs: [{ name: "MODEL", links: [40] }] };
+  const realSource = { id: 4, type: "CheckpointLoaderSimple", outputs: [{ name: "MODEL", links: [40] }] };
+  const links = { 40: { id: 40, origin_id: 4, origin_slot: 0, target_id: 8, target_slot: 0 } };
+
+  assert.deepEqual(
+    renderOutgoing({ node: staleSource, nodes: [staleSource, realSource, target], links }),
+    [],
+    "the outline must not attribute another source's stored link to node 17",
+  );
+  assert.deepEqual(
+    renderOutgoing({ node: realSource, nodes: [staleSource, realSource, target], links }),
+    ["8.model"],
+    "the stored origin must remain visible from its actual source",
+  );
+});
+
+test("#1590 downstream traversal follows the stored origin, including a Map-backed link store", () => {
+  const target = { id: 8, inputs: [{ name: "model", link: 40 }] };
+  const staleSource = { id: 17, outputs: [{ links: [40] }] };
+  const realSource = { id: 4, outputs: [{ links: [40] }] };
+  const stored = { id: 40, origin_id: 4, origin_slot: 0, target_id: 8, target_slot: 0 };
+  const { down } = queryAdjacency({
+    nodes: [staleSource, realSource, target],
+    links: new Map([[40, stored]]),
+  });
+
+  assert.deepEqual([...down.get("17") ?? []], [], "stale output metadata must not create a consumer");
+  assert.deepEqual([...down.get("4") ?? []], ["8"], "the stored origin must retain its consumer");
 });
 
 test("#342 with no live inputs to verify against, the recorded slot renders as a bare index", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -479,6 +479,7 @@ import {
   findLandedRailLink,
   isRailLinkPersisted,
   landedAfterThrowWarning,
+  readStoredLink,
 } from "./lib/connect-verify.js";
 import {
   snapshotGraphState,
@@ -10494,11 +10495,16 @@ function summarizeNode(node) {
   // renames invisible, so the agent told the user their renames had not stuck when the
   // canvas showed them. `label` rides ALONGSIDE `name` and is emitted ONLY when one is
   // actually carried AND differs — never inferred, never replacing the addressable name.
-  const inputs = (node.inputs ?? []).map((inp, i) => {
+  const inputs = (node.inputs ?? []).map((inp) => {
     let from = null;
     if (inp.link != null) {
-      const link = node.graph?.links?.[inp.link];
-      if (link) from = { node_id: link.origin_id, output_slot: link.origin_slot };
+      const link = readStoredLink(node.graph, inp.link);
+      if (link) {
+        from = {
+          node_id: link.origin_id ?? link[1],
+          output_slot: link.origin_slot ?? link[2],
+        };
+      }
     }
     const label = boundaryInputLabel(inp);
     return {
@@ -12280,19 +12286,31 @@ const GRAPH_TOOL_EXECUTORS = {
         const ins = (n.inputs ?? [])
           .map((inp) => {
             if (inp.link == null) return null;
-            const l = links[inp.link];
+            const l = readStoredLink(graph, inp.link);
             if (!l) return null;
-            const src = byId.get(l.origin_id);
-            return `${l.origin_id}.${src?.outputs?.[l.origin_slot]?.name ?? l.origin_slot}`;
+            const originId = l.origin_id ?? l[1];
+            const originSlot = l.origin_slot ?? l[2];
+            const src = byId.get(originId);
+            return `${originId}.${src?.outputs?.[originSlot]?.name ?? originSlot}`;
           })
           .filter(Boolean);
         if (ins.length) out.push(`     ← ${ins.join(", ")}`);
         const outs = [];
-        for (const out2 of n.outputs ?? []) {
+        for (let outIdx = 0; outIdx < (n.outputs ?? []).length; outIdx++) {
+          const out2 = n.outputs[outIdx];
           for (const lid of out2.links ?? []) {
-            const l = links[lid];
+            const l = readStoredLink(graph, lid);
             if (!l) continue;
-            const tgt = byId.get(l.target_id);
+            const originId = l.origin_id ?? l[1];
+            const originSlot = l.origin_slot ?? l[2];
+            // #1590: outputs[].links is a cached backlink and can retain a link id
+            // after that id was reused/rebound to another source. Without this check
+            // the outline attributed node 4/6's link records to node 17, while detail
+            // and downstream traversal correctly followed the stored origin.
+            if (String(originId) !== String(n.id) || Number(originSlot) !== outIdx) continue;
+            const targetId = l.target_id ?? l[3];
+            const targetSlot = l.target_slot ?? l[4];
+            const tgt = byId.get(targetId);
             // #342: resolve the LIVE target slot through the target's own
             // inputs[].link backlink. The link record's target_slot goes stale
             // when the target's inputs are compacted (dynamic-combo rebuild,
@@ -12305,12 +12323,12 @@ const GRAPH_TOOL_EXECUTORS = {
             // not in this graph's node set (a dangling id the outline does not even
             // list, so a reader can see it is dead) or it carries no inputs array.
             if (!tgt || !Array.isArray(tgt.inputs)) {
-              outs.push(`${l.target_id}.${tgt?.inputs?.[l.target_slot]?.name ?? l.target_slot}`);
+              outs.push(`${targetId}.${tgt?.inputs?.[targetSlot]?.name ?? targetSlot}`);
               continue;
             }
             const live = liveLinkTargetInput(tgt, lid);
             if (!live) continue;
-            outs.push(`${l.target_id}.${live.name ?? live.index}`);
+            outs.push(`${targetId}.${live.name ?? live.index}`);
           }
         }
         if (outs.length) out.push(`     → ${outs.join(", ")}`);
@@ -12489,7 +12507,6 @@ const GRAPH_TOOL_EXECUTORS = {
     // recomputes geometric membership (summarizeGroup), so it never reports stale ids.
     syncGraphNodeAreas(graph);
     const nodes = graph._nodes ?? [];
-    const links = graph.links ?? {};
     const byId = new Map(nodes.map((n) => [String(n.id), n]));
     const total = nodes.length;
     const lim = Math.min(Math.max(Number(limit) || 40, 1), 200);
@@ -12502,9 +12519,9 @@ const GRAPH_TOOL_EXECUTORS = {
       const id = String(n.id);
       for (const inp of n.inputs ?? []) {
         if (inp.link == null) continue;
-        const l = links[inp.link];
+        const l = readStoredLink(graph, inp.link);
         if (!l) continue;
-        const src = String(l.origin_id);
+        const src = String(l.origin_id ?? l[1]);
         if (!up.has(id)) up.set(id, new Set());
         up.get(id).add(src);
         if (!down.has(src)) down.set(src, new Set());

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10495,7 +10495,7 @@ function summarizeNode(node) {
   // renames invisible, so the agent told the user their renames had not stuck when the
   // canvas showed them. `label` rides ALONGSIDE `name` and is emitted ONLY when one is
   // actually carried AND differs — never inferred, never replacing the addressable name.
-  const inputs = (node.inputs ?? []).map((inp) => {
+  const inputs = (node.inputs ?? []).map((inp, i) => {
     let from = null;
     if (inp.link != null) {
       const link = readStoredLink(node.graph, inp.link);


### PR DESCRIPTION
Recovered abandoned issue #1590. The implementation agent committed and pushed the narrow stale-output-link audit fix with focused coverage. Please review against current main.