### PR TITLE
fix(1645): panel_list_nodes returns an inspectable fallback when Manager is unreachable

### DIFF
--- a/browser_tests/unit/nodes-list-manager-unreachable.test.mjs
+++ b/browser_tests/unit/nodes-list-manager-unreachable.test.mjs
@@ -166,8 +166,24 @@ test("#1645 core-only object_info is still an inspectable inventory, not a throw
   });
   assert.equal(res.managerReachable, false);
   assert.equal(res.source, "object_info");
-  assert.deepEqual(res.installed, {});
+  assert.deepEqual(res.installed, Object.create(null));
   assert.match(res.note, /object_info/);
+});
+
+test("#1645 object_info pack names cannot reach inherited object keys", async () => {
+  const res = await listNodesVia(throwUnreachable, throwUnreachable, {
+    args: {},
+    objectInfoGet: async () => ({
+      ProtoNode: { python_module: "custom_nodes.__proto__" },
+      ConstructorNode: { python_module: "custom_nodes.constructor" },
+      ToStringNode: { python_module: "custom_nodes.toString" },
+    }),
+  });
+  assert.deepEqual(Object.keys(res.installed).sort(), ["__proto__", "constructor", "toString"]);
+  assert.deepEqual(res.installed.__proto__.classes, ["ProtoNode"]);
+  assert.deepEqual(res.installed.constructor.classes, ["ConstructorNode"]);
+  assert.deepEqual(res.installed.toString.classes, ["ToStringNode"]);
+  assert.equal(Object.prototype.classes, undefined);
 });
 
 test("#1645 a failing object_info fetch degrades to structured unavailable, never throws", async () => {

--- a/browser_tests/unit/nodes-list-manager-unreachable.test.mjs
+++ b/browser_tests/unit/nodes-list-manager-unreachable.test.mjs
@@ -201,7 +201,7 @@ test("#1645 a failing object_info fetch degrades to structured unavailable, neve
 });
 
 test("#1645 a non-map object_info response degrades to structured unavailable", async () => {
-  for (const malformed of [null, [], "offline", 204]) {
+  for (const malformed of [null, [], "offline", 204, {}, { error: "backend unavailable" }, { error: { message: "backend unavailable" } }]) {
     const res = await listNodesVia(throwUnreachable, throwUnreachable, {
       args: {},
       objectInfoGet: async () => malformed,

--- a/browser_tests/unit/nodes-list-manager-unreachable.test.mjs
+++ b/browser_tests/unit/nodes-list-manager-unreachable.test.mjs
@@ -200,6 +200,19 @@ test("#1645 a failing object_info fetch degrades to structured unavailable, neve
   assert.match(res.message, /panel_graph_outline/);
 });
 
+test("#1645 a non-map object_info response degrades to structured unavailable", async () => {
+  for (const malformed of [null, [], "offline", 204]) {
+    const res = await listNodesVia(throwUnreachable, throwUnreachable, {
+      args: {},
+      objectInfoGet: async () => malformed,
+    });
+    assert.equal(res.supported, false, `malformed object_info: ${String(malformed)}`);
+    assert.equal(res.managerReachable, false);
+    assert.deepEqual(res.installed, {});
+    assert.equal(res.source, undefined);
+  }
+});
+
 test("#1645 with no objectInfoGet, BOTH unreachable returns structured unavailable — never throws", async () => {
   const res = await listNodesVia(throwUnreachable, throwUnreachable, { args: {} });
   assert.equal(res.supported, false);

--- a/browser_tests/unit/nodes-list-manager-unreachable.test.mjs
+++ b/browser_tests/unit/nodes-list-manager-unreachable.test.mjs
@@ -1,0 +1,224 @@
+/**
+ * #1645 — `panel_list_nodes` threw when ComfyUI-Manager was unreachable even
+ * though the live canvas was connected and `panel_graph_outline` worked.
+ *
+ * THE REPORTED FAILURE. A read-only `panel_list_nodes({})` returned
+ * `Error: ComfyUI-Manager injoignable (le gestionnaire intégré est-il activé ?)`
+ * (the French catalogue string for the Manager-not-reachable 404). Inventory of
+ * already-loaded custom-node packs should still return an inspectable fallback
+ * instead of failing closed.
+ *
+ * THE MECHANISM. `nodes_list` already retried the absolute legacy
+ * `/customnode/installed` on an unreachable dialect-routed GET, then rethrew
+ * when that was unreachable too. `searchNodesVia` already degrades past that
+ * last throw (#251/#255/#426); list did not.
+ *
+ * These tests drive the shipped `listNodesVia` (the decision path `nodes_list`
+ * now calls), with injected Manager + `/object_info` fetches. The reporter's
+ * exact French string is produced from the shipped catalogue, not assumed.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { tr, __setCatalogForTest } from "../../web/js/lib/i18n.js";
+import { classifyManager404 } from "../../web/js/lib/manager-404.js";
+import {
+  listNodesVia,
+  listedNodesResult,
+  managerListUnavailableResult,
+} from "../../web/js/lib/manager-install.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const PANEL = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+const NS = "comfyuiMcpPanel";
+const catalogFor = (locale) => {
+  const file = JSON.parse(readFileSync(join(ROOT, "locales", locale, "main.json"), "utf8"));
+  const inner = file?.[NS];
+  assert.ok(inner, `locales/${locale}/main.json must be namespaced under ${NS}`);
+  return inner;
+};
+
+const INSTALLED_MAP = {
+  "ComfyUI-SeedVR2_VideoUpscaler": {
+    ver: "1.2.0",
+    cnr_id: "seedvr2",
+    aux_id: "numz/ComfyUI-SeedVR2_VideoUpscaler",
+    enabled: true,
+  },
+  "rgthree-comfy": { ver: "1.0.0", cnr_id: "rgthree-comfy", enabled: true },
+};
+
+const OBJECT_INFO = {
+  KSampler: { python_module: "nodes", display_name: "KSampler" },
+  CLIPTextEncode: { python_module: "comfy_extras.nodes_clip", display_name: "CLIP Text Encode" },
+  ReActorFaceSwap: {
+    python_module: "custom_nodes.comfyui-reactor-node",
+    display_name: "ReActor",
+  },
+  ImpactWildcardProcessor: {
+    python_module: "custom_nodes.ComfyUI-Impact-Pack.nodes",
+    display_name: "Impact Wildcard Processor",
+  },
+};
+
+const UNREACHABLE = new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+UNREACHABLE.managerRouteMissing = true;
+
+const throwUnreachable = async () => {
+  throw UNREACHABLE;
+};
+
+/** Rebuild the reporter's exact 404 the way managerV2/managerCall do. */
+const frenchUnreachable = () => {
+  __setCatalogForTest("fr", catalogFor("fr"));
+  const { routeMissing, message } = classifyManager404("");
+  const err = new Error(message);
+  if (routeMissing) err.managerRouteMissing = true;
+  return err;
+};
+
+test.afterEach(() => __setCatalogForTest("en", {}));
+
+test("#1645 the reporter's exact French string is what the panel produces", () => {
+  const err = frenchUnreachable();
+  assert.equal(
+    err.message,
+    "ComfyUI-Manager injoignable (le gestionnaire intégré est-il activé ?)",
+  );
+  assert.equal(err.managerRouteMissing, true);
+  assert.notEqual(
+    tr(
+      "manager_404.comfyui_manager_not_reachable_is_the_built",
+      "ComfyUI-Manager not reachable (is the built-in Manager enabled?)",
+    ),
+    "ComfyUI-Manager not reachable (is the built-in Manager enabled?)",
+    "tr() is genuinely in the path — this is not testing a constant",
+  );
+});
+
+test("#1645 dialect-routed GET still returns the Manager inventory", async () => {
+  const res = await listNodesVia(async () => INSTALLED_MAP, throwUnreachable, { args: {} });
+  assert.deepEqual(res, listedNodesResult(INSTALLED_MAP, {}));
+  assert.equal("managerReachable" in res, false);
+});
+
+test("#1645 absolute legacy route is used when the dialect-routed GET is unreachable", async () => {
+  const res = await listNodesVia(throwUnreachable, async () => INSTALLED_MAP, {
+    args: { search: "SeedVR2" },
+  });
+  assert.deepEqual(res, listedNodesResult(INSTALLED_MAP, { search: "SeedVR2" }));
+});
+
+test("#1645 BOTH Manager routes unreachable + loaded object_info returns inspectable packs, never throws", async () => {
+  const res = await listNodesVia(throwUnreachable, throwUnreachable, {
+    args: {},
+    objectInfoGet: async () => OBJECT_INFO,
+  });
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.source, "object_info");
+  assert.equal("supported" in res, false);
+  assert.deepEqual(Object.keys(res.installed).sort(), [
+    "ComfyUI-Impact-Pack",
+    "comfyui-reactor-node",
+  ]);
+  assert.deepEqual(res.installed["comfyui-reactor-node"].classes, ["ReActorFaceSwap"]);
+  assert.deepEqual(res.installed["ComfyUI-Impact-Pack"].classes, ["ImpactWildcardProcessor"]);
+  assert.equal("KSampler" in res.installed, false);
+  assert.equal("nodes" in res.installed, false);
+  assert.match(res.note, /object_info/);
+});
+
+test("#1645 the reporter's French unreachable error degrades to object_info instead of throwing", async () => {
+  const err = frenchUnreachable();
+  const boom = async () => {
+    throw err;
+  };
+  const res = await listNodesVia(boom, boom, {
+    args: {},
+    objectInfoGet: async () => OBJECT_INFO,
+  });
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.source, "object_info");
+  assert.ok(res.installed["comfyui-reactor-node"]);
+});
+
+test("#1645 search still filters the object_info pack inventory", async () => {
+  const res = await listNodesVia(throwUnreachable, throwUnreachable, {
+    args: { search: "Impact" },
+    objectInfoGet: async () => OBJECT_INFO,
+  });
+  assert.equal(res.search, "Impact");
+  assert.equal(res.count, 1);
+  assert.deepEqual(Object.keys(res.installed), ["ComfyUI-Impact-Pack"]);
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.source, "object_info");
+});
+
+test("#1645 core-only object_info is still an inspectable inventory, not a throw", async () => {
+  const res = await listNodesVia(throwUnreachable, throwUnreachable, {
+    args: {},
+    objectInfoGet: async () => ({
+      KSampler: { python_module: "nodes" },
+    }),
+  });
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.source, "object_info");
+  assert.deepEqual(res.installed, {});
+  assert.match(res.note, /object_info/);
+});
+
+test("#1645 a failing object_info fetch degrades to structured unavailable, never throws", async () => {
+  const res = await listNodesVia(throwUnreachable, throwUnreachable, {
+    args: {},
+    objectInfoGet: async () => {
+      throw new Error("object_info 503");
+    },
+  });
+  assert.deepEqual(res, managerListUnavailableResult(UNREACHABLE));
+  assert.equal(res.supported, false);
+  assert.equal(res.managerReachable, false);
+  assert.deepEqual(res.installed, {});
+  assert.match(res.message, /panel_graph_outline/);
+});
+
+test("#1645 with no objectInfoGet, BOTH unreachable returns structured unavailable — never throws", async () => {
+  const res = await listNodesVia(throwUnreachable, throwUnreachable, { args: {} });
+  assert.equal(res.supported, false);
+  assert.equal(res.managerReachable, false);
+  assert.deepEqual(res.installed, {});
+});
+
+test("#1645 a genuine server error still propagates", async () => {
+  const boom = async () => {
+    throw new Error("Manager customnode/installed: HTTP 500");
+  };
+  await assert.rejects(
+    () => listNodesVia(boom, boom, { args: {} }),
+    /HTTP 500/,
+    "a real server error must propagate, not degrade to unavailable",
+  );
+});
+
+test("#1645 a non-unreachable error from the absolute fallback also propagates", async () => {
+  const managerCall = async () => {
+    throw new Error("Manager customnode/installed: HTTP 403");
+  };
+  await assert.rejects(
+    () => listNodesVia(throwUnreachable, managerCall, { args: {} }),
+    /HTTP 403/,
+  );
+});
+
+test("#1645 nodes_list wires listNodesVia with the live object_info fetch", () => {
+  const start = PANEL.indexOf("async nodes_list(");
+  assert.notEqual(start, -1, "nodes_list executor must exist");
+  const end = PANEL.indexOf("async nodes_install(", start);
+  assert.ok(end > start, "nodes_install must follow nodes_list");
+  const body = PANEL.slice(start, end);
+  assert.match(body, /listNodesVia\(managerGet,\s*managerCall/);
+  assert.match(body, /objectInfoGet:\s*fetchObjectInfo/);
+  assert.match(body, /retryDuringReconnect/);
+});

--- a/browser_tests/unit/nodes-list-search.test.mjs
+++ b/browser_tests/unit/nodes-list-search.test.mjs
@@ -124,18 +124,15 @@ test("#1496 README names the accepted keys", () => {
   assert.match(row, /`query`/);
 });
 
-test("#1496 nodes_list feeds the command args through listedNodesResult on BOTH list routes", () => {
+test("#1496 nodes_list feeds the command args through listNodesVia", () => {
   const start = PANEL.indexOf("async nodes_list(");
   assert.notEqual(start, -1, "nodes_list executor must exist");
   const end = PANEL.indexOf("async nodes_install(", start);
   assert.ok(end > start, "nodes_install must follow nodes_list");
   const body = PANEL.slice(start, end);
   assert.match(body, /async nodes_list\(args\s*=\s*\{\}\)/);
-  assert.equal(
-    [...body.matchAll(/listedNodesResult\(/g)].length,
-    2,
-    "both the dialect-routed GET and the absolute legacy fallback must filter",
+  assert.match(
+    body,
+    /listNodesVia\(managerGet,\s*managerCall,\s*\{\s*args,\s*objectInfoGet:\s*fetchObjectInfo\s*\}\)/,
   );
-  assert.match(body, /listedNodesResult\(await managerGet\(route\), args\)/);
-  assert.match(body, /listedNodesResult\(await managerCall\(route\), args\)/);
 });

--- a/browser_tests/unit/nodes-list-search.test.mjs
+++ b/browser_tests/unit/nodes-list-search.test.mjs
@@ -84,7 +84,7 @@ test("#1496 a miss discloses total so it cannot be read as nothing installed", (
   const res = listedNodesResult(INSTALLED_MAP, { search: "definitely-not-here" });
   assert.equal(res.count, 0);
   assert.equal(res.total, 3);
-  assert.deepEqual(res.installed, {});
+  assert.deepEqual(res.installed, Object.create(null));
   assert.match(res.note, /0 of 3 installed packs matched search "definitely-not-here"/);
   assert.match(res.note, /panel_search_nodes/);
   assert.match(res.note, /query/);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -121,7 +121,7 @@ import {
   taskHistoryBlindNote,
   installGitUrl,
   installedListRoute,
-  listedNodesResult,
+  listNodesVia,
   isManagerRouteMissing,
   isManagerUnreachable,
   markManagerUnreachable,
@@ -7405,11 +7405,12 @@ async function resolveManagerUpdateTarget(requestedId) {
   return resolveInstalledUpdateId(requestedId, installed);
 }
 
-/** #426 — fetch the connected ComfyUI's full `/object_info` map (node CLASS →
+/** #426/#1645 — fetch the connected ComfyUI's full `/object_info` map (node CLASS →
  *  metadata). Always present on a running ComfyUI (no Manager needed), so it is
- *  the installed-node fallback for nodes_search when the Manager registry search
- *  is unreachable. Bounded by the shared Manager timeout; throws on any non-ok /
- *  parse failure (searchNodesVia's fallback swallows it and degrades). */
+ *  the installed-node fallback for nodes_search and the installed-pack fallback
+ *  for nodes_list when Manager is unreachable. Bounded by the shared Manager
+ *  timeout; throws on any non-ok / parse failure (the Via fallbacks swallow it
+ *  and degrade). */
 async function fetchObjectInfo() {
   const res = await api.fetchApi("/object_info", {
     method: "GET",
@@ -22297,32 +22298,23 @@ const GRAPH_TOOL_EXECUTORS = {
 
   async nodes_list(args = {}) {
     // #423: route the installed-node list by dialect (managerGet strips /v2 for
-    // legacy) with an explicit ?mode=default — matching the live-tested
-    // orchestrator. A pip Manager in --enable-manager-legacy-ui mode can answer
-    // the /v2 queue probe yet NOT register the /v2 data GETs, so the dialect-
-    // routed /v2/customnode/installed 404s ("not reachable") while the absolute
-    // /customnode/installed serves fine. On that unreachable signal, fall back
-    // to the absolute (no-/v2) legacy list route instead of surfacing a generic
-    // "unreachable" error. managerGet already self-heals a stale dialect and
-    // retries legacy internally (#605); this catch is the last-resort layer for
-    // when BOTH routed attempts reported unreachable.
-    const route = installedListRoute();
+    // legacy) with an explicit ?mode=default. A pip Manager in
+    // --enable-manager-legacy-ui mode can answer the /v2 queue probe yet NOT
+    // register the /v2 data GETs, so the dialect-routed GET 404s while the
+    // absolute /customnode/installed serves. listNodesVia retries that absolute
+    // route, then #1645: when BOTH Manager routes are unreachable, reconstruct
+    // loaded custom-node packs from /object_info (or a structured unavailable
+    // result) instead of throwing. managerGet already self-heals a stale
+    // dialect (#605).
     // #332 — immediately after panel_restart_comfyui, a Manager fetch throws a
-    // bare transport error ("Failed to fetch") before any HTTP status exists, so
-    // the 404/unreachable fallback below never fires and the raw error leaked to
-    // the agent. Retry transient transport failures with a short bounded backoff,
-    // then reword into an actionable "still reconnecting" status.
+    // bare transport error ("Failed to fetch") before any HTTP status exists.
+    // Retry transient transport failures with a short bounded backoff, then
+    // reword into an actionable "still reconnecting" status.
     // #1496 — `search` (reporter) or `query` (panel_search_nodes alias) filters
-    // the installed payload. The MCP schema is still empty `{}` today, so this
-    // is inert until the orchestrator forwards the key.
-    return retryDuringReconnect(async () => {
-      try {
-        return listedNodesResult(await managerGet(route), args);
-      } catch (err) {
-        if (!isManagerUnreachable(err)) throw err;
-        return listedNodesResult(await managerCall(route), args);
-      }
-    });
+    // the installed payload.
+    return retryDuringReconnect(async () =>
+      listNodesVia(managerGet, managerCall, { args, objectInfoGet: fetchObjectInfo }),
+    );
   },
 
   async nodes_install(args) {

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -1075,6 +1075,14 @@ export async function objectInfoListFallback(objectInfoGet, args, err) {
   if (!info || typeof info !== "object" || Array.isArray(info)) {
     return managerListUnavailableResult(err);
   }
+  const hasNodeDefinition = Object.values(info).some((meta) => {
+    if (!meta || typeof meta !== "object" || Array.isArray(meta)) return false;
+    return ["python_module", "input", "output", "display_name", "category", "description"]
+      .some((key) => Object.prototype.hasOwnProperty.call(meta, key));
+  });
+  if (Object.keys(info).length === 0 || !hasNodeDefinition) {
+    return managerListUnavailableResult(err);
+  }
   const listed = listedNodesResult(installedPacksFromObjectInfo(info), args);
   return {
     ...listed,

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -243,7 +243,7 @@ export function filterInstalledPayload(raw, query) {
     const entries = Object.entries(raw);
     const total = entries.length;
     if (!terms.length) return { installed: raw, total, count: total };
-    const installed = {};
+    const installed = Object.create(null);
     for (const [k, v] of entries) {
       if (matchesAllTerms(installedEntryHay(v, k), terms)) installed[k] = v;
     }
@@ -1032,7 +1032,10 @@ export async function searchNodesVia(
  * would have listed. Core modules (`nodes`, `comfy_extras.*`) are not packs.
  */
 export function installedPacksFromObjectInfo(objectInfo) {
-  const installed = {};
+  // Pack names come from the connected ComfyUI's untrusted /object_info
+  // response. A null-prototype map keeps names such as __proto__, constructor,
+  // and toString as ordinary pack keys instead of inherited properties.
+  const installed = Object.create(null);
   if (!objectInfo || typeof objectInfo !== "object") return installed;
   for (const [cls, meta] of Object.entries(objectInfo)) {
     const pythonModule = meta && typeof meta === "object" ? meta.python_module : "";

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -1025,6 +1025,109 @@ export async function searchNodesVia(
   return parsed.count === 0 ? { ...parsed, ...cachedCatalogueNoMatch(query, parsed.catalogue_size, route) } : parsed;
 }
 
+/**
+ * #1645 — reconstruct installed custom-node PACKS from ComfyUI's `/object_info`
+ * map. Each loaded class carries `python_module` (`custom_nodes.<folder>` or
+ * `custom_nodes.<folder>.<sub>`); the folder is the on-disk pack name Manager
+ * would have listed. Core modules (`nodes`, `comfy_extras.*`) are not packs.
+ */
+export function installedPacksFromObjectInfo(objectInfo) {
+  const installed = {};
+  if (!objectInfo || typeof objectInfo !== "object") return installed;
+  for (const [cls, meta] of Object.entries(objectInfo)) {
+    const pythonModule = meta && typeof meta === "object" ? meta.python_module : "";
+    const s = String(pythonModule || "").trim();
+    const m = /^(?:custom_nodes)[./]([^./\\]+)/i.exec(s);
+    if (!m) continue;
+    const pack = m[1];
+    if (!installed[pack]) {
+      installed[pack] = { python_module: s, classes: [] };
+    }
+    installed[pack].classes.push(cls);
+  }
+  return installed;
+}
+
+const LIST_OBJECT_INFO_NOTE =
+  "ComfyUI-Manager is unreachable; these packs were reconstructed from the connected " +
+  "ComfyUI's /object_info (loaded custom-node python_module folders). Manager metadata " +
+  "(version, cnr_id, enabled) is not available. Enable the built-in Manager for the " +
+  "full installed-pack inventory.";
+
+/**
+ * #1645 — when BOTH Manager installed-list routes are unreachable, try the
+ * loaded `/object_info` registry before giving up. On a readable map, return
+ * an inspectable pack inventory (possibly empty — core-only is still an
+ * inventory). Any `/object_info` failure degrades to managerListUnavailableResult
+ * rather than throwing.
+ */
+export async function objectInfoListFallback(objectInfoGet, args, err) {
+  if (typeof objectInfoGet !== "function") return managerListUnavailableResult(err);
+  let info;
+  try {
+    info = await objectInfoGet();
+  } catch {
+    return managerListUnavailableResult(err);
+  }
+  const listed = listedNodesResult(installedPacksFromObjectInfo(info), args);
+  return {
+    ...listed,
+    managerReachable: false,
+    source: "object_info",
+    note: listed.note ? `${listed.note} ${LIST_OBJECT_INFO_NOTE}` : LIST_OBJECT_INFO_NOTE,
+  };
+}
+
+/**
+ * #1645 — structured unavailable result for panel_list_nodes when Manager AND
+ * `/object_info` cannot inventory packs. Inspectable (never a raw throw) so a
+ * connected canvas is not blocked by a missing Manager.
+ */
+export function managerListUnavailableResult(err) {
+  return {
+    supported: false,
+    managerReachable: false,
+    installed: {},
+    reason: String(err?.message ?? err ?? "ComfyUI-Manager not reachable"),
+    message:
+      "Installed custom-node pack inventory from ComfyUI-Manager is unavailable: " +
+      "the built-in Manager could not be reached on this ComfyUI (it may be disabled, " +
+      "or a legacy/partial build without /customnode/installed). The live canvas is " +
+      "still usable — inspect the current graph with panel_graph_outline / " +
+      "panel_query_graph. Enable the built-in Manager for the full pack list " +
+      "(version, cnr_id, enabled).",
+  };
+}
+
+/**
+ * Run the nodes_list flow with graceful degradation against an unreachable
+ * ComfyUI-Manager (#1645). Same ladder as searchNodesVia: dialect-routed GET,
+ * absolute legacy retry on unreachable/404, then `/object_info` pack
+ * reconstruction, then a structured unavailable result. Never throws on
+ * unreachable. Genuine server errors (500/403) still propagate.
+ */
+export async function listNodesVia(
+  managerGet,
+  managerCall,
+  { args = {}, objectInfoGet } = {},
+) {
+  const route = installedListRoute();
+  let raw;
+  try {
+    raw = await managerGet(route);
+  } catch (err) {
+    if (!isManagerUnreachable(err)) throw err;
+    try {
+      raw = await managerCall(route);
+    } catch (err2) {
+      if (isManagerUnreachable(err2))
+        return objectInfoListFallback(objectInfoGet, args, err2);
+      throw err2;
+    }
+  }
+  return listedNodesResult(raw, args);
+}
+
 /** #425 — ordered reboot {route, method} candidates for the detected dialect.
  *  The released 3.x Manager serves ONLY `POST /manager/reboot` (the pre-#230
  *  panel tried `GET /manager/reboot` → 404, after `POST /v2/manager/reboot` →

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -1072,6 +1072,9 @@ export async function objectInfoListFallback(objectInfoGet, args, err) {
   } catch {
     return managerListUnavailableResult(err);
   }
+  if (!info || typeof info !== "object" || Array.isArray(info)) {
+    return managerListUnavailableResult(err);
+  }
   const listed = listedNodesResult(installedPacksFromObjectInfo(info), args);
   return {
     ...listed,


### PR DESCRIPTION
Fixes #1645

A read-only `panel_list_nodes({})` returned `Error: ComfyUI-Manager injoignable (le gestionnaire intégré est-il activé ?)` when the built-in Manager was unreachable. The live canvas was connected and `panel_graph_outline` worked.

`nodes_list` already retried the absolute `/customnode/installed` on an unreachable dialect-routed GET, then rethrew when that was unreachable too. `searchNodesVia` already degrades past that last throw; list did not.

`listNodesVia` now walks the same ladder as search:

1. dialect-routed GET
2. absolute legacy retry on unreachable/404
3. reconstruct loaded custom-node packs from `/object_info` (`python_module` folders)
4. structured `{supported:false, managerReachable:false, installed:{}}` if object_info also fails

Genuine server errors (500/403) still propagate. Transient reconnect transport failures still go through `retryDuringReconnect`.
