### PR TITLE
fix(1610): a finished stills render notifies the agent before the orchestrator fallback

### DIFF
--- a/browser_tests/unit/run-completion-stills-metadata.test.mjs
+++ b/browser_tests/unit/run-completion-stills-metadata.test.mjs
@@ -1,0 +1,172 @@
+// panel#1610 — a finished stills render must notify the agent BEFORE the
+// orchestrator's history fallback synthesises a completion of its own.
+//
+// THE REPORT. `panel_run(to_node_id=10)` finished successfully in ComfyUI and
+// the panel's completion event never showed up; ~6 s later the orchestrator
+// synthesised a success notice from history. Same notice, same ~5 s number,
+// as #1485 — but this filing is a STILLS run, not a video.
+//
+// WHY THE PANEL LOSES THAT RACE. composeRunCompletionFrame does not send until
+// every part of the one frame resolves. For stills that included a HEAD of
+// /view (Content-Length) and an Image() decode (natural size) per final
+// output, each bounded at 8 s inside the helpers. The orchestrator's
+// `DEFAULT_SYNTHESIS_GRACE_MS` on 0.52.45 is 5 s. A stalled HEAD against a
+// ComfyUI busy with the next job is enough for the watchdog to declare the
+// panel silent while it is still composing — the stills twin of #1485, and
+// the shape comfyui-mcp#2001 measured from the other side of the bridge.
+//
+// The panel's half: bound the metadata gather well under that grace, send the
+// frame with the output refs it already has, and start the video storyboard
+// without waiting for the HEAD. Fast probes still enrich the note.
+//
+// These drive the REAL composeRunCompletionFrame with injected deps. A
+// source-regex pin of the timeout constant cannot promise the hung HEAD
+// actually lets sendFrame fire.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  composeRunCompletionFrame,
+  STILLS_METADATA_TIMEOUT_MS,
+} from "../../web/js/lib/run-completion-frame.js";
+
+function stillsPayload() {
+  return {
+    promptId: "p-1610",
+    images: [{ filename: "ComfyUI_00010_.png", subfolder: "", type: "output" }],
+    videos: [],
+    durationMs: 3_100,
+  };
+}
+
+function sheetBlob({ size = 4096, paintedFrames = 20 } = {}) {
+  return { size, paintedFrames };
+}
+
+function makeDeps(overrides = {}) {
+  const calls = { frames: [], sizeHeads: [], dimLoads: [], storyboards: [] };
+  const deps = {
+    sendFrame: (frame) => {
+      calls.frames.push(frame);
+      return true;
+    },
+    coerceMessageText: (v) => (typeof v === "string" ? v : v == null ? "" : String(v)),
+    formatDuration: (ms) => `${Math.round(ms / 1000)}s`,
+    formatClock: () => "11:13:07",
+    imageViewUrl: (ref) => `/view?filename=${ref?.filename ?? ""}`,
+    fetchImageBytes: async (url) => {
+      calls.sizeHeads.push(url);
+      return 2048;
+    },
+    fetchImageDimensions: async (url) => {
+      calls.dimLoads.push(url);
+      return { w: 512, h: 512 };
+    },
+    humanizeBytes: (n) => (n == null ? null : `${n} B`),
+    buildVideoStoryboard: async (url) => {
+      calls.storyboards.push(url);
+      return sheetBlob();
+    },
+    uploadBlobToInput: async (_blob, name) => ({ filename: name, subfolder: "", type: "temp" }),
+    storyboardFrameCount: () => 20,
+    paintImage: () => {},
+    videoStoryboardEnabled: true,
+    agentReceivesImages: () => true,
+    warn: () => {},
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+test("#1610: the stills metadata bound is shorter than the orchestrator 5s grace", () => {
+  // The bound exists to win DEFAULT_SYNTHESIS_GRACE_MS = 5_000 on 0.52.45.
+  // A constant at or above that grace cannot be why the synthesised notice
+  // stopped arriving.
+  assert.ok(
+    STILLS_METADATA_TIMEOUT_MS < 5_000,
+    `stills metadata bound ${STILLS_METADATA_TIMEOUT_MS}ms must lose to a 5s grace, not beat it`,
+  );
+});
+
+test("#1610: a stalled /view HEAD does not delay the stills completion past the metadata bound", async () => {
+  const { deps, calls } = makeDeps({
+    fetchImageBytes: () => new Promise(() => {}),
+    fetchImageDimensions: () => new Promise(() => {}),
+    stillsMetadataTimeoutMs: 25,
+  });
+  const t0 = Date.now();
+  const frame = await composeRunCompletionFrame(stillsPayload(), deps);
+  const elapsed = Date.now() - t0;
+
+  assert.equal(calls.frames.length, 1, "the one completion frame is still sent");
+  assert.equal(frame, calls.frames[0]);
+  assert.equal(frame.type, "agent_event");
+  assert.equal(frame.kind, "executed");
+  assert.equal(frame.prompt_id, "p-1610");
+  assert.equal(frame.images[0].filename, "ComfyUI_00010_.png", "the output ref the agent was promised still rides the frame");
+  assert.match(frame.note, /ComfyUI_00010_\.png/, "the filename note does not wait on metadata");
+  assert.ok(
+    elapsed < 400,
+    `a hung HEAD must not hold sendFrame; took ${elapsed}ms with a 25ms bound`,
+  );
+});
+
+test("#1610: stills metadata that arrives in time still rides the note", async () => {
+  const { deps, calls } = makeDeps();
+  const frame = await composeRunCompletionFrame(stillsPayload(), deps);
+  assert.equal(calls.frames.length, 1);
+  assert.ok(calls.sizeHeads.length > 0, "the happy path still HEADs /view");
+  assert.ok(calls.dimLoads.length > 0, "the happy path still reads dimensions");
+  assert.match(frame.note, /2048 B/, "size reaches the note when the probe lands");
+  assert.match(frame.note, /512×512/, "dimensions reach the note when the probe lands");
+});
+
+test("#1610: video storyboard starts while a stills HEAD is still in flight", async () => {
+  // FAIL-before: stills ran to completion (including its metadata await) BEFORE
+  // buildVideoStoryboard was called, so a HEAD that has not settled yet held
+  // the sheet off the critical path of a mixed run as well.
+  let releaseHead;
+  const headHold = new Promise((resolve) => {
+    releaseHead = resolve;
+  });
+  let storyboardStarted = false;
+  const { deps, calls } = makeDeps({
+    fetchImageBytes: () => headHold,
+    fetchImageDimensions: () => headHold,
+    buildVideoStoryboard: async () => {
+      storyboardStarted = true;
+      return sheetBlob();
+    },
+    // Long enough that a sequential compose would still be inside stills
+    // metadata when we sample. Parallel compose must have started the sheet
+    // already.
+    stillsMetadataTimeoutMs: 5_000,
+  });
+  const done = composeRunCompletionFrame(
+    {
+      promptId: "p-1610-mixed",
+      images: [{ filename: "final.png", type: "output" }],
+      videos: [{ m: { filename: "clip.mp4", type: "output" }, nodeId: "10" }],
+      durationMs: 8_000,
+    },
+    deps,
+  );
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(
+    storyboardStarted,
+    true,
+    "the storyboard must start without waiting for the stills HEAD to settle",
+  );
+  releaseHead(2048);
+  const frame = await done;
+  assert.equal(calls.frames.length, 1);
+  assert.ok(
+    frame.images.some((m) => m.filename === "final.png"),
+    "the still rides the mixed frame",
+  );
+  assert.ok(
+    frame.images.some((m) => m.filename === "storyboard_clip.png"),
+    "the sheet rides the mixed frame once the HEAD is released",
+  );
+});

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -25,6 +25,18 @@
 import { duplicateCompletionNote } from "./completion-dedupe.js";
 import { withTimeout } from "./bounded-step.js";
 
+// #1610 — stills metadata (HEAD /view for size + Image() decode for pixels) is
+// best-effort decoration on the completion note. It is NOT needed to attach the
+// output refs the agent was promised. The helpers themselves are bounded at 8 s
+// each, which is LONGER than the orchestrator's synthesis grace on 0.52.45
+// (`DEFAULT_SYNTHESIS_GRACE_MS = 5_000`). A stalled HEAD against a ComfyUI busy
+// with the next job is enough for the orchestrator to declare the panel silent
+// and synthesise a notice ~6 s later — the reported shape, and the stills twin
+// of #1485. This bound is the panel's half: wait this long for metadata, then
+// send the frame with the filenames it already has. Fast localhost probes still
+// enrich the note; a stall cannot beat the grace.
+export const STILLS_METADATA_TIMEOUT_MS = 1000;
+
 /**
  * Build and send the single consolidated completion frame for one finished
  * prompt. Resolves to the frame that was sent (for tests), or null when the
@@ -84,6 +96,9 @@ export async function composeRunCompletionFrame(
     // and, on timeout, degrades to its note-only fallback so the one frame always
     // sends. Injectable for tests.
     videoStoryboardTimeoutMs = 25000,
+    // #1610 — same shape as the video bound, for the stills metadata probes.
+    // Injectable so a test can prove a hung HEAD cannot delay sendFrame past it.
+    stillsMetadataTimeoutMs = STILLS_METADATA_TIMEOUT_MS,
     setTimer = (fn, ms) => setTimeout(fn, ms),
     clearTimer = (t) => clearTimeout(t),
   } = deps;
@@ -144,31 +159,33 @@ export async function composeRunCompletionFrame(
   const leadingSectionCount = noteSections.length;
   let metadata = [];
 
-  // ── Stills segment ─────────────────────────────────────────────────────
-  if (images.length) {
-    const seg = await buildStillsSegment(images, {
-      coerceMessageText,
-      imageViewUrl,
-      fetchImageBytes,
-      fetchImageDimensions,
-      humanizeBytes,
-      duration,
-      durationMs,
-      finishedClock,
-      finishedAt,
-    });
-    outImages.push(...seg.images);
-    if (seg.note) noteSections.push(seg.note);
-    metadata = seg.metadata;
-  }
-
-  // ── Video segments (built in PARALLEL, each bounded, then folded in order) ─
-  // Parallel + per-segment timeout means neither a slow nor a permanently-
-  // pending storyboard for one video can delay or suppress the single frame:
-  // the worst case is ONE timeout window, and a stalled segment degrades to its
-  // note-only fallback. Order is preserved (Promise.all keeps input order), so
-  // the storyboards appear in video order.
-  const videoSegs = await Promise.all(
+  // ── Stills + video segments in PARALLEL ────────────────────────────────
+  // #1610 — these used to be sequential: stills metadata (HEAD + Image decode,
+  // each bounded at 8 s inside the helpers) ran to completion BEFORE the
+  // storyboard even started. A stalled /view against a busy ComfyUI therefore
+  // delayed EVERYTHING, including a mixed run's sheet, past the orchestrator's
+  // 5 s synthesis grace. They share no data, so they overlap; the stills
+  // metadata gather is itself bounded (see buildStillsSegment) so a hang
+  // cannot serialise in front of the sheet OR hold the one send. Video
+  // segments stay parallel with each other, same as before. Fold order is
+  // stills then videos, unchanged.
+  const stillsP = images.length
+    ? buildStillsSegment(images, {
+        coerceMessageText,
+        imageViewUrl,
+        fetchImageBytes,
+        fetchImageDimensions,
+        humanizeBytes,
+        duration,
+        durationMs,
+        finishedClock,
+        finishedAt,
+        stillsMetadataTimeoutMs,
+        setTimer,
+        clearTimer,
+      })
+    : Promise.resolve({ images: [], note: "", metadata: [] });
+  const videosP = Promise.all(
     videos.map((v) =>
       buildVideoSegment(v, {
         coerceMessageText,
@@ -196,6 +213,10 @@ export async function composeRunCompletionFrame(
       }),
     ),
   );
+  const [stillsSeg, videoSegs] = await Promise.all([stillsP, videosP]);
+  outImages.push(...stillsSeg.images);
+  if (stillsSeg.note) noteSections.push(stillsSeg.note);
+  metadata = stillsSeg.metadata;
   // #609 — ONE sighted/blind decision for the whole frame, made HERE: after the
   // slowest segment resolved and immediately before send (nothing below awaits
   // until sendFrame, so the toggle cannot interleave). A per-segment read would
@@ -359,6 +380,9 @@ async function buildStillsSegment(bufImages, deps) {
     durationMs,
     finishedClock,
     finishedAt,
+    stillsMetadataTimeoutMs = STILLS_METADATA_TIMEOUT_MS,
+    setTimer = (fn, ms) => setTimeout(fn, ms),
+    clearTimer = (t) => clearTimeout(t),
   } = deps;
 
   if (!bufImages.length) return { images: [], note: "", metadata: [] };
@@ -401,42 +425,52 @@ async function buildStillsSegment(bufImages, deps) {
   }
 
   // ── Rich per-output metadata (parallel, bounded, never drops the note) ──
+  // #1610 — the helpers' own 8 s AbortController / Image() timeouts are NOT
+  // this bound. Those stop a hang from lasting forever; this one stops a hang
+  // from lasting past the orchestrator's grace. On timeout the filename note
+  // still sends; size/pixels are omitted the same way a thrown gather is.
   const total = finals.length;
   const finalNameSet = finalNames;
   let metadata = [];
   try {
-    metadata = await Promise.all(
-      finals.map(async (m, idx) => {
-        const filename = coerceMessageText(m?.filename) || "(unknown)";
-        const subfolder = coerceMessageText(m?.subfolder);
-        const path = subfolder ? `${subfolder}/${filename}` : filename;
-        const url = imageViewUrl(m);
-        const [sizeRes, dimRes] = await Promise.allSettled([
-          fetchImageBytes(url),
-          fetchImageDimensions(url),
-        ]);
-        const sizeBytes = sizeRes.status === "fulfilled" ? sizeRes.value : null;
-        const dim = dimRes.status === "fulfilled" ? dimRes.value : null;
-        const siblings = finalNameSet.filter((n) => n !== filename);
-        return {
-          filename,
-          path,
-          subfolder,
-          sizeBytes,
-          size: humanizeBytes(sizeBytes),
-          width: dim?.w ?? null,
-          height: dim?.h ?? null,
-          dimensions: dim ? `${dim.w}×${dim.h}` : null,
-          index: idx + 1,
-          total,
-          siblings,
-          durationMs,
-          duration,
-          finishedAt: finishedAt.toISOString?.() ?? null,
-          finishedClock,
-        };
-      }),
+    const gathered = await withTimeout(
+      Promise.all(
+        finals.map(async (m, idx) => {
+          const filename = coerceMessageText(m?.filename) || "(unknown)";
+          const subfolder = coerceMessageText(m?.subfolder);
+          const path = subfolder ? `${subfolder}/${filename}` : filename;
+          const url = imageViewUrl(m);
+          const [sizeRes, dimRes] = await Promise.allSettled([
+            fetchImageBytes(url),
+            fetchImageDimensions(url),
+          ]);
+          const sizeBytes = sizeRes.status === "fulfilled" ? sizeRes.value : null;
+          const dim = dimRes.status === "fulfilled" ? dimRes.value : null;
+          const siblings = finalNameSet.filter((n) => n !== filename);
+          return {
+            filename,
+            path,
+            subfolder,
+            sizeBytes,
+            size: humanizeBytes(sizeBytes),
+            width: dim?.w ?? null,
+            height: dim?.h ?? null,
+            dimensions: dim ? `${dim.w}×${dim.h}` : null,
+            index: idx + 1,
+            total,
+            siblings,
+            durationMs,
+            duration,
+            finishedAt: finishedAt.toISOString?.() ?? null,
+            finishedClock,
+          };
+        }),
+      ),
+      stillsMetadataTimeoutMs,
+      () => [],
+      { setTimer, clearTimer },
     );
+    metadata = Array.isArray(gathered) ? gathered : [];
   } catch {
     metadata = [];
   }


### PR DESCRIPTION
Fixes #1610

A `panel_run` stills render finished in ComfyUI and the panel's completion event did not arrive; about 6s later the orchestrator synthesised a success notice from history. That number is the orchestrator's 5s synthesis grace on 0.52.45 (`DEFAULT_SYNTHESIS_GRACE_MS`), not a missing send.

`composeRunCompletionFrame` does not send until every part of the one frame resolves. For stills that included a HEAD of `/view` (Content-Length) and an `Image()` decode (natural size) per final output, each bounded at 8s inside the helpers — longer than the grace. A stalled HEAD against a ComfyUI busy with the next job is enough for the watchdog to declare the panel silent while it is still composing. Same race as #1485, for stills rather than video; comfyui-mcp#2001 measured it from the other side of the bridge.

The panel's half:

- Bound the stills metadata gather at 1s (well under the 5s grace). A hang no longer holds the send; the filename note and output refs still go out.
- Start the video storyboard without waiting for that HEAD, so a mixed run cannot serialise an 8s probe in front of the sheet.
- Fast probes still enrich the note. The orchestrator history fallback stays the safety net.

What this does not do: a send/ack protocol on `agent_event` (the original suggested journal-before-delivery). That is a cross-repo bridge change; user-message resume already has `mid`/ack, completion `sendFrame` still returns true on `WebSocket.send()`. The remaining orchestrator half (grace vs storyboard, attaching history outputs on the synthesised notice) lives in artokun/comfyui-mcp (#2001 / 0.52.48 already lengthened grace as a workaround).
