### PR TITLE
fix(1582): panel_set_widget no longer re-waits on silent schema probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget no longer re-waits on silent `api.getNodeDefs()` / `GET /object_info` probes when a same-connection schema snapshot is already held (#1582)
+
 ## [0.15.43] - 2026-08-22
 
 ### Fixed

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -26,6 +26,7 @@ import {
   noBackendAnswerEstablished,
   snapshotAuthorizationNote,
 } from "../../web/js/lib/object-info-snapshot.js";
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
 import {
   TRANSPORT_OUTCOME,
   fetchWholeObjectInfo,
@@ -294,6 +295,49 @@ test("#1582 snapshot budget shortening keeps the reconnect and socket-down fence
   assert.equal(snap.isReusable({ epoch: 3, socketDown: false }), true, "the original connection is reusable");
 });
 
+test("#1582 the first silence does not skip — an answered error must still be able to refuse", () => {
+  const snap = createObjectInfoSnapshot();
+  stored(snap, SCHEMA, 3);
+  assert.equal(
+    snap.shouldSkipProbe({ epoch: 3, socketDown: false }),
+    false,
+    "holding a snapshot is not itself evidence the live routes went silent",
+  );
+});
+
+test("#1582 after silence on a held snapshot, later probes may skip", () => {
+  const snap = createObjectInfoSnapshot();
+  stored(snap, SCHEMA, 3);
+  snap.markProbesSilent();
+  assert.equal(snap.shouldSkipProbe({ epoch: 3, socketDown: false }), true);
+  const held = snap.authorize({ epoch: 3, socketDown: false, requireSilence: false });
+  assert.ok(held.defs, "skipping the probe still authorizes from the held map");
+  assert.ok(Object.prototype.hasOwnProperty.call(held.defs, "H3Keyframes"));
+});
+
+test("#1582 a skip still refuses a down socket, a reconnect, and an empty store", () => {
+  const empty = createObjectInfoSnapshot();
+  empty.markProbesSilent();
+  assert.equal(empty.shouldSkipProbe({ epoch: 3, socketDown: false }), false, "silence without a map licenses nothing");
+
+  const snap = createObjectInfoSnapshot();
+  stored(snap, SCHEMA, 3);
+  snap.markProbesSilent();
+  assert.equal(snap.shouldSkipProbe({ epoch: 3, socketDown: true }), false, "a down socket may be restarting");
+  assert.equal(snap.shouldSkipProbe({ epoch: 4, socketDown: false }), false, "a new epoch may define different types");
+  snap.clear();
+  assert.equal(snap.shouldSkipProbe({ epoch: 3, socketDown: false }), false, "clearing the snapshot clears the silence latch");
+});
+
+test("#1582 a later live record unlatches silence so the next write prefers a live schema", () => {
+  const snap = createObjectInfoSnapshot();
+  stored(snap, SCHEMA, 3);
+  snap.markProbesSilent();
+  assert.equal(snap.shouldSkipProbe({ epoch: 3, socketDown: false }), true);
+  stored(snap, SCHEMA, 3);
+  assert.equal(snap.shouldSkipProbe({ epoch: 3, socketDown: false }), false, "a live map means the routes answered again");
+});
+
 test("#1223 what is stored is DETACHED — registration hooks mutate defs in place", () => {
   // `registerNodesFromDefs` runs `beforeRegisterNodeDef` hooks that mutate the definitions
   // in place (Comfy's own upload hook adds an input the backend never declared). Retaining
@@ -407,6 +451,22 @@ test("#1223 a backend that ANSWERED is told apart from an empty snapshot in the 
   });
   assert.equal(defs, null);
   assert.match(reason, /ANSWERED/);
+});
+
+test("#1582 requireSilence false does not invent silence — it only skips the outcomes check", () => {
+  const snap = createObjectInfoSnapshot();
+  stored(snap, SCHEMA, 1);
+  const withoutOutcomes = snap.authorize({ epoch: 1, socketDown: false, requireSilence: false });
+  assert.ok(withoutOutcomes.defs, "a held same-connection map authorizes when silence is already known");
+  const answered = snap.authorize({
+    epoch: 1,
+    socketDown: false,
+    outcomes: [{ route: "http", kind: TRANSPORT_OUTCOME.THREW }],
+    requireSilence: false,
+  });
+  assert.ok(answered.defs, "an answered-error list must not veto a skip that already established silence earlier");
+  const reconnect = snap.authorize({ epoch: 2, socketDown: false, requireSilence: false });
+  assert.equal(reconnect.defs, null, "the reconnect fence is still load-bearing");
 });
 
 test("#1223 only a payload that could authorize anything is stored", () => {
@@ -676,6 +736,87 @@ test("#1582 SHIPPED: the reported case — a held snapshot shortens hung probes"
   assert.deepEqual(deadlines, [2000], "the reusable snapshot caps the serial oracle before the 15s stall");
   assert.match(o.readNote(), /did not answer/);
   assert.equal(o.readFailures().length, 2, "the fallback still discloses both silent routes");
+});
+
+test("#1582 SHIPPED: a second ordinary read does not re-wait on probes that already went silent", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  stored(snapshot, SCHEMA, 5);
+  let clientCalls = 0;
+  let httpCalls = 0;
+  const o = buildShippedOracle({
+    api: {
+      getNodeDefs: () => {
+        clientCalls += 1;
+        return new Promise(() => {});
+      },
+      fetchApi: () => {
+        httpCalls += 1;
+        return new Promise(() => {});
+      },
+    },
+    snapshot,
+    epoch: 5,
+    socketDown: false,
+  });
+  assert.ok(await o.getFreshObjectInfo(), "the first write still discovers silence");
+  assert.equal(clientCalls, 1);
+  assert.equal(httpCalls, 1);
+
+  const started = performance.now();
+  const defs = await o.getFreshObjectInfo();
+  const elapsed = performance.now() - started;
+  assert.ok(defs && Object.prototype.hasOwnProperty.call(defs, "H3Keyframes"), "the second write is still authorized");
+  assert.equal(clientCalls, 1, "getNodeDefs is not contacted again");
+  assert.equal(httpCalls, 1, "GET /object_info is not contacted again");
+  assert.ok(elapsed < 50, `second read stalled ${elapsed}ms on probes that were already silent`);
+  assert.match(o.readNote(), /#1582/);
+});
+
+test("#1582 SHIPPED set_widget: a second successful write does not re-wait on silent probes", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  stored(snapshot, SCHEMA, 5);
+  let clientCalls = 0;
+  const o = buildShippedOracle({
+    api: {
+      getNodeDefs: () => {
+        clientCalls += 1;
+        return new Promise(() => {});
+      },
+      fetchApi: () => new Promise(() => {}),
+    },
+    snapshot,
+    epoch: 5,
+  });
+  const ctor = function NodeCtor() {};
+  ctor.nodeData = { input: { required: {} } };
+  const node = {
+    id: 3,
+    type: "KSampler",
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    constructor: ctor,
+  };
+  const reg = { KSampler: ctor };
+  const hooks = { beforeChange() {}, afterChange() {}, setDirty() {} };
+  const opts = {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: o.getFreshObjectInfo,
+    schemaProvenance: () => "snapshot",
+    ...hooks,
+  };
+
+  const first = await runSetWidget(node, "steps", 30, opts);
+  assert.equal(first.set.value, 30, "the first write lands");
+  assert.equal(node.widgets[0].value, 30);
+  assert.equal(clientCalls, 1, "the first write still probes");
+
+  const started = performance.now();
+  const second = await runSetWidget(node, "steps", 40, opts);
+  const elapsed = performance.now() - started;
+  assert.equal(second.set.value, 40, "the second write lands");
+  assert.equal(node.widgets[0].value, 40);
+  assert.equal(clientCalls, 1, "the second write must not contact the silent routes again");
+  assert.ok(elapsed < 50, `second set_widget stalled ${elapsed}ms on probes that were already silent`);
 });
 
 test("#1582 the forced live reread does not take the snapshot shortcut", async () => {

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -449,6 +449,16 @@ test("#1582 wiring: a reusable snapshot shortens only the ordinary schema probe"
   );
   assert.match(
     body,
+    /objectInfoSnapshot\.shouldSkipProbe\(/,
+    "a later ordinary write must be able to skip probes that already went silent",
+  );
+  assert.match(
+    body,
+    /objectInfoSnapshot\.markProbesSilent\(/,
+    "the first silent fallback must latch so the next write can skip",
+  );
+  assert.match(
+    body,
     /objectInfoCache\.readFresh\([\s\S]{0,120}\{ reuseSnapshot: false \}/,
     "the forced live recovery must bypass that cap",
   );

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1057,11 +1057,14 @@ function noteOpenAttempt({ cmd, rid, requested, resolved, applied, error }) {
 const NODE_DEFS_FETCH_TIMEOUT_MS = 10000;
 
 /**
- * #1582 — when a same-connection whole-schema snapshot is already held, do not spend the
- * full serial 10s client share plus 5s raw-route share proving that both routes are silent.
- * Two seconds still leaves roughly four times the measured warm whole-schema read while
- * keeping the existing fail-closed outcome distinction: an answered bad response refuses,
- * and only actual silence licenses the last-observed snapshot.
+ * #1582 — when a same-connection whole-schema snapshot is already held, the FIRST silent
+ * call still has to discover that the live routes will not answer. Do not spend the full
+ * serial 10s client share plus 5s raw-route share on that discovery. Two seconds still
+ * leaves roughly four times the measured warm whole-schema read while keeping the existing
+ * fail-closed outcome distinction: an answered bad response refuses, and only actual
+ * silence licenses the last-observed snapshot. Once that silence is recorded, later
+ * ordinary writes skip the probes entirely (`shouldSkipProbe`) rather than paying this
+ * budget again on every widget edit.
  */
 const OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS = 2000;
 
@@ -15029,10 +15032,35 @@ const GRAPH_TOOL_EXECUTORS = {
       readObjectInfo: async (readThroughCache, { reuseSnapshot = true } = {}) => {
         // #1582 — a whole schema observed on this SAME backend connection makes silence
         // recoverable, but it must not suppress a route that answers with an unusable schema.
-        // When that snapshot is reusable, shorten the serial oracle budget so the panel spends
-        // at most two seconds discovering silence before the existing snapshot authorization.
-        // A forced reread keeps the normal budget: its purpose is to obtain a live answer for
-        // the blind-write recovery and it must not be shortened by the old snapshot.
+        // The FIRST silent call still probes, with the serial oracle capped at two seconds so
+        // the panel spends at most that discovering silence before the existing snapshot
+        // authorization. Once those routes have already gone silent on this connection,
+        // later ordinary writes skip them: repeating the wait is the recurrence (healthy
+        // graph reads, 1s getNodeDefs + 0.5s /object_info on every set_widget). A forced
+        // reread keeps the normal budget and never skips: its purpose is to obtain a live
+        // answer for the blind-write recovery.
+        const snapshotFence = {
+          epoch: backendReconnectEpoch,
+          socketDown: comfyBackendIsDown(),
+        };
+        if (
+          reuseSnapshot &&
+          typeof objectInfoSnapshot.shouldSkipProbe === "function" &&
+          objectInfoSnapshot.shouldSkipProbe(snapshotFence)
+        ) {
+          const held = objectInfoSnapshot.authorize({
+            epoch: snapshotFence.epoch,
+            socketDown: snapshotFence.socketDown,
+            requireSilence: false,
+          });
+          if (held.defs) {
+            setWidgetSchemaFromSnapshot =
+              " This call did not wait on live schema probes again (#1582).";
+            setWidgetSchemaProvenance = () => "snapshot";
+            return held.defs;
+          }
+          snapshotIneligibility = held.reason;
+        }
         // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
         // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
         // Still the WHOLE payload, so no question this fence asks changes scope —
@@ -15144,6 +15172,11 @@ const GRAPH_TOOL_EXECUTORS = {
           // not told that cannot tell this apart from a fully live authorization.
           setWidgetSchemaFromSnapshot = objectInfoOracleFailureNote(oracleFailures);
           setWidgetSchemaProvenance = () => "snapshot";
+          // #1582 — remember the silence so the NEXT ordinary write does not re-wait on
+          // the same hung getNodeDefs /object_info pair. A later live `record` clears it.
+          if (typeof objectInfoSnapshot.markProbesSilent === "function") {
+            objectInfoSnapshot.markProbesSilent();
+          }
           // NOT recorded into the ever-seen history: it is not a new observation of the
           // backend, it is the old one being re-read. Recording it would let a snapshot
           // keep its own types "ever seen" after the backend stopped defining them.

--- a/web/js/lib/object-info-snapshot.js
+++ b/web/js/lib/object-info-snapshot.js
@@ -134,6 +134,14 @@ export function noBackendAnswerEstablished(outcomes) {
 export function createObjectInfoSnapshot() {
   let defs = null;
   let epoch = null;
+  // #1582 — have the live whole-map routes already gone silent on THIS connection,
+  // after a snapshot was held? The first silent call still has to probe: that is how
+  // an answered error keeps refusing, and how a healthy backend still wins. Once
+  // silence is established, repeating the same 1s+0.5s wait on every widget write is
+  // the recurrence — graph reads stay healthy while set_widget stalls on routes that
+  // will not answer. Cleared by `record` (a live map means the routes work again)
+  // and by `clear` (the connection is no longer the one that went quiet).
+  let probesSilent = false;
 
   return {
     /**
@@ -200,6 +208,9 @@ export function createObjectInfoSnapshot() {
       // not a hole in the suite, and it is recorded here so the next run does not re-chase
       // it. `currentEpoch` is written because it is the one `authorize` compares against.
       epoch = currentEpoch;
+      // A live observation means the whole-map routes answered. The next widget write
+      // must be allowed to prefer that live path rather than inheriting a prior silence.
+      probesSilent = false;
       return true;
     },
 
@@ -209,9 +220,14 @@ export function createObjectInfoSnapshot() {
      * The reason is for the refusal message, so it names the condition that failed rather
      * than the general shape of the rule — a caller told "no snapshot" when the real cause
      * was a reconnect goes looking in the wrong place (#982's lesson).
+     *
+     * `requireSilence` defaults true: the first fallback still needs the transports to
+     * establish that the backend never answered. Pass `false` only after
+     * `shouldSkipProbe` has already recorded that silence on this connection (#1582), so
+     * a later write can reuse the held map without minting fake outcomes.
      */
-    authorize({ epoch: currentEpoch, socketDown, outcomes } = {}) {
-      if (!noBackendAnswerEstablished(outcomes)) {
+    authorize({ epoch: currentEpoch, socketDown, outcomes, requireSilence = true } = {}) {
+      if (requireSilence !== false && !noBackendAnswerEstablished(outcomes)) {
         return {
           defs: null,
           reason:
@@ -245,12 +261,14 @@ export function createObjectInfoSnapshot() {
     },
 
     /**
-     * Is this snapshot current enough to shorten the next probe budget?
+     * Is this snapshot current enough to shorten the next probe budget, or to skip a
+     * later probe after silence has already been established?
      *
-     * This does not authorize anything and does not expose the names-only map. The actual
+     * This does not authorize anything and does not expose the names-only map. The first
      * `authorize` call still requires the transport outcome to establish silence, preserving
      * the distinction between a busy backend and one that answered with an unusable schema.
-     * The same socket/epoch fence is used so a reconnect cannot inherit the shorter budget.
+     * The same socket/epoch fence is used so a reconnect cannot inherit the shorter budget
+     * or the skip.
      */
     isReusable({ epoch: currentEpoch, socketDown } = {}) {
       return (
@@ -261,10 +279,31 @@ export function createObjectInfoSnapshot() {
       );
     },
 
+    /**
+     * Remember that the live whole-map routes went silent while this snapshot was held.
+     *
+     * No-op when nothing is held: silence without a map must not license a later skip.
+     */
+    markProbesSilent() {
+      if (defs !== null) probesSilent = true;
+    },
+
+    /**
+     * May the next ordinary set_widget skip live whole-map probes?
+     *
+     * True only after `markProbesSilent` on a still-reusable snapshot. The first silent
+     * call still probes so an answered error can refuse; a reconnect, a down socket, or a
+     * later live `record` all return false.
+     */
+    shouldSkipProbe({ epoch: currentEpoch, socketDown } = {}) {
+      return probesSilent === true && this.isReusable({ epoch: currentEpoch, socketDown });
+    },
+
     /** Drop it — for anything that knows, or merely suspects, the schema moved. */
     clear() {
       defs = null;
       epoch = null;
+      probesSilent = false;
     },
 
     /** Test/diagnostic view. Never used to make a decision. */


### PR DESCRIPTION
Fixes #1582

## What the user sees

Repeated successful `panel_set_widget` calls no longer stall on hung `api.getNodeDefs()` (1s) and `GET /object_info` (0.5s) after a same-connection schema snapshot has already authorized from last-observed silence. The write still lands; it just stops re-waiting for routes that already went quiet.

## Why this recurred

PR #1604 (`630eabd2`) shortened the first silent probe to 2s when a snapshot was held. That stopped the original 15s serial wait, but every later widget write still contacted both silent routes, then authorized from `last-observed`. On panel 0.15.43 that is exactly the reopened report: graph reads stay healthy, each `set_widget` still waits 1000ms + 500ms.

## Fix

- The first silent call still probes (capped at 2s) so an answered error can refuse.
- Once silence is established against a reusable snapshot, later ordinary reads skip the live whole-map probes and reuse the held map.
- A live `record`, a reconnect, or a down socket unlatches the skip. Forced live rereads never skip.

## Tests

- Shipped `readObjectInfo` + `runSetWidget`: second write after silent probes does not contact `getNodeDefs` / `/object_info` again.
- Skip still refuses a down socket, a reconnect, and an empty store; a later live record prefers a live schema.
