### PR TITLE
fix(1641): first open of the active workflow after restart succeeds

### DIFF
--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -40,6 +40,7 @@ import { describeNodeDefRefresh } from "../../web/js/lib/node-def-refresh.js";
 import { confirmCanvasNavigation } from "../../web/js/lib/canvas-navigation.js";
 import {
   watchPostReconnectSettle,
+  waitForReconnectHandshakeBeforeOpen,
   graphMutationReconnectGate,
 } from "../../web/js/lib/reconnect-recovery.js";
 import {
@@ -95,10 +96,11 @@ test("panel ↔ media-preview.js / run-completion-frame.js ↔ bounded-step.js e
   assert.equal(typeof withTimeout, "function");
 });
 
-test("panel ↔ node-def-refresh.js / canvas-navigation.js / reconnect-recovery.js edges link (#635/#619/#663/#646)", () => {
+test("panel ↔ node-def-refresh.js / canvas-navigation.js / reconnect-recovery.js edges link (#635/#619/#663/#646/#1641)", () => {
   assert.equal(typeof describeNodeDefRefresh, "function");
   assert.equal(typeof confirmCanvasNavigation, "function");
   assert.equal(typeof watchPostReconnectSettle, "function");
+  assert.equal(typeof waitForReconnectHandshakeBeforeOpen, "function");
   assert.equal(typeof graphMutationReconnectGate, "function");
 });
 

--- a/browser_tests/unit/open-workflow-after-restart.test.mjs
+++ b/browser_tests/unit/open-workflow-after-restart.test.mjs
@@ -1,0 +1,240 @@
+// #1641 — the first panel_open_workflow of the already-active workflow after a
+// ComfyUI restart must succeed (or wait for handshake) instead of a content
+// mismatch / fence-not-cleared error that only a retry clears.
+//
+// THE REPORT. After a controlled restart, panel_list_workflows named the
+// intended active workflow, then the first panel_open_workflow for that same
+// path returned:
+//
+//   workflow_open RAN and the canvas IS bound … the graph on it does not match
+//   the state that was loaded … FENCE: NOT cleared (active identity UNCONFIRMED
+//   after reconnect handshake).
+//
+// The next retry succeeded without changing the workflow.
+//
+// THE MECHANISM. workflow_open is exempt from the #646 mutation gate (it is
+// the documented recovery for a restore that never settles), so it ran during
+// the post-restart window: backend socket still coming up, the node-def refresh
+// kicked on `reconnected` still in flight, canvas binding not yet re-proven.
+// loadGraphData then compared content against a canvas the restore was still
+// rewriting. CONTENT_UNVERIFIED throws, publishes no workflow_uuid, and
+// `active_confirmed` stays false until a successful open — so the orchestrator
+// handshake cannot confirm either. Waiting HERE, before the freeze and the
+// load, makes the first open the one that succeeds.
+//
+// Tests drive the shipped wait (`waitForReconnectHandshakeBeforeOpen`) — the
+// function workflow_open now calls on this path — and pin the panel wiring so
+// deleting the await, moving it past the freeze, or dropping a handshake
+// signal fails here. Cadence is the shipped steps, never restated.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  OPEN_RECONNECT_HANDSHAKE_STEPS_MS,
+  waitForReconnectHandshakeBeforeOpen,
+} from "../../web/js/lib/reconnect-recovery.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function handlerBody(src, sig) {
+  const start = src.indexOf(sig);
+  if (start === -1) return "";
+  const after = start + sig.length;
+  const m = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  return src.slice(start, m ? after + m.index : src.length);
+}
+
+const OPEN_BODY = handlerBody(SRC, "async workflow_open({");
+
+function recordSleep() {
+  const slept = [];
+  return {
+    slept,
+    sleep: async (ms) => {
+      slept.push(ms);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The shipped wait
+// ---------------------------------------------------------------------------
+
+test("#1641 a settled tab does not wait — the common path pays nothing", async () => {
+  const { slept, sleep } = recordSleep();
+  const outcome = await waitForReconnectHandshakeBeforeOpen({
+    needsWait: () => false,
+    isReady: () => true,
+    sleep,
+  });
+  assert.equal(outcome, "ready");
+  assert.deepEqual(slept, [], "no handshake in flight means no sleep");
+});
+
+test("#1641 a handshake that is already ready does not sleep", async () => {
+  const { slept, sleep } = recordSleep();
+  const outcome = await waitForReconnectHandshakeBeforeOpen({
+    needsWait: () => true,
+    isReady: () => true,
+    sleep,
+  });
+  assert.equal(outcome, "ready");
+  assert.deepEqual(slept, [], "the restored canvas is already bound — proceed");
+});
+
+test("#1641 the reporter's case: first probe unready, next probe ready — first open waits then proceeds", async () => {
+  const { slept, sleep } = recordSleep();
+  let probes = 0;
+  const outcome = await waitForReconnectHandshakeBeforeOpen({
+    needsWait: () => true,
+    isReady: () => {
+      probes += 1;
+      return probes >= 2;
+    },
+    sleep,
+  });
+  assert.equal(outcome, "ready", "the first open must succeed once the handshake lands");
+  assert.equal(slept.length, 1, "one retry, not the full budget");
+  assert.equal(slept[0], OPEN_RECONNECT_HANDSHAKE_STEPS_MS[0]);
+});
+
+test("#1641 a handshake that never lands times out on the shipped steps — the open still proceeds", async () => {
+  const { slept, sleep } = recordSleep();
+  const outcome = await waitForReconnectHandshakeBeforeOpen({
+    needsWait: () => true,
+    isReady: () => false,
+    sleep,
+  });
+  assert.equal(outcome, "timeout", "a restore that never settles must not hang the open");
+  assert.deepEqual(slept, [...OPEN_RECONNECT_HANDSHAKE_STEPS_MS], "every shipped step is waited, none invented");
+});
+
+test("#1641 the window closing mid-wait is ready, not a timeout", async () => {
+  const { slept, sleep } = recordSleep();
+  let pending = true;
+  const outcome = await waitForReconnectHandshakeBeforeOpen({
+    needsWait: () => pending,
+    isReady: () => false,
+    sleep: async (ms) => {
+      slept.push(ms);
+      pending = false;
+    },
+  });
+  assert.equal(outcome, "ready");
+  assert.equal(slept.length, 1);
+});
+
+test("#1641 a throwing ready-probe is 'not yet', never 'ready'", async () => {
+  const { slept, sleep } = recordSleep();
+  let probes = 0;
+  const outcome = await waitForReconnectHandshakeBeforeOpen({
+    needsWait: () => true,
+    isReady: () => {
+      probes += 1;
+      if (probes < 3) throw new Error("getGraphCtx: graph not available");
+      return true;
+    },
+    sleep,
+  });
+  assert.equal(outcome, "ready");
+  assert.equal(probes, 3);
+  assert.equal(slept.length, 2);
+});
+
+test("#1641 a throwing needsWait does not stall the open", async () => {
+  const { slept, sleep } = recordSleep();
+  const outcome = await waitForReconnectHandshakeBeforeOpen({
+    needsWait: () => {
+      throw new Error("epoch unreadable");
+    },
+    isReady: () => false,
+    sleep,
+  });
+  assert.equal(outcome, "ready");
+  assert.deepEqual(slept, []);
+});
+
+test("#1641 missing probes are ready — the wait cannot invent a handshake", async () => {
+  const outcome = await waitForReconnectHandshakeBeforeOpen({ sleep: async () => {} });
+  assert.equal(outcome, "ready");
+});
+
+// ---------------------------------------------------------------------------
+// Panel wiring — deleting the await, moving it past the freeze, or dropping a
+// handshake signal fails these. The function under test is workflow_open.
+// ---------------------------------------------------------------------------
+
+test("#1641 wiring: workflow_open awaits the shipped handshake wait", () => {
+  assert.match(
+    OPEN_BODY,
+    /await waitForReconnectHandshakeBeforeOpen\(\{/,
+    "workflow_open must wait on the shipped handshake helper, not a private copy",
+  );
+});
+
+test("#1641 wiring: the wait is BEFORE the freeze and BEFORE the load", () => {
+  const waitAt = OPEN_BODY.indexOf("await waitForReconnectHandshakeBeforeOpen({");
+  const freezeAt = OPEN_BODY.indexOf("acquireCanvasInteractionLock(canvasView)");
+  const openAt = OPEN_BODY.indexOf("await s.openWorkflow(target);");
+  const loadAt = OPEN_BODY.indexOf("await app.loadGraphData(repaintState, true, true, target);");
+  assert.notEqual(waitAt, -1);
+  assert.notEqual(freezeAt, -1);
+  assert.notEqual(openAt, -1);
+  assert.notEqual(loadAt, -1);
+  assert.ok(waitAt < freezeAt, "do not hold the canvas lock across the handshake");
+  assert.ok(waitAt < openAt, "do not switch tabs before the restore has a chance to land");
+  assert.ok(waitAt < loadAt, "the content comparison must not run against a still-restoring canvas");
+});
+
+test("#1641 wiring: wasOpen / wasDirty are snapshotted AFTER the wait, BEFORE openWorkflow", () => {
+  // The handshake wait can populate changeTracker as the restore finishes; capturing
+  // wasOpen before that would treat a now-open tab as first-time. wasDirty still
+  // has to beat openWorkflow, because that is the await that erases it.
+  const waitAt = OPEN_BODY.indexOf("await waitForReconnectHandshakeBeforeOpen({");
+  const wasOpenAt = OPEN_BODY.indexOf("const wasOpen = !!target.changeTracker;");
+  const wasDirtyAt = OPEN_BODY.indexOf("const wasDirty = !!target.isModified;");
+  const openAt = OPEN_BODY.indexOf("await s.openWorkflow(target);");
+  assert.ok(waitAt < wasOpenAt && wasOpenAt < openAt);
+  assert.ok(waitAt < wasDirtyAt && wasDirtyAt < openAt);
+});
+
+test("#1641 wiring: the wait reads every post-restart handshake signal", () => {
+  const waitAt = OPEN_BODY.indexOf("await waitForReconnectHandshakeBeforeOpen({");
+  const brace = OPEN_BODY.indexOf("{", waitAt);
+  let depth = 0;
+  let end = brace;
+  for (let i = brace; i < OPEN_BODY.length; i += 1) {
+    if (OPEN_BODY[i] === "{") depth += 1;
+    if (OPEN_BODY[i] === "}" && --depth === 0) {
+      end = i;
+      break;
+    }
+  }
+  const call = OPEN_BODY.slice(waitAt, end + 1);
+  assert.match(call, /needsWait:/, "the wait must know when a handshake is in flight");
+  assert.match(call, /isReady:/, "and when the open may compare content");
+  assert.match(call, /comfyBackendIsDown\(\)/, "backend socket still down");
+  assert.match(call, /postReconnectBindingSettleWindow\(\)/, "canvas binding not yet re-proven");
+  assert.match(call, /nodeDefRefreshInFlight/, "node-def refresh kicked on reconnected still running");
+  assert.match(
+    call,
+    /assertGraphBoundToActiveWorkflow\(graph, rootGraph, \{ includeBaselineReadGuard: true \}\)/,
+    "a ready probe that can prove the binding uses the same bar as the settle watch",
+  );
+  assert.match(
+    call,
+    /postReconnectBindingProofEpoch = openedForEpoch/,
+    "proving the binding here must stamp the epoch so the mutation gate opens",
+  );
+});
+
+test("#1641 wiring: the panel imports the shipped helper, not a local copy", () => {
+  assert.match(
+    SRC,
+    /import \{[\s\S]*?waitForReconnectHandshakeBeforeOpen,[\s\S]*?\} from "\.\/lib\/reconnect-recovery\.js"/,
+  );
+});

--- a/browser_tests/unit/reconnect-recovery.test.mjs
+++ b/browser_tests/unit/reconnect-recovery.test.mjs
@@ -670,7 +670,10 @@ test("#646 wiring: the dispatch fence gates MUTATING graph commands through the 
 test("#663 wiring: BOTH resync sites (open + new) stamp the binding proof, TOCTOU-guarded", () => {
   const stamps =
     SRC.match(/if \(backendReconnectEpoch === openedForEpoch\) postReconnectBindingProofEpoch = openedForEpoch;/g) ?? [];
-  assert.equal(stamps.length, 2, "workflow_new AND workflow_open both stamp the proof");
+  // #1641 added a third stamp: the open's pre-load handshake wait, when it
+  // proves the restored canvas is already bound. Still TOCTOU-guarded; still
+  // only these two executors.
+  assert.equal(stamps.length, 3, "workflow_new, workflow_open success, and the #1641 handshake wait");
 });
 
 test("#663/#646 wiring: the binding gate consults the #433 window AND the proof epoch, one invariant", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -314,6 +314,7 @@ import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fi
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import {
   watchPostReconnectSettle,
+  waitForReconnectHandshakeBeforeOpen,
   graphMutationReconnectGate,
   reconnectRefusalError,
   readReconnectRefusal,
@@ -18376,6 +18377,35 @@ const GRAPH_TOOL_EXECUTORS = {
         throw failOpen(new Error(openWorkflowNotFoundMessage({ path, refresh, known, disk })));
       }
     }
+    // #1641 — after a ComfyUI restart the tab can answer this command before the
+    // backend socket, the node-def refresh kicked on `reconnected`, and the
+    // restored canvas binding have finished one handshake. Opening the
+    // already-active workflow in that window compares content against a canvas
+    // the restore is still rewriting, reports CONTENT_UNVERIFIED, and publishes
+    // no fence — so the orchestrator answers "FENCE: NOT cleared (active identity
+    // UNCONFIRMED after reconnect handshake)". A retry a moment later succeeds
+    // without changing the workflow. Wait here, BEFORE the freeze and the load,
+    // so the first open is the one that succeeds. If the handshake never lands
+    // the open still proceeds: it is the #646 recovery for a restore that never
+    // settles. Bounded (~2.9s); a healthy already-settled tab returns immediately.
+    await waitForReconnectHandshakeBeforeOpen({
+      needsWait: () =>
+        comfyBackendIsDown() ||
+        postReconnectBindingSettleWindow() ||
+        nodeDefRefreshInFlight != null,
+      isReady: () => {
+        if (comfyBackendIsDown()) return false;
+        if (nodeDefRefreshInFlight != null) return false;
+        if (!postReconnectBindingSettleWindow()) return true;
+        // Same evidence bar the settle watch runs: if the restored canvas is
+        // already bound, stamp the proof so we do not wait out the budget for a
+        // handshake that has in fact landed.
+        const { graph, rootGraph } = getGraphCtx();
+        assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: true });
+        if (backendReconnectEpoch === openedForEpoch) postReconnectBindingProofEpoch = openedForEpoch;
+        return true;
+      },
+    });
     // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
     // never re-read from disk. If the .json changed on disk out-of-band the canvas
     // would silently keep the pre-edit graph and this open would report a bland
@@ -18389,11 +18419,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // reads it fresh from disk. openWorkflow does NOT mutate originalContent for an
     // already-open tab (its load() early-returns), so the baseline stays valid.
     const wasOpen = !!target.changeTracker;
-    // #442 / codex — SNAPSHOT the tab's unsaved-edit state BEFORE any await. It cannot be
-    // recovered later: `clearSpuriousOpenModified` below force-clears `isModified`, so by
-    // the time the reload gate samples the flag, a tab that arrived here WITH unsaved
-    // edits (or was edited during `openWorkflow`) already reads clean. That erased signal
-    // is what would authorize the destructive re-read to discard the user's work.
+    // #442 / codex — SNAPSHOT the tab's unsaved-edit state BEFORE the mutating
+    // awaits (`openWorkflow`, the freeze, the re-baseline). The #1641 handshake
+    // wait above is not one of those: it does not touch `isModified`. The flag
+    // cannot be recovered later — `clearSpuriousOpenModified` below force-clears
+    // it — so by the time the reload gate samples, a tab that arrived here WITH
+    // unsaved edits (or was edited during `openWorkflow`) already reads clean.
+    // That erased signal is what would authorize the destructive re-read to
+    // discard the user's work.
     const wasDirty = !!target.isModified;
     // #1215 — WHO was active before this open moves the pointer, snapshotted now:
     // `s.openWorkflow(target)` below changes the answer. The #874 canvas capture's

--- a/web/js/lib/reconnect-recovery.js
+++ b/web/js/lib/reconnect-recovery.js
@@ -94,6 +94,72 @@ export async function watchPostReconnectSettle({
 }
 
 /**
+ * #1641 — wait for the post-restart handshake before `workflow_open` compares
+ * content.
+ *
+ * After a ComfyUI restart the tab can answer `workflow_open` (and even
+ * `workflow_list`) before the backend socket, the node-def refresh kicked on
+ * `reconnected`, and the restored canvas binding have finished one synchronized
+ * handshake. The first open of the already-active workflow then reports
+ * CONTENT_UNVERIFIED — "the graph on it does not match the state that was
+ * loaded" — and publishes no `workflow_uuid`, so the orchestrator answers
+ * `FENCE: NOT cleared (active identity UNCONFIRMED after reconnect handshake)`.
+ * A retry a moment later succeeds without changing the workflow.
+ *
+ * This wait is NOT a binding proof and does not repaint. If the handshake never
+ * lands, the open proceeds: it is the documented recovery for a restore that
+ * never settles (#646). The wait only buys a settled canvas for the common
+ * case so the first open is the one that succeeds.
+ *
+ * Cadence matches the orchestrator's post-open handshake ([400, 900, 1600] ms)
+ * so a caller that already waited there is not waiting a second, longer budget
+ * here; a caller that hits the panel first pays the same ~2.9s once.
+ */
+export const OPEN_RECONNECT_HANDSHAKE_STEPS_MS = Object.freeze([400, 900, 1600]);
+
+/**
+ * @param {{
+ *   needsWait?: () => boolean,  // true while the handshake is still in flight
+ *   isReady?: () => boolean,    // true when the open may compare content
+ *   sleep?: (ms: number) => Promise<void>,
+ *   stepsMs?: readonly number[],
+ * }} o
+ * @returns {Promise<"ready"|"timeout">}
+ */
+export async function waitForReconnectHandshakeBeforeOpen({
+  needsWait,
+  isReady,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  stepsMs = OPEN_RECONNECT_HANDSHAKE_STEPS_MS,
+} = {}) {
+  const pending = () => {
+    try {
+      return typeof needsWait === "function" && needsWait() === true;
+    } catch {
+      // An unreadable probe is not a reason to stall the open — the open itself
+      // is the recovery (#646). Same direction as a throwing settle-watch proof.
+      return false;
+    }
+  };
+  const ready = () => {
+    try {
+      return typeof isReady === "function" && isReady() === true;
+    } catch {
+      return false;
+    }
+  };
+  if (!pending()) return "ready";
+  if (ready()) return "ready";
+  const steps = Array.isArray(stepsMs) && stepsMs.length ? stepsMs : OPEN_RECONNECT_HANDSHAKE_STEPS_MS;
+  for (const waitMs of steps) {
+    const ms = Number(waitMs);
+    if (Number.isFinite(ms) && ms > 0) await sleep(ms);
+    if (ready() || !pending()) return "ready";
+  }
+  return ready() ? "ready" : "timeout";
+}
+
+/**
  * The #646 graph-mutation gate: the refusal message for a mutating graph
  * command that arrives while the post-reconnect environment is known-unstable,
  * or null when the command may run. Two independent instability signals:


### PR DESCRIPTION
Fixes #1641

After a controlled ComfyUI restart, `panel_list_workflows` named the intended active workflow, but the first `panel_open_workflow` for that same path returned a content mismatch / fence-not-cleared error (`FENCE: NOT cleared (active identity UNCONFIRMED after reconnect handshake)`). A retry after the reconnect handshake succeeded without changing the workflow.

`workflow_open` is exempt from the post-reconnect mutation gate (it is the recovery for a restore that never settles), so it ran during the handshake window: backend socket still coming up, the node-def refresh kicked on `reconnected` still in flight, canvas binding not yet re-proven. The content proof then compared against a canvas the restore was still rewriting, threw, and published no `workflow_uuid` — so `active_confirmed` stayed false until a later successful open.

This waits for that handshake **before** the freeze and the load, on the shipped `waitForReconnectHandshakeBeforeOpen` path. A already-settled tab returns immediately. If the restore never settles, the open still proceeds.

Not #1645 (presentation-only size/`ue_properties` after restart).
