### PR TITLE
fix(1650): rehydrate Ideogram region editor writes

### DIFF
--- a/browser_tests/unit/ideogram4-prompt-builder.test.mjs
+++ b/browser_tests/unit/ideogram4-prompt-builder.test.mjs
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 
 import {
   classifyIdeogram4PromptBuilderWrite,
+  applyIdeogram4PromptBuilderWrite,
   ideogram4PromptBuilderRefusal,
   IDEOGRAM4_PROMPT_BUILDER_TYPE,
   IDEOGRAM4_ELEMENTS_WIDGET,
@@ -123,7 +124,7 @@ test("#1569: the guard is WIRED into graph_set_widget, ahead of the generic writ
   // failure this asserts against. The refusal has to run BEFORE runSetWidget, or the write
   // lands and reports success before anyone asks whether it can reach the render.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  assert.match(src, /import \{\s*classifyIdeogram4PromptBuilderWrite,\s*ideogram4PromptBuilderRefusal,\s*\} from "\.\/lib\/ideogram4-prompt-builder\.js";/);
+  assert.match(src, /import \{[\s\S]*classifyIdeogram4PromptBuilderWrite,[\s\S]*applyIdeogram4PromptBuilderWrite,[\s\S]*ideogram4PromptBuilderRefusal,[\s\S]*\} from "\.\/lib\/ideogram4-prompt-builder\.js";/);
 
   const handler = src.slice(src.indexOf("async graph_set_widget("));
   assert.ok(handler.startsWith("async graph_set_widget("), "graph_set_widget handler not found");
@@ -133,4 +134,115 @@ test("#1569: the guard is WIRED into graph_set_widget, ahead of the generic writ
   assert.ok(writeAt > 0, "runSetWidget call site not found in graph_set_widget");
   assert.ok(guardAt < writeAt, "the guard must run BEFORE runSetWidget");
   assert.match(handler.slice(guardAt, writeAt), /throw new Error\(ideogram4PromptBuilderRefusal\(widget, node\.id\)\)/);
+});
+
+function editorFixture({ boxes = [], importLink = null } = {}) {
+  const node = {
+    id: 217,
+    type: TYPE,
+    _boxes: boxes.map((box) => ({ ...box })),
+    _stylePalette: ["#112233"],
+    inputs: [{ name: "import_json", link: importLink }],
+    graph: { links: importLink == null ? {} : { [importLink]: { origin_id: 91 } } },
+    widgets: [
+      { name: "high_level_description", value: "existing subject" },
+      { name: "background", value: "existing background" },
+      { name: "style", value: "photo" },
+      { name: "style.photo", value: "film still" },
+      { name: "aesthetics", value: "grainy" },
+      { name: "lighting", value: "soft" },
+      { name: "medium", value: "35mm" },
+      { name: IDEOGRAM4_ELEMENTS_WIDGET, value: "", serializeValue: () => JSON.stringify(node._boxes) },
+    ],
+  };
+  node.onExecuted = (message) => {
+    const caption = JSON.parse(message.caption[0]);
+    const elements = caption.compositional_deconstruction.elements;
+    node._boxes = elements.map((element) => {
+      const [ymin, xmin, ymax, xmax] = element.bbox ?? [30, 30, 170, 250];
+      return {
+        x: xmin / 1000,
+        y: ymin / 1000,
+        w: (xmax - xmin) / 1000,
+        h: (ymax - ymin) / 1000,
+        type: element.type,
+        text: element.text || "",
+        desc: element.desc || "",
+        palette: element.color_palette || [],
+        ...(element.bbox ? {} : { nobbox: true }),
+      };
+    });
+  };
+  return node;
+}
+
+test("#1650: elements_data rehydrates the live editor and verifies the serialized regions", () => {
+  const node = editorFixture({
+    boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2, type: "obj", text: "", desc: "old" }],
+  });
+  const calls = [];
+  const result = applyIdeogram4PromptBuilderWrite(
+    node,
+    JSON.stringify([
+      {
+        x: 0.1,
+        y: 0.2,
+        w: 0.3,
+        h: 0.4,
+        type: "text",
+        text: "NEW",
+        desc: "new region",
+        palette: ["#abcdef"],
+        locked: true,
+      },
+    ]),
+    {
+      beforeChange: () => calls.push("before"),
+      afterChange: () => calls.push("after"),
+      setDirty: () => calls.push("dirty"),
+    },
+  );
+  assert.deepEqual(calls, ["before", "after", "dirty"]);
+  assert.deepEqual(result.ideogram4_prompt_builder, {
+    node_id: 217,
+    widget: "elements_data",
+    driven: true,
+    editor_driven: true,
+    previous_regions: 1,
+    regions: 1,
+    verified: true,
+  });
+  assert.equal(node._boxes[0].text, "NEW");
+  assert.equal(node._boxes[0].locked, true, "editor-only lock state survives the import route");
+  assert.equal(node.widgets.find((w) => w.name === IDEOGRAM4_ELEMENTS_WIDGET).value, JSON.stringify(node._boxes));
+  assert.equal(node.widgets.find((w) => w.name === "high_level_description").value, "existing subject");
+});
+
+test("#1650: an empty region list clears the editor without requiring an import wire", () => {
+  const node = editorFixture({
+    boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2, type: "obj", text: "", desc: "old" }],
+  });
+  const result = applyIdeogram4PromptBuilderWrite(node, "[]");
+  assert.equal(result.ideogram4_prompt_builder.previous_regions, 1);
+  assert.equal(result.ideogram4_prompt_builder.regions, 0);
+  assert.deepEqual(node._boxes, []);
+});
+
+test("#1650: a connected import_json source remains authoritative", () => {
+  const node = editorFixture({ importLink: 7, boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2 }] });
+  assert.throws(
+    () => applyIdeogram4PromptBuilderWrite(node, "[]"),
+    /live import_json connection.*authoritative/,
+  );
+  assert.equal(node._boxes.length, 1, "the ambiguous write does not touch the editor");
+});
+
+test("#1650: malformed region input is rejected before opening an undo step", () => {
+  const node = editorFixture();
+  let before = 0;
+  assert.throws(
+    () => applyIdeogram4PromptBuilderWrite(node, JSON.stringify([{ x: 0, y: 0, w: 2, h: 0.1 }]), { beforeChange: () => before++ }),
+    /outside the normalized/,
+  );
+  assert.equal(before, 0);
 });

