### PR TITLE
fix(1585): the Agent tab appears in the sidebar after a clean load

### DIFF
--- a/browser_tests/unit/i18n.test.mjs
+++ b/browser_tests/unit/i18n.test.mjs
@@ -268,11 +268,11 @@ test("the catalog is loaded at startup, before the panel paints", () => {
   const setupAt = src.indexOf("async setup() {");
   assert.notEqual(setupAt, -1, "registerExtension must still have a setup()");
   // The window covers everything setup() does BEFORE the catalog load. It grew
-  // 900 → 1200 with #1269, whose duplicate-copy gate is itself mandated-first
-  // (a copy that lost the page arbitration must stop before anything wraps or
-  // connects); the pin's purpose — awaited, and before the first paint — is
-  // unchanged.
-  const head = src.slice(setupAt, setupAt + 1200);
+  // 900 → 1200 with #1269 (duplicate-copy gate mandated-first) and 1200 → 1600
+  // with #1585 (idempotent setup so a late registration that missed ComfyUI's
+  // setup wave still paints the Agent tab). The pin's purpose — awaited, and
+  // before the first paint — is unchanged.
+  const head = src.slice(setupAt, setupAt + 1600);
   assert.match(head, /await applyPanelLocale\(\)/, "setup() must await the catalog load");
 
   // AWAITED, not fired-and-forgotten: an unawaited load resolves after the first render and

--- a/browser_tests/unit/resolve-comfy-app.test.mjs
+++ b/browser_tests/unit/resolve-comfy-app.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * #1585 — the Agent tab never appears if we look for ComfyApp in the wrong
+ * place, or if registerExtension lands after ComfyUI's setup() wave.
+ *
+ * The reporter's JS loaded (190 files, 200) and Settings search for "mcp"
+ * found nothing: `registerExtension` itself never ran. The lookup was
+ * `window.comfyAPI.app.app || window.app`. These drive the REAL resolver
+ * against the three shapes the frontend has shipped, plus the "invoke
+ * setup ourselves when the tab API is already live" decision.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  canInstallSidebarTab,
+  isComfyApp,
+  resolveComfyApi,
+  resolveComfyApp,
+  tryRegisterWhenReady,
+} from "../../web/js/lib/resolve-comfy-app.js";
+
+function appLike(extra = {}) {
+  return { registerExtension() {}, ...extra };
+}
+
+test("isComfyApp: only an object with registerExtension counts", () => {
+  assert.equal(isComfyApp(null), false);
+  assert.equal(isComfyApp({}), false);
+  assert.equal(isComfyApp({ registerExtension: 1 }), false);
+  assert.equal(isComfyApp(appLike()), true);
+});
+
+test("#1585: the Vite shim shape (comfyAPI.app.app) still wins", () => {
+  const instance = appLike({ id: "nested" });
+  const root = { comfyAPI: { app: { app: instance, ComfyApp: function ComfyApp() {} } } };
+  assert.equal(resolveComfyApp(root), instance);
+});
+
+test("#1585: a flattened comfyAPI.app (the 1.49 miss) is the live app", () => {
+  // This is the reporter's frontend: `window.comfyAPI.app` IS the instance,
+  // `.app.app` is missing, and `window.app` was never assigned. The old
+  // lookup polled for 10s and the tab never registered.
+  const instance = appLike({ id: "flat" });
+  const root = { comfyAPI: { app: instance } };
+  assert.equal(resolveComfyApp(root), instance);
+  assert.equal(resolveComfyApp({ comfyAPI: { app: { ComfyApp: function C() {} } } }), null);
+});
+
+test("#1585: nested instance beats a namespace that is not itself the app", () => {
+  const instance = appLike({ id: "nested" });
+  const namespace = { app: instance, ComfyApp: function ComfyApp() {} };
+  assert.equal(resolveComfyApp({ comfyAPI: { app: namespace } }), instance);
+});
+
+test("#1585: legacy window.app is the last fallback", () => {
+  const instance = appLike({ id: "legacy" });
+  assert.equal(resolveComfyApp({ app: instance }), instance);
+  assert.equal(resolveComfyApp({}), null);
+  assert.equal(resolveComfyApp(null), null);
+});
+
+test("#1585: resolveComfyApi mirrors the same three shapes", () => {
+  const api = { fetchApi() {} };
+  assert.equal(resolveComfyApi({ comfyAPI: { api: { api } } }), api);
+  assert.equal(resolveComfyApi({ comfyAPI: { api } }), api);
+  assert.equal(resolveComfyApi({ api: { addEventListener() {} } }).addEventListener !== undefined, true);
+  assert.equal(resolveComfyApi({}), null);
+});
+
+test("#1585: canInstallSidebarTab is evidence the setup wave is reachable now", () => {
+  assert.equal(canInstallSidebarTab(null), false);
+  assert.equal(canInstallSidebarTab(appLike()), false);
+  assert.equal(
+    canInstallSidebarTab(appLike({ extensionManager: { registerSidebarTab() {} } })),
+    true,
+  );
+});
+
+test("#1585 tryRegisterWhenReady: pending until an app exists", () => {
+  const calls = [];
+  const out = tryRegisterWhenReady({
+    root: {},
+    register: (args) => calls.push(args),
+  });
+  assert.equal(out.status, "pending");
+  assert.deepEqual(calls, []);
+});
+
+test("#1585 tryRegisterWhenReady: a stood-down copy never registers", () => {
+  const calls = [];
+  const instance = appLike();
+  const out = tryRegisterWhenReady({
+    root: { comfyAPI: { app: instance } },
+    active: () => false,
+    register: (args) => calls.push(args),
+  });
+  assert.equal(out.status, "stood-down");
+  assert.deepEqual(calls, []);
+});
+
+test("#1585 tryRegisterWhenReady: flattened app registers and asks setup to run when the tab API is live", () => {
+  const calls = [];
+  const instance = appLike({
+    extensionManager: { registerSidebarTab() {} },
+  });
+  const api = { fetchApi() {} };
+  const out = tryRegisterWhenReady({
+    root: { comfyAPI: { app: instance, api } },
+    active: () => true,
+    register: (args) => calls.push(args),
+  });
+  assert.equal(out.status, "registered");
+  assert.equal(out.invokeSetup, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].comfyApp, instance);
+  assert.equal(calls[0].api, api);
+  assert.equal(calls[0].invokeSetup, true);
+});
+
+test("#1585 tryRegisterWhenReady: early registration does not invoke setup itself", () => {
+  // loadExtensions() runs BEFORE extensionManager exists. setup() must wait
+  // for the framework's wave, or it would paint then get skipped on the
+  // real call.
+  const calls = [];
+  const instance = appLike();
+  const out = tryRegisterWhenReady({
+    root: { comfyAPI: { app: { app: instance } } },
+    register: (args) => calls.push(args),
+  });
+  assert.equal(out.status, "registered");
+  assert.equal(out.invokeSetup, false);
+  assert.equal(calls[0].invokeSetup, false);
+});
+
+test("#1585 wiring: the panel drives tryRegisterWhenReady, not a second lookup", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  assert.match(src, /from "\.\/lib\/resolve-comfy-app\.js"/);
+  const fnAt = src.indexOf("function registerExtensionWhenReady(");
+  assert.notEqual(fnAt, -1);
+  const body = src.slice(fnAt, src.indexOf("\nregisterExtensionWhenReady();"));
+  assert.match(body, /tryRegisterWhenReady\(/);
+  assert.doesNotMatch(
+    body,
+    /window\.comfyAPI\?\.app\?\.app \|\| window\.app/,
+    "the old two-shape lookup must not still be the registration gate",
+  );
+  // A late registration (tab API already live) must invoke setup() itself —
+  // that is the only way the Agent tab appears when the poller missed the wave.
+  assert.match(body, /invokeSetup/);
+  assert.match(body, /extension\.setup\(\)/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -84,6 +84,7 @@ import {
   describeUnguardedDuplicatePanelCopy,
   PANEL_EXTENSION_NAME,
 } from "./lib/duplicate-panel-guard.js";
+import { tryRegisterWhenReady } from "./lib/resolve-comfy-app.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
 import { sanitizeNodeAuxId, sanitizeNodesAuxId } from "./lib/aux-id-sanitize.js";
@@ -752,6 +753,11 @@ import {
 
 let app = null;
 let api = null;
+// #1585 — setup() is invoked by ComfyUI after registerExtension, AND by us
+// when the tab API is already live (a poller that missed the setup wave).
+// First successful entry wins; a second call is a no-op so the tab cannot
+// register twice.
+let panelSetupStarted = false;
 
 // The live run-completion tracker (created in buildPanel). Held at module scope
 // so the module-level tool handlers (e.g. graph_run) can register a freshly
@@ -40029,41 +40035,38 @@ function panelCopyGuardBlocksSetup(comfyApp) {
 }
 
 function registerExtensionWhenReady(tries = 0) {
-  const comfyApp = window.comfyAPI?.app?.app || window.app;
-  if (!comfyApp || typeof comfyApp.registerExtension !== "function") {
-    if (tries >= 1000) {
-      console.error(
-        "[comfyui-mcp-panel] app.registerExtension never became available — incompatible ComfyUI frontend version.",
-      );
-      return;
-    }
-    setTimeout(() => registerExtensionWhenReady(tries + 1), 10);
-    return;
-  }
-  app = comfyApp;
-  api = window.comfyAPI?.api?.api || window.api || null;
-  // #1269 — a copy that LOST the module-scope arbitration never registers: no
-  // sidebar tab, no bridge socket, no hello. Loud, never silent — a page with
-  // no panel and no explanation is the worst outcome.
-  if (!panelCopyArbitration.active()) return notePanelCopyStandDown();
-  // #570 P0 — wrap app.loadGraphData so every workflow CREATION (import/paste/duplicate/
-  // new) mints a fresh per-instance uuid, so a copy can't inherit the source's session.
-  installCreateBoundaryFork(app);
-  setupListeners();
+  let outcome;
+  try {
+    outcome = tryRegisterWhenReady({
+      root: globalThis,
+      active: () => panelCopyArbitration.active(),
+      register: ({ comfyApp, api: resolvedApi, invokeSetup }) => {
+        app = comfyApp;
+        api = resolvedApi || null;
+        // #1269 — a copy that LOST the module-scope arbitration never registers: no
+        // sidebar tab, no bridge socket, no hello. Loud, never silent — a page with
+        // no panel and no explanation is the worst outcome.
+        if (!panelCopyArbitration.active()) return notePanelCopyStandDown();
+        // #570 P0 — wrap app.loadGraphData so every workflow CREATION (import/paste/duplicate/
+        // new) mints a fresh per-instance uuid, so a copy can't inherit the source's session.
+        installCreateBoundaryFork(app);
+        setupListeners();
 
-  // TODO(v2): replace with `defineExtension({ name, setup() {...} })`.
-  app.registerExtension({
-    name: "comfyui-mcp.agent-panel",
-    // Standard ComfyUI Settings dialog entries (persisted to comfy.settings.json).
-    // Grouped under "Comfy MCP Agent". These seed the panel's runtime defaults and
-    // stay in sync with the in-panel pickers; token entries are secure buttons that
-    // never persist a raw value here. See panelSettingsList() above.
-    settings: panelSettingsList(),
-    async setup() {
-      // #1269 — the page arbitration can move AFTER registration (a later-
-      // evaluated newer copy stood this one down); honor it, and name a
-      // guardless duplicate, before anything wraps, probes, or connects.
-      if (panelCopyGuardBlocksSetup(app)) return;
+        // TODO(v2): replace with `defineExtension({ name, setup() {...} })`.
+        const extension = {
+          name: "comfyui-mcp.agent-panel",
+          // Standard ComfyUI Settings dialog entries (persisted to comfy.settings.json).
+          // Grouped under "Comfy MCP Agent". These seed the panel's runtime defaults and
+          // stay in sync with the in-panel pickers; token entries are secure buttons that
+          // never persist a raw value here. See panelSettingsList() above.
+          settings: panelSettingsList(),
+          async setup() {
+            // #1269 — the page arbitration can move AFTER registration (a later-
+            // evaluated newer copy stood this one down); honor it, and name a
+            // guardless duplicate, before anything wraps, probes, or connects.
+            if (panelCopyGuardBlocksSetup(app)) return;
+            if (panelSetupStarted) return;
+            panelSetupStarted = true;
       // #1667 P0 — wrap the workflow store's saveWorkflow with the stale-canvas
       // persist guard FIRST, before any of the below can trigger a graph change that
       // the frontend autosave would persist unchecked. setup() runs post-app-init, so
@@ -40207,8 +40210,28 @@ function registerExtensionWhenReady(tries = 0) {
         };
         setTimeout(reopen, 120);
       }
-    },
-  });
+          },
+        };
+        app.registerExtension(extension);
+        // #1585 — if the sidebar-tab API is already live, ComfyUI's setup()
+        // wave has passed or will not call us. Invoke it ourselves; the
+        // panelSetupStarted flag makes a later framework call a no-op.
+        if (invokeSetup) void extension.setup();
+      },
+    });
+    if (outcome.status === "stood-down") return notePanelCopyStandDown();
+    if (outcome.status === "pending") {
+      if (tries >= 1000) {
+        console.error(
+          "[comfyui-mcp-panel] app.registerExtension never became available — incompatible ComfyUI frontend version.",
+        );
+        return;
+      }
+      setTimeout(() => registerExtensionWhenReady(tries + 1), 10);
+    }
+  } catch (err) {
+    console.error("[comfyui-mcp-panel] registerExtension failed", err);
+  }
 }
 
 registerExtensionWhenReady();

--- a/web/js/lib/resolve-comfy-app.js
+++ b/web/js/lib/resolve-comfy-app.js
@@ -1,0 +1,106 @@
+/**
+ * #1585 — find the live ComfyApp across frontend shapes.
+ *
+ * The Agent tab is registered from `setup()`, and `setup()` only runs if
+ * `app.registerExtension(...)` landed BEFORE ComfyUI's setup wave. The
+ * previous lookup was `window.comfyAPI.app.app || window.app`. On some
+ * 1.49.x Vite/Rolldown builds the instance is `window.comfyAPI.app` (the
+ * namespace flattened), so `.app.app` is missing, the poller waits out,
+ * `registerExtension` never runs, Settings search finds nothing, and the
+ * sidebar never grows an Agent tab — with no `[comfyui-mcp-panel]` line
+ * until the 10s timeout, which a "mcp" console filter can miss.
+ *
+ * These helpers are PURE / dependency-injected (the page is passed in) so
+ * the lookup is unit-testable without a browser.
+ */
+
+/** True when `value` is something we can call `registerExtension` on. */
+export function isComfyApp(value) {
+  return Boolean(value && typeof value.registerExtension === "function");
+}
+
+/**
+ * The live ComfyApp, or `null` if this page has not exposed one yet.
+ *
+ * Order is load-bearing: the Vite shim puts the instance at
+ * `comfyAPI.app.app` and the class at `comfyAPI.app.ComfyApp`, so the
+ * nested instance must win over the namespace object. A flattened
+ * `comfyAPI.app` (the 1.49 miss) is next. Legacy `window.app` last.
+ */
+export function resolveComfyApp(root = globalThis) {
+  if (!root || (typeof root !== "object" && typeof root !== "function")) return null;
+  const comfy = root.comfyAPI;
+  const candidates = [
+    comfy && comfy.app && comfy.app.app,
+    comfy && comfy.app,
+    root.app,
+  ];
+  for (const candidate of candidates) {
+    if (isComfyApp(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * The live ComfyApi used for `/extensions`-era fetches. Same three shapes
+ * as the app, because the shim wraps `api` the same way it wraps `app`.
+ */
+export function resolveComfyApi(root = globalThis) {
+  if (!root || (typeof root !== "object" && typeof root !== "function")) return null;
+  const comfy = root.comfyAPI;
+  const candidates = [
+    comfy && comfy.api && comfy.api.api,
+    comfy && comfy.api,
+    root.api,
+  ];
+  for (const candidate of candidates) {
+    if (
+      candidate &&
+      (typeof candidate.fetchApi === "function" || typeof candidate.addEventListener === "function")
+    ) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * True when the workspace API that paints sidebar tabs is already live.
+ *
+ * ComfyUI creates `extensionManager` on the Vue workspace *before*
+ * `loadExtensions()` returns on current frontends, and it is definitely
+ * live after `invokeExtensionsAsync('setup')`. A registration that lands
+ * once this is true can install the tab itself; one that lands earlier
+ * must wait for the framework's `setup()` call.
+ */
+export function canInstallSidebarTab(comfyApp) {
+  return typeof comfyApp?.extensionManager?.registerSidebarTab === "function";
+}
+
+/**
+ * One poll/register cycle. The panel owns the extension object (settings,
+ * setup); this module only decides WHETHER to register and WHETHER setup
+ * must be invoked here because the framework's wave already passed.
+ *
+ * Returns:
+ *   `{ status: "pending" }` — no app yet; caller retries
+ *   `{ status: "stood-down", comfyApp }` — duplicate-copy guard; do not register
+ *   `{ status: "registered", comfyApp, api, invokeSetup }` — `register()` ran
+ */
+export function tryRegisterWhenReady({
+  root = globalThis,
+  active,
+  register,
+} = {}) {
+  const comfyApp = resolveComfyApp(root);
+  if (!isComfyApp(comfyApp)) return { status: "pending" };
+  if (typeof active === "function" && !active()) {
+    return { status: "stood-down", comfyApp };
+  }
+  const api = resolveComfyApi(root);
+  const invokeSetup = canInstallSidebarTab(comfyApp);
+  if (typeof register === "function") {
+    register({ comfyApp, api, invokeSetup });
+  }
+  return { status: "registered", comfyApp, api, invokeSetup };
+}


### PR DESCRIPTION
The Agent tab never joined the ComfyUI sidebar even though the pack JS loaded (network 200, ~190 files) and the backend started clean. Settings search for mcp/agent also found nothing, so `app.registerExtension` itself never ran.

The lookup was `window.comfyAPI.app.app || window.app`. On frontend 1.49.x the instance can sit at `window.comfyAPI.app` (flattened namespace). That miss made the poller wait out, `setup()` never installed the tab, and a console filter for "mcp" stayed empty until a 10s timeout that is easy to miss.

This resolves every shipped ComfyApp shape, invokes `setup()` ourselves when `registerSidebarTab` is already live (a registration that landed after ComfyUI's setup wave), and logs `[comfyui-mcp-panel] registerExtension failed` instead of throwing silently from the poller.

Fixes #1585
