### PR TITLE
fix(1589): trust live VIDEO producers for add-node socket proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - opening an already-open saved workflow publishes the live fence uuid, so the next graph read is not refused as a stale instance (#1581)
+- `panel_add_node` accepts a core VIDEO socket when a live canvas producer exposes VIDEO, even if the full `/object_info` read times out (#1589)
 
 - opening a saved workflow leaves graph tools on that canvas
 - report the tab re-list from the open LIST, and hold the fence across the load

--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -130,6 +130,42 @@ function wildcardDictObjectInfo() {
   };
 }
 
+function videoObjectInfo({ widgetInput = false } = {}) {
+  return {
+    LoadVideo: {
+      name: "LoadVideo",
+      input: { required: {} },
+      output: ["VIDEO"],
+    },
+    GetVideoComponents: {
+      name: "GetVideoComponents",
+      input: {
+        required: {
+          video: ["VIDEO", widgetInput ? { default: "a-video-value" } : {}],
+        },
+      },
+      output: ["IMAGE", "AUDIO"],
+    },
+  };
+}
+
+function apiForObjectInfo(defs) {
+  return {
+    // The issue is the bounded whole-schema read not answering. The per-class route still
+    // answers, which is the production fast path for an already-registered core class.
+    async getNodeDefs() {
+      return NODE_DEFS_NO_ANSWER;
+    },
+    async fetchApi(route) {
+      const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+      const body = Object.prototype.hasOwnProperty.call(defs, classType)
+        ? { [classType]: defs[classType] }
+        : {};
+      return { status: 200, json: async () => body };
+    },
+  };
+}
+
 function makeComfy(defs = backendObjectInfo()) {
   const widgets = {
     COMBO(node, name, spec) {
@@ -433,6 +469,83 @@ test("#1584: a live wildcard producer makes a custom dict input addable", async 
   assert.equal(consumer.added.type, "DictGetNode");
   assert.deepEqual(consumer.added.inputs, ["py_dict"]);
   assert.equal(comfy.graph._nodes.length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// #1589 — a producer already live on the canvas is direct socket evidence even when the
+// bounded whole-schema widen cannot answer. The call-site tests below drive the shipped
+// graph_add_node body; helper-only coverage would miss the captured live graph callback.
+// ---------------------------------------------------------------------------
+
+function addLiveVideoProducer(comfy, outputType) {
+  comfy.graph._nodes.push({
+    type: "LoadVideo",
+    outputs: [{ name: "video", type: outputType }],
+    inputs: [],
+    widgets: [],
+  });
+}
+
+function videoAdd(comfy, defs = videoObjectInfo()) {
+  return realGraphAddNode(comfy, {
+    api: apiForObjectInfo(defs),
+    // Keep the regression test bounded without waiting ten seconds for a synthetic
+    // half-open whole-schema request.
+    boundedGetNodeDefs: async () => NODE_DEFS_NO_ANSWER,
+  });
+}
+
+test("#1589: GetVideoComponents adds when a live producer exposes VIDEO", async () => {
+  const comfy = makeComfy(videoObjectInfo());
+  addLiveVideoProducer(comfy, "VIDEO");
+  const { graph_add_node } = videoAdd(comfy);
+
+  const result = await graph_add_node({ class_type: "GetVideoComponents" });
+
+  assert.equal(result.added.type, "GetVideoComponents");
+  assert.deepEqual(result.added.inputs, ["video"]);
+  assert.deepEqual(result.added.widgets, []);
+  assert.equal(comfy.graph._nodes.length, 2);
+});
+
+test("#1589: no live VIDEO producer still refuses GetVideoComponents", async () => {
+  const comfy = makeComfy(videoObjectInfo());
+  const { graph_add_node } = videoAdd(comfy);
+
+  await assert.rejects(
+    () => graph_add_node({ class_type: "GetVideoComponents" }),
+    (err) => {
+      assert.match(err.message, /whether any installed node outputs it is UNKNOWN/);
+      assert.match(err.message, /VIDEO/);
+      return true;
+    },
+  );
+  assert.equal(comfy.graph._nodes.length, 0, "the refused add does not mutate the graph");
+});
+
+test("#1589: a live producer of another type does not prove VIDEO", async () => {
+  const comfy = makeComfy(videoObjectInfo());
+  addLiveVideoProducer(comfy, "IMAGE");
+  const { graph_add_node } = videoAdd(comfy);
+
+  await assert.rejects(
+    () => graph_add_node({ class_type: "GetVideoComponents" }),
+    /VIDEO/,
+  );
+  assert.equal(comfy.graph._nodes.length, 1, "the unrelated producer remains the only live node");
+});
+
+test("#1589: a VIDEO producer does not waive a widget-valued VIDEO input", async () => {
+  const defs = videoObjectInfo({ widgetInput: true });
+  const comfy = makeComfy(defs);
+  addLiveVideoProducer(comfy, "VIDEO");
+  const { graph_add_node } = videoAdd(comfy, defs);
+
+  await assert.rejects(
+    () => graph_add_node({ class_type: "GetVideoComponents" }),
+    /needs a registered widget/,
+  );
+  assert.equal(comfy.graph._nodes.length, 1, "the widget-shaped refusal does not add a node");
 });
 
 // ---------------------------------------------------------------------------

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11477,6 +11477,7 @@ async function awaitRequiredCustomWidgetRegistration(
   classType,
   widenSocketProof,
   liveNodeOfClass,
+  liveOutputSocketTypes,
   budgetMs,
 ) {
   // MONOTONIC, like every other elapsed-time measurement in this panel. On the wall clock
@@ -11497,8 +11498,28 @@ async function awaitRequiredCustomWidgetRegistration(
       : CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
   const deadline = startedAt + wait;
   let socketTypes = knownSocketTypes;
-  const check = () =>
-    unavailableRequiredWidgetReport(nodeData, comfyApp?.widgets, socketTypes, currentDef);
+  const check = () => {
+    // A live output slot is direct evidence that its exact datatype is a link socket,
+    // even when the whole /object_info read that would normally prove it did not answer.
+    // Keep this on the OUTPUT side only: unavailableRequiredWidgetReport still requires
+    // the consumer input itself to declare socket shape, so a widget-valued input cannot
+    // be waived merely because another node emits the same type.
+    if (typeof liveOutputSocketTypes === "function") {
+      try {
+        const live = liveOutputSocketTypes();
+        if (live && typeof live[Symbol.iterator] === "function") {
+          const proof = new Set(socketTypes ?? []);
+          for (const type of live) {
+            if (typeof type === "string" && type) proof.add(type);
+          }
+          socketTypes = proof;
+        }
+      } catch {
+        // An unreadable live graph supplies no proof; keep the schema snapshot unchanged.
+      }
+    }
+    return unavailableRequiredWidgetReport(nodeData, comfyApp?.widgets, socketTypes, currentDef);
+  };
   let unavailable = check();
   // #821 — the socket proof may have been read off a single-class /object_info, which is
   // silent about every type a SIBLING node outputs. Widen it once against the whole
@@ -13704,6 +13725,28 @@ const GRAPH_TOOL_EXECUTORS = {
           const graph = getGraphCtx()?.graph ?? app?.graph ?? null;
           const nodes = graph?._nodes ?? graph?.nodes ?? [];
           return nodes.find((n) => n?.type === cls) ?? null;
+        } catch {
+          return null;
+        }
+      },
+      // A producer already materialised on this live graph is stronger evidence than an
+      // incomplete whole-schema read for the exact output type it exposes. This is read
+      // lazily by the registration guard, so ordinary adds keep the cheap path.
+      () => {
+        try {
+          const graph = capturedContext?.graph ?? null;
+          const nodes = Array.isArray(graph?._nodes)
+            ? graph._nodes
+            : Array.isArray(graph?.nodes)
+              ? graph.nodes
+              : [];
+          const types = new Set();
+          for (const node of nodes) {
+            for (const output of Array.isArray(node?.outputs) ? node.outputs : []) {
+              if (typeof output?.type === "string" && output.type) types.add(output.type);
+            }
+          }
+          return types;
         } catch {
           return null;
         }


### PR DESCRIPTION
## Summary

- Let `panel_add_node` use exact output types from the live canvas when the bounded whole `/object_info` socket-proof read does not answer.
- Preserve the existing input-shape guard so widget-valued inputs and unrelated producer types still refuse.
- Add production-path regression coverage for `GetVideoComponents` and the refusal cases.

Fixes #1589

## Validation

- `node --test browser_tests/unit/*.test.mjs` — 6431 passed, 1 todo, 0 failed
- Focused add-node suites — 137 passed
- `node --check` passed for the changed JS files
- `git diff --check` passed

The TypeScript-backed `check-panel-scope` gate could not run in the isolated worktree because `node_modules/typescript` is absent; direct full unit tests passed.