### PR TITLE
fix: fail honestly when remote /view is unavailable

### DIFF
--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -19,6 +19,7 @@ import {
   isVideoShowMediaItem,
   MEDIA_PREVIEW_TIMEOUT_MS,
   MEDIA_SIZE_PROBE_TIMEOUT_MS,
+  MEDIA_VIEW_PROBE_TIMEOUT_MS,
 } from "../../web/js/lib/media-preview.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 
@@ -176,6 +177,75 @@ test("an image-only call paints exactly as before and claims no sampled preview"
   assert.equal(reply.painted, 2);
   assert.doesNotMatch(reply.note, /SAMPLED PREVIEW/);
   assert.doesNotMatch(reply.note, /contact sheet/);
+});
+
+test("a remote /view outage is dropped before it can be counted as painted (#1620)", async () => {
+  const h = harness({
+    probeMedia: async (url, ref) => {
+      assert.match(url, /\/view\?/);
+      assert.equal(ref.filename, "remote.png");
+      return { ok: false, reason: "/view returned HTTP 401" };
+    },
+  });
+  const reply = await composeShowMediaReply(
+    [{
+      kind: "viewRef",
+      viewRef: { filename: "remote.png", subfolder: "final", type: "output" },
+      filename: "remote.png",
+    }],
+    h.deps,
+  );
+
+  assert.equal(h.calls.paintedImages.length, 0, "the failed remote ref must never reach the painter");
+  assert.equal(reply.painted, 0, "an unavailable /view must not be called painted");
+  assert.equal(reply.unconfirmed, 0);
+  assert.match(reply.note, /remote\.png — the panel could not serve its ComfyUI \/view reference: \/view returned HTTP 401/);
+  assert.match(reply.note, /call get_image with filename "remote\.png", type "output", subfolder "final"/);
+  assert.match(reply.note, /fix the remote \/view authorization or target/);
+});
+
+test("a browser-verified /view ref still paints normally (#1620)", async () => {
+  const h = harness({ probeMedia: async () => ({ ok: true }) });
+  const reply = await composeShowMediaReply(
+    [{ kind: "viewRef", viewRef: { filename: "local.png", type: "output" }, filename: "local.png" }],
+    h.deps,
+  );
+
+  assert.equal(h.calls.paintedImages.length, 1);
+  assert.equal(reply.painted, 1);
+  assert.equal(reply.unconfirmed, 0);
+});
+
+test("the remote /view probe does not change verified inline media (#1620)", async () => {
+  let probes = 0;
+  const h = harness({
+    probeMedia: () => {
+      probes += 1;
+      return { ok: false, reason: "remote /view unavailable" };
+    },
+  });
+  const reply = await composeShowMediaReply(
+    [{ kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "local.png" }],
+    h.deps,
+  );
+
+  assert.equal(probes, 0, "inline bytes have no remote /view to probe");
+  assert.equal(h.calls.paintedImages.length, 1);
+  assert.equal(reply.painted, 1);
+});
+
+test("a hanging remote /view probe is bounded and not reported as painted (#1620)", async () => {
+  const h = harness({ probeMedia: () => new Promise(() => {}) });
+  const p = composeShowMediaReply(
+    [{ kind: "viewRef", viewRef: { filename: "remote.png", type: "output" }, filename: "remote.png" }],
+    h.deps,
+  );
+  await h.elapse(MEDIA_VIEW_PROBE_TIMEOUT_MS);
+  const reply = await p;
+
+  assert.equal(h.calls.paintedImages.length, 0);
+  assert.equal(reply.painted, 0);
+  assert.match(reply.note, /availability probe timed out before it answered/);
 });
 
 test("an inlined (under-cap) video is still disclosed as sampled, with its exact size", async () => {
@@ -1321,6 +1391,7 @@ test("onShowMedia routes through composeShowMediaReply with the storyboard pipel
     "storyboardFrameCount",
     "humanizeBytes",
     "fetchMediaBytes: fetchImageBytes",
+    "probeMedia: probeShowMediaView",
     "videoStoryboardEnabled",
   ]) {
     assert.ok(handler[0].includes(dep), `onShowMedia must pass ${dep} through`);
@@ -1336,6 +1407,18 @@ test("onShowMedia routes through composeShowMediaReply with the storyboard pipel
   for (const dep of ["paintAudio", "paintFileLink"]) {
     assert.ok(handler[0].includes(dep), `onShowMedia must pass ${dep} through (#710)`);
   }
+});
+
+test("the #1620 /view probe uses the panel browser session and the same media URL", () => {
+  const src = panelSource();
+  const start = src.indexOf("async function probeShowMediaView(url)");
+  assert.ok(start > 0, "the browser-side /view probe is missing");
+  const body = src.slice(start, src.indexOf("\n}\n\n/** Load an Image", start) + 2);
+  assert.match(body, /fetch\(url,\s*\{/);
+  assert.match(body, /credentials: "include"/);
+  assert.match(body, /Range: "bytes=0-0"/);
+  assert.match(body, /!res\?\.ok/);
+  assert.match(body, /content-type/);
 });
 
 /** One `function name(...) { … }` at the panel closure's 2-space indent, sliced

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -1413,7 +1413,13 @@ test("the #1620 /view probe uses the panel browser session and the same media UR
   const src = panelSource();
   const start = src.indexOf("async function probeShowMediaView(url)");
   assert.ok(start > 0, "the browser-side /view probe is missing");
-  const body = src.slice(start, src.indexOf("\n}\n\n/** Load an Image", start) + 2);
+  // The checked-out panel bundle may be CRLF even though the source assertions
+  // are written with LF delimiters. Normalize only this inspected slice so the
+  // bound remains the probe's closing brace, regardless of checkout settings.
+  const afterStart = src.slice(start).replace(/\r\n/g, "\n");
+  const end = afterStart.indexOf("\n}\n\n/** Load an Image");
+  assert.ok(end > 0, "could not bound the browser-side /view probe");
+  const body = afterStart.slice(0, end + 2);
   assert.match(body, /fetch\(url,\s*\{/);
   assert.match(body, /credentials: "include"/);
   assert.match(body, /Range: "bytes=0-0"/);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7767,6 +7767,41 @@ async function fetchImageBytes(url) {
   }
 }
 
+/**
+ * Probe the exact browser URL a ComfyUI viewRef painter will use.
+ *
+ * A panel_show_media card is otherwise created before the browser makes its
+ * own /view request, so a remote/authenticated 401 becomes painted:1 followed
+ * by a later image error. The range request keeps this check bounded and
+ * cheap, while credentials:include keeps it in the panel browser's session.
+ * The caller treats every non-media, non-2xx, or unreachable response as a
+ * delivery failure; a probe from the orchestrator cannot stand in for this one.
+ */
+async function probeShowMediaView(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 4000);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      cache: "no-store",
+      credentials: "include",
+      headers: { Range: "bytes=0-0" },
+      signal: ctrl.signal,
+    });
+    const mime = typeof res?.headers?.get === "function" ? res.headers.get("content-type") || "" : "";
+    if (!res?.ok) return { ok: false, reason: `/view returned HTTP ${res?.status ?? "no response"}` };
+    if (!/^(image|video|audio)\//i.test(mime)) {
+      return { ok: false, reason: `/view returned non-media content-type "${mime || "unset"}"` };
+    }
+    try { await res.body?.cancel?.(); } catch { /* best effort */ }
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "the browser could not reach /view" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** Load an Image() from a /view URL to read natural pixel dimensions. Resolves
  *  {w,h} or null. Bounded by a timeout so a stuck decode can't hang the flush. */
 function fetchImageDimensions(url) {
@@ -34362,6 +34397,7 @@ function buildPanel() {
         applyVideoPoster,
         humanizeBytes,
         fetchMediaBytes: fetchImageBytes,
+        probeMedia: probeShowMediaView,
         videoStoryboardEnabled: prefs.videoStoryboard !== false,
         warn: (...a) => console.warn(...a),
       });

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -58,6 +58,9 @@ export const MEDIA_PREVIEW_TIMEOUT_MS = 20000;
  *  the storyboard needs. Unknown size still produces a preview. */
 export const MEDIA_SIZE_PROBE_TIMEOUT_MS = 8000;
 
+/** Bound on the browser-side /view availability check for a ComfyUI ref. */
+export const MEDIA_VIEW_PROBE_TIMEOUT_MS = 4000;
+
 /**
  * WHAT THE PANEL CAN ACTUALLY PRESENT (#710).
  *
@@ -313,6 +316,19 @@ function safePaint(paint, url, caption, warn, what) {
   return deferred ? "unconfirmed" : "shown";
 }
 
+/** A failed browser-side /view check, or null when the check passed. */
+function viewProbeFailure(result) {
+  try {
+    if (result === true || (result && result.ok === true)) return null;
+    if (result && typeof result.reason === "string" && result.reason.trim()) {
+      return result.reason.trim();
+    }
+  } catch {
+    // A malformed probe result must still become an honest delivery failure.
+  }
+  return "the panel could not verify that the requested /view media was served";
+}
+
 /** A ComfyUI ref written the way `get_image` takes its arguments. */
 function refClause(ref, coerce) {
   const filename = coerce(ref?.filename);
@@ -359,6 +375,8 @@ export async function composeShowMediaReply(items, deps = {}) {
     warn = () => {},
     timeoutMs = MEDIA_PREVIEW_TIMEOUT_MS,
     sizeProbeTimeoutMs = MEDIA_SIZE_PROBE_TIMEOUT_MS,
+    viewProbeTimeoutMs = MEDIA_VIEW_PROBE_TIMEOUT_MS,
+    probeMedia,
     setTimer,
     clearTimer,
   } = deps;
@@ -494,6 +512,35 @@ export async function composeShowMediaReply(items, deps = {}) {
                 `player did not appear.`,
       });
       continue;
+    }
+    // A viewRef is fetched by the browser AFTER this handler returns. A card
+    // created before that request answers is not evidence that the requested
+    // media can be served — especially on a remote/authenticated /view route.
+    // Probe the same URL in the panel's browser session first, and fail closed
+    // when it is unavailable or the probe is inconclusive. Inline data URLs do
+    // not take this branch: their bytes are already in the panel.
+    if (ref && typeof probeMedia === "function") {
+      const probe = await withTimeout(
+        Promise.resolve().then(() => probeMedia(url, ref)),
+        viewProbeTimeoutMs,
+        () => ({
+          ok: false,
+          reason: "the panel's /view availability probe timed out before it answered",
+        }),
+        { setTimer, clearTimer },
+      );
+      const probeWhy = viewProbeFailure(probe);
+      if (probeWhy) {
+        dropped.push({
+          name,
+          why: `the panel could not serve its ComfyUI /view reference: ${probeWhy}`,
+          remedy:
+            `The reference itself is intact — call get_image with ${refClause(ref, text)} ` +
+            `to fetch it without relying on this panel's browser /view session, then fix the ` +
+            `remote /view authorization or target and retry panel_show_media.`,
+        });
+        continue;
+      }
     }
     const shownState = safePaint(painter, url, caption, note, name);
     if (shownState === "failed") {


### PR DESCRIPTION
## Summary
- Probe the exact browser /view URL with the panel session before counting a ComfyUI viewRef as painted.
- Drop unavailable or inconclusive refs with a get_image recovery path; inline media and other media paths retain their existing behavior.
- Add focused outage, healthy, inline, timeout, and production-wiring regression coverage.

Refs #1620

## Validation
- npm.cmd run test:unit
- npm.cmd run typecheck
- npm.cmd run check:scope