### PR TITLE
fix(1608): panel_open_workflow no longer reports unknown content when only randomMin/randomMax normalize

### DIFF
--- a/browser_tests/unit/node-properties-random-range.test.mjs
+++ b/browser_tests/unit/node-properties-random-range.test.mjs
@@ -1,0 +1,196 @@
+/**
+ * #1608 — `panel_open_workflow` reported UNKNOWN / no `workflow_uuid` on a
+ * faithful open because live rgthree Seed `properties.randomMin` /
+ * `randomMax` differed from the serialized payload.
+ *
+ * MEASURED from rgthree Seed (`src_web/comfyui/seed.ts`): the constructor
+ * stamps `randomMin: 0`, `randomMax: 1125899906842624` before LiteGraph
+ * merges the saved bag, and `onPropertyChanged` Number()-coerces and clamps
+ * the same two keys. A file that omitted them, or stored them as a different
+ * numeric type, cannot round-trip. Authored widgets and the node set were
+ * intact; the open verifier treated the frontend-computed bounds as lost
+ * content.
+ *
+ * The check admits exactly that rewrite. Any other property key, and any
+ * other per-node field that is not already characterised (`size` height-only,
+ * `inputs` rebuild), must still refuse.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { nodePropertiesDifferOnlyByRandomRangeNormalization } from "../../web/js/lib/node-properties-random-range.js";
+import { graphRootReproducesStateContent } from "../../web/js/lib/graph-binding.js";
+
+const SEED = "Seed (rgthree)";
+const DEFAULTS = { randomMin: 0, randomMax: 1125899906842624 };
+
+const node = (id, extra = {}) => ({
+  id,
+  type: extra.type ?? SEED,
+  pos: [0, 0],
+  size: [200, 100],
+  widgets_values: extra.widgets_values ?? [-1],
+  ...extra,
+});
+
+test("identical properties bags are trivially explained", () => {
+  const n = node(1, { properties: { ...DEFAULTS, ver: "1" } });
+  assert.equal(
+    nodePropertiesDifferOnlyByRandomRangeNormalization([n], [structuredClone(n)]),
+    true,
+  );
+});
+
+test("constructor fill — live stamps defaults the file never saved — is explained", () => {
+  // The reported shape: saved bag omitted the keys; the constructor left them.
+  const saved = [node(1, { properties: { ver: "1" } })];
+  const live = [node(1, { properties: { ver: "1", ...DEFAULTS } })];
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization(saved, live), true);
+});
+
+test("a missing properties bag vs constructor defaults is explained", () => {
+  const saved = [node(1)];
+  const live = [node(1, { properties: { ...DEFAULTS } })];
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization(saved, live), true);
+});
+
+test("a numeric rewrite of only randomMin/randomMax is explained", () => {
+  const saved = [node(1, { properties: { randomMin: "0", randomMax: "1125899906842624" } })];
+  const live = [node(1, { properties: { ...DEFAULTS } })];
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization(saved, live), true);
+});
+
+test("an unrelated properties KEY is NOT explained", () => {
+  const saved = [node(1, { properties: { ver: "v1", ...DEFAULTS } })];
+  const live = [node(1, { properties: { ver: "1", ...DEFAULTS } })];
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization(saved, live), false);
+});
+
+test("randomMin plus an unrelated key still refuses — the bag is not allowlisted", () => {
+  const saved = [node(1, { properties: { ver: "1" } })];
+  const live = [node(1, { properties: { ver: "1", cnr_id: "rgthree", ...DEFAULTS } })];
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization(saved, live), false);
+});
+
+test("unreadable properties prove NOTHING (false, not true)", () => {
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization(null, []), false);
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization([node(1)], undefined), false);
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization([null], [node(1)]), false);
+  for (const bad of [null, [1, 2], "string"]) {
+    assert.equal(
+      nodePropertiesDifferOnlyByRandomRangeNormalization(
+        [node(1, { properties: { ...DEFAULTS } })],
+        [node(1, { properties: bad })],
+      ),
+      false,
+      JSON.stringify(bad),
+    );
+  }
+});
+
+test("a node whose id/type moved is not paired and refuses", () => {
+  assert.equal(
+    nodePropertiesDifferOnlyByRandomRangeNormalization(
+      [node(1, { properties: { ...DEFAULTS } })],
+      [{ ...node(1, { properties: { ...DEFAULTS } }), type: "KSampler" }],
+    ),
+    false,
+  );
+});
+
+test("every node's bag must be explained, not just one", () => {
+  const saved = [node(1, { properties: {} }), node(2, { properties: { ver: "1" } })];
+  const live = [node(1, { properties: { ...DEFAULTS } }), node(2, { properties: { ver: "2" } })];
+  assert.equal(nodePropertiesDifferOnlyByRandomRangeNormalization(saved, live), false);
+});
+
+test("a THROWING properties bag proves nothing — the catch must answer false", () => {
+  // The getter has to sit on a key we actually READ. `randomMin`/`randomMax` are
+  // skipped without reading, so a throw there never reaches the catch — the same
+  // lesson node-inputs-rebuild's first hostile-slot test had to learn.
+  const hostile = { ...DEFAULTS };
+  Object.defineProperty(hostile, "ver", {
+    enumerable: true,
+    get() {
+      throw new Error("hostile getter");
+    },
+  });
+  assert.equal(
+    nodePropertiesDifferOnlyByRandomRangeNormalization(
+      [node(1, { properties: { ...DEFAULTS, ver: "1" } })],
+      [node(1, { properties: hostile })],
+    ),
+    false,
+  );
+});
+
+// ── WIRING: the check must actually gate the verdict ────────────────────────
+//
+// Mutation found that deleting the gate from graph-binding left every test above
+// green — they exercise the pure function, which cannot see whether anything
+// calls it. These drive the real `graphRootReproducesStateContent`.
+
+const graphOf = (nodes) => ({ serialize: () => ({ nodes }) });
+
+test("#1608 the reporter's case: only randomMin/randomMax differ, and the open is PROVEN", () => {
+  // No `loadRanToCompletion`: this is a field-level account, not the watched-
+  // restore ground. The reporter's panel could not license that ground and still
+  // had to publish the fence.
+  const saved = {
+    nodes: [
+      node(12, { properties: { ver: "1.0.0" } }),
+      node(4, { type: "KSampler", widgets_values: [20, "euler"] }),
+    ],
+  };
+  const live = graphOf([
+    node(12, { properties: { ver: "1.0.0", ...DEFAULTS } }),
+    node(4, { type: "KSampler", widgets_values: [20, "euler"] }),
+  ]);
+  const verdict = graphRootReproducesStateContent({ rootGraph: live, state: saved });
+  assert.equal(verdict.proven, true, "the reporter's case must stop refusing");
+  assert.equal(verdict.exact, false, "…but it is not byte-identical, and must not claim to be");
+  assert.deepEqual(verdict.fields, [], "properties must not ride into geometry_rewritten");
+  assert.equal(verdict.normalizedOnly, false, "this ground does not claim a watched restore");
+});
+
+test("#1608 a numeric rewrite of the same two keys is also PROVEN", () => {
+  const saved = { nodes: [node(1, { properties: { randomMin: 5, randomMax: 99 } })] };
+  const live = graphOf([node(1, { properties: { ...DEFAULTS } })]);
+  const verdict = graphRootReproducesStateContent({ rootGraph: live, state: saved });
+  assert.equal(verdict.proven, true);
+  assert.deepEqual(verdict.fields, []);
+});
+
+test("WIRING: a pack-version stamp still refuses through the real gate", () => {
+  const saved = { nodes: [node(1, { properties: { ver: "v1", ...DEFAULTS } })] };
+  const live = graphOf([node(1, { properties: { ver: "1", ...DEFAULTS } })]);
+  assert.equal(graphRootReproducesStateContent({ rootGraph: live, state: saved }).proven, false);
+});
+
+test("WIRING: a widget value still refuses — random-range is not a blanket properties pass", () => {
+  const saved = { nodes: [node(1, { properties: { ...DEFAULTS }, widgets_values: [-1] })] };
+  const live = graphOf([node(1, { properties: { randomMin: 1, ...DEFAULTS }, widgets_values: [47] })]);
+  const verdict = graphRootReproducesStateContent({ rootGraph: live, state: saved });
+  assert.equal(verdict.proven, false);
+  assert.equal(verdict.presentationOnly, false);
+});
+
+test("WIRING: random-range plus a height-only size is PROVEN, and only size is disclosed", () => {
+  const saved = { nodes: [node(1, { size: [200, 100], properties: { ver: "1" } })] };
+  const live = graphOf([
+    node(1, { size: [200, 60], properties: { ver: "1", ...DEFAULTS } }),
+  ]);
+  const verdict = graphRootReproducesStateContent({ rootGraph: live, state: saved });
+  assert.equal(verdict.proven, true);
+  assert.deepEqual(verdict.fields, ["size"], "geometry_rewritten may only name the height");
+});
+
+test("WIRING: source guard — the open content proof actually calls the check", () => {
+  const src = readFileSync(new URL("../../web/js/lib/graph-binding.js", import.meta.url), "utf8");
+  assert.match(src, /import \{ nodePropertiesDifferOnlyByRandomRangeNormalization \}/);
+  assert.match(
+    src,
+    /if \(!nodePropertiesDifferOnlyByRandomRangeNormalization\(state\?\.nodes, actualState\?\.nodes\)\)/,
+  );
+});

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -3,6 +3,7 @@ import {
   definitionsDifferOnlyByRenumber,
 } from "./definitions-renumber.js";
 import { nodeInputsDifferOnlyByDefinitionRebuild } from "./node-inputs-rebuild.js";
+import { nodePropertiesDifferOnlyByRandomRangeNormalization } from "./node-properties-random-range.js";
 import {
   isEmptyBaselineMismatch,
   emptyBaselineNote,
@@ -878,6 +879,13 @@ export function graphRootMatchesState({ rootGraph, state } = {}) {
  *              appended), so a faithful open cannot round-trip what was saved.
  *              Admitted only when every difference fits that rebuild.
  *
+ * `properties` is deliberately absent even though #1608 characterised a rewrite
+ * inside it. The field is a bag: membership here would admit ANY key that moved
+ * on the strength of evidence about `randomMin`/`randomMax`. Those two keys are
+ * filtered out below, the same way a height-only `size` is admitted by its own
+ * check rather than by the field name. `geometry_rewritten`'s note asserts a
+ * height-only rewrite, so a properties-only proof must not land in that list.
+ *
  * `widgets_values` is deliberately absent despite ALSO being rewritten on every
  * load (`migrateWidgetsValues`): it is the field a genuine partial load drops,
  * which is what #1111/#1089 are about, so admitting it would gut this guard.
@@ -1336,15 +1344,43 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
     ) {
       return notProven;
     }
+    // #1608 — `properties` is a bag, and the characterised rewrite is two keys
+    // inside it (`randomMin`/`randomMax`), not the field. A field-name allowlist
+    // would admit a pack-version stamp on the strength of evidence about Seed
+    // range bounds. The check refuses any other key; when it passes, drop
+    // `properties` from the remaining list so it cannot ride into
+    // `geometry_rewritten` (that note asserts a height-only rewrite).
+    let remaining = fields;
+    if (fields.includes("properties")) {
+      if (!nodePropertiesDifferOnlyByRandomRangeNormalization(state?.nodes, actualState?.nodes)) {
+        return notProven;
+      }
+      remaining = fields.filter((field) => field !== "properties");
+    }
     // An empty field list with a differing `nodes` surface means the two disagreed
     // somewhere this classifier could not name — proving content off a difference
     // nobody can point at is exactly the fabricated all-clear to avoid.
-    if (!fields.length) return notProven;
-    if (!fields.every((field) => RECOMPUTED_NODE_FIELDS.has(field))) return notProven;
+    // An empty REMAINING list after the properties account is the opposite: the
+    // difference was named (`properties`) and fully characterised, same shape as
+    // a definitions-only renumber (proven, not exact, nothing to disclose as
+    // geometry).
+    if (!remaining.length) {
+      if (!fields.length) return notProven;
+      return {
+        proven: true,
+        exact: false,
+        fields: [],
+        presentationOnly: false,
+        normalizedOnly: false,
+        normalizedFields: [],
+        definitionsNormalized: false,
+      };
+    }
+    if (!remaining.every((field) => RECOMPUTED_NODE_FIELDS.has(field))) return notProven;
     return {
       proven: true,
       exact: false,
-      fields,
+      fields: remaining,
       presentationOnly: false,
       normalizedOnly: false,
       normalizedFields: [],

--- a/web/js/lib/node-properties-random-range.js
+++ b/web/js/lib/node-properties-random-range.js
@@ -1,0 +1,112 @@
+/**
+ * Is a per-node `properties` difference ENTIRELY rgthree Seed's random-range rewrite?
+ * (#1608)
+ *
+ * ## The measurement this rests on
+ *
+ * rgthree Seed (`src_web/comfyui/seed.ts`) stamps two keys in the constructor,
+ * before LiteGraph copies the saved bag on top:
+ *
+ *     this.properties["randomMax"] = 1125899906842624;
+ *     this.properties["randomMin"] = 0;
+ *
+ * LiteGraph then MERGES saved properties (missing keys keep the constructor
+ * stamp). `onPropertyChanged` Number()-coerces and clamps the same two keys.
+ * A file that omitted them, or stored them as a different numeric type, cannot
+ * round-trip: the live bag carries frontend-computed bounds the payload never
+ * had, and `panel_open_workflow` reported CONTENT_UNVERIFIED — no
+ * `workflow_uuid` — over a complete node set whose authored widgets matched.
+ *
+ * ## What this does NOT do
+ *
+ * It does not wave the `properties` field through. Any other key that moved —
+ * a pack-version stamp, an extension's stored settings — returns false, and
+ * the caller reads false as NOT PROVEN. Same contract as
+ * `nodeInputsDifferOnlyByDefinitionRebuild` (#1467).
+ */
+
+const RANDOM_RANGE_PROPERTY_KEYS = new Set(["randomMin", "randomMax"]);
+
+function readableProps(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Missing properties is an empty bag: the constructor fills keys, it does not
+ *  replace a bag that was never saved with a non-object. */
+function asBag(value) {
+  if (value === undefined) return {};
+  return value;
+}
+
+const canonicalize = (value) => {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+};
+
+/**
+ * `undefined` is ABSENT, matching `classifyNodeDifference`: JSON cannot carry
+ * it, so a live in-memory key with that value is not a difference from a file.
+ */
+function hasOwnDefined(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key) && obj[key] !== undefined;
+}
+
+function bagsEqualIgnoringRandomRange(before, after) {
+  const left = asBag(before);
+  const right = asBag(after);
+  if (!readableProps(left) || !readableProps(right)) return false;
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (RANDOM_RANGE_PROPERTY_KEYS.has(key)) continue;
+    const present = hasOwnDefined(left, key) === hasOwnDefined(right, key);
+    const a = JSON.stringify(canonicalize(left[key]));
+    const b = JSON.stringify(canonicalize(right[key]));
+    if (!present || a !== b) return false;
+  }
+  return true;
+}
+
+/**
+ * Whole-graph form: every node's properties difference must be confined to
+ * `randomMin` / `randomMax`.
+ *
+ * Pairs nodes by id+type, matching `classifyNodeDifference`'s identity rule —
+ * a caller only reaches here once that classifier has already established the
+ * node SET matches, but this must not depend on that having been done.
+ */
+export function nodePropertiesDifferOnlyByRandomRangeNormalization(expectedNodes, actualNodes) {
+  if (!Array.isArray(expectedNodes) || !Array.isArray(actualNodes)) return false;
+  try {
+    const key = (n) => JSON.stringify([String(n?.id ?? ""), String(n?.type ?? "")]);
+    const byKey = (list) => {
+      const map = new Map();
+      for (const node of list) {
+        if (!node || typeof node !== "object") return null;
+        const k = key(node);
+        if (map.has(k)) return null;
+        map.set(k, node);
+      }
+      return map;
+    };
+    const expected = byKey(expectedNodes);
+    const actual = byKey(actualNodes);
+    if (!expected || !actual) return false;
+    if (expected.size !== actual.size) return false;
+
+    for (const [k, before] of expected) {
+      const after = actual.get(k);
+      if (!after) return false;
+      if (!bagsEqualIgnoringRandomRange(before.properties, after.properties)) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Fixes #1608

Opening a workflow that contains rgthree Seed nodes bound the right tab and restored every node with matching ids/types, but panel_open_workflow still returned UNKNOWN and published no workflow_uuid because live properties randomMin / randomMax differed from the serialized file.

rgthree Seed stamps those two keys in its constructor (defaults 0 and 1125899906842624) before LiteGraph merges the saved bag, and onPropertyChanged Number()-coerces and clamps them. A file that omitted the keys, or stored them as a different numeric type, cannot round-trip. Authored widgets were intact; the open verifier treated the frontend-computed bounds as lost content.

The content proof now accounts for a properties difference that is confined to those two keys — the same characterised-rewrite pattern as height-only size and the inputs rebuild — and publishes the fence. Any other property key, and any unaccounted field (widgets_values, pack-version stamps, …), still refuses.
