### PR TITLE
fix(1625): restart confirmation card appears on the active panel instead of timing out unseen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- a restart confirmation card is brought on screen instead of timing out unseen: the Agent tab opens, stick-to-bottom is forced, and the card scrolls immediately rather than waiting on an rAF a backgrounded tab will never fire (#1625)
+
 ## [0.15.41] - 2026-08-22
 
 ### Fixed
@@ -17,7 +20,6 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_open_workflow keeps authored node size/order and leaves a clean tab unmodified (#1621)
 - replay remote PreviewImage completion (#1624)
-
 
 ## [0.15.39] - 2026-08-22
 

--- a/browser_tests/unit/interactive-card-reveal.test.mjs
+++ b/browser_tests/unit/interactive-card-reveal.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * #1625 — a restart confirmation painted into a transcript the user cannot see
+ * is the same failure as not painting at all.
+ *
+ * `panel_restart_comfyui` blocks on `ask_user`. The panel used to append the card
+ * and call `scrollLog()`, which (a) honours stick-to-bottom, so a scrolled-up
+ * reader never sees it, and (b) defers to `requestAnimationFrame`, which a
+ * backgrounded ComfyUI tab never fires. The orchestrator then waits 90s and
+ * reports the card wasn't answered.
+ *
+ * Two layers, same shape as interactive-card-fence.test.mjs:
+ *   1. the shipped helper (web/js/lib/interactive-card-reveal.js);
+ *   2. the REAL `paintQuestion` / `paintSecret` bodies, so a painter that goes
+ *      back to `scrollLog()` alone fails here rather than only if the helper
+ *      changes.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  INTERACTIVE_CARD_REVEAL_RETRY_MS,
+  revealInteractiveCard,
+} from "../../web/js/lib/interactive-card-reveal.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  const bodyOpen = src.indexOf(") {", start);
+  if (bodyOpen === -1) return null;
+  let depth = 0;
+  for (let i = bodyOpen + 2; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// 1. the shipped helper
+// ---------------------------------------------------------------------------
+
+test("#1625 the card is brought forward NOW, not on an rAF a hidden tab will never fire", () => {
+  const order = [];
+  revealInteractiveCard({
+    forceStick: () => order.push("stick"),
+    openTab: () => order.push("open"),
+    scrollNow: () => order.push("scroll"),
+    schedule: (fn) => order.push(["scheduled", fn]),
+  });
+  assert.deepEqual(
+    order.slice(0, 3),
+    ["stick", "open", "scroll"],
+    "stick, tab-forward and scroll all run in this turn — before any timer",
+  );
+  assert.equal(order.length, 4, "a retry is scheduled, not run inline");
+  assert.equal(typeof order[3][1], "function");
+});
+
+test("#1625 the retry re-opens the tab: the first activate can miss a store that is not ready", () => {
+  // Ask AI / What's New already wait this race out. A confirmation card that
+  // paints into a still-detached keep-alive root is the same miss.
+  const calls = { open: 0, scroll: 0 };
+  let retry;
+  let delay;
+  revealInteractiveCard({
+    openTab: () => {
+      calls.open += 1;
+    },
+    scrollNow: () => {
+      calls.scroll += 1;
+    },
+    schedule: (fn, ms) => {
+      retry = fn;
+      delay = ms;
+    },
+  });
+  assert.equal(calls.open, 1);
+  assert.equal(calls.scroll, 1);
+  assert.equal(delay, INTERACTIVE_CARD_REVEAL_RETRY_MS, "retry uses the shipped delay, not a guess");
+  retry();
+  assert.equal(calls.open, 2, "the retry is another activate, not a no-op");
+  assert.equal(calls.scroll, 2, "and another synchronous scroll after the re-attach");
+});
+
+test("#1625 a tab-activate throw still scrolls — the card is already in the keep-alive tree", () => {
+  const order = [];
+  revealInteractiveCard({
+    forceStick: () => order.push("stick"),
+    openTab: () => {
+      throw new Error("no sidebar store");
+    },
+    scrollNow: () => order.push("scroll"),
+    schedule: () => {},
+  });
+  assert.deepEqual(order, ["stick", "scroll"]);
+});
+
+test("#1625 a scroll throw does not skip the retry — the tab-forward may still land", () => {
+  let retried = false;
+  revealInteractiveCard({
+    openTab: () => {},
+    scrollNow: () => {
+      throw new Error("detached root");
+    },
+    schedule: (fn) => {
+      retried = true;
+      fn();
+    },
+  });
+  assert.equal(retried, true);
+});
+
+test("#1625 retryMs 0 means one attempt, matching a caller that already waited", () => {
+  let scheduled = 0;
+  revealInteractiveCard({
+    openTab: () => {},
+    scrollNow: () => {},
+    schedule: () => {
+      scheduled += 1;
+    },
+    retryMs: 0,
+  });
+  assert.equal(scheduled, 0);
+});
+
+// ---------------------------------------------------------------------------
+// 2. the REAL painters
+// ---------------------------------------------------------------------------
+
+test("#1625 both collecting cards call the reveal helper AFTER they append the card", () => {
+  for (const name of ["paintQuestion", "paintSecret"]) {
+    const src = namedFunctionSource(panelSrc, name);
+    assert.ok(src, `could not locate ${name}`);
+    const appendAt = src.indexOf("log.appendChild(card)");
+    assert.ok(appendAt > 0, `${name} must append the card to the log`);
+    const revealAt = src.indexOf("revealInteractiveCard(", appendAt);
+    assert.ok(revealAt > appendAt, `${name} must reveal after the card is in the log`);
+    const afterAppend = src.slice(appendAt, revealAt);
+    assert.equal(
+      afterAppend.includes("scrollLog();"),
+      false,
+      `${name} must not rAF-scroll in the gap before reveal — that is the hidden-tab miss`,
+    );
+  }
+});
+
+test("#1625 the painters inject the live tab-forward, stick, and synchronous scroll", () => {
+  for (const name of ["paintQuestion", "paintSecret"]) {
+    const src = namedFunctionSource(panelSrc, name);
+    assert.match(src, /openTab:\s*openSidebarTab/, `${name} brings the Agent tab forward`);
+    assert.match(src, /stickToBottom = true/, `${name} forces stick so a scrolled-up reader still sees it`);
+    assert.match(src, /log\.scrollTop = log\.scrollHeight/, `${name} scrolls NOW, not via rAF`);
+    assert.match(src, /schedule:\s*\(fn, ms\) => setTimeout\(fn, ms\)/, `${name} retries with a real timer`);
+  }
+});
+
+test("#1625 the module is imported — a painter call without the import is a ReferenceError", () => {
+  assert.match(
+    panelSrc,
+    /import \{ revealInteractiveCard \} from "\.\/lib\/interactive-card-reveal\.js";/,
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -640,6 +640,7 @@ import {
   classifyInteractiveCard,
   refusedInteractiveCardError,
 } from "./lib/interactive-card-fence.js";
+import { revealInteractiveCard } from "./lib/interactive-card-reveal.js";
 import {
   saveActiveWorkflow,
   shouldGroundBeforeTurn,
@@ -32123,7 +32124,27 @@ function buildPanel() {
     card.appendChild(otherRow);
 
     log.appendChild(card);
-    scrollLog();
+    // #1625 — the Discord-style autoscroll helper is not enough: it honours
+    // stick-to-bottom (a scrolled-up reader never sees the card) and defers to rAF
+    // (paused in a backgrounded tab). A restart confirm blocks the tool until they
+    // click, so the card has to be on screen — Agent tab forward, stick forced,
+    // scroll NOW.
+    revealInteractiveCard({
+      openTab: openSidebarTab,
+      forceStick: () => {
+        stickToBottom = true;
+        newMsgBtn.hidden = true;
+      },
+      scrollNow: () => {
+        log.scrollTop = log.scrollHeight;
+        try {
+          card.scrollIntoView({ block: "nearest" });
+        } catch {
+          /* detached keep-alive root: the tab-forward above re-attaches it */
+        }
+      },
+      schedule: (fn, ms) => setTimeout(fn, ms),
+    });
     // #952 — REGISTER THE CARD AGAINST THE CONNECTION THAT PAINTED IT. A reply of this
     // kind is deliberately not replayed across a reconnect, so once this connection is
     // replaced the card cannot deliver an answer to anyone — while still looking exactly
@@ -32391,7 +32412,25 @@ function buildPanel() {
 
     card.appendChild(row);
     log.appendChild(card);
-    scrollLog();
+    // #1625 — same reveal as paintQuestion: a secret card the user cannot see is
+    // the same failure as not painting it. Settings-button callers already open
+    // the tab; this is idempotent and covers the agent-initiated path.
+    revealInteractiveCard({
+      openTab: openSidebarTab,
+      forceStick: () => {
+        stickToBottom = true;
+        newMsgBtn.hidden = true;
+      },
+      scrollNow: () => {
+        log.scrollTop = log.scrollHeight;
+        try {
+          card.scrollIntoView({ block: "nearest" });
+        } catch {
+          /* detached keep-alive root: the tab-forward above re-attaches it */
+        }
+      },
+      schedule: (fn, ms) => setTimeout(fn, ms),
+    });
     setTimeout(() => input.focus(), 0);
     // #952 — the SECRET card needs this more than the question card does (codex). It is
     // a live password field whose reply has nowhere to go once its connection is

--- a/web/js/lib/interactive-card-reveal.js
+++ b/web/js/lib/interactive-card-reveal.js
@@ -1,0 +1,92 @@
+// #1625 — an interactive card the user cannot see is the same failure as not
+// painting at all.
+//
+// `ask_user` and `request_secret` are the only panel commands that BLOCK on a
+// human. `panel_restart_comfyui`'s confirmation is one of them: the orchestrator
+// waits up to 90s for a click, then reports "No confirmation received … the
+// panel tab may be backgrounded or still reconnecting … the confirmation card
+// wasn't answered." That wording is a guess. What the panel actually does is
+// append the card to the chat log and call `scrollLog()`. Three independent
+// ways that leaves the card unreachable, all of them the reported shape:
+//
+//   1. The Agent tab is not selected. Keep-alive detaches `.cmcp-root` rather
+//      than destroying it, so the card is in a tree that is not on screen. The
+//      What's New path already names this: "painting into a transcript the user
+//      cannot see is the same failure as not painting at all."
+//   2. The user has scrolled up. Discord-style stick-to-bottom leaves them
+//      there and only shows a "New messages" pill. A destructive confirm is not
+//      a message they can miss — the tool is blocked on the click.
+//   3. The ComfyUI tab is backgrounded. `scrollLog()` defers to
+//      `requestAnimationFrame`, which browsers pause in a hidden tab
+//      (hidden-tab.spec.ts). A card appended below the fold stays there until
+//      the tab is looked at, which is past the 90s budget.
+//
+// This helper does not paint and does not answer. Call it AFTER the card is in
+// the log. It brings the Agent tab forward, forces stick-to-bottom, and scrolls
+// NOW — not on an rAF tick a backgrounded tab will never fire. The retry covers
+// the same "first activate lands before the tab store is ready" race Ask AI and
+// What's New already wait out.
+//
+// WHAT THIS DOES NOT DO. A card that never arrived (the socket was down, the
+// command landed on a superseded connection) cannot be revealed; #952 retires
+// those, and the orchestrator re-asks. A click after the 90s cap is orchestrator
+// recovery (panel#1554), not a panel-visibility problem.
+//
+// Dependency-free (no DOM, no sockets, no timers of its own). The callers inject
+// `openTab` / `forceStick` / `scrollNow` / `schedule` so this is unit-testable
+// with plain functions.
+
+/** Retry delay matching Ask AI / What's New — the tab store can miss the first set. */
+export const INTERACTIVE_CARD_REVEAL_RETRY_MS = 120;
+
+/**
+ * Make a just-painted interactive card reachable: Agent tab forward, stick to
+ * the bottom, scroll synchronously.
+ *
+ * Each injected action is best-effort and isolated — a throw from `openTab`
+ * must not skip the scroll; the card is already in the keep-alive tree.
+ *
+ * @param {{
+ *   openTab?: () => void,
+ *   forceStick?: () => void,
+ *   scrollNow?: () => void,
+ *   schedule?: (fn: () => void, ms: number) => unknown,
+ *   retryMs?: number,
+ * }} [opts]
+ */
+export function revealInteractiveCard({
+  openTab,
+  forceStick,
+  scrollNow,
+  schedule,
+  retryMs = INTERACTIVE_CARD_REVEAL_RETRY_MS,
+} = {}) {
+  try {
+    forceStick?.();
+  } catch {
+    /* stick is cosmetic next to a card the user still cannot see */
+  }
+  try {
+    openTab?.();
+  } catch {
+    /* the card still lives in the keep-alive root */
+  }
+  try {
+    scrollNow?.();
+  } catch {
+    /* scroll is best-effort; the card is still in the tree */
+  }
+  if (!(retryMs > 0) || typeof schedule !== "function") return;
+  schedule(() => {
+    try {
+      openTab?.();
+    } catch {
+      /* same as the first attempt */
+    }
+    try {
+      scrollNow?.();
+    } catch {
+      /* same as the first attempt */
+    }
+  }, retryMs);
+}


### PR DESCRIPTION
Fixes #1625

## What the user now observes
`panel_restart_comfyui` shows its Yes/No confirmation card on the Agent tab instead of waiting 90s and reporting that no confirmation arrived. The card is reachable even when the Agent tab was not selected, the user had scrolled up, or the ComfyUI tab was backgrounded.

## Why
The restart confirm is an `ask_user` card. The panel appended it to the chat log and called the Discord-style autoscroll helper, which (a) leaves a scrolled-up reader where they are with only a "New messages" pill, and (b) defers to `requestAnimationFrame`, which a backgrounded tab never fires (the same class as the hidden-tab stream bug). Keep-alive also detaches `.cmcp-root` when another sidebar tab is selected, so the card sat in a tree that was not on screen — the What's New path already names that: "painting into a transcript the user cannot see is the same failure as not painting at all."

The orchestrator then hit the 90s cap and reported the card was not answered. Related orchestrator recovery for a *late* click is panel#1554; this is the case where nobody could click because the card never reached the screen.

## Fix
After painting `ask_user` / `request_secret`, call `revealInteractiveCard`: open the Agent tab, force stick-to-bottom, and scroll **now** (not on rAF). Retry once after 120ms for the same tab-store race Ask AI / What's New already wait out.

A card that never arrived (superseded socket) is unchanged — #952 still retires those.

## Tests
`browser_tests/unit/interactive-card-reveal.test.mjs` drives the shipped helper (sync reveal, retry, throw isolation) and pins both painters to call it after `log.appendChild(card)` with the live `openSidebarTab` / stick / `log.scrollTop` injections.
