### PR TITLE
fix(1580): a save whose only drift is node geometry is no longer refused

### DIFF
--- a/browser_tests/unit/save-path-guard.test.mjs
+++ b/browser_tests/unit/save-path-guard.test.mjs
@@ -333,17 +333,26 @@ function staleFixture({ suppressed = true, live = "extra-group", active = true }
     groups: [{ id: 1, title: "Pre", bounding: [0, 0, 10, 10] }],
     extra: {},
   };
-  const liveState =
-    live === "extra-group"
-      ? {
-          nodes: [{ id: 1, type: "VAEDecode", pos: [0, 0] }],
-          groups: [
-            { id: 1, title: "Pre", bounding: [0, 0, 10, 10] },
-            { id: 2, title: "New17", bounding: [20, 0, 10, 10] },
-          ],
-          extra: {},
-        }
-      : JSON.parse(JSON.stringify(snapshot));
+  let liveState;
+  if (live === "extra-group") {
+    liveState = {
+      nodes: [{ id: 1, type: "VAEDecode", pos: [0, 0] }],
+      groups: [
+        { id: 1, title: "Pre", bounding: [0, 0, 10, 10] },
+        { id: 2, title: "New17", bounding: [20, 0, 10, 10] },
+      ],
+      extra: {},
+    };
+  } else if (live === "pos-only") {
+    liveState = JSON.parse(JSON.stringify(snapshot));
+    liveState.nodes[0].pos = [100, 50];
+  } else if (live === "widget-value") {
+    snapshot.nodes[0] = { ...snapshot.nodes[0], widgets_values: ["a"] };
+    liveState = JSON.parse(JSON.stringify(snapshot));
+    liveState.nodes[0].widgets_values = ["b"];
+  } else {
+    liveState = JSON.parse(JSON.stringify(snapshot));
+  }
   const wfA = {
     path: "workflows/A.json",
     isTemporary: false,
@@ -571,4 +580,50 @@ test("#1563 r4 WIRING: the guard is installed on the COPY point, from the source
   const throwAt = body.indexOf("throw workflowSaveRefusalError(verdict);");
   const callAt = body.indexOf("return origSaveAs(");
   assert.ok(throwAt > 0 && callAt > throwAt, "the refusal must precede the copy");
+});
+
+// ---------------------------------------------------------------------------
+// 5. panel#1580 — presentation-only drift is not a stale snapshot.
+//
+// `graphRootReproducesStateContent` answers `proven: false` AND `presentationOnly: true`
+// for a canvas that differs from the snapshot only by node geometry (`pos`). Conjunct
+// 2 used to read `proven !== true` alone, so a suppressed capture whose only drift
+// was a dragged node refused autosave and Ctrl+S. The classifier already vouches that
+// nothing AUTHORED is behind the canvas — the same reading #1477 and #1623 applied
+// on the open path. Widget values and groups stay refused: those are the defect
+// #1567 exists to stop.
+// ---------------------------------------------------------------------------
+
+test("#1580 WRAPPER: a suppressed capture whose only drift is node geometry still saves", async () => {
+  // The reported false positive: undo's `_restoringState` window is still open, the
+  // canvas and snapshot agree on every authored field, and a node was dragged. The
+  // save must go through — refusing it tells the user to reload the tab over a `pos`.
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture({ live: "pos-only" });
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  await fx.store.saveWorkflow(fx.wfA);
+  assert.deepEqual(fx.store.saved, ["workflows/A.json"]);
+});
+
+test("#1580 WRAPPER: a widget-value difference is still refused — authored drift is not cosmetic", async () => {
+  // Row 3 of the measured table: same suppression window, same `nodes` surface, but
+  // the field that moved is `widgets_values`. Softening conjunct 2 onto presentation-
+  // only must not also wave this through.
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture({ live: "widget-value" });
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  await assert.rejects(() => fx.store.saveWorkflow(fx.wfA), /BEHIND the live canvas/);
+  assert.deepEqual(fx.store.saved, []);
+});
+
+test("#1580 WRAPPER: a Save-As whose only drift is node geometry still copies", () => {
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture({ live: "pos-only" });
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  const made = fx.store.saveAs(fx.wfA, "workflows/Copy.json");
+  assert.equal(made.path, "workflows/Copy.json");
+  assert.deepEqual(fx.store.copies, [{ from: "workflows/A.json", to: "workflows/Copy.json" }]);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3724,15 +3724,17 @@ const _savePathGuardRefusalsLogged = new Set();
  *      `prepareForSave` would have resolved a microsecond later.
  *   2. a comparison of the live root against the state about to be written ACTUALLY
  *      HAPPENED (`describeGraphStateDifference(...).comparable === true`) and the
- *      tolerant proof (`graphRootReproducesStateContent`) did not vouch for it. Both
- *      halves are load-bearing: the tolerance stops a frontend that re-measures node
- *      boxes or renumbers subgraph link ids from manufacturing a refusal, and the
- *      comparability stops an ABSENT comparison from doing the same — the proof
- *      answers `proven:false` for "could not compare" exactly as it does for "differs",
- *      so reading it alone made a root that cannot be serialized indistinguishable
- *      from a canvas with lost work. Without conjunct 2 at all, a suppressed capture
- *      on an already-equal canvas — the ordinary state of a clean tab — would block
- *      every save.
+ *      tolerant proof (`graphRootReproducesStateContent`) did not vouch for it — neither
+ *      `proven` nor `presentationOnly`. Both halves are load-bearing: the tolerance
+ *      stops a frontend that re-measures node boxes or renumbers subgraph link ids
+ *      from manufacturing a refusal, and the comparability stops an ABSENT comparison
+ *      from doing the same — the proof answers `proven:false` for "could not compare"
+ *      exactly as it does for "differs", so reading it alone made a root that cannot
+ *      be serialized indistinguishable from a canvas with lost work. Without conjunct
+ *      2 at all, a suppressed capture on an already-equal canvas — the ordinary state
+ *      of a clean tab — would block every save. Reading `proven !== true` alone also
+ *      refused a dragged node: `pos` is presentation-only (nothing AUTHORED is behind
+ *      the canvas) and this guard gates autosave and Ctrl+S (#1580).
  *
  * ACTIVE WORKFLOW ONLY. `app.rootGraph` is the ACTIVE tab's canvas; comparing it with
  * an inactive tab's snapshot would compare two different workflows and refuse a save
@@ -3800,7 +3802,13 @@ function saveWouldPersistStaleSnapshot(wf, state) {
     if (describeGraphStateDifference({ rootGraph: frozen, state })?.comparable !== true) {
       return false;
     }
-    return graphRootReproducesStateContent({ rootGraph: frozen, state })?.proven !== true;
+    const reproduces = graphRootReproducesStateContent({ rootGraph: frozen, state });
+    // #1580 — a difference the panel's own classifier vouches for as presentation-only
+    // means nothing AUTHORED is behind the canvas. Refusing the save there is louder
+    // than the drift, and this guard gates autosave and Ctrl+S as well as
+    // panel_save_workflow. `proven` is the stricter measured-rewrite proof and does
+    // not cover a dragged node (`pos`); reading it alone was the false positive.
+    return reproduces?.proven !== true && reproduces?.presentationOnly !== true;
   } catch {
     return false;
   }


### PR DESCRIPTION
Fixes #1580

Follow-up to #1567. `saveWouldPersistStaleSnapshot` refuses a save when two conjuncts hold: upstream positively reports it skipped the pre-save capture, **and** the live root does not reproduce the state about to be written.

The second conjunct was `graphRootReproducesStateContent(...)?.proven !== true`. That is also true of a difference the panel's own classifier already vouches for as losing nothing authored — `presentationOnly: true`. A canvas that differs from its snapshot only by node geometry (`pos`) therefore refused autosave and Ctrl+S, with a message telling the user to reload the tab over a dragged node.

The open path already treats `presentationOnly` as success (#1477 / #1623). The save guard now does the same:

```js
const reproduces = graphRootReproducesStateContent({ rootGraph: frozen, state });
return reproduces?.proven !== true && reproduces?.presentationOnly !== true;
```

Widget values and added groups still refuse — those are the defect #1567 exists to stop.

Pinned on the real installer (`installSavePathGuard` sliced from the panel source, driven over a fake workflow store — the same path the #1567 tests use):

- a suppressed capture whose only drift is node geometry still saves
- a widget-value difference is still refused
- a Save-As whose only drift is node geometry still copies

## Verification

- `node --test browser_tests/unit/save-path-guard.test.mjs` — 34 pass (including the three #1580 cases)
- `node --test browser_tests/unit/graph-binding.test.mjs browser_tests/unit/open-presentation-only.test.mjs browser_tests/unit/change-tracker-snapshot.test.mjs` — 183 pass
