### PR TITLE
fix(1647): prefer live ComfyUI base path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -897,22 +897,22 @@ def _local_comfyui_path():
     so the panel can advertise it in its session-init hello (#296/#291).
 
     READ-ONLY/advisory only — never used to spawn or write. Prefers an explicit
-    COMFYUI_PATH override, then folder_paths.base_path. Returns "" when it cannot
-    be determined (headless/older host) so the panel advertises no local path and
-    the orchestrator falls back to its own workspace detection."""
+    live folder_paths.base_path, then falls back to the COMFYUI_PATH override.
+    Returns "" when it cannot be determined (headless/older host) so the panel
+    advertises no local path and the orchestrator falls back to its own workspace
+    detection."""
     override = (environ.get("COMFYUI_PATH") or "").strip()
-    if override:
-        return override
     try:
         import folder_paths  # type: ignore
 
         base = getattr(folder_paths, "base_path", None)
-        if base and isinstance(base, str):
-            return base
+        if isinstance(base, str) and base.strip():
+            return base.strip()
     except Exception:
-        # folder_paths not importable (headless / older host) — no local path.
-        return ""
-    return ""
+        # folder_paths not importable (headless / older host) — use the
+        # configured fallback below, if one exists.
+        pass
+    return override
 
 
 _LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", _ANY_IPV4_HOST, ""}

--- a/__init__.py
+++ b/__init__.py
@@ -911,7 +911,7 @@ def _local_comfyui_path():
     except Exception:
         # folder_paths not importable (headless / older host) — use the
         # configured fallback below, if one exists.
-        pass
+        return override
     return override
 
 

--- a/browser_tests/unit/test_local_comfyui_path.py
+++ b/browser_tests/unit/test_local_comfyui_path.py
@@ -1,0 +1,51 @@
+"""#1647 — advertise the running ComfyUI base, not a stale inherited path."""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+_REPO = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+
+
+def _load_init():
+    spec = importlib.util.spec_from_file_location(
+        "cmcp_panel_init_local_path", os.path.join(_REPO, "__init__.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_init()
+
+
+class LocalComfyUiPath(unittest.TestCase):
+    def test_live_folder_paths_wins_over_stale_environment_override(self):
+        folder_paths = types.ModuleType("folder_paths")
+        folder_paths.base_path = r"E:\ComfyUI\running"
+        with patch.dict(mod.environ, {"COMFYUI_PATH": r"C:\ComfyUI\stale"}), patch.dict(
+            sys.modules, {"folder_paths": folder_paths}
+        ):
+            self.assertEqual(mod._local_comfyui_path(), r"E:\ComfyUI\running")
+
+    def test_environment_override_is_fallback_when_folder_paths_is_unavailable(self):
+        with patch.dict(mod.environ, {"COMFYUI_PATH": r"C:\ComfyUI\configured"}), patch.dict(
+            sys.modules, {"folder_paths": None}
+        ):
+            self.assertEqual(mod._local_comfyui_path(), r"C:\ComfyUI\configured")
+
+    def test_blank_live_base_falls_back_to_environment_override(self):
+        folder_paths = types.ModuleType("folder_paths")
+        folder_paths.base_path = "  "
+        with patch.dict(mod.environ, {"COMFYUI_PATH": r"C:\ComfyUI\configured"}), patch.dict(
+            sys.modules, {"folder_paths": folder_paths}
+        ):
+            self.assertEqual(mod._local_comfyui_path(), r"C:\ComfyUI\configured")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1647. Prefer the connected ComfyUI's live folder_paths.base_path when advertising the local path, and fall back to COMFYUI_PATH only when the live module is unavailable or blank. Adds isolated regression coverage for stale environment overrides.\n\nIndependent Codex gate: SHIP.