### PR TITLE
fix(1618): panel_open_workflow keeps authored node size/order and leaves a clean tab unmodified

### DIFF
--- a/browser_tests/unit/open-node-presentation.test.mjs
+++ b/browser_tests/unit/open-node-presentation.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * #1618 — `panel_open_workflow` rewrote node size/order on a faithful load and
+ * marked the tab modified. Saving then persisted hydration the user did not author.
+ *
+ * THE MECHANISM. `loadGraphData` / `configure` recomputes box height and
+ * execution `order`. The open already treated those as presentation-only for
+ * pass/fail (#1001 / #1623) and disclosed them, but left the live graph rewritten
+ * and the change tracker dirty.
+ *
+ * THE FIX is the shipped `applySavedNodePresentation`: after the load, write the
+ * payload's size/order back onto matching id+type nodes so the canvas — and a
+ * later save — keep the authored presentation. Widget values, title, flags and
+ * mode are never touched.
+ *
+ * These tests drive that function, then the same content proof `workflow_open`
+ * uses, rather than re-deriving the comparison.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  applySavedNodePresentation,
+  graphRootReproducesStateContent,
+  classifyNodeDifference,
+} from "../../web/js/lib/graph-binding.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const PANEL = readFileSync(PANEL_JS, "utf8");
+
+const node = (id, type, extra = {}) => ({
+  id,
+  type,
+  pos: [0, 0],
+  size: [200, 100],
+  order: 0,
+  widgets_values: ["a"],
+  ...extra,
+});
+const stateOf = (nodes) => ({ nodes, links: [], groups: [], config: {}, extra: {} });
+
+function liveRootFrom(nodes) {
+  return {
+    _nodes: nodes,
+    serialize: () => stateOf(nodes),
+  };
+}
+
+test("#1618 restoring saved size/order makes the open content proof exact", () => {
+  const saved = stateOf([
+    node(1, "SaveVideo", { size: [1030, 358], order: 2 }),
+    node(2, "LoadImage", { size: [225, 0], order: 0 }),
+  ]);
+  const liveNodes = [
+    node(1, "SaveVideo", { size: [1030, 126], order: 0 }),
+    node(2, "LoadImage", { size: [225, 22], order: 1 }),
+  ];
+  const live = liveRootFrom(liveNodes);
+  const before = graphRootReproducesStateContent({ rootGraph: live, state: saved });
+  assert.equal(before.exact, false, "the frontend rewrite is a real difference before restore");
+  assert.equal(before.proven || before.presentationOnly, true, "it is still a faithful load");
+
+  const applied = applySavedNodePresentation(live, saved);
+  assert.equal(applied.restored, saved.nodes.length);
+
+  const after = graphRootReproducesStateContent({ rootGraph: live, state: saved });
+  assert.equal(after.proven, true);
+  assert.equal(after.exact, true);
+  assert.deepEqual(liveNodes[0].size, saved.nodes[0].size);
+  assert.equal(liveNodes[0].order, saved.nodes[0].order);
+  assert.deepEqual(liveNodes[1].size, saved.nodes[1].size);
+  assert.equal(liveNodes[1].order, saved.nodes[1].order);
+});
+
+test("#1618 widget values are never overwritten — a partial load still fails the proof", () => {
+  const liveWidgets = ["a", 7];
+  const saved = stateOf([node(1, "KSampler", { size: [210, 90], order: 3, widgets_values: ["a", 42] })]);
+  const liveNodes = [node(1, "KSampler", { size: [210, 40], order: 0, widgets_values: liveWidgets })];
+  const live = liveRootFrom(liveNodes);
+  applySavedNodePresentation(live, saved);
+  assert.deepEqual(liveNodes[0].size, saved.nodes[0].size);
+  assert.equal(liveNodes[0].order, saved.nodes[0].order);
+  assert.deepEqual(liveNodes[0].widgets_values, liveWidgets, "authored widget values stay as the live graph had them");
+  const proof = graphRootReproducesStateContent({ rootGraph: live, state: saved });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.presentationOnly, false);
+});
+
+test("#1618 a type mismatch is skipped — id reuse is a different node", () => {
+  const saved = stateOf([node(1, "KSampler", { size: [210, 90], order: 3 })]);
+  const liveSize = [180, 40];
+  const liveOrder = 0;
+  const liveNodes = [node(1, "VAEDecode", { size: liveSize, order: liveOrder, widgets_values: ["a"] })];
+  const applied = applySavedNodePresentation(liveRootFrom(liveNodes), saved);
+  assert.equal(applied.restored, 0);
+  assert.deepEqual(liveNodes[0].size, liveSize);
+  assert.equal(liveNodes[0].order, liveOrder);
+});
+
+test("#1618 missing or unreadable inputs are a no-op, not a throw", () => {
+  const saved = stateOf([node(1, "KSampler")]);
+  const live = liveRootFrom([node(1, "KSampler")]);
+  assert.deepEqual(applySavedNodePresentation(null, saved), { restored: 0, skipped: 0 });
+  assert.deepEqual(applySavedNodePresentation(live, null), { restored: 0, skipped: 0 });
+  assert.deepEqual(applySavedNodePresentation({ _nodes: "nope" }, saved), { restored: 0, skipped: 0 });
+});
+
+test("#1618 in-place size write keeps the live array object LiteGraph holds", () => {
+  const saved = stateOf([node(1, "SaveVideo", { size: [1030, 358], order: 1 })]);
+  const size = [1030, 126];
+  const liveNodes = [node(1, "SaveVideo", { size, order: 0 })];
+  applySavedNodePresentation(liveRootFrom(liveNodes), saved);
+  assert.equal(liveNodes[0].size, size, "the same array instance is mutated");
+  assert.deepEqual(size, saved.nodes[0].size);
+});
+
+test("#1618 after restore, classifyNodeDifference names no size/order drift", () => {
+  const savedNodes = [node(1, "SaveVideo", { size: [400, 200], order: 5 })];
+  const liveNodes = [node(1, "SaveVideo", { size: [400, 80], order: 1 })];
+  applySavedNodePresentation(liveRootFrom(liveNodes), { nodes: savedNodes });
+  const diff = classifyNodeDifference({ expectedNodes: savedNodes, actualNodes: liveNodes });
+  assert.equal(diff.comparable, true);
+  assert.equal(diff.sameNodeSet, true);
+  assert.deepEqual(diff.fields, []);
+});
+
+test("#1618 wiring: workflow_open restores presentation before the content proof", () => {
+  const openAt = PANEL.indexOf("async workflow_open({");
+  assert.notEqual(openAt, -1);
+  const open = PANEL.slice(openAt, PANEL.indexOf("\n  async workflow_live_sync", openAt));
+  const restoreAt = open.indexOf("applySavedNodePresentation(rootGraph, repaintState)");
+  const proofAt = open.indexOf("graphRootReproducesStateContent({");
+  assert.notEqual(restoreAt, -1, "the repaint path must restore from the payload it just loaded");
+  assert.notEqual(proofAt, -1);
+  assert.ok(restoreAt < proofAt, "restore must run before the proof, or the proof still sees hydration");
+});
+
+test("#1618 wiring: first-time open restores FILE presentation before re-baseline", () => {
+  const openAt = PANEL.indexOf("async workflow_open({");
+  const open = PANEL.slice(openAt, PANEL.indexOf("\n  async workflow_live_sync", openAt));
+  const fileRestoreAt = open.indexOf("applySavedNodePresentation(app?.graph, saved)");
+  const rebaselineAt = open.indexOf("await clearSpuriousOpenModified(target, {");
+  assert.notEqual(fileRestoreAt, -1, "a cold open must restore from originalContent, not only from already-rewritten activeState");
+  assert.notEqual(rebaselineAt, -1);
+  assert.ok(
+    fileRestoreAt < rebaselineAt,
+    "restoring after re-baseline would dirty the tab we just marked clean",
+  );
+  const wasOpenGuardAt = open.lastIndexOf("if (!wasOpen)", fileRestoreAt);
+  assert.ok(wasOpenGuardAt > 0 && wasOpenGuardAt < fileRestoreAt, "already-open tabs keep their in-memory presentation");
+});
+
+test("#1618 wiring: the disk-reload path restores presentation after loadGraphData", () => {
+  assert.match(
+    PANEL,
+    /applySavedSubgraphHostWidgets\(app\?\.graph, diskGraph\);\s*\n\s*applySavedNodePresentation\(app\?\.graph, diskGraph\);/,
+    "an on-disk reload must put file size/order back after configure",
+  );
+});
+
+test("#1618 wiring: first-time opens freeze so the clean re-baseline is safe", () => {
+  const openAt = PANEL.indexOf("async workflow_open({");
+  const open = PANEL.slice(openAt, PANEL.indexOf("\n  async workflow_live_sync", openAt));
+  assert.match(open, /const priorInteraction = acquireCanvasInteractionLock\(canvasView\);/);
+  assert.doesNotMatch(open, /wasOpen \? acquireCanvasInteractionLock/);
+});

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -847,8 +847,9 @@ test("#442 round-2: with NO freeze available the tracker is NOT re-baselined eit
   // makes that frame safe. On a frontend WITHOUT the flag the reload is skipped for
   // exactly that reason (priorInteraction === null) — so the tracker must not be
   // re-baselined either: an edit landing in the unprotected frame would be adopted as
-  // clean, erasing unsaved-work protection and inviting later silent loss. (Round 3
-  // extended the same exclusion to the first-time open — see the round-3 test below.)
+  // clean, erasing unsaved-work protection and inviting later silent loss. Round 3
+  // keeps the freeze-gated re-baseline; #1618 makes first-time opens freeze too so
+  // they can take that gated path.
   const skipGate = body.indexOf("if (staleInfo.reload && !dirtyNow && !wasDirty && priorInteraction === null)");
   const firstRebaseline = body.indexOf("await clearSpuriousOpenModified(target, {");
   assert.notEqual(skipGate, -1, "the no-freeze skip gate must exist");
@@ -872,23 +873,28 @@ test("#442 round-2: with NO freeze available the tracker is NOT re-baselined eit
   );
 });
 
