### PR TITLE
fix(panel#1654): preserve graph serializer failures

### DIFF
--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -25,6 +25,7 @@ import assert from "node:assert/strict";
 import {
   unrunnableNodeIds,
   graphToPromptUnusable,
+  graphToPromptFailureRefusal,
   unserializableGraphRefusal,
   unresolvedNodeTypes,
 } from "../../web/js/lib/missing-node-preflight.js";
@@ -51,6 +52,30 @@ test("#1582 a USABLE result is not flagged", () => {
   ]) {
     assert.equal(graphToPromptUnusable(ok), false, JSON.stringify(ok));
   }
+});
+
+test("#1654 a frontend serializer throw is preserved as a fail-closed refusal", () => {
+  const msg = graphToPromptFailureRefusal(new Error("Dynamic widget doesn't exist on node"));
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /graphToPrompt threw/);
+  assert.match(msg, /Dynamic widget doesn't exist on node/);
+  assert.match(msg, /Nothing was queued/);
+  assert.match(msg, /frontend or an extension's serializer/);
+});
+
+test("#1654 serializer refusal rendering is total and bounded for hostile throws", () => {
+  const hostile = new Proxy({}, {
+    get() {
+      throw new Error("hostile getter");
+    },
+  });
+  const msg = graphToPromptFailureRefusal(hostile);
+  assert.match(msg, /^NOT queued:/);
+  assert.ok(msg.length < 1400);
+
+  const long = graphToPromptFailureRefusal("x".repeat(1000));
+  assert.ok(long.length < 1400);
+  assert.match(long, /…/);
 });
 
 test("#1582 the refusal says WHAT failed and that nothing was queued", () => {
@@ -136,6 +161,19 @@ test("#1582 the run path guards graphToPrompt BEFORE reading offenders", async (
   assert.match(block, /unserializableGraphRefusal\(/);
 });
 
+test("#1654 the real graph_run preflight surfaces a serializer throw and refuses queueing", async () => {
+  const msg = await runPreflight({
+    graphToPrompt: async () => {
+      throw new Error("Dynamic widget doesn't exist on node");
+    },
+    nodes: [{ id: 136, type: "MiniMaxH3ReferenceToVideo" }],
+    registry: { MiniMaxH3ReferenceToVideo: {} },
+  });
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /Dynamic widget doesn't exist on node/);
+  assert.match(msg, /Nothing was queued/);
+});
+
 test("#1582 the refusal keeps the prefix its own catch requires", async () => {
   // The pre-flight is wrapped in a try whose catch re-throws ONLY /^NOT queued:/ — anything
   // else is swallowed so a broken pre-flight cannot become a new failure mode. A refusal
@@ -174,6 +212,7 @@ async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry
     "describeUnrunnable",
     "missingNodeRunRefusal",
     "graphToPromptUnusable",
+    "graphToPromptFailureRefusal",
     "unserializableGraphRefusal",
     // #1582 review: the block became ROOT-scoped, so the harness has to supply the root
     // graph and the walker. Not injecting them made the extracted body throw a
@@ -209,6 +248,7 @@ async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry
     mod.describeUnrunnable,
     mod.missingNodeRunRefusal,
     mod.graphToPromptUnusable,
+    mod.graphToPromptFailureRefusal,
     mod.unserializableGraphRefusal,
     { _nodes: nodes },
     mod.unresolvedNodeTypes,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -417,6 +417,7 @@ import {
   describeUnrunnable,
   missingNodeRunRefusal,
   graphToPromptUnusable,
+  graphToPromptFailureRefusal,
   unserializableGraphRefusal,
   unresolvedNodeTypes,
 } from "./lib/missing-node-preflight.js";
@@ -16535,7 +16536,13 @@ const GRAPH_TOOL_EXECUTORS = {
       if (preflightBuild == null) throw new Error("graph_run pre-flight: graphToPrompt did not answer in time");
       // `"error" in` rather than a truthiness test: a falsy thrown value must still reach
       // the pre-flight catch as a throw, exactly as the bare await delivered it.
-      if ("error" in preflightBuild) throw preflightBuild.error;
+      if ("error" in preflightBuild) {
+        // #1654 — a frontend dynamic-widget/extension serializer throw is a real
+        // graph failure, not an unavailable preflight. Preserve the frontend's
+        // bounded detail and refuse before queuePrompt can retry the same broken
+        // graph or replace it with a less useful queue-time error.
+        throw new Error(graphToPromptFailureRefusal(preflightBuild.error));
+      }
       const built = preflightBuild.value;
       preflightPrompt = built;
       // comfyui-mcp#1582 — SERIALIZATION ITSELF CAN FAIL, and this is where that has to

--- a/web/js/lib/missing-node-preflight.js
+++ b/web/js/lib/missing-node-preflight.js
@@ -124,6 +124,42 @@ export function graphToPromptUnusable(built) {
 }
 
 /**
+ * A refusal for a graph serializer that THREW rather than returning an unusable result.
+ *
+ * `graph_run` preflights `graphToPrompt()` before handing the graph to the frontend queue.
+ * The thrown value is the only useful evidence when a dynamic widget or extension
+ * serializer rejects the live graph, so keep a bounded, total rendering of it in the
+ * refusal. This is deliberately a separate helper from `unserializableGraphRefusal`: a
+ * thrown serializer does not establish that any node type is missing.
+ */
+export function graphToPromptFailureRefusal(error) {
+  let raw = "";
+  try {
+    if (error instanceof Error) raw = error.message;
+    else if (typeof error === "string") raw = error;
+    else raw = String(error ?? "");
+  } catch {
+    raw = "";
+  }
+  let detail = "";
+  try {
+    detail = String(raw ?? "").trim().replace(/\s+/g, " ");
+  } catch {
+    detail = "";
+  }
+  if (detail.length > 400) detail = `${detail.slice(0, 400)}…`;
+  const cause = detail
+    ? ` The frontend serializer reported: "${detail}".`
+    : " The frontend did not provide an error detail.";
+  return (
+    `NOT queued: this workflow could not be serialized into a prompt because ` +
+    `graphToPrompt threw.${cause} Nothing was queued and the queue is untouched. ` +
+    `This is the ComfyUI frontend or an extension's serializer error, not evidence that ` +
+    `a node type is missing; inspect the named widget or extension before retrying.`
+  );
+}
+
+/**
  * #1582 — every node type in the workflow the frontend cannot resolve, ROOT-SCOPED.
  *
  * Serialization is root-scoped: `graphToPrompt` walks the whole workflow, including every


### PR DESCRIPTION
## Summary

- preserve the exact bounded error when the graph serializer throws during graph_run preflight
- fail closed with a NOT queued refusal before queuePrompt can retry the same broken graph
- distinguish serializer failures from missing node types; no link or dynamic-widget mutation is attempted

Fixes #1654

## Validation

- node --test browser_tests/unit/graph-to-prompt-failure.test.mjs browser_tests/unit/missing-node-preflight.test.mjs — 49 passed
- node --test browser_tests/unit/run-command-budget.test.mjs browser_tests/unit/queue-rejection.test.mjs browser_tests/unit/read-only-graph-commands.test.mjs — 61 passed
- node --test browser_tests/unit/connect-verify.test.mjs browser_tests/unit/connect-matcher.test.mjs — 13 passed
- npm.cmd run test:unit — 6559 passed, 0 failed, 1 todo
- independent Codex gate — SHIP