--- a/browser_tests/unit/ideogram4-prompt-builder.test.mjs
+++ b/browser_tests/unit/ideogram4-prompt-builder.test.mjs
@@ -136,14 +136,17 @@ test("#1569: the guard is WIRED into graph_set_widget, ahead of the generic writ
   assert.match(handler.slice(guardAt, writeAt), /throw new Error\(ideogram4PromptBuilderRefusal\(widget, node\.id\)\)/);
 });
 
-function editorFixture({ boxes = [], importLink = null } = {}) {
+function editorFixture({ boxes = [], importLink = null, importMode = "when empty", originMode = 0 } = {}) {
   const node = {
     id: 217,
     type: TYPE,
     _boxes: boxes.map((box) => ({ ...box })),
     _stylePalette: ["#112233"],
     inputs: [{ name: "import_json", link: importLink }],
-    graph: { links: importLink == null ? {} : { [importLink]: { origin_id: 91 } } },
+    graph: {
+      links: importLink == null ? {} : { [importLink]: { origin_id: 91 } },
+      getNodeById: () => ({ mode: originMode }),
+    },
     widgets: [
       { name: "high_level_description", value: "existing subject" },
       { name: "background", value: "existing background" },
@@ -152,6 +155,7 @@ function editorFixture({ boxes = [], importLink = null } = {}) {
       { name: "aesthetics", value: "grainy" },
       { name: "lighting", value: "soft" },
       { name: "medium", value: "35mm" },
+      { name: "import_mode", value: importMode },
       { name: "style_palette_data", value: "[\"#112233\"]" },
       {
         name: IDEOGRAM4_ELEMENTS_WIDGET,
@@ -237,13 +241,45 @@ test("#1650: an empty region list clears the editor without requiring an import 
   assert.deepEqual(node._boxes, []);
 });
 
-test("#1650: a connected import_json source remains authoritative", () => {
-  const node = editorFixture({ importLink: 7, boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2 }] });
+test("#1650: always-mode import_json remains authoritative", () => {
+  const node = editorFixture({ importLink: 7, importMode: "always", boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2 }] });
   assert.throws(
     () => applyIdeogram4PromptBuilderWrite(node, "[]"),
     /live import_json connection.*authoritative/,
   );
   assert.equal(node._boxes.length, 1, "the ambiguous write does not touch the editor");
+});
+
+test("#1650: when-empty import_json permits replacement while local regions exist", () => {
+  const node = editorFixture({ importLink: 7, boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2 }] });
+  const result = applyIdeogram4PromptBuilderWrite(node, "[]");
+  assert.equal(result.ideogram4_prompt_builder.verified, true);
+  assert.deepEqual(node._boxes, []);
+});
+
+test("#1650: muted import_json links do not block local editor writes", () => {
+  const node = editorFixture({ importLink: 7, importMode: "always", originMode: 2, boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2 }] });
+  const result = applyIdeogram4PromptBuilderWrite(node, "[]");
+  assert.equal(result.ideogram4_prompt_builder.verified, true);
+  assert.deepEqual(node._boxes, []);
+});
+
+test("#1650: nobbox regions retain unplaced semantics through rehydration", () => {
+  const node = editorFixture({ boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2 }] });
+  const result = applyIdeogram4PromptBuilderWrite(node, JSON.stringify([
+    { x: 0.5, y: 0.5, w: 0.1, h: 0.1, nobbox: true, desc: "unplaced" },
+  ]));
+  assert.equal(result.ideogram4_prompt_builder.verified, true);
+  assert.equal(node._boxes[0].nobbox, true);
+  assert.equal(node._boxes[0].desc, "unplaced");
+});
+
+test("#1650: incompatible callback failures roll back the editor", () => {
+  const node = editorFixture({ boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2, desc: "old" }] });
+  const before = JSON.stringify(node._boxes);
+  node.onExecuted = () => { node._boxes = [{ x: 0.4, y: 0.4, w: 0.1, h: 0.1 }]; };
+  assert.throws(() => applyIdeogram4PromptBuilderWrite(node, "[]"), /did not rehydrate/);
+  assert.equal(JSON.stringify(node._boxes), before);
 });
 
 test("#1650: malformed region input is rejected before opening an undo step", () => {

--- a/browser_tests/unit/ideogram4-prompt-builder.test.mjs
+++ b/browser_tests/unit/ideogram4-prompt-builder.test.mjs
@@ -152,7 +152,13 @@ function editorFixture({ boxes = [], importLink = null } = {}) {
       { name: "aesthetics", value: "grainy" },
       { name: "lighting", value: "soft" },
       { name: "medium", value: "35mm" },
-      { name: IDEOGRAM4_ELEMENTS_WIDGET, value: "", serializeValue: () => JSON.stringify(node._boxes) },
+      { name: "style_palette_data", value: "[\"#112233\"]" },
+      {
+        name: IDEOGRAM4_ELEMENTS_WIDGET,
+        value: "",
+        // KJNodes returns an empty string, rather than JSON [], for an empty editor.
+        serializeValue: () => (node._boxes.length ? JSON.stringify(node._boxes) : ""),
+      },
     ],
   };
   node.onExecuted = (message) => {
@@ -172,6 +178,7 @@ function editorFixture({ boxes = [], importLink = null } = {}) {
         ...(element.bbox ? {} : { nobbox: true }),
       };
     });
