### PR TITLE
fix(1651): skip frontend-authored CustomCombo availability

### DIFF
--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -80,6 +80,17 @@ test("#745 an EMPTY option list is a real answer, not an unknown one", async () 
   assert.deepEqual(r.unknown, []);
 });
 
+test("#1651 frontend-authored CustomCombo choices are not judged by /object_info", async () => {
+  let lookups = 0;
+  const r = await scanComboAvailability(
+    [node(73, "CustomCombo", [{ name: "choice", value: "Auto - Smart Engine + Compatible LoRA" }])],
+    async () => { lookups += 1; return EMPTY_LORA; },
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.deepEqual(r.unknown, []);
+  assert.equal(lookups, 0, "the server's intentionally empty CustomCombo list is not authoritative");
+});
+
 test("#745 an ABSENT class is UNKNOWN — never a finding, never healthy", async () => {
   // /object_info/<absent> answers `{}` with HTTP 200, not a 404. If that collapsed
   // into "no combos", every widget on the node would pass as fine; if it collapsed

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -414,6 +414,10 @@ export async function scanComboAvailability(
     // A node whose pack is NOT loaded is a defless placeholder, carries no `isVirtualNode`,
     // and is still scanned and still reported (see frontend-virtual-nodes.js).
     if (isFrontendVirtualNode(node)) continue;
+    // panel#1651 — CustomCombo choices are authored by the frontend widget. Its
+    // intentionally empty server COMBO list is not evidence that the selected
+    // frontend value names a missing asset, so /object_info has no authority here.
+    if (className === "CustomCombo") continue;
     const entry = await comboMapFor(className);
     if (!entry.combos) {
       // Unjudgeable. Report the node once, with the REASON it was skipped — a


### PR DESCRIPTION
Fixes #1651.\n\nCustomCombo choices are authored by the frontend, while its intentionally empty /object_info COMBO list cannot establish that a selected choice is a missing asset. Skip this node type before the live class lookup; preserve normal empty-list judgment for all other combo nodes.\n\nValidation: npm.cmd run test:unit (6556 pass, 0 fail, 1 todo); focused availability tests 95/95; independent Codex gate SHIP.