### PR TITLE
Fix stale deliberate-sweep prompt snapshots (#1588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project are documented here. This project adheres to
 - report the tab re-list from the open LIST, and hold the fence across the load
 - the adopt arm requires the same workflow FILE, not just a matching selector
 - reopening a closed tab loads the workflow the store's early return skipped
-
+- deliberate-sweep runs retain their prompt and SaveImage filename widgets when the frontend queue is already busy (#1588)
 
 ## [0.15.36] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project are documented here. This project adheres to
 - a finished stills render notifies the agent before the orchestrator fallback (#1612)
 - trust live VIDEO producers for add-node socket proof
 
+### Fixed
+- deliberate-sweep runs retain their prompt and SaveImage filename widgets when the frontend queue is already busy (#1588)
 
 ## [0.15.37] - 2026-08-22
 
@@ -24,7 +26,6 @@ All notable changes to this project are documented here. This project adheres to
 - report the tab re-list from the open LIST, and hold the fence across the load
 - the adopt arm requires the same workflow FILE, not just a matching selector
 - reopening a closed tab loads the workflow the store's early return skipped
-- deliberate-sweep runs retain their prompt and SaveImage filename widgets when the frontend queue is already busy (#1588)
 
 ## [0.15.36] - 2026-08-22
 

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -627,6 +627,51 @@ test("#1588: deferred serialization runs queue hooks on the correct graph snapsh
   }
 });
 
+test("#1588 P1: a foreign graphToPrompt between the hook and queue serializer cannot consume the item snapshot", async () => {
+  const stop = keepAlive();
+  try {
+    const widget = {
+      name: "seed",
+      type: "number",
+      value: 10,
+      beforeQueued() {
+        this.value += 1;
+      },
+    };
+    const apiTarget = { fetchApi: makeServer() };
+    const app = {
+      graph: { _nodes: [{ id: 1, widgets: [widget] }] },
+      queueItems: [{ active: true }],
+      graphToPrompt: async () => ({
+        output: { "1": { class_type: "KSampler", inputs: { seed: widget.value } } },
+        workflow: {},
+      }),
+      queuePrompt: async (number, batchCount) => {
+        app.queueItems.push({ number, batchCount });
+        return false;
+      },
+    };
+    const built = realGraphRun({ app, apiTarget, budgetMs: 3000, serializeMs: 500 });
+
+    await built.graph_run({});
+    widget.value = 20;
+
+    // This is the pinned queue gap: the exact item has been popped and its
+    // beforeQueued hook has run, but the queue loop has not called its real
+    // graphToPrompt(this.rootGraph) yet.
+    app.queueItems.pop();
+    widget.beforeQueued({ isPartialExecution: false });
+    const foreign = await app.graphToPrompt();
+    const actual = await app.graphToPrompt(app.graph);
+
+    assert.equal(foreign.output["1"].inputs.seed, 11, "the foreign call may observe the queue snapshot");
+    assert.equal(actual.output["1"].inputs.seed, 11, "the real queue serializer still consumes that same snapshot");
+    assert.equal(widget.value, 20, "finishing the exact queue item restores the live graph");
+  } finally {
+    stop();
+  }
+});
+
 test("#1588/#445: the first graph_run preflight is null-widget safe", async () => {
   const stop = keepAlive();
   try {

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -52,9 +52,9 @@ import { buildQueueAcceptResult, summarizePromptRejection } from "../../web/js/l
 import { installGraphToPromptNullSafety } from "../../web/js/lib/widget-null-safety.js";
 import {
   installGraphToPromptSnapshotBarrier,
+  queuePromptWithGraphToPromptSnapshot,
   reserveGraphToPromptSnapshot,
   releaseGraphToPromptSnapshot,
-  withoutGraphToPromptSnapshot,
 } from "../../web/js/lib/run-prompt-snapshot.js";
 import { collectAllGraphs } from "../../web/js/lib/asset-staleness.js";
 import {
@@ -443,9 +443,9 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch }) {
     describeUnrunnable,
     installGraphToPromptNullSafety,
     installGraphToPromptSnapshotBarrier,
+    queuePromptWithGraphToPromptSnapshot,
     reserveGraphToPromptSnapshot,
     releaseGraphToPromptSnapshot,
-    withoutGraphToPromptSnapshot,
     collectAllGraphs,
     findRepeatingControlWidgets,
     findRgthreeSeedNodes,
@@ -544,6 +544,12 @@ test("#1588 CALL SITE: a busy queue serializes each deliberate-sweep prompt snap
     await built.graph_run({});
 
     livePrompt = promptFor("B");
+    const foreign = await app.graphToPrompt();
+    assert.equal(
+      foreign.output["1"].inputs.text,
+      "B",
+      "an intervening foreign graphToPrompt call uses the live graph and cannot consume A's reservation",
+    );
     await built.graph_run({});
     livePrompt = promptFor("C");
     await built.graph_run({});
@@ -563,6 +569,158 @@ test("#1588 CALL SITE: a busy queue serializes each deliberate-sweep prompt snap
         `${label}'s five SaveImage filename_prefix widgets must stay with its prompt`,
       );
     }
+  } finally {
+    stop();
+  }
+});
+
+test("#1588: deferred serialization runs queue hooks on the correct graph snapshot", async () => {
+  const stop = keepAlive();
+  try {
+    const widget = {
+      name: "seed",
+      type: "number",
+      value: 10,
+      beforeQueued() {
+        this.value += 1;
+      },
+    };
+    const calls = [];
+    const apiTarget = { fetchApi: makeServer() };
+    const app = {
+      graph: { _nodes: [{ id: 1, widgets: [widget] }] },
+      queueItems: [{ active: true }],
+      graphToPrompt: async () => ({
+        output: { "1": { class_type: "KSampler", inputs: { seed: widget.value } } },
+        workflow: {},
+      }),
+      queuePrompt: async (number, batchCount) => {
+        app.queueItems.push({ number, batchCount });
+        return false;
+      },
+      async drain() {
+        while (app.queueItems.length) {
+          const item = app.queueItems.pop();
+          if (!item.active) {
+            widget.beforeQueued({ isPartialExecution: false });
+            calls.push(await app.graphToPrompt(app.graph));
+          }
+        }
+      },
+    };
+
+    const built = realGraphRun({ app, apiTarget, budgetMs: 3000, serializeMs: 500 });
+    await built.graph_run({});
+    widget.value = 20;
+    await built.graph_run({});
+
+    await app.drain();
+
+    assert.deepEqual(
+      calls.map((prompt) => prompt.output["1"].inputs.seed),
+      [21, 11],
+      "the LIFO queue serializes each run's captured widget state, then applies beforeQueued",
+    );
+    assert.equal(widget.value, 20, "temporary snapshot restoration does not clobber the live graph");
+  } finally {
+    stop();
+  }
+});
+
+test("#1588/#445: the first graph_run preflight is null-widget safe", async () => {
+  const stop = keepAlive();
+  try {
+    const widget = { name: "filename_prefix", type: "text", value: null };
+    let preflightSawSafeValue = false;
+    const apiTarget = { fetchApi: makeServer() };
+    const app = {
+      graph: { _nodes: [{ id: 1, widgets: [widget] }] },
+      queueItems: [],
+      graphToPrompt: async () => {
+        if (widget.value == null) throw new Error("null widget reached serializer");
+        preflightSawSafeValue = true;
+        return {
+          output: { "1": { class_type: "SaveImage", inputs: { filename_prefix: widget.value } } },
+          workflow: {},
+        };
+      },
+      queuePrompt: async (number, batchCount) => {
+        app.queueItems.push({ number, batchCount });
+        return false;
+      },
+    };
+    const built = realGraphRun({ app, apiTarget, budgetMs: 3000, serializeMs: 500 });
+
+    await built.graph_run({});
+
+    assert.equal(preflightSawSafeValue, true, "null-safety was installed before the first preflight");
+    assert.equal(widget.value, null, "the preflight guard restores the live null widget");
+  } finally {
+    stop();
+  }
+});
+
+test("#1588: a post-enqueue queuePrompt failure removes its queued item", async () => {
+  const stop = keepAlive();
+  try {
+    const calls = [];
+    const apiTarget = { fetchApi: makeServer() };
+    const app = {
+      graph: { _nodes: [] },
+      queueItems: [],
+      graphToPrompt: async () => ({
+        output: { "1": { class_type: "KSampler", inputs: { text: "A" } } },
+        workflow: {},
+      }),
+      queuePrompt: async (number, batchCount) => {
+        app.queueItems.push({ number, batchCount });
+        throw new Error("post-enqueue queue failure");
+      },
+      async drain() {
+        while (app.queueItems.length) calls.push(await app.graphToPrompt(app.graph));
+      },
+    };
+    const built = realGraphRun({ app, apiTarget, budgetMs: 3000, serializeMs: 500 });
+
+    await assert.rejects(() => built.graph_run({}), /post-enqueue queue failure/);
+    await app.drain();
+
+    assert.equal(app.queueItems.length, 0, "the item that failed after enqueue is cleaned up");
+    assert.equal(calls.length, 0, "cleanup prevents a later serializer from using the wrong prompt");
+  } finally {
+    stop();
+  }
+});
+
+test("#1588: a failure after dequeue cancels an unsupported snapshot before serialization", async () => {
+  const stop = keepAlive();
+  try {
+    const widget = { name: "host_value", type: "custom", value: new WeakMap() };
+    const apiTarget = { fetchApi: makeServer() };
+    const app = {
+      graph: { _nodes: [{ id: 1, widgets: [widget] }] },
+      queueItems: [],
+      graphToPrompt: async () => ({
+        output: { "1": { class_type: "Custom", inputs: { host_value: widget.value } } },
+        workflow: {},
+      }),
+      queuePrompt: async (number, batchCount) => {
+        app.queueItems.push({ number, batchCount });
+        await Promise.resolve();
+        app.queueItems.pop();
+        await Promise.resolve();
+        throw new Error("post-dequeue queue failure");
+      },
+    };
+    const built = realGraphRun({ app, apiTarget, budgetMs: 3000, serializeMs: 500 });
+
+    await assert.rejects(() => built.graph_run({}), /post-dequeue queue failure/);
+    assert.equal(app.queueItems.length, 0, "the dequeued item is no longer pending");
+    assert.throws(
+      () => app.graphToPrompt(app.graph),
+      /graph_run queue item was cancelled after queuePrompt failed/,
+      "a later serializer cannot fall through to the live graph after failure",
+    );
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -50,6 +50,12 @@ import {
 } from "../../web/js/lib/missing-node-preflight.js";
 import { buildQueueAcceptResult, summarizePromptRejection } from "../../web/js/lib/queue-rejection.js";
 import { installGraphToPromptNullSafety } from "../../web/js/lib/widget-null-safety.js";
+import {
+  installGraphToPromptSnapshotBarrier,
+  reserveGraphToPromptSnapshot,
+  releaseGraphToPromptSnapshot,
+  withoutGraphToPromptSnapshot,
+} from "../../web/js/lib/run-prompt-snapshot.js";
 import { collectAllGraphs } from "../../web/js/lib/asset-staleness.js";
 import {
   findRepeatingControlWidgets,
@@ -436,6 +442,10 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch }) {
     missingNodeRunRefusal,
     describeUnrunnable,
     installGraphToPromptNullSafety,
+    installGraphToPromptSnapshotBarrier,
+    reserveGraphToPromptSnapshot,
+    releaseGraphToPromptSnapshot,
+    withoutGraphToPromptSnapshot,
     collectAllGraphs,
     findRepeatingControlWidgets,
     findRgthreeSeedNodes,
@@ -486,6 +496,73 @@ test("#1565 CALL SITE: graph_run hands the dispatch its own command budget", asy
     );
     assert.equal(passed.totalMs, 600, "the budget is the command's own, not one invented inside the dispatch");
     assert.ok(passed.bounded(999999) <= 600, "every allowance is capped by what the COMMAND has left");
+  } finally {
+    stop();
+  }
+});
+
+test("#1588 CALL SITE: a busy queue serializes each deliberate-sweep prompt snapshot", async () => {
+  const stop = keepAlive();
+  try {
+    const promptFor = (label) => {
+      const output = {
+        "1": { class_type: "CLIPTextEncode", inputs: { text: label } },
+      };
+      for (let i = 0; i < 5; i++) {
+        output[String(i + 2)] = {
+          class_type: "SaveImage",
+          inputs: { filename_prefix: `${label}/stage${i}` },
+        };
+      }
+      return { output, workflow: {} };
+    };
+
+    let livePrompt = promptFor("A");
+    const calls = [];
+    const apiTarget = { fetchApi: makeServer() };
+    const app = {
+      graph: { _nodes: [] },
+      // The first item represents the already-running render. New graph_run
+      // calls are accepted into the frontend's pending queue and return false.
+      queueItems: [{ active: true }],
+      processing: true,
+      graphToPrompt: async () => JSON.parse(JSON.stringify(livePrompt)),
+      queuePrompt: async (number, batchCount) => {
+        app.queueItems.push({ number, batchCount });
+        return false;
+      },
+      async drain() {
+        while (app.queueItems.length) {
+          const item = app.queueItems.pop();
+          if (!item.active) calls.push(await app.graphToPrompt(app.graph));
+        }
+        app.processing = false;
+      },
+    };
+
+    const built = realGraphRun({ app, apiTarget, budgetMs: 3000, serializeMs: 500 });
+    await built.graph_run({});
+
+    livePrompt = promptFor("B");
+    await built.graph_run({});
+    livePrompt = promptFor("C");
+    await built.graph_run({});
+
+    await app.drain();
+
+    assert.equal(calls.length, 3, "the three pending graph_run items must serialize");
+    assert.deepEqual(
+      calls.map((prompt) => prompt.output["1"].inputs.text),
+      ["C", "B", "A"],
+      "the frontend queue is LIFO, and each item must retain its own command snapshot",
+    );
+    for (const [index, label] of ["C", "B", "A"].entries()) {
+      assert.deepEqual(
+        Array.from({ length: 5 }, (_, i) => calls[index].output[String(i + 2)].inputs.filename_prefix),
+        Array.from({ length: 5 }, (_, i) => `${label}/stage${i}`),
+        `${label}'s five SaveImage filename_prefix widgets must stay with its prompt`,
+      );
+    }
   } finally {
     stop();
   }

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -162,7 +162,7 @@ test("#988 (codex) source guard: the scan runs BEFORE dispatch, not after", () =
   const dispatch = src.indexOf("app.queuePrompt(0, batch, undefined)");
   assert.match(
     src.slice(Math.max(0, dispatch - 200), dispatch + 200),
-    /Promise\.resolve\(app\.queuePrompt\(0, batch, undefined\)\)/,
+    /Promise\.resolve\(\s*queuePromptWithGraphToPromptSnapshot\([\s\S]*?app\.queuePrompt\(0, batch, undefined\)/,
     "the unscoped dispatch must stay bounded — an unbounded one hangs past the relay window",
   );
   const scopedDispatch = src.indexOf("runScopeResult = await dispatchScopedRun({");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -524,9 +524,9 @@ import { isImeComposing } from "./lib/ime.js";
 import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
 import {
   installGraphToPromptSnapshotBarrier,
+  queuePromptWithGraphToPromptSnapshot,
   reserveGraphToPromptSnapshot,
   releaseGraphToPromptSnapshot,
-  withoutGraphToPromptSnapshot,
 } from "./lib/run-prompt-snapshot.js";
 import {
   recordCopiedNodes,
@@ -16333,6 +16333,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // cannot succeed, so this blocks no working run. It fails SOFT — a lookup that
     // could not be reached is `unknown`, never `missing`, because refusing on a
     // failed metadata probe would trade one false failure for another.
+    // #445/#1588 — install both serializer guards BEFORE this first pre-flight. The
+    // pre-flight is itself graphToPrompt and must not be the one serialization that
+    // can still hit a null widget or establish a reservation before the guard exists.
+    installGraphToPromptNullSafety(app);
+    installGraphToPromptSnapshotBarrier(app);
     try {
       // Inspect the SERIALIZED prompt, not the canvas. graphToPrompt has already
       // dropped or rewritten every virtual and frontend-only node (Note, Reroute,
@@ -16357,7 +16362,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // `.then` on it throws, and the catch below would silently skip a pre-flight that
       // used to run — a bound that removes a guard is the failure it exists to prevent.
       const preflightBuild = await withTimeout(
-        Promise.resolve(withoutGraphToPromptSnapshot(app, () => app.graphToPrompt())).then(
+        Promise.resolve(app.graphToPrompt()).then(
           (value) => ({ value }),
           (error) => ({ error }),
         ),
@@ -16520,23 +16525,8 @@ const GRAPH_TOOL_EXECUTORS = {
     const captureAcceptedNodeErrors = (ne) => {
       acceptedNodeErrors = { ...(ne ?? {}), ...(acceptedNodeErrors ?? {}) };
     };
-    // #445: guard the VHS null-widget serialization crash. ComfyUI core / node
-    // extensions (notably VHS_VideoCombine) serialize EVERY node's widgets when
-    // building the prompt — even unused branches, even under "run to node" — and
-    // call string ops like `.replace()` on those values (in graphToPrompt via the
-    // node's own serializeValue). A null widget value (e.g. VHS
-    // `filename_prefix:null`) throws `Cannot read properties of null (reading
-    // 'replace')` DURING serialization, killing the run before it queues. Install
-    // an idempotent, self-restoring wrap on app.graphToPrompt so every prompt
-    // build is null-safe for exactly its serialization window (which also covers
-    // the deferred serialization queuePrompt runs when its processor is already
-    // busy) without permanently altering the live workflow.
-    installGraphToPromptNullSafety(app);
-    // #1588 — ComfyUI may defer graphToPrompt until its busy queue processor
-    // reaches this item. Keep the prompt captured by this command for the
-    // single-prompt deliberate-sweep path so later widget mutations cannot
-    // rewrite a queued job. Batches retain their queue-time callback semantics.
-    installGraphToPromptSnapshotBarrier(app);
+    // #445/#1588 guards were installed before the pre-flight above. They remain
+    // installed here while the queue call and any deferred serializer run.
     // #988 — computed BEFORE dispatch (codex). Measuring it afterwards described a
     // run that had already been submitted, while the note claimed it let the caller
     // cancel — a remedy it could not offer. Reading the graph first means the finding
@@ -16583,7 +16573,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // UNSCOPED full run — the historical single-shot path: capture wrap for
       // exactly the duration of the queuePrompt call, then restore.
       if (batch === 1 && preflightPrompt != null) {
-        promptSnapshotReservation = reserveGraphToPromptSnapshot(app, preflightPrompt);
+        promptSnapshotReservation = reserveGraphToPromptSnapshot(app, preflightPrompt, rootGraph);
       }
       if (origFetchApi) {
         runInterceptor = createRunFetchInterceptor({
@@ -16624,7 +16614,11 @@ const GRAPH_TOOL_EXECUTORS = {
         // The whole remainder of the budget, not a slice: unlike the scoped path there is
         // one queue call here, so nothing is owed to a later attempt.
         const queued = await withTimeout(
-          Promise.resolve(app.queuePrompt(0, batch, undefined)).then(
+          Promise.resolve(
+            queuePromptWithGraphToPromptSnapshot(app, promptSnapshotReservation, () =>
+              app.queuePrompt(0, batch, undefined),
+            ),
+          ).then(
             (value) => ({ value }),
             (error) => ({ error }),
           ),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -523,6 +523,12 @@ import { ackVisibleCanvasMutation, withVisibleCanvasAck } from "./lib/visible-ca
 import { isImeComposing } from "./lib/ime.js";
 import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
 import {
+  installGraphToPromptSnapshotBarrier,
+  reserveGraphToPromptSnapshot,
+  releaseGraphToPromptSnapshot,
+  withoutGraphToPromptSnapshot,
+} from "./lib/run-prompt-snapshot.js";
+import {
   recordCopiedNodes,
   getVerifiedSnapshot,
   parseClipboardNodes,
@@ -16351,7 +16357,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // `.then` on it throws, and the catch below would silently skip a pre-flight that
       // used to run — a bound that removes a guard is the failure it exists to prevent.
       const preflightBuild = await withTimeout(
-        Promise.resolve(app.graphToPrompt()).then(
+        Promise.resolve(withoutGraphToPromptSnapshot(app, () => app.graphToPrompt())).then(
           (value) => ({ value }),
           (error) => ({ error }),
         ),
@@ -16487,6 +16493,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // one exit that needs them: a queue call abandoned at the command budget.
     let runInterceptor = null;
     let fullRunAbandoned = false;
+    let promptSnapshotReservation = null;
     const queuedPromptIds = [];
     const prevFetchApi =
       typeof api?.fetchApi === "function" ? api.fetchApi : null;
@@ -16525,6 +16532,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // the deferred serialization queuePrompt runs when its processor is already
     // busy) without permanently altering the live workflow.
     installGraphToPromptNullSafety(app);
+    // #1588 — ComfyUI may defer graphToPrompt until its busy queue processor
+    // reaches this item. Keep the prompt captured by this command for the
+    // single-prompt deliberate-sweep path so later widget mutations cannot
+    // rewrite a queued job. Batches retain their queue-time callback semantics.
+    installGraphToPromptSnapshotBarrier(app);
     // #988 — computed BEFORE dispatch (codex). Measuring it afterwards described a
     // run that had already been submitted, while the note claimed it let the caller
     // cancel — a remedy it could not offer. Reading the graph first means the finding
@@ -16570,6 +16582,9 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!partialTargets) {
       // UNSCOPED full run — the historical single-shot path: capture wrap for
       // exactly the duration of the queuePrompt call, then restore.
+      if (batch === 1 && preflightPrompt != null) {
+        promptSnapshotReservation = reserveGraphToPromptSnapshot(app, preflightPrompt);
+      }
       if (origFetchApi) {
         runInterceptor = createRunFetchInterceptor({
           origFetchApi,
@@ -16619,6 +16634,12 @@ const GRAPH_TOOL_EXECUTORS = {
         if (queued == null) fullRunAbandoned = true;
         // `"error" in` rather than a truthiness test — a falsy thrown value still throws.
         else if ("error" in queued) throw queued.error;
+      } catch (error) {
+        // A busy queue returns before consuming its item, so its reservation
+        // must survive this command's normal `false` result. Release only when
+        // queuePrompt rejected before the item could be processed.
+        releaseGraphToPromptSnapshot(app, promptSnapshotReservation);
+        throw error;
       } finally {
         if (origFetchApi) api.fetchApi = prevFetchApi;
       }

--- a/web/js/lib/run-prompt-snapshot.js
+++ b/web/js/lib/run-prompt-snapshot.js
@@ -221,6 +221,25 @@ function installHookObservers(app, state, rootGraph) {
   });
 }
 
+function isQueueLoopSerializerCall(state, graph, argumentCount) {
+  // ComfyUI_frontend 1.48.7 calls graphToPrompt(this.rootGraph) from the queue
+  // loop. A foreign app.graphToPrompt() can run after beforeQueued while that
+  // loop is between its hook and serializer calls; it may observe the temporary
+  // queue state, but it must not consume the exact-item reservation.
+  if (argumentCount === 0 || graph == null) return false;
+  try {
+    const rootGraph = state.app?.rootGraph;
+    if (rootGraph) return graph === rootGraph;
+  } catch {
+    // Fall through to the legacy graph property when rootGraph is unavailable.
+  }
+  try {
+    return graph === state.app?.graph;
+  } catch {
+    return false;
+  }
+}
+
 function associateQueueItem(state, entry, beforeLength) {
   const queueItems = state.queueItems ?? queueItemsOf(state.app);
   if (!queueItems) return false;
@@ -304,7 +323,9 @@ export function installGraphToPromptSnapshotBarrier(app) {
     // A serializer called synchronously by a queue hook is not the queue loop's
     // serializer. It must see the temporary queue state but must not consume the
     // exact-item association needed by the call that follows the hook loop.
-    if (entry.inHook) return original(graph, ...rest);
+    if (entry.inHook || !isQueueLoopSerializerCall(state, graph, arguments.length)) {
+      return original(graph, ...rest);
+    }
 
     entry.consumed = true;
     state.active = null;

--- a/web/js/lib/run-prompt-snapshot.js
+++ b/web/js/lib/run-prompt-snapshot.js
@@ -1,0 +1,68 @@
+// Preserve the prompt captured by a graph_run until ComfyUI's queue processor
+// serializes that item. ComfyUI returns from queuePrompt immediately when its
+// processor is already busy, but serializes the queued item later from the
+// live graph. A panel command must not let that deferred serialization observe
+// the next deliberate-sweep mutation.
+
+const SNAPSHOT_STATE = Symbol.for("comfyui-mcp.graphToPromptRunSnapshots");
+
+/**
+ * Install one app-level snapshot shim. ComfyUI's queue is LIFO, so
+ * reservations are consumed from the end as queue items are popped. Calls
+ * without a reservation retain the original serializer behaviour.
+ */
+export function installGraphToPromptSnapshotBarrier(app) {
+  if (!app || typeof app.graphToPrompt !== "function") return null;
+  if (app[SNAPSHOT_STATE]) return app[SNAPSHOT_STATE];
+
+  const original = app.graphToPrompt.bind(app);
+  const state = { pending: [], original };
+  app.graphToPrompt = function runSnapshotGraphToPrompt(graph, ...rest) {
+    const entry = state.pending.pop();
+    if (entry) {
+      entry.consumed = true;
+      return Promise.resolve(entry.prompt);
+    }
+    return original(graph, ...rest);
+  };
+  Object.defineProperty(app, SNAPSHOT_STATE, {
+    value: state,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+  return state;
+}
+
+/** Run a live preflight without consuming a deferred queue-item reservation. */
+export function withoutGraphToPromptSnapshot(app, invoke) {
+  const state = app?.[SNAPSHOT_STATE];
+  if (state?.original) return state.original();
+  return invoke?.();
+}
+
+/** Reserve a prompt for the next deferred queue-item serialization. */
+export function reserveGraphToPromptSnapshot(app, prompt) {
+  const state = app?.[SNAPSHOT_STATE];
+  if (!state) return null;
+  const entry = { prompt, consumed: false };
+  state.pending.push(entry);
+  return entry;
+}
+
+/**
+ * Remove a reservation only if queuePrompt failed before consuming it. A busy
+ * queue returns before consuming its item, so a successful `false` result must
+ * leave the reservation installed for the later processor pass.
+ */
+export function releaseGraphToPromptSnapshot(app, entry) {
+  if (!entry?.consumed) {
+    const pending = app?.[SNAPSHOT_STATE]?.pending;
+    const index = pending?.indexOf(entry) ?? -1;
+    if (index >= 0) {
+      pending.splice(index, 1);
+      return true;
+    }
+  }
+  return false;
+}

--- a/web/js/lib/run-prompt-snapshot.js
+++ b/web/js/lib/run-prompt-snapshot.js
@@ -1,29 +1,347 @@
-// Preserve the prompt captured by a graph_run until ComfyUI's queue processor
-// serializes that item. ComfyUI returns from queuePrompt immediately when its
-// processor is already busy, but serializes the queued item later from the
-// live graph. A panel command must not let that deferred serialization observe
-// the next deliberate-sweep mutation.
+// Keep a batch=1 graph_run tied to the exact ComfyUI queue item it created.
+//
+// ComfyUI's queuePrompt() pushes an item and, when another item is already being
+// processed, returns before that item is serialized. The later queue loop pops
+// that item, runs its queue-time hooks, and only then calls graphToPrompt(). A
+// prompt captured before the queue call therefore cannot simply replace that
+// later serializer: doing so skips the hooks that are part of the real queue
+// ordering. Instead this shim temporarily restores the graph state captured by
+// this run before the queue loop starts, lets the real hooks and serializer run,
+// and restores the live state as soon as serialization finishes.
 
 const SNAPSHOT_STATE = Symbol.for("comfyui-mcp.graphToPromptRunSnapshots");
+const SNAPSHOT_QUEUE_POP = Symbol.for("comfyui-mcp.graphToPromptRunSnapshotQueuePop");
+const SNAPSHOT_QUEUE_PROMPT = Symbol.for("comfyui-mcp.graphToPromptRunSnapshotQueuePrompt");
+const SNAPSHOT_HOOK = Symbol.for("comfyui-mcp.graphToPromptRunSnapshotHook");
+
+function cloneValue(value) {
+  if (value === null || typeof value !== "object") return { ok: true, value };
+  if (typeof structuredClone === "function") {
+    try {
+      return { ok: true, value: structuredClone(value) };
+    } catch {
+      // Some extension widget values are host objects. Do not guess at a clone
+      // for those: leaving the real queue path untouched is safer than restoring
+      // an incomplete value and silently changing the prompt.
+    }
+  }
+  return { ok: false, value: null };
+}
+
+function copyStoredValue(value) {
+  const cloned = cloneValue(value);
+  return cloned.ok ? cloned.value : value;
+}
+
+function forEachGraph(rootGraph, visit) {
+  const stack = [rootGraph];
+  const seen = new Set();
+  while (stack.length) {
+    const graph = stack.pop();
+    if (!graph || seen.has(graph)) continue;
+    seen.add(graph);
+    visit(graph);
+    for (const node of graph._nodes ?? graph.nodes ?? []) {
+      const subgraph = node?.subgraph;
+      if (subgraph) stack.push(subgraph);
+    }
+  }
+}
+
+function captureWidgetState(rootGraph) {
+  const records = [];
+  let supported = true;
+  let hasHooks = false;
+  forEachGraph(rootGraph, (graph) => {
+    for (const node of graph._nodes ?? graph.nodes ?? []) {
+      for (const widget of node?.widgets ?? []) {
+        if (typeof widget?.beforeQueued === "function") hasHooks = true;
+        if (!widget || !("value" in widget)) continue;
+        const cloned = cloneValue(widget.value);
+        if (!cloned.ok) {
+          supported = false;
+          continue;
+        }
+        records.push({ widget, snapshot: cloned.value });
+      }
+    }
+  });
+  return { supported, records, hasHooks };
+}
+
+function captureLiveState(records) {
+  const live = [];
+  for (const record of records) {
+    const cloned = cloneValue(record.widget.value);
+    if (!cloned.ok) return null;
+    live.push({ widget: record.widget, value: cloned.value });
+  }
+  return live;
+}
+
+function restoreState(records, key) {
+  for (const record of records ?? []) {
+    record.widget.value = copyStoredValue(record[key]);
+  }
+}
+
+function removeEntryFromState(state, entry) {
+  const index = state.entries.indexOf(entry);
+  if (index >= 0) state.entries.splice(index, 1);
+  if (entry.item && state.itemEntries.get(entry.item) === entry) {
+    state.itemEntries.delete(entry.item);
+  }
+  if (state.active === entry) state.active = null;
+}
+
+function removeQueuedItem(state, entry) {
+  if (!entry?.item || !Array.isArray(state.queueItems)) return false;
+  const index = state.queueItems.indexOf(entry.item);
+  if (index < 0) return false;
+  state.queueItems.splice(index, 1);
+  entry.removed = true;
+  return true;
+}
+
+function abortEntry(state, entry) {
+  if (!entry) return false;
+  entry.cancelled = true;
+  removeQueuedItem(state, entry);
+  if (entry.prepared && !entry.consumed && state.active === entry) {
+    // If a wrapper rejected after ComfyUI had already popped the item, the
+    // queue loop may still reach graphToPrompt. Restore the live graph now but
+    // keep the cancelled active entry in place so serializer throws rather than
+    // posting the live graph as this failed run.
+    if (entry.liveState) restoreState(entry.liveState, "value");
+    return true;
+  }
+  removeEntryFromState(state, entry);
+  return true;
+}
+
+function prepareEntry(state, entry) {
+  if (!entry || entry.cancelled || entry.prepared) return;
+  entry.prepared = true;
+  if (!entry.graphState?.supported) return;
+  const live = captureLiveState(entry.graphState.records);
+  if (!live) {
+    entry.graphState = null;
+    return;
+  }
+  entry.liveState = live;
+  restoreState(entry.graphState.records, "snapshot");
+}
+
+function finishEntry(state, entry) {
+  if (!entry?.liveState) {
+    removeEntryFromState(state, entry);
+    return;
+  }
+  // Do not overwrite a value changed while the asynchronous serializer was
+  // running. Values still equal to the queue-time state belong to this
+  // temporary restore and can safely return to the live graph's prior state.
+  for (const [index, record] of entry.graphState.records.entries()) {
+    if (Object.is(record.widget.value, entry.queueValues?.[index])) {
+      record.widget.value = copyStoredValue(entry.liveState[index].value);
+    }
+  }
+  removeEntryFromState(state, entry);
+}
+
+function queueItemsOf(app) {
+  try {
+    return Array.isArray(app?.queueItems) ? app.queueItems : null;
+  } catch {
+    return null;
+  }
+}
+
+function installQueuePopObserver(app, state) {
+  const queueItems = queueItemsOf(app);
+  if (!queueItems || queueItems[SNAPSHOT_QUEUE_POP]) return queueItems;
+  const originalPop = queueItems.pop;
+  if (typeof originalPop !== "function") return null;
+  const pop = function snapshotQueuePop(...args) {
+    const item = originalPop.apply(this, args);
+    const entry = item && state.itemEntries.get(item);
+    state.active = entry ?? null;
+    if (entry) {
+      installHookObservers(app, state, app.rootGraph ?? app.graph);
+      prepareEntry(state, entry);
+    }
+    return item;
+  };
+  try {
+    Object.defineProperty(queueItems, SNAPSHOT_QUEUE_POP, {
+      value: true,
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    });
+    queueItems.pop = pop;
+  } catch {
+    return null;
+  }
+  state.queueItems = queueItems;
+  return queueItems;
+}
+
+function installHookObservers(app, state, rootGraph) {
+  forEachGraph(rootGraph, (graph) => {
+    for (const node of graph._nodes ?? graph.nodes ?? []) {
+      for (const widget of node?.widgets ?? []) {
+        if (!widget || typeof widget.beforeQueued !== "function") continue;
+        const marker = widget.beforeQueued[SNAPSHOT_HOOK];
+        if (marker?.state === state) continue;
+        const original = widget.beforeQueued;
+        const wrapped = function snapshotBeforeQueued(...args) {
+          const entry = state.active;
+          if (!entry || entry.cancelled) return original.apply(this, args);
+          entry.inHook = true;
+          try {
+            return original.apply(this, args);
+          } finally {
+            entry.inHook = false;
+          }
+        };
+        try {
+          Object.defineProperty(wrapped, SNAPSHOT_HOOK, {
+            value: { state, original },
+            configurable: false,
+            enumerable: false,
+            writable: false,
+          });
+          widget.beforeQueued = wrapped;
+        } catch {
+          // A frozen extension widget is left on the real queue path. It cannot
+          // be observed safely, so this shim must not make it queue differently.
+        }
+      }
+    }
+  });
+}
+
+function associateQueueItem(state, entry, beforeLength) {
+  const queueItems = state.queueItems ?? queueItemsOf(state.app);
+  if (!queueItems) return false;
+  // ComfyUI pushes exactly one item synchronously at the start of queuePrompt,
+  // before its first await. Restrict the association to items added by this
+  // invocation; a later global reservation cannot be stolen by another caller.
+  const added = queueItems.slice(Math.max(0, beforeLength));
+  const item = added.length ? added[added.length - 1] : null;
+  if (!item || typeof item !== "object") return false;
+  entry.item = item;
+  state.itemEntries.set(item, entry);
+  return true;
+}
+
+function installQueuePromptObserver(app, state) {
+  if (typeof app?.queuePrompt !== "function") return false;
+  if (app[SNAPSHOT_QUEUE_PROMPT]) return true;
+  const original = app.queuePrompt.bind(app);
+  app.queuePrompt = function snapshotQueuePrompt(...args) {
+    const entry = state.claiming;
+    const queueItems = queueItemsOf(app);
+    const beforeLength = queueItems?.length ?? 0;
+    // Only the queuePrompt call made by queuePromptWithGraphToPromptSnapshot
+    // owns this reservation. Events dispatched synchronously by the frontend's
+    // queuePrompt must not let a nested foreign queuePrompt inherit the claim.
+    state.claiming = null;
+    let result;
+    try {
+      result = original(...args);
+      if (entry) associateQueueItem(state, entry, beforeLength);
+    } catch (error) {
+      if (entry) abortEntry(state, entry);
+      throw error;
+    }
+    if (!entry || !result || typeof result.then !== "function") return result;
+    return Promise.resolve(result).catch((error) => {
+      abortEntry(state, entry);
+      throw error;
+    });
+  };
+  Object.defineProperty(app, SNAPSHOT_QUEUE_PROMPT, {
+    value: state,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+  installQueuePopObserver(app, state);
+  return true;
+}
 
 /**
- * Install one app-level snapshot shim. ComfyUI's queue is LIFO, so
- * reservations are consumed from the end as queue items are popped. Calls
- * without a reservation retain the original serializer behaviour.
+ * Install one app-level queue-item association and graph serializer shim.
+ * ComfyUI's queueItems are private in TypeScript but are an ordinary array at
+ * runtime on the supported frontend. If a build hides that array, the shim
+ * deliberately declines to substitute a prompt rather than risk consuming a
+ * reservation belonging to another serializer call.
  */
 export function installGraphToPromptSnapshotBarrier(app) {
   if (!app || typeof app.graphToPrompt !== "function") return null;
   if (app[SNAPSHOT_STATE]) return app[SNAPSHOT_STATE];
 
   const original = app.graphToPrompt.bind(app);
-  const state = { pending: [], original };
+  const state = {
+    app,
+    original,
+    entries: [],
+    itemEntries: new WeakMap(),
+    claiming: null,
+    active: null,
+    queueItems: null,
+  };
   app.graphToPrompt = function runSnapshotGraphToPrompt(graph, ...rest) {
-    const entry = state.pending.pop();
-    if (entry) {
-      entry.consumed = true;
-      return Promise.resolve(entry.prompt);
+    const entry = state.active;
+    if (!entry || entry.consumed) return original(graph, ...rest);
+    if (entry.cancelled) {
+      state.active = null;
+      finishEntry(state, entry);
+      throw new Error("graph_run queue item was cancelled after queuePrompt failed");
     }
-    return original(graph, ...rest);
+
+    // A serializer called synchronously by a queue hook is not the queue loop's
+    // serializer. It must see the temporary queue state but must not consume the
+    // exact-item association needed by the call that follows the hook loop.
+    if (entry.inHook) return original(graph, ...rest);
+
+    entry.consumed = true;
+    state.active = null;
+    if (entry.cancelled) {
+      finishEntry(state, entry);
+      throw new Error("graph_run queue item was cancelled after queuePrompt failed");
+    }
+    if (entry.graphState?.records.length === 0 && !entry.graphState.hasHooks) {
+      const prompt = copyStoredValue(entry.prompt);
+      finishEntry(state, entry);
+      return Promise.resolve(prompt);
+    }
+    if (!entry.graphState?.supported) {
+      const result = original(graph, ...rest);
+      if (result && typeof result.then === "function") {
+        return Promise.resolve(result).finally(() => finishEntry(state, entry));
+      }
+      finishEntry(state, entry);
+      return result;
+    }
+
+    entry.queueValues = entry.graphState.records.map((record) => record.widget.value);
+    let result;
+    try {
+      // This is the real ComfyUI serializer, after its beforeQueued and promoted
+      // queue hooks. The preflight prompt is only used when no restorable widget
+      // state exists; it is never substituted for a hooked serialization.
+      result = original(graph, ...rest);
+    } catch (error) {
+      finishEntry(state, entry);
+      throw error;
+    }
+    if (result && typeof result.then === "function") {
+      return Promise.resolve(result).finally(() => finishEntry(state, entry));
+    }
+    finishEntry(state, entry);
+    return result;
   };
   Object.defineProperty(app, SNAPSHOT_STATE, {
     value: state,
@@ -31,38 +349,55 @@ export function installGraphToPromptSnapshotBarrier(app) {
     enumerable: false,
     writable: false,
   });
+  installQueuePromptObserver(app, state);
   return state;
 }
 
-/** Run a live preflight without consuming a deferred queue-item reservation. */
-export function withoutGraphToPromptSnapshot(app, invoke) {
-  const state = app?.[SNAPSHOT_STATE];
-  if (state?.original) return state.original();
-  return invoke?.();
-}
-
-/** Reserve a prompt for the next deferred queue-item serialization. */
-export function reserveGraphToPromptSnapshot(app, prompt) {
+/** Reserve the preflight prompt and graph state for one explicit queue call. */
+export function reserveGraphToPromptSnapshot(app, prompt, graph) {
   const state = app?.[SNAPSHOT_STATE];
   if (!state) return null;
-  const entry = { prompt, consumed: false };
-  state.pending.push(entry);
+  const entry = {
+    prompt,
+    graphState: captureWidgetState(graph ?? app.graph ?? app.rootGraph ?? null),
+    item: null,
+    consumed: false,
+    cancelled: false,
+    prepared: false,
+    liveState: null,
+    queueValues: null,
+    inHook: false,
+  };
+  state.entries.push(entry);
+  installQueuePopObserver(app, state);
   return entry;
 }
 
-/**
- * Remove a reservation only if queuePrompt failed before consuming it. A busy
- * queue returns before consuming its item, so a successful `false` result must
- * leave the reservation installed for the later processor pass.
- */
-export function releaseGraphToPromptSnapshot(app, entry) {
-  if (!entry?.consumed) {
-    const pending = app?.[SNAPSHOT_STATE]?.pending;
-    const index = pending?.indexOf(entry) ?? -1;
-    if (index >= 0) {
-      pending.splice(index, 1);
-      return true;
-    }
+/** Execute this run's queuePrompt call while explicitly claiming its reservation. */
+export function queuePromptWithGraphToPromptSnapshot(app, entry, invoke) {
+  const state = app?.[SNAPSHOT_STATE];
+  if (!state || !entry) return invoke?.();
+  const previous = state.claiming;
+  state.claiming = entry;
+  try {
+    const result = invoke?.();
+    // A queuePrompt implementation that did not enqueue an observable item is
+    // not safe to leave associated with a future graphToPrompt caller. The real
+    // frontend pushes synchronously before its first await, so this is a failed
+    // association rather than a deferred success.
+    if (!entry.item) abortEntry(state, entry);
+    return result;
+  } catch (error) {
+    abortEntry(state, entry);
+    throw error;
+  } finally {
+    state.claiming = previous;
   }
-  return false;
+}
+
+/** Cancel a reservation and remove its exact queued item when it is still pending. */
+export function releaseGraphToPromptSnapshot(app, entry) {
+  const state = app?.[SNAPSHOT_STATE];
+  if (!state || !entry) return false;
+  return abortEntry(state, entry);
 }


### PR DESCRIPTION
Fixes #1588

Summary:
- Preserve each single-prompt graph_run preflight prompt through ComfyUI's deferred busy-queue serialization.
- Keep later graph_run preflights out of the pending snapshot reservations and retain queue rejection cleanup.
- Add a production-callsite regression covering three queued cases with five SaveImage filename_prefix widgets each.

Validation:
- node --test browser_tests/unit/run-command-budget.test.mjs
- node --test browser_tests/unit/run-scope-guard.test.mjs browser_tests/unit/widget-null-safety.test.mjs
- npm.cmd run check:scope
- ES module syntax and git diff --check

Not merged; changelog entry added under the current release Fixed section.