### PR TITLE
fix-late-workflow-save-receipts

### DIFF
--- a/browser_tests/unit/save-reply-identity.test.mjs
+++ b/browser_tests/unit/save-reply-identity.test.mjs
@@ -84,11 +84,11 @@ test("#747 WIRING: BOTH save handlers report the identity, and the FLAG follows 
   assert.match(src, /import \{[^}]*saveReplyIdentity[^}]*\} from "\.\/lib\/save-reply-identity\.js"/);
 
   const saveIdx = src.search(/async workflow_save\(\{ name(?:, rid)? \} = \{\}\)/);
-  const saveAsIdx = src.indexOf("async workflow_save_as({ name })");
+  const saveAsIdx = src.search(/async workflow_save_as\(\{ name(?:, rid)? \}\)/);
   assert.ok(saveIdx > 0 && saveAsIdx > saveIdx);
 
   const saveBlock = src.slice(saveIdx, saveAsIdx);
-  const saveAsBlock = src.slice(saveAsIdx, saveAsIdx + 1600);
+  const saveAsBlock = src.slice(saveAsIdx, saveAsIdx + 2200);
 
   // workflow_save is only a Save-As when the outcome says so…
   assert.match(saveBlock, /saveReplyIdentity\(outcome\.saved_as \? replyIdentity : replyIdentity \?\? liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: !!outcome\.saved_as \}\)/);

--- a/browser_tests/unit/save-reply-identity.test.mjs
+++ b/browser_tests/unit/save-reply-identity.test.mjs
@@ -83,7 +83,7 @@ test("#747 WIRING: BOTH save handlers report the identity, and the FLAG follows 
   // whether the reply is wired up.
   assert.match(src, /import \{[^}]*saveReplyIdentity[^}]*\} from "\.\/lib\/save-reply-identity\.js"/);
 
-  const saveIdx = src.indexOf("async workflow_save({ name } = {})");
+  const saveIdx = src.search(/async workflow_save\(\{ name(?:, rid)? \} = \{\}\)/);
   const saveAsIdx = src.indexOf("async workflow_save_as({ name })");
   assert.ok(saveIdx > 0 && saveAsIdx > saveIdx);
 

--- a/browser_tests/unit/workflow-save-budget.test.mjs
+++ b/browser_tests/unit/workflow-save-budget.test.mjs
@@ -29,7 +29,7 @@ import {
 } from "../../web/js/lib/workflow-save-budget.js";
 import { PANEL_SRC } from "./_panel-constants.mjs";
 
-const workflowSaveMatch = PANEL_SRC.match(/\n {2}async workflow_save\(\{ name \} = \{\}\) \{[\s\S]*?\n {2}\},/);
+const workflowSaveMatch = PANEL_SRC.match(/\n {2}async workflow_save\(\{ name(?:, rid)? \} = \{\}\) \{[\s\S]*?\n {2}\},/);
 assert.ok(workflowSaveMatch, "could not locate workflow_save in panel source");
 
 const workflowSaveAsMatch = PANEL_SRC.match(/\n {2}async workflow_save_as\(\{ name \}\) \{[\s\S]*?\n {2}\},/);

--- a/browser_tests/unit/workflow-save-budget.test.mjs
+++ b/browser_tests/unit/workflow-save-budget.test.mjs
@@ -32,7 +32,7 @@ import { PANEL_SRC } from "./_panel-constants.mjs";
 const workflowSaveMatch = PANEL_SRC.match(/\n {2}async workflow_save\(\{ name(?:, rid)? \} = \{\}\) \{[\s\S]*?\n {2}\},/);
 assert.ok(workflowSaveMatch, "could not locate workflow_save in panel source");
 
-const workflowSaveAsMatch = PANEL_SRC.match(/\n {2}async workflow_save_as\(\{ name \}\) \{[\s\S]*?\n {2}\},/);
+const workflowSaveAsMatch = PANEL_SRC.match(/\n {2}async workflow_save_as\(\{ name(?:, rid)? \}\) \{[\s\S]*?\n {2}\},/);
 assert.ok(workflowSaveAsMatch, "could not locate workflow_save_as in panel source");
 
 // The orchestrator side of this invariant: ctx.call(..., 15000) in

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11795,7 +11795,7 @@ function pruneLateSaveReceipts() {
   }
 }
 
