### PR TITLE
fix(1634): installed nested models on Windows are not reported missing

### DIFF
--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -571,3 +571,73 @@ test("#745 gate-r2: comboOffers reproduces the interpreter EXACTLY over a measur
     );
   }
 });
+
+// ---------------------------------------------------------------------------
+// #1634 — Windows path separators. Nested model combos are enumerated by
+// folder_paths with os.path.relpath, so /object_info on Windows lists
+// `qwen-image\qwen_image_vae.safetensors` while the workflow stores
+// `qwen-image/qwen_image_vae.safetensors`. The live scan used to compare
+// those literally and emit missing_asset for a file the server has.
+// ---------------------------------------------------------------------------
+
+/** VAELoader.vae_name — reporter's nested model, listed the way Windows /object_info spells it. */
+const WIN_VAE = classBody("VAELoader", {
+  vae_name: [["qwen-image\\qwen_image_vae.safetensors"], {}],
+});
+
+test("#1634 Windows: a nested model listed with backslashes is not missing when the widget uses slashes", async () => {
+  const r = await scanComboAvailability(
+    [node(1, "VAELoader", [{ name: "vae_name", value: "qwen-image/qwen_image_vae.safetensors" }])],
+    async () => WIN_VAE,
+    { backslashIsSeparator: true },
+  );
+  assert.deepEqual(r.unavailable, [], "the server lists this file; only the separator spelling differs");
+  assert.deepEqual(r.unknown, []);
+});
+
+test("#1634 Windows: the reverse spelling (widget backslash, options slash) is the same file", async () => {
+  const body = classBody("VAELoader", {
+    vae_name: [["qwen-image/qwen_image_vae.safetensors"], {}],
+  });
+  const r = await scanComboAvailability(
+    [node(1, "VAELoader", [{ name: "vae_name", value: "qwen-image\\qwen_image_vae.safetensors" }])],
+    async () => body,
+    { backslashIsSeparator: true },
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.deepEqual(r.unknown, []);
+});
+
+test("#1634 POSIX: a backslash in the option is a literal character and does not match a slash path", async () => {
+  const r = await scanComboAvailability(
+    [node(1, "VAELoader", [{ name: "vae_name", value: "qwen-image/qwen_image_vae.safetensors" }])],
+    async () => WIN_VAE,
+    { backslashIsSeparator: false },
+  );
+  assert.equal(r.unavailable.length, 1, "on POSIX those are two different names");
+  assert.equal(r.unavailable[0].kind, "missing_asset");
+  assert.equal(r.unavailable[0].value, "qwen-image/qwen_image_vae.safetensors");
+});
+
+test("#1634 default is POSIX — never equate separators on a guess", async () => {
+  const r = await scanComboAvailability(
+    [node(1, "VAELoader", [{ name: "vae_name", value: "qwen-image/qwen_image_vae.safetensors" }])],
+    async () => WIN_VAE,
+  );
+  assert.equal(r.unavailable.length, 1);
+});
+
+test("#1634 Windows: a genuinely different nested model is still reported", async () => {
+  const r = await scanComboAvailability(
+    [node(1, "VAELoader", [{ name: "vae_name", value: "qwen-image/other.safetensors" }])],
+    async () => WIN_VAE,
+    { backslashIsSeparator: true },
+  );
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].kind, "missing_asset");
+});
+
+test("#1634 Windows separator equivalence never collapses string vs number", () => {
+  assert.equal(comboOffers([10], "10", { backslashIsSeparator: true }), false);
+  assert.equal(comboOffers(["10"], 10, { backslashIsSeparator: true }), false);
+});

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -218,10 +218,18 @@ const UNENUMERABLE_PREFIX =
  * stringifying combo values on queue (Comfy-Org/ComfyUI_frontend#14641) is exactly
  * how a canvas acquires one — which makes reporting it the useful behaviour, since
  * the queue would fail with `Value not in list` and nothing else would have warned.
+ *
+ * #1634 — when `backslashIsSeparator` is true (the server's OS is Windows), a `\`
+ * in a STRING option is a path separator, not a filename character. folder_paths
+ * lists nested models with `os.path.relpath` (backslashes on Windows) while
+ * workflows store the same file with forward slashes, and the loader resolves
+ * either spelling via `os.path`. Treating them as distinct is a false
+ * `missing_asset`. Default false (POSIX): a backslash is literal, so `a\b` is
+ * NOT `a/b`. Never applied to number/boolean — `"10"` still is not `10`.
  */
-export function comboOffers(options, value) {
+export function comboOffers(options, value, { backslashIsSeparator = false } = {}) {
   if (!Array.isArray(options)) return false;
-  return options.some((o) => serverConsidersEqual(o, value));
+  return options.some((o) => serverConsidersEqual(o, value, backslashIsSeparator));
 }
 
 /**
@@ -243,8 +251,16 @@ export function comboOffers(options, value) {
  * A bare `===` would call `true` unavailable on options `[1, 2]`, which the server
  * accepts. JS has one number type, so `10 == 10.0` needs nothing extra.
  */
-function serverConsidersEqual(option, value) {
+function serverConsidersEqual(option, value, backslashIsSeparator = false) {
   if (option === value) return true;
+  if (
+    backslashIsSeparator &&
+    typeof option === "string" &&
+    typeof value === "string" &&
+    option.replace(/\\/g, "/") === value.replace(/\\/g, "/")
+  ) {
+    return true;
+  }
   // bool <-> number only. Never string <-> anything.
   const a = typeof option === "boolean" ? (option ? 1 : 0) : option;
   const b = typeof value === "boolean" ? (value ? 1 : 0) : value;
@@ -444,7 +460,7 @@ export async function scanComboAvailability(
         continue;
       }
       if (value === "") continue;
-      if (comboOffers(options, value)) continue;
+      if (comboOffers(options, value, { backslashIsSeparator })) continue;
       // #1357 — before calling it missing, check whether this combo could have
       // listed it at all. Only a STRING can name a file, so a numeric value skips
       // straight to the verdict rather than through the annotated-filepath parser.


### PR DESCRIPTION
On Windows, \panel_get_errors\ reported installed nested models as missing when the workflow stored forward slashes and \/object_info\ listed the same path with backslashes.

The live combo scan already knew the server OS (\ackslashIsSeparator\) for LoadImage subfolder probes, but combo membership still compared strings literally. When the server is Windows, \\ and \/\ are now treated as the same separator. POSIX still treats a backslash as a literal filename character, so a genuine miss is not suppressed.

Fixes #1634
