### PR TITLE
fix(panel#1655): normalize invalid App Mode canvas metadata

### DIFF
--- a/browser_tests/unit/canvas-center-scale.test.mjs
+++ b/browser_tests/unit/canvas-center-scale.test.mjs
@@ -18,6 +18,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { normalizeCanvasDsInPlace } from "../../web/js/lib/canvas-ds.js";
 
 const src = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
@@ -44,6 +45,7 @@ function run({ canvas, ds }, args) {
   const deps = {
     getGraphCtx: () => ({ graph, canvas }),
     resolveNode: () => node,
+    normalizeCanvasDsInPlace,
   };
   const names = Object.keys(deps);
   const fn = new Function(...names, `const e = {${body[0]}}; return e.graph_canvas;`);

--- a/browser_tests/unit/configure-app-mode.test.mjs
+++ b/browser_tests/unit/configure-app-mode.test.mjs
@@ -14,6 +14,7 @@ import {
   parseAppModeArgs,
   validateAppModeTargets,
 } from "../../web/js/lib/configure-app-mode.js";
+import { normalizedCanvasDs } from "../../web/js/lib/canvas-ds.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -137,7 +138,7 @@ test("#1429 configureAppMode writes tuples, one undo envelope, then captures", (
   assert.equal(captures, 1);
   assert.equal(captureDuringEnvelope, false, "captureCanvasState must run after afterChange");
   assert.equal(graph.extra.comfyui_mcp.workflow_uuid, "wf-A");
-  assert.deepEqual(graph.extra.ds, { scale: 0.8 });
+  assert.deepEqual(graph.extra.ds, { scale: 0.8, offset: [0, 0] });
   assert.deepEqual(graph.extra.linearData.inputs, [[6, "text", { description: "Prompt" }]]);
   assert.deepEqual(graph.extra.linearData.outputs, [9]);
   assert.equal(graph.extra.linearMode, true);
@@ -145,6 +146,29 @@ test("#1429 configureAppMode writes tuples, one undo envelope, then captures", (
   assert.equal(result.default_mode, "app");
   assert.equal(result.preserved_meta, true);
   assert.equal(result.linearMode, true);
+});
+
+test("#1655 configureAppMode repairs malformed persisted canvas metadata", () => {
+  const graph = makeGraph([], { ds: { scale: null, offset: [null, null] } });
+
+  configureAppMode({
+    rootGraph: graph,
+    resolveNode: resolverFor(graph),
+    args: { default_mode: "app" },
+  });
+
+  assert.deepEqual(graph.extra.ds, { scale: 1, offset: [0, 0] });
+});
+
+test("#1655 normalizedCanvasDs defaults malformed and typed viewport values", () => {
+  assert.deepEqual(normalizedCanvasDs({ scale: 0, offset: Float32Array.of(NaN, Infinity) }), {
+    scale: 1,
+    offset: [0, 0],
+  });
+  assert.deepEqual(normalizedCanvasDs({ scale: 0.8, offset: [12, -4] }), {
+    scale: 0.8,
+    offset: [12, -4],
+  });
 });
 
 test("#1429 configureAppMode prefers a live widgetId when the frontend assigned one", () => {

--- a/browser_tests/unit/graph-canvas-zoom-center.test.mjs
+++ b/browser_tests/unit/graph-canvas-zoom-center.test.mjs
@@ -15,6 +15,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { normalizeCanvasDsInPlace } from "../../web/js/lib/canvas-ds.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -29,9 +30,10 @@ function realGraphCanvas(getGraphCtx, resolveNode, activePanelRoot = null) {
     "getGraphCtx",
     "resolveNode",
     "activePanelRoot",
+    "normalizeCanvasDsInPlace",
     `const executors = { ${methodMatch[0]} };\nreturn executors.graph_canvas;`,
   );
-  return factory(getGraphCtx, resolveNode, activePanelRoot);
+  return factory(getGraphCtx, resolveNode, activePanelRoot, normalizeCanvasDsInPlace);
 }
 
 /** A canvas stub whose transform mirrors litegraph's DragAndScale: ds.scale +
@@ -154,4 +156,24 @@ test("#401 zoom still validates scale bounds (no regression)", () => {
   const fn = realGraphCanvas(() => ({ graph: {}, canvas }));
   assert.throws(() => fn({ action: "zoom", scale: 0 }), /scale must be in/);
   assert.throws(() => fn({ action: "zoom", scale: 5 }), /scale must be in/);
+});
+
+test("#1655 graph_canvas repairs a malformed live viewport before returning it", () => {
+  const canvas = makeCanvas({ scale: null, offset: [null, null] });
+  const fn = realGraphCanvas(() => ({ graph: {}, canvas }));
+
+  const result = fn({ action: "pan", dx: 0, dy: 0 });
+
+  assert.deepEqual(result.canvas, { action: "pan", scale: 1, offset: [0, 0] });
+});
+
+test("#1655 graph_canvas replaces a non-writable offset shape", () => {
+  const canvas = makeCanvas();
+  canvas.ds.offset = "ab";
+  const fn = realGraphCanvas(() => ({ graph: {}, canvas }));
+
+  const result = fn({ action: "pan", dx: 0, dy: 0 });
+
+  assert.deepEqual(result.canvas, { action: "pan", scale: 1, offset: [0, 0] });
+  assert.deepEqual(canvas.ds.offset, [0, 0]);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -450,6 +450,7 @@ import {
 
 import { canonicalNodeId, isQualifiedNodeId } from "./lib/node-id.js";
 import { configureAppMode } from "./lib/configure-app-mode.js";
+import { normalizeCanvasDsInPlace } from "./lib/canvas-ds.js";
 import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import { reconcileWidgetClaims, supersededNote } from "./lib/manual-change-claims.js";
@@ -16262,6 +16263,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const { graph, canvas } = getGraphCtx();
     if (!canvas?.ds) throw new Error("Canvas is not available");
     const ds = canvas.ds;
+    normalizeCanvasDsInPlace(ds);
     switch (action) {
       case "center_on_node": {
         const node = resolveNode(graph, node_id);

--- a/web/js/lib/canvas-ds.js
+++ b/web/js/lib/canvas-ds.js
@@ -1,0 +1,39 @@
+// LiteGraph's viewport transform is serialized into workflow metadata as
+// `extra.ds`. Older or partially initialized App Mode canvases can expose null,
+// NaN, or otherwise unusable values; keep those values out of saved workflows.
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+export function normalizedCanvasDs(ds) {
+  const scale = finiteNumber(ds?.scale);
+  const rawOffset = ds?.offset;
+  const hasOffsetPair = Number(rawOffset?.length) >= 2;
+  const x = hasOffsetPair ? finiteNumber(rawOffset[0]) : null;
+  const y = hasOffsetPair ? finiteNumber(rawOffset[1]) : null;
+  return {
+    scale: scale !== null && scale > 0 ? scale : 1,
+    offset: [x ?? 0, y ?? 0],
+  };
+}
+
+/** Normalize a live LiteGraph transform without replacing a typed offset. */
+export function normalizeCanvasDsInPlace(ds) {
+  if (!ds || typeof ds !== "object") return normalizedCanvasDs(null);
+  const normalized = normalizedCanvasDs(ds);
+  ds.scale = normalized.scale;
+  const offset = ds.offset;
+  const hasMutableOffsetPair =
+    offset !== null &&
+    (typeof offset === "object" || typeof offset === "function") &&
+    Number(offset.length) >= 2;
+  if (hasMutableOffsetPair) {
+    offset[0] = normalized.offset[0];
+    offset[1] = normalized.offset[1];
+  } else {
+    ds.offset = normalized.offset;
+  }
+  return normalized;
+}

--- a/web/js/lib/configure-app-mode.js
+++ b/web/js/lib/configure-app-mode.js
@@ -8,6 +8,8 @@
 // module merges linearData / linearMode onto the EXISTING bag and never replaces
 // extra or touches that namespace.
 
+import { normalizedCanvasDs } from "./canvas-ds.js";
+
 export const APP_MODE_META_NAMESPACE = "comfyui_mcp";
 
 function isPlainObject(value) {
@@ -256,6 +258,10 @@ export function configureAppMode({
   before?.();
   try {
     const extra = extraBag(rootGraph);
+    // `extra.ds` is part of the saved ROOT workflow. Normalize that object in
+    // place; the currently viewed canvas may be a subgraph with a different
+    // viewport and must never overwrite the root's transform.
+    extra.ds = normalizedCanvasDs(extra.ds);
     mergeAppModeExtra(extra, {
       inputTuples,
       outputIds,


### PR DESCRIPTION
## Summary
- normalize malformed live canvas viewport transforms before graph_canvas actions return or persist them
- copy validated viewport metadata into the root workflow when configuring App Mode
- add regressions for null/non-finite and typed LiteGraph offsets

## Validation
- npm.cmd run test:unit (6562 passed, 0 failed, 1 todo)
- independent Codex merge gate running

Closes #1655