### PR TITLE
fix(1600): resolve Manager installed directory IDs before update

### DIFF
--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -589,6 +589,7 @@ function buildGraphUpdateNode(deps) {
 function graphUpdateDeps(overrides) {
   return {
     detectManagerDialect: async () => "legacy",
+    resolveManagerUpdateTarget: async (id) => id,
     crypto: { randomUUID: () => "u-1" },
     api: { clientId: "c-1" },
     legacyUpdateBody,

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -16,6 +16,7 @@ const {
   buildInstallRequest,
   parseInstalled,
   nodeInstalledMatches,
+  resolveInstalledUpdateId,
   queueDrained,
   isReadableInstalledList,
   queueFailureSignal,
@@ -215,6 +216,37 @@ test("nodeInstalledMatches accepts a full git URL directly and matches by repo n
   );
   assert.equal(nodeInstalledMatches(undefined, installed), false);
   assert.equal(nodeInstalledMatches("rgthree-comfy", {}), false);
+});
+
+test("#1600 resolves an installed directory to Manager's active_nodes identity", () => {
+  const installed = {
+    "comfyui-minimax-h3-prompt-enhancer-T8": {
+      ver: "nightly",
+      cnr_id: "comfyui-minimax-h3-prompt-enhancer",
+      aux_id: "example/comfyui-minimax-h3-prompt-enhancer",
+      enabled: true,
+    },
+  };
+  assert.equal(
+    resolveInstalledUpdateId("comfyui-minimax-h3-prompt-enhancer-T8", installed),
+    "comfyui-minimax-h3-prompt-enhancer",
+  );
+  assert.equal(
+    resolveInstalledUpdateId("comfyui-minimax-h3-prompt-enhancer", installed),
+    "comfyui-minimax-h3-prompt-enhancer",
+  );
+  assert.equal(resolveInstalledUpdateId("not-installed", installed), null);
+});
+
+test("#1600 uses the aux repository basename for an installed unknown git pack", () => {
+  const installed = {
+    "local-renamed-folder": {
+      ver: "unknown",
+      aux_id: "owner/original-repo",
+      enabled: true,
+    },
+  };
+  assert.equal(resolveInstalledUpdateId("local-renamed-folder", installed), "original-repo");
 });
 
 // --- queueDrained: POSITIVE evidence only (codex round 2 #1) ----------------

--- a/browser_tests/unit/manager-update-installed-id.test.mjs
+++ b/browser_tests/unit/manager-update-installed-id.test.mjs
@@ -1,0 +1,127 @@
+// Regression coverage for panel issue #1600. ComfyUI-Manager's installed list
+// is keyed by the on-disk directory, while its active update map is keyed by
+// the registry/aux identity stored in that entry. Exercise the shipped
+// graph_update_node against the documented renamed directory shape so a
+// Manager KeyError cannot return.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertBatchOk,
+  classifyUpdateOutcome,
+  dialectRetryTarget,
+  isManagerRouteMissing,
+  isManagerUnreachable,
+  isMethodNotAllowed,
+  legacyUpdateBody,
+  resolveInstalledUpdateId,
+  taskFailureReason,
+} from "../../web/js/lib/manager-install.js";
+import { isGenericManagerUpdateError } from "../../web/js/lib/manager-update-traceback.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const DIRECTORY_ID = "comfyui-minimax-h3-prompt-enhancer-T8";
+const MANAGER_ID = "comfyui-minimax-h3-prompt-enhancer";
+const INSTALLED = {
+  [DIRECTORY_ID]: {
+    ver: "nightly",
+    cnr_id: MANAGER_ID,
+    aux_id: "example/comfyui-minimax-h3-prompt-enhancer",
+    enabled: true,
+  },
+};
+
+function readPanelSource() {
+  return readFileSync(PANEL_JS, "utf8");
+}
+
+function buildGraphUpdateNode({ resolveTarget, managerV2 }) {
+  const src = readPanelSource();
+  const method = src.match(
+    /async graph_update_node\(\{ id, version, channel, mode \}\) \{[\s\S]*?\n  \},\r?\n/,
+  );
+  assert.ok(method, "graph_update_node not found in the shipped source");
+  const deps = {
+    resolveManagerUpdateTarget: resolveTarget,
+    detectManagerDialect: async () => "v2",
+    crypto: { randomUUID: () => "u-1600" },
+    api: { clientId: "c-1600" },
+    legacyUpdateBody,
+    managerCall: async () => {
+      throw new Error("legacy path should not run");
+    },
+    managerV2,
+    isMethodNotAllowed,
+    assertBatchOk,
+    isManagerUnreachable,
+    isManagerRouteMissing,
+    dialectRetryTarget,
+    noteManagerDialectDowngrade: () => {},
+    reProbeManagerDialect: async () => "v2",
+    waitForUpdateResult: async () => ({
+      item: {
+        ui_id: "u-1600",
+        kind: "update",
+        result: "success",
+        status: { status_str: "success", completed: true, messages: [] },
+      },
+      status: { total_count: 1, done_count: 1, is_processing: false },
+    }),
+    classifyUpdateOutcome,
+    taskFailureReason,
+    isGenericManagerUpdateError,
+    readUpdateTraceback: async () => null,
+  };
+  const factory = new Function(
+    ...Object.keys(deps),
+    `const handlers = { ${method[0]} };\nreturn handlers.graph_update_node;`,
+  );
+  return factory(...Object.values(deps));
+}
+
+test("#1600 renamed installed directory resolves before Manager update enqueue", async () => {
+  const calls = [];
+  const update = buildGraphUpdateNode({
+    resolveTarget: async (requested) => resolveInstalledUpdateId(requested, INSTALLED),
+    managerV2: async (route, { body } = {}) => {
+      calls.push({ route, body });
+      if (route === "manager/queue/task") {
+        // This is the documented Manager failure when the directory spelling
+        // leaks through: active_nodes is keyed by MANAGER_ID, not DIRECTORY_ID.
+        if (body.params.node_name !== MANAGER_ID) {
+          throw new Error(`KeyError: '${body.params.node_name.toLowerCase()}'`);
+        }
+      }
+      return {};
+    },
+  });
+
+  const result = await update({ id: DIRECTORY_ID, version: "nightly" });
+  assert.equal(result.updated, true);
+  assert.equal(result.verified, true);
+  assert.equal(calls[0].route, "manager/queue/task");
+  assert.equal(calls[0].body.params.node_name, MANAGER_ID);
+  assert.equal(calls[0].body.params.node_ver, "nightly");
+});
+
+test("#1600 an unresolved installed name returns unmanaged_pack without queueing", async () => {
+  let mutations = 0;
+  const update = buildGraphUpdateNode({
+    resolveTarget: async () => null,
+    managerV2: async () => {
+      mutations += 1;
+      throw new Error("a mutation must not be submitted");
+    },
+  });
+
+  const result = await update({ id: "local-only-pack", version: "nightly" });
+  assert.equal(result.queued, false);
+  assert.equal(result.updated, false);
+  assert.equal(result.verified, false);
+  assert.equal(result.unmanaged_pack, true);
+  assert.match(result.note, /No update was queued/);
+  assert.equal(mutations, 0);
+});

--- a/browser_tests/unit/manager-update-traceback.test.mjs
+++ b/browser_tests/unit/manager-update-traceback.test.mjs
@@ -270,11 +270,15 @@ function buildGraphUpdateNode(deps) {
     /async graph_update_node\(\{ id, version, channel, mode \}\) \{[\s\S]*?\n  \},\r?\n/,
     "graph_update_node",
   );
+  const boundDeps = {
+    resolveManagerUpdateTarget: async (id) => id,
+    ...deps,
+  };
   const factory = new Function(
-    ...Object.keys(deps),
+    ...Object.keys(boundDeps),
     `const handlers = { ${methodSrc} };\nreturn handlers.graph_update_node;`,
   );
-  return factory(...Object.values(deps));
+  return factory(...Object.values(boundDeps));
 }
 
 test("#1320 graph_update_node CALLS readUpdateTraceback on a generic Manager failure", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -131,6 +131,7 @@ import {
   parseTaskHistoryItem,
   queueDrained,
   rebootCandidates,
+  resolveInstalledUpdateId,
   searchNodesVia,
   taskFailureReason,
   unlistedGitUrlAdvice,
@@ -7363,6 +7364,31 @@ async function managerGet(route, { signal } = {}) {
     if (!retry || retry === dialect) throw err;
     return retry === "legacy" ? managerCall(route, opts) : managerV2(route, opts);
   }
+}
+
+/** Resolve an update target against the installed-pack metadata before queueing
+ * a mutation. Manager's installed endpoint is keyed by the directory name,
+ * while its update queue expects the registry/aux identity used by active_nodes.
+ * A miss is returned to the caller as a no-queue unmanaged-pack result; a list
+ * read failure is kept distinct so it cannot be mistaken for an unmanaged pack.
+ */
+async function resolveManagerUpdateTarget(requestedId) {
+  const route = installedListRoute();
+  let installed;
+  try {
+    try {
+      installed = await managerGet(route);
+    } catch (err) {
+      if (!isManagerUnreachable(err)) throw err;
+      installed = await managerCall(route);
+    }
+  } catch (err) {
+    throw new Error(
+      `Could not resolve "${requestedId}" against ComfyUI-Manager's installed-pack list; ` +
+        `no update was queued. ${String(err?.message ?? err)}`,
+    );
+  }
+  return resolveInstalledUpdateId(requestedId, installed);
 }
 
 /** #426 — fetch the connected ComfyUI's full `/object_info` map (node CLASS →
@@ -22349,6 +22375,26 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!id) throw new Error("id (installed pack name/dir or registry id) is required");
     const sel = version === "nightly" ? "nightly" : "latest";
     let dialect = await detectManagerDialect();
+    const requestedId = id;
+    const managerId = await resolveManagerUpdateTarget(requestedId);
+    if (!managerId) {
+      return {
+        queued: false,
+        updated: false,
+        verified: false,
+        unmanaged_pack: true,
+        id: requestedId,
+        version: sel,
+        dialect,
+        note:
+          `Could not resolve "${requestedId}" to a ComfyUI-Manager-managed installed pack. ` +
+          "No update was queued. If this is a local Git checkout, pull it on the ComfyUI host; " +
+          "otherwise retry with the pack's registry id or repository URL.",
+      };
+    }
+    // Manager's queue indexes active_nodes by the resolved registry/aux id,
+    // not necessarily by the directory spelling supplied by the caller.
+    id = managerId;
     const ui_id = crypto.randomUUID();
     const client_id = api.clientId ?? api.initialClientId ?? "comfyui-mcp-panel";
     // #424: the absolute (no-/v2) legacy self-update route. Updating the

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -302,6 +302,39 @@ export function nodeInstalledMatches(idOrUrl, installed) {
   });
 }
 
+/**
+ * Resolve a caller's installed directory, registry id, or repository spelling
+ * to the key ComfyUI-Manager uses for `active_nodes` updates. The installed
+ * endpoint is keyed by the on-disk module name, but a registry install may
+ * carry a different `cnr_id`; Manager indexes that same pack by `cnr_id`.
+ * Unknown git packs use the repository basename from `aux_id` before their
+ * directory name.
+ * Returns null when the installed list does not identify a matching pack.
+ */
+export function resolveInstalledUpdateId(idOrUrl, installed) {
+  if (!idOrUrl) return null;
+  const nodes = Array.isArray(installed) && installed.every((n) => n && "module" in n)
+    ? installed
+    : parseInstalled(installed);
+  const wanted = String(idOrUrl).trim().toLowerCase();
+  const repoName = looksLikeGitUrl(idOrUrl) ? gitRepoName(idOrUrl).toLowerCase() : wanted;
+  const node = nodes.find((entry) => {
+    const candidates = [];
+    for (const value of [entry.module, entry.cnrId, entry.auxId]) {
+      if (!value) continue;
+      const normalized = String(value).trim().toLowerCase();
+      candidates.push(normalized, baseName(normalized));
+    }
+    return candidates.includes(wanted) || candidates.includes(repoName);
+  });
+  if (!node) return null;
+  return (
+    node.cnrId ||
+    (node.auxId ? baseName(node.auxId) : null) ||
+    (node.module && node.module !== "unknown" ? node.module : null)
+  );
+}
+
 /** Has the Manager queue POSITIVELY drained? True ONLY for a well-formed status
  *  object that says it stopped AND accounts for every task with coherent counts
  *  (is_processing===false, numeric done_count/total_count, done>=total). A null,


### PR DESCRIPTION
Fixes #1600\n\nResolve documented installed directory names to ComfyUI-Manager's active update identity before enqueueing an update. Unknown installed names return a structured unmanaged-pack result without submitting a mutation. Adds focused regression coverage for registry and unknown-git pack shapes.\n\nRecovery note: this branch was already implemented in the issue-number worktree before the agent quota wall; it was rebased onto current origin/main and is now posted for independent exact-head review.