-test("#442 round-3: a FIRST-TIME open never re-baselines without the freeze (edit in the frame stays dirty)", () => {
+test("#442 round-3 / #1618: re-baseline stays gated on the freeze; first-time opens freeze too", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const body = handlerBody(src, "async workflow_open({");
-  // The freeze handle is non-null ONLY for an already-open tab on a frontend exposing
-  // allow_interaction — exactly the case where the freeze below is actually applied.
+  // #1618 — a first-time open must freeze so the post-open re-baseline is safe.
+  // Without it, frontend size/order hydration leaves a clean tab modified.
+  // priorInteraction !== null still means "the freeze is holding"; the acquire
+  // is no longer gated on wasOpen. Disk reload stays gated on wasOpen via
+  // decideOpenStaleness (`if (!wasOpen) return { stale: false, reload: false }`).
   assert.match(
     body,
+    /const priorInteraction = acquireCanvasInteractionLock\(canvasView\);/,
+    "first-time opens freeze too — that is what makes the re-baseline safe",
+  );
+  assert.doesNotMatch(
+    body,
     /const priorInteraction = wasOpen \? acquireCanvasInteractionLock\(canvasView\) : null;/,
-    "priorInteraction !== null ⟺ the freeze is held",
+    "the freeze must not skip first-time opens",
   );
   // clearSpuriousOpenModified awaits a frame, then captures the canvas as the CLEAN
-  // baseline and forces isModified=false. A first-time open holds NO freeze by design,
-  // so if the cleanup ran there an edit landing in that frame would be adopted as
-  // clean — and a later stale open could then auto-reload the disk file over that
-  // unsaved work (the round-3 DATA-LOSS finding). The gate must require the freeze
-  // with NO !wasOpen exception; the fresh tab keeps a spurious flag (loud, cosmetic)
-  // instead of a silent clean-slate.
+  // baseline and forces isModified=false. The gate must still require the freeze
+  // with NO !wasOpen exception: a frontend without allow_interaction still must
+  // not re-baseline in an unprotected frame (the round-3 DATA-LOSS finding).
   const gate = body.match(
     /if \(\s*!wasDirty &&\s*priorInteraction !== null &&\s*ownsWorkflowReloadGuard\(reloadGuardToken\)\s*\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
   );
@@ -898,9 +904,6 @@ test("#442 round-3: a FIRST-TIME open never re-baselines without the freeze (edi
     /!wasOpen/,
     "no first-time-open exception may re-open the unprotected frame",
   );
-  // …which means a first-time open (wasOpen false ⇒ priorInteraction null) can NEVER
-  // reach the capture/reset: an in-frame edit keeps the tracker dirty, so BOTH reload
-  // paths below (each requires !dirtyNow && !wasDirty) stay closed over that work.
   const gates = [...body.matchAll(/if \(staleInfo\.reload && !dirtyNow[^)]*\)/g)].map((m) => m[0]);
   assert.ok(gates.length >= 2, "both reload paths stay gated on the fresh dirty re-check");
 });

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -869,10 +869,9 @@ test("#1089: the tab's dirty flag is NOT an input — it is wrong in both direct
   //   marks the tab modified, and was never saved. An auto-correct from disk gated on
   //   "clean" would silently replace exactly what an agent just generated.
   //
-  //   spuriously TRUE — a first-time open never runs clearSpuriousOpenModified (it is
-  //   gated on the freeze, and the freeze is scoped to wasOpen), so a cold-opened tab
-  //   reads modified for its whole life. Gating on it would have disarmed this guard
-  //   for that entire population — the #1089 report, unprevented.
+  //   spuriously TRUE — a first-time open still reads modified when the freeze
+  //   is unavailable (no allow_interaction), so gating on it would have disarmed
+  //   this guard for that population — the #1089 report, unprevented.
   //
   // So the classification is evidence-only and the flag is not consulted. Passing one
   // must change nothing, in either direction.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -672,6 +672,7 @@ import {
   graphRootWorkflowUuidMatches,
   graphRootMatchesState,
   graphRootReproducesStateContent,
+  applySavedNodePresentation,
   describeRepaintSourceBinding,
   graphCommandBindingBar,
   graphCommandMayMutateWorkflow,
@@ -6955,9 +6956,9 @@ function nextFrame() {
  *
  *  Callers must hold the canvas interaction freeze around this — the awaited
  *  frame below is exactly the gap in which an UNPROTECTED edit would be adopted
- *  as the new clean baseline (a silent clean-slate over real work). A first-time
- *  open is never frozen by design, so it does not get this cleanup at all: it
- *  keeps the spurious flag (loud, cosmetic) instead. */
+ *  as the new clean baseline (a silent clean-slate over real work). First-time
+ *  opens freeze for that reason too (#1618): without this cleanup, frontend
+ *  size/order hydration leaves a clean tab `modified:true`. */
 async function clearSpuriousOpenModified(wf, { stillOwns } = {}) {
   if (!wf) return;
   try {
@@ -18263,9 +18264,11 @@ const GRAPH_TOOL_EXECUTORS = {
     const canvasView = app?.canvas;
     // FREEZE canvas interaction across the WHOLE mutating sequence — the tab switch, the
     // repaint, the re-baseline, the bounded disk read and the reload — so no edit can land
-    // in a window whose dirty signal we are about to overwrite. Scoped to `wasOpen` (the
-    // only case that can reload) so a plain first-time open never freezes, and restored in
-    // a finally on every path.
+    // in a window whose dirty signal we are about to overwrite. First-time opens freeze
+    // too: that is what makes the post-open re-baseline safe, and without it a clean
+    // open stays `modified:true` from frontend size/order hydration (#1618). The disk
+    // reload stays gated on `wasOpen` via decideOpenStaleness. Restored in a finally
+    // on every path.
     // Taken through the OWNED lock so this and a concurrent snapshot restore cannot
     // release each other's freeze: `allow_interaction` is a bare boolean, and a
     // section that saved `true` before the other one froze would otherwise unlock
@@ -18273,7 +18276,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // meaning here — non-null means "the freeze is holding", which the re-baseline
     // and disk-reload steps below gate on — it is now a token rather than the saved
     // boolean, and the saved boolean lives inside the lock.
-    const priorInteraction = wasOpen ? acquireCanvasInteractionLock(canvasView) : null;
+    const priorInteraction = acquireCanvasInteractionLock(canvasView);
     let onDiskContent = null;
     let dirtyNow = false;
     let staleInfo = { stale: false, reload: false };
@@ -18450,8 +18453,9 @@ const GRAPH_TOOL_EXECUTORS = {
       // edit the user makes during that frame is absorbed as the new CLEAN baseline, so the
       // later dirty gate reads false and would authorize the disk reload to overwrite that
       // very edit. Sampling the flag later cannot fix that — the signal is already gone — so
-      // the window has to be closed instead. Scoped to `wasOpen` (the only case that can
-      // reload) so a plain first-time open never freezes, and always restored in a finally.
+      // the window has to be closed instead. First-time opens freeze too (#1618): the
+      // re-baseline that keeps a clean open clean needs the same protected frame. Always
+      // restored in a finally.
       // Bound to a local whose name does NOT end in "s": the #268 frontend-contract scanner
       // captures members off the workflow-service alias `s` with an unanchored `s\.` pattern,
       // so `canvas.<member>` would be misread as a new workflow-SERVICE dependency. This is a
@@ -18774,6 +18778,14 @@ const GRAPH_TOOL_EXECUTORS = {
               // report "could not prove rebound" on every call with no way to learn
               // which check fired. Evidence first, verdict second.
               const { rootGraph } = getGraphCtx();
+              // #1618 — undo configure's size/order rewrite against the payload we
+              // just loaded, before the content proof, so a faithful open compares
+              // exact and a later save does not persist hydration.
+              try {
+                applySavedNodePresentation(rootGraph, repaintState);
+              } catch {
+                /* live graph stays as the frontend left it */
+              }
               const activeNow = activeWorkflowRef();
               // Proxy-safe, like every other workflow-object comparison in this file:
               // the store hands out Vue proxies while lookups can yield raw objects, so
@@ -18963,12 +18975,25 @@ const GRAPH_TOOL_EXECUTORS = {
         // helper's awaited frame is otherwise unprotected: an edit landing in it would be
         // captured as the new CLEAN baseline, silently erasing unsaved-work protection —
         // and a later stale open could then auto-reload the disk file over that work.
-        // That excludes BOTH the no-freeze frontend (priorInteraction === null, the same
-        // condition that skips the reload below) AND the first-time open, which is never
-        // frozen by design (the freeze stays scoped to wasOpen — see above). A spurious
-        // "modified" flag on a fresh open is cosmetic (it may block an unforced close
-        // until a save) and keeps the dirty signal alive; a silent clean-slate over a
-        // real edit is neither.
+        // That excludes the no-freeze frontend (priorInteraction === null, the same
+        // condition that skips the reload below). First-time opens now freeze too, so
+        // they can re-baseline: otherwise size/order hydration leaves a clean tab
+        // modified and the next save writes those live values (#1618).
+        // #1618 — a first-time open loaded through openWorkflow, which already
+        // rewrote presentation into activeState. Restore the FILE's size/order
+        // (and subgraph host widgets) before the re-baseline so the clean
+        // snapshot is the authored graph.
+        if (!wasOpen) {
+          try {
+            const raw = target.originalContent ?? target.content;
+            const saved = typeof raw === "string" ? JSON.parse(raw) : raw;
+            applySavedSubgraphHostWidgets(app?.graph, saved);
+            applySavedNodePresentation(app?.graph, saved);
+            applySavedNodePresentation(app?.rootGraph, saved);
+          } catch {
+            /* unreadable file content — live graph stays as the frontend left it */
+          }
+        }
         // Ownership re-check before EVERY re-baseline / destructive step: if this open
         // outlived its own section (the 30s safety expiry, or a newer open taking over),
         // other commands have been let through and we must not keep mutating as though we
@@ -19134,6 +19159,7 @@ const GRAPH_TOOL_EXECUTORS = {
             await app.loadGraphData(diskGraph, true, true, target, { __cmcpKeepInstance: true });
             try {
               applySavedSubgraphHostWidgets(app?.graph, diskGraph);
+              applySavedNodePresentation(app?.graph, diskGraph);
             } catch {
               /* live graph stays as the file load left it */
             }
@@ -19187,21 +19213,10 @@ const GRAPH_TOOL_EXECUTORS = {
       releaseWorkflowReloadGuard(reloadGuardToken);
       releaseCanvasInteractionLock(priorInteraction, canvasView);
     }
-    // #874 — a FIRST-TIME open loads through ComfyUI's openWorkflow, which runs
-    // the same SubgraphNode.configure that drops host widgets_values. Apply the
-    // FILE's host values AFTER content proof so a widget rewrite cannot fail the
-    // open, and only when this tab was not already open (an already-open tab
-    // may hold unsaved edits the file does not). Skip if the disk re-read
-    // already applied the on-disk graph.
-    if (!openFailed && !rebindFailed && !wasOpen && !reloaded) {
-      try {
-        const raw = target.originalContent ?? target.content;
-        const saved = typeof raw === "string" ? JSON.parse(raw) : raw;
-        applySavedSubgraphHostWidgets(app?.graph, saved);
-      } catch {
-        /* unreadable file content — live graph stays as the frontend left it */
-      }
-    }
+    // #874 — first-time host widgets (and #1618 presentation) are restored
+    // inside the freeze, before re-baseline, so they cannot fail the open and
+    // cannot dirty a tab that was just marked clean. Skip here if that ran, or
+    // if the disk re-read already applied the on-disk graph.
     if (openFailed) throw failOpen(openFailed);
     if (rebindFailed) {
       // #1089 follow-up — the foreign-source finding rides the FAILURE too.

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -614,6 +614,108 @@ function nodeIdentityKey(node) {
 }
 
 /**
+ * #1618 — fields the ComfyUI frontend recomputes while loading a graph it
+ * otherwise reproduced. Restoring them from the payload we asked to load undoes
+ * that hydration so a later save does not persist box heights / execution order
+ * the user never authored. Color/bgcolor stay out: those are authored, and a
+ * difference in them is not a measured rewrite.
+ */
+const HYDRATED_PRESENTATION_FIELDS = ["size", "order"];
+
+function cloneHydratedPresentationValue(field, value) {
+  if (field === "size") {
+    if (!Array.isArray(value) || value.length < 2) return undefined;
+    const width = Number(value[0]);
+    const height = Number(value[1]);
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return undefined;
+    return [width, height];
+  }
+  if (field === "order") {
+    const order = Number(value);
+    return Number.isFinite(order) ? order : undefined;
+  }
+  return undefined;
+}
+
+function presentationFieldEquals(field, liveValue, savedValue) {
+  const saved = cloneHydratedPresentationValue(field, savedValue);
+  if (saved === undefined) return false;
+  if (field === "size") {
+    const live = cloneHydratedPresentationValue("size", liveValue);
+    return live !== undefined && live[0] === saved[0] && live[1] === saved[1];
+  }
+  return Number(liveValue) === saved;
+}
+
+function writeHydratedPresentationField(live, field, value) {
+  const copy = cloneHydratedPresentationValue(field, value);
+  if (copy === undefined) return false;
+  if (field === "size") {
+    const cur = live.size;
+    if (cur && typeof cur === "object") {
+      cur[0] = copy[0];
+      cur[1] = copy[1];
+      return true;
+    }
+    live.size = copy;
+    return true;
+  }
+  live.order = copy;
+  return true;
+}
+
+/**
+ * Put the saved `size` / `order` back onto live nodes after `loadGraphData`.
+ *
+ * The frontend recomputes both during configure. Leaving them rewritten marks
+ * a clean tab modified and makes the next save persist hydration (#1618).
+ * Only nodes with the same id AND type are written; widgets, title, flags and
+ * mode are never touched. Missing or unreadable inputs are a no-op.
+ *
+ * @returns {{ restored: number, skipped: number }}
+ */
+export function applySavedNodePresentation(liveRoot, savedGraph) {
+  const result = { restored: 0, skipped: 0 };
+  if (!liveRoot || !savedGraph || typeof savedGraph !== "object") return result;
+  const savedNodes = savedGraph.nodes;
+  if (!Array.isArray(savedNodes)) return result;
+  let liveNodes;
+  try {
+    liveNodes = liveRoot._nodes ?? liveRoot.nodes;
+  } catch {
+    return result;
+  }
+  if (!Array.isArray(liveNodes)) return result;
+
+  const savedByKey = new Map();
+  for (const node of savedNodes) {
+    if (!node || typeof node !== "object") continue;
+    savedByKey.set(nodeIdentityKey(node), node);
+  }
+
+  for (const live of liveNodes) {
+    if (!live || typeof live !== "object") {
+      result.skipped += 1;
+      continue;
+    }
+    const saved = savedByKey.get(nodeIdentityKey(live));
+    if (!saved) {
+      result.skipped += 1;
+      continue;
+    }
+    let restoredThis = false;
+    for (const field of HYDRATED_PRESENTATION_FIELDS) {
+      if (!Object.prototype.hasOwnProperty.call(saved, field) || saved[field] === undefined) continue;
+      if (presentationFieldEquals(field, live[field], saved[field])) continue;
+      if (writeHydratedPresentationField(live, field, saved[field])) restoredThis = true;
+    }
+    if (restoredThis) result.restored += 1;
+    else result.skipped += 1;
+  }
+  return result;
+}
+
+/**
  * WHY two node arrays differ — specifically, whether anything was LOST.
  *
  * THE DEFECT THIS ANSWERS (#825). `nodes` is a single surface holding the whole
@@ -1841,9 +1943,9 @@ export function graphRootCarriesOpenProof({ rootGraph, proofMarker } = {}) {
  *   NODE wrote (a populated wildcard, a rolled seed) is on the canvas, never marks
  *   the tab modified, and was never saved — the re-read would silently replace
  *   exactly what an agent just generated. The same flag fails in the other direction
- *   too: a first-time open never runs `clearSpuriousOpenModified`, so a cold-opened
- *   tab reads modified forever, and gating on it would have disarmed this guard for
- *   that entire population. #442's re-read survives the argument only because it
+ *   too: a first-time open can still read modified when freeze/re-baseline is
+ *   unavailable, and gating on it would have disarmed this guard for that
+ *   population. #442's re-read survives the argument only because it
  *   fires on the FILE provably having changed, which is independent evidence about
  *   the disk copy. A foreign source tag is no evidence about the file at all.
  *


### PR DESCRIPTION
Fixes #1618

## What the user now observes
Opening a saved workflow with `panel_open_workflow` no longer rewrites node `size`/`order` onto the live graph, and a previously unmodified tab stays `modified: false`. Saving afterwards writes the authored presentation, not frontend-hydrated heights and execution order.

## Why
`loadGraphData` / `configure` recomputes box height and LiteGraph `order`. The open already treated those as presentation-only for pass/fail (#1001 / #1623) and disclosed them, but left the live nodes rewritten and the change tracker dirty. A later save persisted hydration the user did not author.

## Fix
- Restore the payload's `size`/`order` onto matching id+type nodes after the load (`applySavedNodePresentation`), before the content proof.
- First-time opens restore from the FILE (not already-rewritten `activeState`) and freeze so the existing re-baseline is safe.
- Widget values, title, flags, and mode are never touched.

## Tests
`browser_tests/unit/open-node-presentation.test.mjs` drives the shipped restore, then `graphRootReproducesStateContent` (the same proof `workflow_open` uses). Wiring pins the three open-path call sites and the first-time freeze.
