### PR TITLE
fix(1636): outline reporting root after reconnect lets enter_subgraph use the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- after a reconnect, a graph outline that reports viewing.scope root makes the immediately following enter/mutation use root, instead of rejecting a root node as "currently inside a subgraph" (#1636)
 - panel_set_widget no longer re-waits on silent `api.getNodeDefs()` / `GET /object_info` probes when a same-connection schema snapshot is already held (#1582)
 
 ## [0.15.43] - 2026-08-22

--- a/browser_tests/unit/canvas-graph-divergence.test.mjs
+++ b/browser_tests/unit/canvas-graph-divergence.test.mjs
@@ -56,6 +56,7 @@ import {
   rememberAutoLayoutScope,
   layoutScopeFingerprint,
 } from "../../web/js/lib/auto-layout-scope.js";
+import { applyReconnectScopeFence } from "../../web/js/lib/reconnect-scope-fence.js";
 import {
   graphBindingRefusalMessage,
   graphCommandBindingBar,
@@ -107,10 +108,11 @@ function buildGetGraphCtx(app) {
     "app",
     "window",
     "resolveScope",
+    "applyReconnectScopeFence",
     "rememberAutoLayoutScope",
     "layoutScopeFingerprint",
     `${source}\nreturn getGraphCtx;`,
-  )(app, { LiteGraph: {} }, resolveScope, rememberAutoLayoutScope, layoutScopeFingerprint);
+  )(app, { LiteGraph: {} }, resolveScope, applyReconnectScopeFence, rememberAutoLayoutScope, layoutScopeFingerprint);
 }
 
 function nodes(n, offset = 0) {

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -241,6 +241,8 @@ function buildEnterSubgraph(doubles) {
     "describeActiveGraph",
     "assertGraphBoundToActiveWorkflow",
     "coerceMessageText",
+    "pinReconnectScope",
+    "releaseReconnectScopePin",
     `return (${body});`,
   );
   return factory(
@@ -250,6 +252,8 @@ function buildEnterSubgraph(doubles) {
     doubles.describeActiveGraph,
     doubles.assertGraphBoundToActiveWorkflow,
     doubles.coerceMessageText ?? ((v) => String(v)),
+    doubles.pinReconnectScope ?? (() => {}),
+    doubles.releaseReconnectScopePin ?? (() => {}),
   );
 }
 
@@ -443,6 +447,8 @@ function buildExitSubgraph(doubles) {
     "clearAutoLayoutScope",
     "rememberAutoLayoutScope",
     "layoutScopeFingerprint",
+    "pinReconnectScope",
+    "releaseReconnectScopePin",
     `return (${body});`,
   );
   return factory(
@@ -455,6 +461,8 @@ function buildExitSubgraph(doubles) {
     doubles.clearAutoLayoutScope ?? (() => {}),
     doubles.rememberAutoLayoutScope ?? (() => {}),
     doubles.layoutScopeFingerprint ?? (() => ({ scope: "root" })),
+    doubles.pinReconnectScope ?? (() => {}),
+    doubles.releaseReconnectScopePin ?? (() => {}),
   );
 }
 

--- a/browser_tests/unit/outline-mutation-scope-reconnect.test.mjs
+++ b/browser_tests/unit/outline-mutation-scope-reconnect.test.mjs
@@ -1,0 +1,402 @@
+// #1636 — Graph outline scope can disagree with mutation scope after reconnect.
+//
+// Reporter: panel_graph_outline returned viewing.scope="root", then the
+// immediately following panel_enter_subgraph({node_id:1067}) failed with
+// "Node 1067 is on the ROOT graph, but you are currently inside a subgraph."
+// No user canvas change. panel_exit_subgraph then panel_enter_subgraph recovered.
+//
+// Cause: a read during post-reconnect restore sees the canvas at root and
+// publishes that as viewing; the frontend then restores the pre-reconnect
+// subgraph; enter_subgraph searches that subgraph. Outline and mutation must
+// share one fenced scope so a root outline makes the next enter use root.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  resolveScope,
+  describeScope,
+  findSubgraphOwner,
+  isSubgraphInRoot,
+  resolveRailNode,
+} from "../../web/js/lib/subgraph-scope.js";
+import { describeMissingNode } from "../../web/js/lib/node-scope-locator.js";
+import { canonicalNodeId } from "../../web/js/lib/node-id.js";
+import { withWorkflowUuid } from "../../web/js/lib/graph-view-identity.js";
+import {
+  rememberAutoLayoutScope,
+  clearAutoLayoutScope,
+  layoutScopeFingerprint,
+} from "../../web/js/lib/auto-layout-scope.js";
+import {
+  applyReconnectScopeFence,
+  noteReconnectScopeFence,
+  pinReconnectScope,
+  releaseReconnectScopePin,
+  disarmReconnectScopeFence,
+  peekReconnectScopeFence,
+} from "../../web/js/lib/reconnect-scope-fence.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const PANEL_SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function panelFunctionStart(src, name, from = 0) {
+  const bare = src.indexOf(`function ${name}(`, from);
+  assert.notEqual(bare, -1, `could not locate ${name} in panel source`);
+  const asyncAt = bare - "async ".length;
+  return asyncAt >= 0 && src.startsWith("async ", asyncAt) ? asyncAt : bare;
+}
+
+function panelFunctionSource(src, name, nextName) {
+  const start = panelFunctionStart(src, name);
+  const end = panelFunctionStart(src, nextName, start + 1);
+  assert.ok(end > start, `could not locate ${nextName} after ${name}`);
+  return src.slice(start, end);
+}
+
+function makeGraph(nodes) {
+  const g = { _nodes: nodes };
+  g.getNodeById = (id) => nodes.find((n) => n.id === id) ?? null;
+  return g;
+}
+
+function makeSubgraph({ name = "inner", nodes = [] } = {}) {
+  const sub = {
+    name,
+    _nodes: nodes,
+    inputNode: { id: -10 },
+    outputNode: { id: -20 },
+    getNodeById: (id) => nodes.find((n) => n.id === id) ?? null,
+  };
+  sub.serialize = () => ({ nodes: nodes.map((n) => ({ ...n })) });
+  return sub;
+}
+
+function makeApp({ rootGraph, canvasGraph }) {
+  const canvas = {
+    graph: canvasGraph ?? rootGraph,
+    setGraph(g) {
+      this.graph = g;
+    },
+    setDirty() {},
+  };
+  return { graph: rootGraph, canvas };
+}
+
+test.beforeEach(() => {
+  disarmReconnectScopeFence();
+  clearAutoLayoutScope();
+});
+
+// ---------------------------------------------------------------------------
+// Pure fence
+// ---------------------------------------------------------------------------
+
+test("#1636 a reconnect drops the stored pin so the next observation re-pins", () => {
+  noteReconnectScopeFence();
+  pinReconnectScope("subgraph");
+  assert.equal(peekReconnectScopeFence().viewing, "subgraph");
+  noteReconnectScopeFence();
+  assert.deepEqual(peekReconnectScopeFence(), { armed: true, viewing: null });
+});
+
+test("#1636 first observation after reconnect pins whatever resolveScope reported", () => {
+  noteReconnectScopeFence();
+  const root = makeGraph([{ id: 1 }]);
+  const live = { graph: root, rootGraph: root, scope: "root", owner: null, stale: false, diverged: false };
+  const out = applyReconnectScopeFence(live);
+  assert.equal(out, live);
+  assert.equal(peekReconnectScopeFence().viewing, "root");
+});
+
+test("#1636 a root pin holds when the live canvas later sits in a subgraph", () => {
+  noteReconnectScopeFence();
+  const inner = makeSubgraph({ nodes: [{ id: 2 }] });
+  const owner = { id: 1067, type: "Graph", subgraph: inner, title: "Detail" };
+  const root = makeGraph([owner]);
+  applyReconnectScopeFence({
+    graph: root,
+    rootGraph: root,
+    scope: "root",
+    owner: null,
+    stale: false,
+    diverged: false,
+  });
+  const liveSub = {
+    graph: inner,
+    rootGraph: root,
+    scope: "subgraph",
+    owner: { id: 1067, title: "Detail" },
+    stale: false,
+    diverged: false,
+  };
+  const held = applyReconnectScopeFence(liveSub);
+  assert.equal(held.scope, "root", "mutations must keep the graph the outline promised");
+  assert.equal(held.graph, root);
+  assert.equal(held.stale, true, "the caller rebinds the canvas to match");
+  assert.equal(held.diverged, false, "this is not a #604 content-bearing ghost");
+});
+
+test("#1636 a subgraph pin does not yank the canvas back into a subgraph", () => {
+  noteReconnectScopeFence();
+  const inner = makeSubgraph({ nodes: [{ id: 2 }] });
+  const root = makeGraph([{ id: 1067, subgraph: inner }]);
+  applyReconnectScopeFence({
+    graph: inner,
+    rootGraph: root,
+    scope: "subgraph",
+    owner: { id: 1067 },
+    stale: false,
+    diverged: false,
+  });
+  const liveRoot = {
+    graph: root,
+    rootGraph: root,
+    scope: "root",
+    owner: null,
+    stale: false,
+    diverged: false,
+  };
+  const out = applyReconnectScopeFence(liveRoot);
+  assert.equal(out, liveRoot, "a breadcrumb exit stays at root");
+});
+
+test("#1636 explicit enter is allowed to move a root pin into a subgraph", () => {
+  noteReconnectScopeFence();
+  pinReconnectScope("root");
+  pinReconnectScope("subgraph");
+  const inner = makeSubgraph({ nodes: [{ id: 2 }] });
+  const root = makeGraph([{ id: 1067, subgraph: inner }]);
+  const liveSub = {
+    graph: inner,
+    rootGraph: root,
+    scope: "subgraph",
+    owner: { id: 1067 },
+    stale: false,
+    diverged: false,
+  };
+  const out = applyReconnectScopeFence(liveSub);
+  assert.equal(out, liveSub, "panel_enter_subgraph must not be rebounded to root");
+});
+
+test("#1636 the fence is inert until a reconnect arms it", () => {
+  const inner = makeSubgraph({ nodes: [{ id: 2 }] });
+  const root = makeGraph([{ id: 1067, subgraph: inner }]);
+  pinReconnectScope("root"); // no-op — not armed
+  const liveSub = {
+    graph: inner,
+    rootGraph: root,
+    scope: "subgraph",
+    owner: { id: 1067 },
+    stale: false,
+    diverged: false,
+  };
+  assert.equal(applyReconnectScopeFence(liveSub), liveSub);
+});
+
+test("#1636 a diverged live scope is not rewritten into a stale rebind", () => {
+  noteReconnectScopeFence();
+  pinReconnectScope("root");
+  const root = makeGraph([]);
+  const ghost = makeSubgraph({ nodes: [{ id: 1 }, { id: 2 }] });
+  const diverged = {
+    graph: ghost,
+    rootGraph: root,
+    scope: "root",
+    owner: null,
+    stale: false,
+    diverged: true,
+    divergedKind: "subgraph",
+  };
+  const out = applyReconnectScopeFence(diverged);
+  assert.equal(out, diverged, "#604: a content-bearing ghost must still refuse, never repaint");
+});
+
+// ---------------------------------------------------------------------------
+// Shipped getGraphCtx + describeActiveGraph + resolveNode
+// ---------------------------------------------------------------------------
+
+function buildShippedScopeTools(app) {
+  const getGraphCtx = new Function(
+    "app",
+    "window",
+    "resolveScope",
+    "applyReconnectScopeFence",
+    "rememberAutoLayoutScope",
+    "layoutScopeFingerprint",
+    `${panelFunctionSource(PANEL_SRC, "getGraphCtx", "workflowOwnsRootUuidTag")}\nreturn getGraphCtx;`,
+  )(
+    app,
+    { LiteGraph: {} },
+    resolveScope,
+    applyReconnectScopeFence,
+    rememberAutoLayoutScope,
+    layoutScopeFingerprint,
+  );
+
+  const describeActiveGraph = new Function(
+    "app",
+    "activeWorkflowRef",
+    "workflowObjectUuid",
+    "workflowStableUuid",
+    "withWorkflowUuid",
+    "findSubgraphOwner",
+    "isSubgraphInRoot",
+    `${panelFunctionSource(PANEL_SRC, "describeActiveGraph", "captureGraphSnapshot")}\nreturn describeActiveGraph;`,
+  )(app, () => null, () => "", () => "", withWorkflowUuid, findSubgraphOwner, isSubgraphInRoot);
+
+  const resolveNode = new Function(
+    "canonicalNodeId",
+    "resolveRailNode",
+    "getGraphCtx",
+    "describeMissingNode",
+    `${panelFunctionSource(PANEL_SRC, "resolveNode", "normalizeLegacyNodeId")}\nreturn resolveNode;`,
+  )(canonicalNodeId, resolveRailNode, getGraphCtx, describeMissingNode);
+
+  return { getGraphCtx, describeActiveGraph, resolveNode };
+}
+
+function reporterGraph() {
+  const inner = makeSubgraph({ name: "Detail", nodes: [{ id: 10, type: "CLIPTextEncode" }] });
+  const owner = { id: 1067, type: "Graph", title: "Detail", subgraph: inner };
+  const root = makeGraph([owner, { id: 1, type: "KSampler" }]);
+  return { inner, owner, root };
+}
+
+test("#1636 outline reporting root makes the immediate enter search root (reporter case)", () => {
+  const { inner, owner, root } = reporterGraph();
+  const app = makeApp({ rootGraph: root, canvasGraph: root });
+  const { getGraphCtx, describeActiveGraph, resolveNode } = buildShippedScopeTools(app);
+
+  noteReconnectScopeFence();
+
+  const outlineCtx = getGraphCtx();
+  const viewing = describeActiveGraph(outlineCtx.graph);
+  assert.equal(viewing.scope, "root", "outline published root");
+  assert.equal(outlineCtx.graph, root);
+
+  // Frontend restore: the pre-reconnect subgraph is back on the canvas.
+  // No user action — this is what "immediately following" looks like.
+  app.canvas.graph = inner;
+  assert.equal(resolveScope(app).scope, "subgraph", "the live canvas DID move into the subgraph");
+
+  const enterCtx = getGraphCtx();
+  assert.equal(describeActiveGraph(enterCtx.graph).scope, "root", "viewing stays at the outlined scope");
+  assert.equal(enterCtx.graph, root, "enter must search the root, not the restored subgraph");
+  const node = resolveNode(enterCtx.graph, 1067);
+  assert.equal(node, owner, "panel_enter_subgraph({node_id:1067}) resolves the root host");
+  assert.equal(app.canvas.graph, root, "the physical view is rebound to match");
+});
+
+test("#1636 without a reconnect the live subgraph is still the mutation target", () => {
+  const { inner, root } = reporterGraph();
+  const app = makeApp({ rootGraph: root, canvasGraph: inner });
+  const { getGraphCtx, describeActiveGraph, resolveNode } = buildShippedScopeTools(app);
+
+  const ctx = getGraphCtx();
+  assert.equal(describeActiveGraph(ctx.graph).scope, "subgraph");
+  assert.equal(ctx.graph, inner);
+  assert.throws(
+    () => resolveNode(ctx.graph, 1067),
+    /you are currently inside a subgraph/,
+    "a genuine subgraph view still gets the EXIT remedy",
+  );
+});
+
+test("#1636 explicit enter after a root pin is allowed to target the subgraph", () => {
+  const { inner, owner, root } = reporterGraph();
+  const app = makeApp({ rootGraph: root, canvasGraph: root });
+  const { getGraphCtx, describeActiveGraph, resolveNode } = buildShippedScopeTools(app);
+
+  noteReconnectScopeFence();
+  const outlineCtx = getGraphCtx();
+  assert.equal(describeActiveGraph(outlineCtx.graph).scope, "root");
+  const host = resolveNode(outlineCtx.graph, 1067);
+  assert.equal(host, owner);
+
+  app.canvas.setGraph(inner);
+  pinReconnectScope("subgraph");
+  const inside = getGraphCtx();
+  assert.equal(inside.graph, inner);
+  assert.equal(describeActiveGraph(inside.graph).scope, "subgraph");
+});
+
+test("#1636 a failed enter releases the pin so the next observation re-pins", () => {
+  noteReconnectScopeFence();
+  pinReconnectScope("root");
+  releaseReconnectScopePin();
+  assert.equal(peekReconnectScopeFence().viewing, null);
+  const inner = makeSubgraph({ nodes: [{ id: 2 }] });
+  const root = makeGraph([{ id: 1067, subgraph: inner }]);
+  const liveSub = {
+    graph: inner,
+    rootGraph: root,
+    scope: "subgraph",
+    owner: { id: 1067 },
+    stale: false,
+    diverged: false,
+  };
+  assert.equal(applyReconnectScopeFence(liveSub), liveSub);
+});
+
+// ---------------------------------------------------------------------------
+// Panel wiring — deleting the fence from getGraphCtx / reconnect / enter-exit
+// fails these, so a helper-only green cannot hide an unwired panel.
+// ---------------------------------------------------------------------------
+
+test("#1636 wiring: getGraphCtx runs the fence on the same resolveScope result writes use", () => {
+  const body = panelFunctionSource(PANEL_SRC, "getGraphCtx", "workflowOwnsRootUuidTag");
+  assert.match(body, /applyReconnectScopeFence\(resolveScope\(app\)\)/);
+});
+
+test("#1636 wiring: reconnect clears the stored subgraph owner and arms the fence", () => {
+  const start = PANEL_SRC.indexOf('api.addEventListener("reconnected"');
+  assert.notEqual(start, -1);
+  const end = PANEL_SRC.indexOf("});", PANEL_SRC.indexOf("void healStaleBundleIfNeeded();", start));
+  const block = PANEL_SRC.slice(start, end);
+  assert.match(block, /clearAutoLayoutScope\(\)/, "the remembered subgraph owner must not survive reconnect");
+  assert.match(block, /noteReconnectScopeFence\(\)/, "the viewing/mutation pin is reset for this epoch");
+});
+
+test("#1636 wiring: enter pins subgraph before any post-nav getGraphCtx, exit pins the parent", () => {
+  const enterStart = PANEL_SRC.indexOf("async graph_enter_subgraph({ node_id })");
+  const enterEnd = PANEL_SRC.indexOf("async graph_exit_subgraph()", enterStart);
+  const enter = PANEL_SRC.slice(enterStart, enterEnd);
+  const pinAt = enter.indexOf('pinReconnectScope("subgraph")');
+  const openAt = enter.indexOf("canvas.openSubgraph");
+  const confirmAt = enter.indexOf("confirmCanvasNavigation");
+  assert.ok(pinAt > openAt && pinAt < confirmAt, "pin before the receipt's getGraphCtx or hold-root undoes the enter");
+  assert.match(enter, /releaseReconnectScopePin\(\)/, "a never-landed enter must not leave a subgraph pin");
+
+  const exitStart = PANEL_SRC.indexOf("async graph_exit_subgraph()");
+  const exitEnd = PANEL_SRC.indexOf("graph_move_rail({ rail, pos })", exitStart);
+  const exit = PANEL_SRC.slice(exitStart, exitEnd);
+  assert.match(exit, /pinReconnectScope\("root"\)/);
+  assert.match(exit, /pinReconnectScope\("subgraph"\)/);
+});
+
+test("#1636 describeScope of a fenced hold-root is root, matching the mutation graph", () => {
+  noteReconnectScopeFence();
+  const inner = makeSubgraph({ nodes: [{ id: 2 }] });
+  const root = makeGraph([{ id: 1067, subgraph: inner }]);
+  applyReconnectScopeFence({
+    graph: root,
+    rootGraph: root,
+    scope: "root",
+    owner: null,
+    stale: false,
+    diverged: false,
+  });
+  const held = applyReconnectScopeFence({
+    graph: inner,
+    rootGraph: root,
+    scope: "subgraph",
+    owner: { id: 1067, title: "Detail" },
+    stale: false,
+    diverged: false,
+  });
+  assert.deepEqual(describeScope(held), { scope: "root" });
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -341,6 +341,12 @@ import {
   clearAutoLayoutScope,
   layoutScopeFingerprint,
 } from "./lib/auto-layout-scope.js";
+import {
+  applyReconnectScopeFence,
+  noteReconnectScopeFence,
+  pinReconnectScope,
+  releaseReconnectScopePin,
+} from "./lib/reconnect-scope-fence.js";
 import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "./lib/set-widget.js";
 import { declaredInputNames, runRemoveWidget } from "./lib/remove-widget.js";
 import {
@@ -2352,6 +2358,9 @@ function setupListeners() {
       // The watch runs only the same safe heals a graph command runs lazily;
       // it never repaints the canvas from serialized state (#604).
       kickPostReconnectSettleWatch(backendReconnectEpoch);
+      // #1636: drop the remembered subgraph owner and re-pin viewing/mutation scope.
+      clearAutoLayoutScope();
+      noteReconnectScopeFence();
       // #584: this reconnect can ALSO be a backend restart that swapped the
       // pack on disk (a panel update + panel_restart_comfyui / Manager reboot)
       // under the live tab. The running bundle is then older than the
@@ -8168,7 +8177,7 @@ function getGraphCtx() {
   if (!app || !app.graph || !LG) {
     throw new Error("ComfyUI graph is not available (app.graph / LiteGraph missing)");
   }
-  const scope = resolveScope(app);
+  const scope = applyReconnectScopeFence(resolveScope(app));
   // #604 — CANVAS/ROOT DIVERGENCE. The canvas holds a graph the live root neither
   // owns nor registers, and that graph is NOT provably content-free. Reported after
   // a backend restart with no page reload: `app.graph` was empty while the canvas
@@ -21829,6 +21838,9 @@ const GRAPH_TOOL_EXECUTORS = {
       throw new Error("subgraph navigation unavailable on this frontend");
     }
     canvas.openSubgraph(sub, node);
+    // Pin BEFORE the receipt's getGraphCtx (assertBound). A root pin still
+    // armed from outline would otherwise hold-root and undo this enter (#1636).
+    pinReconnectScope("subgraph");
     canvas.setDirty?.(true, true);
     const receipt = await confirmCanvasNavigation({
       readCanvasGraph: () => comfyApp?.canvas?.graph ?? null,
@@ -21849,6 +21861,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // — a landing displaced between two polls is invisible to a sampler
       // (codex gate r5). Say what is known (no observation) and make the next
       // step a scope READ, not a blind retry of a possibly-applied navigation.
+      releaseReconnectScopePin();
       throw new Error(
         `panel_enter_subgraph could not confirm that the canvas moved into node ${node.id}'s ` +
           `subgraph: no observation ever saw the canvas inside it. The navigation may not have ` +
@@ -21952,6 +21965,19 @@ const GRAPH_TOOL_EXECUTORS = {
     const parentGraph = findSubgraphOwner(rootGraph, graph)?.parentGraph ?? graph.rootGraph ?? rootGraph;
     canvas.setGraph(parentGraph);
     canvas.setDirty?.(true, true);
+    // #1328 — an explicit exit is the one root observation that MAY drop the
+    // captured subgraph identity. Escape (canvas jumped to root without this
+    // call) must keep it so auto-layout apply can still find the subgraph.
+    // #1636 — pin BEFORE the receipt's getGraphCtx, same as enter: a root pin
+    // still armed from outline would hold-root and undo an exit to a parent
+    // subgraph.
+    if (parentGraph === rootGraph) {
+      clearAutoLayoutScope();
+      pinReconnectScope("root");
+    } else {
+      rememberAutoLayoutScope(layoutScopeFingerprint(parentGraph, rootGraph));
+      pinReconnectScope("subgraph");
+    }
     // #619: same post-navigation receipt as graph_enter_subgraph — a bare setGraph
     // that did not observably land must not report a scope the canvas is not in.
     const receipt = await confirmCanvasNavigation({
@@ -21969,6 +21995,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // — a landing displaced between two polls is invisible to a sampler
       // (codex gate r5). Say what is known (no observation) and make the next
       // step a scope READ, not a blind retry of a possibly-applied navigation.
+      releaseReconnectScopePin();
       throw new Error(
         `panel_exit_subgraph could not confirm that the canvas returned to the parent graph: no ` +
           `observation ever saw the canvas there. The navigation may not have taken effect — or ` +
@@ -21977,11 +22004,6 @@ const GRAPH_TOOL_EXECUTORS = {
           `subgraph, retry, or leave it on the ComfyUI canvas (its breadcrumb, or double-click out).`,
       );
     }
-    // #1328 — an explicit exit is the one root observation that MAY drop the
-    // captured subgraph identity. Escape (canvas jumped to root without this
-    // call) must keep it so auto-layout apply can still find the subgraph.
-    if (parentGraph === rootGraph) clearAutoLayoutScope();
-    else rememberAutoLayoutScope(layoutScopeFingerprint(parentGraph, rootGraph));
     let viewing = null;
     try {
       viewing = describeActiveGraph(getGraphCtx().graph);

--- a/web/js/lib/reconnect-scope-fence.js
+++ b/web/js/lib/reconnect-scope-fence.js
@@ -1,0 +1,80 @@
+// #1636 — after a reconnect, panel_graph_outline.viewing and the graph a
+// mutation/enter searches can disagree: a read during restore sees the canvas
+// at root, then the frontend puts the pre-reconnect subgraph back, and the
+// immediately following enter_subgraph searches that subgraph ("currently
+// inside a subgraph") even though the outline just promised root.
+//
+// One fence, armed on reconnect. The first resolved scope this epoch pins.
+// Explicit enter/exit update it. A canvas that later drifts into a subgraph
+// without panel_enter_subgraph cannot change a root pin — the caller rebinds
+// so the next mutation uses the same graph the outline reported.
+//
+// Hold-root is the only direction: a subgraph pin never yanks the canvas back
+// into a subgraph (that is auto-layout's remembered identity, a different job,
+// and it would fight a breadcrumb exit). Content-bearing unreachable canvases
+// still arrive as resolveScope's diverged verdict — this fence does not arm
+// the #604 repaint.
+
+let armed = false;
+let viewing = null; // "root" | "subgraph" | null (unpinned this epoch)
+
+/** Arm a fresh epoch: drop the stored pin (and the caller drops auto-layout's
+ *  remembered subgraph owner). Next resolveScope observation pins. */
+export function noteReconnectScopeFence() {
+  armed = true;
+  viewing = null;
+}
+
+export function peekReconnectScopeFence() {
+  return { armed, viewing };
+}
+
+/** Explicit navigation (enter/exit) is allowed to move the pin. No-ops when
+ *  the fence is not armed, so a double-click enter outside a reconnect epoch
+ *  does not start holding the canvas at root. */
+export function pinReconnectScope(scopeName) {
+  if (!armed) return peekReconnectScopeFence();
+  viewing = scopeName === "subgraph" ? "subgraph" : "root";
+  return peekReconnectScopeFence();
+}
+
+/** Enter that never landed: forget the pin so the next observation re-pins
+ *  whatever the canvas actually shows. */
+export function releaseReconnectScopePin() {
+  if (!armed) return peekReconnectScopeFence();
+  viewing = null;
+  return peekReconnectScopeFence();
+}
+
+export function disarmReconnectScopeFence() {
+  armed = false;
+  viewing = null;
+}
+
+/**
+ * Fold a live resolveScope result through the fence.
+ *
+ * @param {object|null} liveScope  resolveScope(app) result
+ * @returns the scope the caller must use (possibly a hold-root rebind trigger)
+ */
+export function applyReconnectScopeFence(liveScope) {
+  if (!armed || !liveScope) return liveScope;
+  if (viewing == null) {
+    viewing = liveScope.scope === "subgraph" ? "subgraph" : "root";
+    return liveScope;
+  }
+  // Outline (or any earlier command) promised root. A restore that re-opened
+  // a live subgraph must not become the mutation target.
+  if (viewing === "root" && liveScope.scope === "subgraph") {
+    return {
+      graph: liveScope.rootGraph,
+      rootGraph: liveScope.rootGraph,
+      scope: "root",
+      owner: null,
+      stale: true,
+      diverged: false,
+      divergedKind: liveScope.divergedKind,
+    };
+  }
+  return liveScope;
+}


### PR DESCRIPTION
Fixes #1636

After reconnect, `panel_graph_outline` could report `viewing.scope="root"` while the immediately following `panel_enter_subgraph` searched a restored subgraph and rejected a root host ("currently inside a subgraph"). No user canvas change in between; `panel_exit_subgraph` then retry recovered.

Reconnect now drops the remembered subgraph owner and arms a viewing/mutation fence. The first resolved scope this epoch pins; a later canvas restore into a subgraph cannot change a root pin, so enter/mutations use the same graph the outline published. Explicit enter/exit update the pin so a real navigation is not undone.

Regression: outline at root, canvas restored into subgraph, `resolveNode(1067)` still hits the root host.