-function rememberLateWorkflowSave(rid, raw) {
+function rememberLateWorkflowSave(rid, raw, cmd = "workflow_save") {
   if (typeof rid !== "string" || !rid) return;
   if (!raw || typeof raw !== "object") return;
   const producedRecord = raw.producedRecord;
@@ -11813,7 +11813,7 @@ function rememberLateWorkflowSave(rid, raw) {
   pruneLateSaveReceipts();
   lateSaveReceipts.set(rid, {
     rid,
-    cmd: "workflow_save",
+    cmd,
     completed_at: Date.now(),
     result: outcome,
   });
@@ -17852,7 +17852,7 @@ const GRAPH_TOOL_EXECUTORS = {
     return { saved: true, workflow, ...outcome, ...saveReplyIdentity(outcome.saved_as ? replyIdentity : replyIdentity ?? liveWorkflowListActive().activeIdentity, { savedAs: !!outcome.saved_as }) };
   },
 
-  async workflow_save_as({ name }) {
+  async workflow_save_as({ name, rid }) {
     if (!name || typeof name !== "string") throw new Error("name (string) is required");
     // #1434 — same bound as workflow_save: both go through programmaticSave, both
     // are relayed at 15 s, and a hung copy trio is the same silence.
@@ -17865,6 +17865,9 @@ const GRAPH_TOOL_EXECUTORS = {
         observeWorkflow: observeActiveWorkflowSaveState,
         // #1455 — the destination, not whatever the canvas shows when the budget fires.
         targetName: name,
+        onLateSuccess: (result) => {
+          if (typeof rid === "string" && rid) rememberLateWorkflowSave(rid, result, "workflow_save_as");
+        },
       },
     );
     // #747 — this path ALWAYS changes which workflow is active, so it is the one

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11775,6 +11775,55 @@ function rebootTargetFields() {
   return target ? { target } : {};
 }
 
+// #2078 — a timed-out save still has a live promise behind the bounded reply.
+// Keep a short, rid-correlated success receipt for the orchestrator's follow-up
+// workflow_list probe. Flags alone cannot tell which clean canvas completed a
+// save after a tab switch; the command rid is the transaction identity.
+const LATE_SAVE_RECEIPT_TTL_MS = 10 * 60 * 1000;
+const MAX_LATE_SAVE_RECEIPTS = 32;
+const lateSaveReceipts = new Map();
+
+function pruneLateSaveReceipts() {
+  const now = Date.now();
+  for (const [rid, receipt] of lateSaveReceipts) {
+    if (now - receipt.completed_at > LATE_SAVE_RECEIPT_TTL_MS) lateSaveReceipts.delete(rid);
+  }
+  while (lateSaveReceipts.size > MAX_LATE_SAVE_RECEIPTS) {
+    const oldest = lateSaveReceipts.keys().next();
+    if (oldest.done) break;
+    lateSaveReceipts.delete(oldest.value);
+  }
+}
+
+function rememberLateWorkflowSave(rid, raw) {
+  if (typeof rid !== "string" || !rid) return;
+  if (!raw || typeof raw !== "object") return;
+  const producedRecord = raw.producedRecord;
+  const savedAs = raw.saved_as === true;
+  const firstSave = raw.first_save === true;
+  const identity = saveProducedIdentity(producedRecord, { savedAs, firstSave });
+  const outcome = {
+    saved: true,
+    ...(typeof raw.name === "string" ? { workflow: raw.name } : {}),
+    ...(savedAs ? { saved_as: true } : {}),
+    ...(firstSave ? { first_save: true } : {}),
+    ...(identity?.routingKey ? { routing_key: identity.routingKey } : {}),
+    ...(identity?.uuid ? { workflow_uuid: identity.uuid } : {}),
+  };
+  pruneLateSaveReceipts();
+  lateSaveReceipts.set(rid, {
+    rid,
+    cmd: "workflow_save",
+    completed_at: Date.now(),
+    result: outcome,
+  });
+}
+
+function lateWorkflowSaveReceipts() {
+  pruneLateSaveReceipts();
+  return Array.from(lateSaveReceipts.values()).map((receipt) => ({ ...receipt }));
+}
+
 const GRAPH_TOOL_EXECUTORS = {
   // #608: force a fresh /object_info re-register + combo refresh so an asset that
   // appeared server-side AFTER page-load — an upload_image action:"stage" input, a freshly
@@ -17757,7 +17806,7 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
-  async workflow_save({ name } = {}) {
+  async workflow_save({ name, rid } = {}) {
     // Fully programmatic — no Save/Rename dialog. Auto-names a never-saved
     // workflow; saves in place otherwise.
     // #1434 — userdata HEAD/GET/PUT on this path can hang while the tab stays
@@ -17773,6 +17822,9 @@ const GRAPH_TOOL_EXECUTORS = {
         observeWorkflow: observeActiveWorkflowSaveState,
         // #1455 — the destination, not whatever the canvas shows when the budget fires.
         targetName: name,
+        onLateSuccess: (result) => {
+          if (typeof rid === "string" && rid) rememberLateWorkflowSave(rid, result);
+        },
       },
     );
     // #978 recurrence — a FIRST save swaps the active object too, and the #557 carry
@@ -17899,6 +17951,7 @@ const GRAPH_TOOL_EXECUTORS = {
             "never received the answer.",
         }
       : null;
+    const lateSaveReceipts = lateWorkflowSaveReceipts();
     return {
       active: active
         ? {
@@ -17948,6 +18001,10 @@ const GRAPH_TOOL_EXECUTORS = {
       // workflow would otherwise be read as proof that a LATER, dropped open ran.
       // No correlating receipt ⇒ the honest verdict is UNDETERMINED, never "opened".
       ...(lastOpen ? { last_open: lastOpen } : {}),
+      // #2078 — exact command-rid receipts for saves that completed after the bounded
+      // workflow_save reply. The orchestrator must match the rid and the active identity;
+      // this field is not a generic "some save succeeded" flag.
+      ...(lateSaveReceipts.length ? { late_save_receipts: lateSaveReceipts } : {}),
       ...(activeMaybeStale
         ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
         : {}),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18007,7 +18007,10 @@ const GRAPH_TOOL_EXECUTORS = {
       // #2078 — exact command-rid receipts for saves that completed after the bounded
       // workflow_save reply. The orchestrator must match the rid and the active identity;
       // this field is not a generic "some save succeeded" flag.
-      ...(lateSaveReceipts.length ? { late_save_receipts: lateSaveReceipts } : {}),
+      // Always advertise the receipt capability, including an empty list. The
+      // orchestrator uses absence to recognize an older panel and presence to
+      // fail closed when a current panel has no receipt for this save RID.
+      late_save_receipts: lateSaveReceipts,
       ...(activeMaybeStale
         ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
         : {}),

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -220,7 +220,15 @@ export function describeWorkflowSaveTimeout({
  */
 export async function runBoundedWorkflowSave(
   saveFn,
-  { budgetMs = WORKFLOW_SAVE_COMMAND_BUDGET_MS, now, withTimeout, observeWorkflow, targetName } = {},
+  {
+    budgetMs = WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    now,
+    withTimeout,
+    observeWorkflow,
+    targetName,
+    onTimeout,
+    onLateSuccess,
+  } = {},
 ) {
   if (typeof saveFn !== "function") {
     throw new Error("runBoundedWorkflowSave requires a save function");
@@ -241,17 +249,36 @@ export async function runBoundedWorkflowSave(
   } catch {
     priorActive = {};
   }
+  let timedOut = false;
+  const saveWork = Promise.resolve()
+    .then(() => saveFn())
+    .then(
+      (result) => {
+        if (timedOut) {
+          try {
+            onLateSuccess?.(result);
+          } catch {
+            // A late-success observer is bookkeeping only; never rewrite the save result.
+          }
+        }
+        return { ok: true, result };
+      },
+      (error) => ({ ok: false, error }),
+    );
   const settled = await withTimeout(
-    Promise.resolve()
-      .then(() => saveFn())
-      .then(
-        (result) => ({ ok: true, result }),
-        (error) => ({ ok: false, error }),
-      ),
+    saveWork,
     budget.bounded(),
-    () => WORKFLOW_SAVE_TIMEOUT,
+    () => {
+      timedOut = true;
+      return WORKFLOW_SAVE_TIMEOUT;
+    },
   );
   if (settled === WORKFLOW_SAVE_TIMEOUT || settled == null) {
+    try {
+      onTimeout?.();
+    } catch {
+      // A timeout observer is bookkeeping only; it must never change the save verdict.
+    }
     let observed = {};
     try {
       observed = typeof observeWorkflow === "function" ? observeWorkflow() || {} : {};


### PR DESCRIPTION
Supports artokun/comfyui-mcp#2078.

- retain success-only late workflow_save receipts keyed by the panel command rid
- expose bounded receipts through workflow_list for exact orchestrator correlation
- keep first-save and tab-switch identity fail-closed

Tests: node --test browser_tests/unit/workflow-save-budget.test.mjs browser_tests/unit/save-reply-identity.test.mjs; npm.cmd run typecheck