+    node._stylePalette = caption.style_description?.color_palette ?? [];
   };
   return node;
 }
@@ -180,6 +187,7 @@ test("#1650: elements_data rehydrates the live editor and verifies the serialize
   const node = editorFixture({
     boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2, type: "obj", text: "", desc: "old" }],
   });
+  node.widgets.find((w) => w.name === "style_palette_data").value = "[\"#abcdef\"]";
   const calls = [];
   const result = applyIdeogram4PromptBuilderWrite(
     node,
@@ -216,6 +224,7 @@ test("#1650: elements_data rehydrates the live editor and verifies the serialize
   assert.equal(node._boxes[0].locked, true, "editor-only lock state survives the import route");
   assert.equal(node.widgets.find((w) => w.name === IDEOGRAM4_ELEMENTS_WIDGET).value, JSON.stringify(node._boxes));
   assert.equal(node.widgets.find((w) => w.name === "high_level_description").value, "existing subject");
+  assert.deepEqual(node._stylePalette, ["#abcdef"], "the live hidden palette value is preserved");
 });
 
 test("#1650: an empty region list clears the editor without requiring an import wire", () => {

--- a/browser_tests/unit/ideogram4-prompt-builder.test.mjs
+++ b/browser_tests/unit/ideogram4-prompt-builder.test.mjs
@@ -282,6 +282,19 @@ test("#1650: incompatible callback failures roll back the editor", () => {
   assert.equal(JSON.stringify(node._boxes), before);
 });
 
+test("#1650: palette mismatches are not reported as verified", () => {
+  const node = editorFixture({ boxes: [{ x: 0, y: 0, w: 0.2, h: 0.2, palette: ["#00f"] }] });
+  const before = JSON.stringify(node._boxes);
+  node.onExecuted = () => { node._boxes = [{ x: 0, y: 0, w: 0.2, h: 0.2, palette: ["#00f"] }]; };
+  assert.throws(
+    () => applyIdeogram4PromptBuilderWrite(node, JSON.stringify([
+      { x: 0, y: 0, w: 0.2, h: 0.2, palette: ["#f00"] },
+    ])),
+    /did not rehydrate/,
+  );
+  assert.equal(JSON.stringify(node._boxes), before);
+});
+
 test("#1650: malformed region input is rejected before opening an undo step", () => {
   const node = editorFixture();
   let before = 0;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -453,6 +453,7 @@ import {
 } from "./lib/rgthree-fast-groups.js";
 import {
   classifyIdeogram4PromptBuilderWrite,
+  applyIdeogram4PromptBuilderWrite,
   ideogram4PromptBuilderRefusal,
 } from "./lib/ideogram4-prompt-builder.js";
 import {
@@ -14515,16 +14516,22 @@ const GRAPH_TOOL_EXECUTORS = {
     if (classifyRgthreeFastGroupsWrite(node, widget) === "derived") {
       throw new Error(rgthreeFastGroupsRefusal(widget, node.id, node.type));
     }
-    // comfyui-mcp#1569: KJNodes' Ideogram4PromptBuilderKJ holds its regions in the node's
-    // own in-browser editor and installs a `serializeValue()` on `elements_data` that builds
-    // the queued value from that state without ever reading the widget. ComfyUI queues
-    // `serializeValue()`, so a direct write showed a clean success AND showed up in
-    // panel_query_graph while the render kept using the old regions. Refused loudly, keyed to
-    // the node type, the widget name, AND the live presence of the serializer — so nothing
-    // else on the node is affected and the guard cannot outlive the pack behaviour that
-    // justifies it. See the lib for the four source facts and for why style_palette_data,
-    // which has no serializer of its own, is deliberately still writable.
+    // comfyui-mcp#1569/#1650: KJNodes' Ideogram4PromptBuilderKJ holds its regions in the
+    // node's own in-browser editor and installs a `serializeValue()` on `elements_data` that
+    // builds the queued value from that state without ever reading the widget. Route this
+    // one derived write through the node's import callback, which is the frontend half of
+    // its supported `import_json` path, and verify the callback's serialized result before
+    // reporting success. A live import_json wire remains refused by the helper because its
+    // source is authoritative at queue time. Other widgets on the node remain on the normal
+    // path. See the lib for the mechanism and the fail-closed validation.
     if (classifyIdeogram4PromptBuilderWrite(node, widget) === "derived") {
+      if (widget === "elements_data") {
+        return applyIdeogram4PromptBuilderWrite(node, value, {
+          beforeChange: () => graph.beforeChange(),
+          afterChange: () => graph.afterChange(),
+          setDirty: () => graph.setDirtyCanvas(true, true),
+        });
+      }
       throw new Error(ideogram4PromptBuilderRefusal(widget, node.id));
     }
     // #1549: MiniMaxH3PromptBuilder's editor Save writes prompt_text and builder_state

--- a/web/js/lib/ideogram4-prompt-builder.js
+++ b/web/js/lib/ideogram4-prompt-builder.js
@@ -302,6 +302,7 @@ function regionShape(box) {
     w: Number(box?.w),
     h: Number(box?.h),
     nobbox: box?.nobbox === true,
+    palette: Array.isArray(box?.palette) ? box.palette.map((color) => String(color)) : [],
   };
 }
 
@@ -313,6 +314,8 @@ function sameRegionShape(actual, expected) {
     a.text === e.text &&
     a.desc === e.desc &&
     a.nobbox === e.nobbox &&
+    a.palette.length === e.palette.length &&
+    a.palette.every((color, index) => color === e.palette[index]) &&
     (e.nobbox || ["x", "y", "w", "h"].every((key) => Math.abs(a[key] - e[key]) <= 0.001))
   );
 }

--- a/web/js/lib/ideogram4-prompt-builder.js
+++ b/web/js/lib/ideogram4-prompt-builder.js
@@ -280,7 +280,13 @@ function connectedImportSource(node) {
     const input = (node?.inputs ?? []).find((entry) => entry?.name === "import_json");
     const link = input?.link;
     if (link == null) return null;
-    return node.graph?.links?.[link] ?? null;
+    const source = node.graph?.links?.[link] ?? null;
+    if (!source) return null;
+    // KJNodes deliberately keeps muted/bypassed links in the graph while treating
+    // them as disconnected for queue-time authority.
+    const origin = node.graph?.getNodeById?.(source.origin_id);
+    if (origin && [2, 4].includes(origin.mode)) return null;
+    return source;
   } catch {
     return null;
   }
@@ -307,8 +313,15 @@ function sameRegionShape(actual, expected) {
     a.text === e.text &&
     a.desc === e.desc &&
     a.nobbox === e.nobbox &&
-    ["x", "y", "w", "h"].every((key) => Math.abs(a[key] - e[key]) <= 0.001)
+    (e.nobbox || ["x", "y", "w", "h"].every((key) => Math.abs(a[key] - e[key]) <= 0.001))
   );
+}
+
+function cloneEditorBoxes(boxes) {
+  return (Array.isArray(boxes) ? boxes : []).map((box) => ({
+    ...box,
+    ...(Array.isArray(box?.palette) ? { palette: [...box.palette] } : {}),
+  }));
 }
 
 function readSerializedRegions(elementsWidget) {
@@ -327,9 +340,11 @@ function readSerializedRegions(elementsWidget) {
  * refreshes the hidden widgets, and repaints the editor. Calling the generic widget
  * setter cannot do that because `serializeValue()` ignores `widget.value`.
  *
- * A live import_json connection remains authoritative at queue time, so silently
- * changing the local editor would be overwritten by that source on the next run.
- * Refuse that ambiguous case and tell the caller to update the connected source.
+ * An active import_json connection is authoritative in "always" mode, and while
+ * the local editor is empty in "when empty" mode. In the latter mode, existing
+ * local regions are intentionally authoritative, matching KJNodes' serializer.
+ * Refuse only the source-authoritative cases and tell the caller to update the
+ * connected source.
  */
 export function applyIdeogram4PromptBuilderWrite(
   node,
@@ -343,13 +358,6 @@ export function applyIdeogram4PromptBuilderWrite(
     );
   }
   const importLink = connectedImportSource(node);
-  if (importLink) {
-    throw new Error(
-      `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} has a live import_json connection, which is ` +
-        "the queue's authoritative region source. Update the connected PrimitiveStringMultiline value " +
-        "and keep import_mode set to always; panel_set_widget cannot safely override that source.",
-    );
-  }
   const boxes = normalizeRegionBoxes(value);
   const elementsWidget = findWidget(node, IDEOGRAM4_ELEMENTS_WIDGET);
   let current;
@@ -367,6 +375,14 @@ export function applyIdeogram4PromptBuilderWrite(
         "nothing was changed.",
     );
   }
+  const importMode = stringWidgetValue(node, "import_mode");
+  if (importLink && (importMode === "always" || current.length === 0)) {
+    throw new Error(
+      `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} has a live import_json connection, which is ` +
+        "the queue's authoritative region source in the current import mode. Update the connected " +
+        "PrimitiveStringMultiline value or leave local regions in place before using panel_set_widget.",
+    );
+  }
   if (typeof node?.onExecuted !== "function") {
     throw new Error(
       `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} has no live import callback; ` +
@@ -374,6 +390,11 @@ export function applyIdeogram4PromptBuilderWrite(
     );
   }
 
+  const previousBoxes = cloneEditorBoxes(node._boxes);
+  const previousPalette = Array.isArray(node._stylePalette) ? [...node._stylePalette] : node._stylePalette;
+  const previousLastImported = node._lastImported;
+  const previousWidgets = (node.widgets ?? []).map((widget) => ({ widget, value: widget.value }));
+  const previousSize = Array.isArray(node.size) ? [...node.size] : null;
   beforeChange?.();
   try {
     node.onExecuted({ caption: [JSON.stringify(currentCaptionForRegions(node, boxes))] });
@@ -398,6 +419,16 @@ export function applyIdeogram4PromptBuilderWrite(
       if (boxes[i].locked === true && node._boxes?.[i]) node._boxes[i].locked = true;
     }
     elementsWidget.value = JSON.stringify(node._boxes ?? serialized);
+  } catch (error) {
+    // The callback is third-party node code. If a future KJNodes build changes its
+    // caption semantics, restore every state we can observe before exposing the
+    // failure to the generic handler.
+    node._boxes = previousBoxes;
+    node._stylePalette = previousPalette;
+    node._lastImported = previousLastImported;
+    for (const { widget, value: previousValue } of previousWidgets) widget.value = previousValue;
+    if (previousSize && typeof node.setSize === "function") node.setSize(previousSize);
+    throw error;
   } finally {
     afterChange?.();
   }

--- a/web/js/lib/ideogram4-prompt-builder.js
+++ b/web/js/lib/ideogram4-prompt-builder.js
@@ -159,6 +159,20 @@ function stringWidgetValue(node, name) {
   return typeof value === "string" ? value : value == null ? "" : String(value);
 }
 
+function currentStylePalette(node) {
+  const widgetValue = findWidget(node, "style_palette_data")?.value;
+  if (typeof widgetValue === "string") {
+    try {
+      const parsed = JSON.parse(widgetValue);
+      if (Array.isArray(parsed) && parsed.every((color) => typeof color === "string")) return parsed;
+    } catch {
+      // Fall through to the live editor state. A malformed hidden widget is not
+      // evidence that the editor has no palette.
+    }
+  }
+  return Array.isArray(node?._stylePalette) ? node._stylePalette : [];
+}
+
 function finiteBoxNumber(value, field, index) {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     throw new Error(`elements_data[${index}].${field} must be a finite number`);
@@ -252,8 +266,9 @@ function currentCaptionForRegions(node, boxes) {
     };
     if (style === "photo") styleDescription.photo = stringWidgetValue(node, "style.photo");
     else styleDescription.art_style = stringWidgetValue(node, "style.art_style");
-    if (Array.isArray(node?._stylePalette) && node._stylePalette.length) {
-      styleDescription.color_palette = [...node._stylePalette];
+    const palette = currentStylePalette(node);
+    if (palette.length) {
+      styleDescription.color_palette = [...palette];
     }
     caption.style_description = styleDescription;
   }
@@ -296,6 +311,14 @@ function sameRegionShape(actual, expected) {
   );
 }
 
+function readSerializedRegions(elementsWidget) {
+  const raw = elementsWidget.serializeValue();
+  // KJNodes uses an empty string for an empty editor, not JSON `[]`.
+  if (raw === "") return [];
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : null;
+}
+
 /**
  * Rehydrate the live KJNodes editor from an elements_data region list.
  *
@@ -331,7 +354,7 @@ export function applyIdeogram4PromptBuilderWrite(
   const elementsWidget = findWidget(node, IDEOGRAM4_ELEMENTS_WIDGET);
   let current;
   try {
-    current = JSON.parse(elementsWidget.serializeValue());
+    current = readSerializedRegions(elementsWidget);
   } catch {
     throw new Error(
       `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} did not expose a readable elements_data serialization; ` +
@@ -357,7 +380,7 @@ export function applyIdeogram4PromptBuilderWrite(
     // The callback is the mutation boundary. Verify the exact semantic fields that
     // the caption format carries before reporting success; a callback that exists but
     // is from an incompatible KJNodes build must not become a silent success.
-    const serialized = JSON.parse(elementsWidget.serializeValue());
+    const serialized = readSerializedRegions(elementsWidget);
     if (
       !Array.isArray(serialized) ||
       serialized.length !== boxes.length ||

--- a/web/js/lib/ideogram4-prompt-builder.js
+++ b/web/js/lib/ideogram4-prompt-builder.js
@@ -149,3 +149,245 @@ export function ideogram4PromptBuilderRefusal(widgetName, nodeId) {
     `string widgets that reach the render normally.`
   );
 }
+
+function findWidget(node, name) {
+  return Array.isArray(node?.widgets) ? node.widgets.find((w) => w?.name === name) : null;
+}
+
+function stringWidgetValue(node, name) {
+  const value = findWidget(node, name)?.value;
+  return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function finiteBoxNumber(value, field, index) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`elements_data[${index}].${field} must be a finite number`);
+  }
+  return value;
+}
+
+function normalizeRegionBoxes(value) {
+  let parsed = value;
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (!text) return [];
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new Error("elements_data must be a JSON array of Ideogram region objects");
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("elements_data must be a JSON array of Ideogram region objects");
+  }
+  return parsed.map((box, index) => {
+    if (!box || typeof box !== "object" || Array.isArray(box)) {
+      throw new Error(`elements_data[${index}] must be an object`);
+    }
+    const x = finiteBoxNumber(box.x, "x", index);
+    const y = finiteBoxNumber(box.y, "y", index);
+    const w = finiteBoxNumber(box.w, "w", index);
+    const h = finiteBoxNumber(box.h, "h", index);
+    if (x < 0 || y < 0 || w < 0 || h < 0 || x + w > 1 || y + h > 1) {
+      throw new Error(`elements_data[${index}] has a region outside the normalized 0..1 canvas`);
+    }
+    const text = box.text == null ? "" : box.text;
+    const desc = box.desc == null ? "" : box.desc;
+    if (typeof text !== "string" || typeof desc !== "string") {
+      throw new Error(`elements_data[${index}].text and .desc must be strings when present`);
+    }
+    const palette = box.palette == null ? [] : box.palette;
+    if (!Array.isArray(palette) || palette.some((color) => typeof color !== "string")) {
+      throw new Error(`elements_data[${index}].palette must be an array of strings when present`);
+    }
+    return {
+      x,
+      y,
+      w,
+      h,
+      type: box.type === "text" ? "text" : "obj",
+      text,
+      desc,
+      palette: [...palette],
+      ...(box.nobbox === true ? { nobbox: true } : {}),
+      ...(box.locked === true ? { locked: true } : {}),
+    };
+  });
+}
+
+function regionToCaptionElement(box) {
+  const element = { type: box.type, desc: box.desc };
+  if (box.type === "text") element.text = box.text;
+  if (!box.nobbox) {
+    // KJNodes' import callback accepts the same 0..1000 y/x/y/x order that its
+    // caption exporter emits. Round at the boundary so the rehydrated editor has
+    // the exact representation its own serializer will produce.
+    element.bbox = [
+      Math.round(box.y * 1000),
+      Math.round(box.x * 1000),
+      Math.round((box.y + box.h) * 1000),
+      Math.round((box.x + box.w) * 1000),
+    ];
+  }
+  if (box.palette.length) element.color_palette = [...box.palette];
+  return element;
+}
+
+function currentCaptionForRegions(node, boxes) {
+  const caption = {
+    compositional_deconstruction: {
+      background: stringWidgetValue(node, "background"),
+      elements: boxes.map(regionToCaptionElement),
+    },
+  };
+  const highLevel = stringWidgetValue(node, "high_level_description");
+  if (highLevel) caption.high_level_description = highLevel;
+
+  const style = stringWidgetValue(node, "style");
+  if (style === "photo" || style === "art_style") {
+    const styleDescription = {
+      aesthetics: stringWidgetValue(node, "aesthetics"),
+      lighting: stringWidgetValue(node, "lighting"),
+      medium: stringWidgetValue(node, "medium"),
+    };
+    if (style === "photo") styleDescription.photo = stringWidgetValue(node, "style.photo");
+    else styleDescription.art_style = stringWidgetValue(node, "style.art_style");
+    if (Array.isArray(node?._stylePalette) && node._stylePalette.length) {
+      styleDescription.color_palette = [...node._stylePalette];
+    }
+    caption.style_description = styleDescription;
+  }
+  return caption;
+}
+
+function connectedImportSource(node) {
+  try {
+    const input = (node?.inputs ?? []).find((entry) => entry?.name === "import_json");
+    const link = input?.link;
+    if (link == null) return null;
+    return node.graph?.links?.[link] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function regionShape(box) {
+  return {
+    type: box?.type === "text" ? "text" : "obj",
+    text: typeof box?.text === "string" ? box.text : "",
+    desc: typeof box?.desc === "string" ? box.desc : "",
+    x: Number(box?.x),
+    y: Number(box?.y),
+    w: Number(box?.w),
+    h: Number(box?.h),
+    nobbox: box?.nobbox === true,
+  };
+}
+
+function sameRegionShape(actual, expected) {
+  const a = regionShape(actual);
+  const e = regionShape(expected);
+  return (
+    a.type === e.type &&
+    a.text === e.text &&
+    a.desc === e.desc &&
+    a.nobbox === e.nobbox &&
+    ["x", "y", "w", "h"].every((key) => Math.abs(a[key] - e[key]) <= 0.001)
+  );
+}
+
+/**
+ * Rehydrate the live KJNodes editor from an elements_data region list.
+ *
+ * The node's own `onExecuted({caption:[…]})` callback is the frontend half of its
+ * supported `import_json` path: KJNodes parses the caption, rebuilds `_boxes`,
+ * refreshes the hidden widgets, and repaints the editor. Calling the generic widget
+ * setter cannot do that because `serializeValue()` ignores `widget.value`.
+ *
+ * A live import_json connection remains authoritative at queue time, so silently
+ * changing the local editor would be overwritten by that source on the next run.
+ * Refuse that ambiguous case and tell the caller to update the connected source.
+ */
+export function applyIdeogram4PromptBuilderWrite(
+  node,
+  value,
+  { beforeChange, afterChange, setDirty } = {},
+) {
+  if (classifyIdeogram4PromptBuilderWrite(node, IDEOGRAM4_ELEMENTS_WIDGET) !== "derived") {
+    throw new Error(
+      `Ideogram4PromptBuilder node ${node?.id ?? "?"} does not expose the live elements editor serializer; ` +
+        "refresh the ComfyUI tab and retry.",
+    );
+  }
+  const importLink = connectedImportSource(node);
+  if (importLink) {
+    throw new Error(
+      `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} has a live import_json connection, which is ` +
+        "the queue's authoritative region source. Update the connected PrimitiveStringMultiline value " +
+        "and keep import_mode set to always; panel_set_widget cannot safely override that source.",
+    );
+  }
+  const boxes = normalizeRegionBoxes(value);
+  const elementsWidget = findWidget(node, IDEOGRAM4_ELEMENTS_WIDGET);
+  let current;
+  try {
+    current = JSON.parse(elementsWidget.serializeValue());
+  } catch {
+    throw new Error(
+      `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} did not expose a readable elements_data serialization; ` +
+        "nothing was changed.",
+    );
+  }
+  if (!Array.isArray(current)) {
+    throw new Error(
+      `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} returned a non-array elements_data serialization; ` +
+        "nothing was changed.",
+    );
+  }
+  if (typeof node?.onExecuted !== "function") {
+    throw new Error(
+      `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} has no live import callback; ` +
+        "refresh the ComfyUI tab and retry.",
+    );
+  }
+
+  beforeChange?.();
+  try {
+    node.onExecuted({ caption: [JSON.stringify(currentCaptionForRegions(node, boxes))] });
+    // The callback is the mutation boundary. Verify the exact semantic fields that
+    // the caption format carries before reporting success; a callback that exists but
+    // is from an incompatible KJNodes build must not become a silent success.
+    const serialized = JSON.parse(elementsWidget.serializeValue());
+    if (
+      !Array.isArray(serialized) ||
+      serialized.length !== boxes.length ||
+      serialized.some((box, index) => !sameRegionShape(box, boxes[index]))
+    ) {
+      throw new Error(
+        `Ideogram4PromptBuilderKJ node ${node?.id ?? "?"} did not rehydrate elements_data to the requested ` +
+          "regions; nothing was reported as applied.",
+      );
+    }
+    // The caption format has no lock bit; restore that editor-only flag after the
+    // node's own import callback and refresh the serialized hidden widget so a locked
+    // region is not silently unlocked by a programmatic replacement.
+    for (let i = 0; i < boxes.length; i++) {
+      if (boxes[i].locked === true && node._boxes?.[i]) node._boxes[i].locked = true;
+    }
+    elementsWidget.value = JSON.stringify(node._boxes ?? serialized);
+  } finally {
+    afterChange?.();
+  }
+  setDirty?.();
+  return {
+    ideogram4_prompt_builder: {
+      node_id: node?.id,
+      widget: IDEOGRAM4_ELEMENTS_WIDGET,
+      driven: true,
+      editor_driven: true,
+      previous_regions: current.length,
+      regions: boxes.length,
+      verified: true,
+    },
+  };
+}


### PR DESCRIPTION
Fixes #1650.\n\n- Rehydrates the live Ideogram4PromptBuilderKJ editor through its supported caption callback when writing elements_data.\n- Preserves palettes and editor-only locks, supports clearing and unplaced nobbox regions, and verifies the semantic result.\n- Respects KJNodes import authority for active always/when-empty sources and ignores muted/bypassed links.\n- Rolls back observed editor state if a future callback build cannot verify the write.\n\nValidation: npm.cmd run test:unit (6174 pass, 0 fail, 1 todo); independent Codex gate SHIP.