### PR TITLE
fix(panel#1668): recover link-disconnect restore crashes

### DIFF
--- a/browser_tests/unit/load-reply-identity.test.mjs
+++ b/browser_tests/unit/load-reply-identity.test.mjs
@@ -104,11 +104,18 @@ test("#1668 graph_load freezes the canvas across restore retry and refuses unsaf
   const body = graphLoadBody();
   const retryAt = body.indexOf("retryNodeRestores(app?.graph");
   assert.notEqual(retryAt, -1, "the UI path must retain the restore retry");
-  const acquireAt = body.lastIndexOf("acquireCanvasInteractionLock(app?.canvas)", retryAt);
-  const releaseAt = body.indexOf("releaseCanvasInteractionLock(retryInteractionToken, app?.canvas)", retryAt);
+  const canvasCaptureAt = body.lastIndexOf("const retryCanvas = app?.canvas", retryAt);
+  const acquireAt = body.indexOf("acquireCanvasInteractionLock(retryCanvas)", canvasCaptureAt);
+  const releaseAt = body.indexOf("releaseCanvasInteractionLock(retryInteractionToken, retryCanvas)", retryAt);
+  assert.ok(canvasCaptureAt >= 0 && canvasCaptureAt < retryAt, "the retry must capture its canvas first");
   assert.ok(acquireAt >= 0 && acquireAt < retryAt, "the retry must acquire the user interaction fence first");
   assert.ok(releaseAt > retryAt, "the interaction fence must be released after the awaited retry");
   assert.match(body, /retry:\s*"no-interaction-lock"/, "an unfreezable canvas must disclose rather than retry unsafely");
+  assert.match(
+    body,
+    /retry:\s*"blank-load-target-unverified"/,
+    "a blank-canvas load without a pre-load workflow identity must disclose rather than retarget a switched tab",
+  );
 });
 
 test("#1478 the identity is published only when it is PROVABLY this load's", () => {

--- a/browser_tests/unit/load-reply-identity.test.mjs
+++ b/browser_tests/unit/load-reply-identity.test.mjs
@@ -100,6 +100,17 @@ test("#1478 the UI path reads through the same gate, against its own pre-load ta
   );
 });
 
+test("#1668 graph_load freezes the canvas across restore retry and refuses unsafe fallback", () => {
+  const body = graphLoadBody();
+  const retryAt = body.indexOf("retryNodeRestores(app?.graph");
+  assert.notEqual(retryAt, -1, "the UI path must retain the restore retry");
+  const acquireAt = body.lastIndexOf("acquireCanvasInteractionLock(app?.canvas)", retryAt);
+  const releaseAt = body.indexOf("releaseCanvasInteractionLock(retryInteractionToken, app?.canvas)", retryAt);
+  assert.ok(acquireAt >= 0 && acquireAt < retryAt, "the retry must acquire the user interaction fence first");
+  assert.ok(releaseAt > retryAt, "the interaction fence must be released after the awaited retry");
+  assert.match(body, /retry:\s*"no-interaction-lock"/, "an unfreezable canvas must disclose rather than retry unsafely");
+});
+
 test("#1478 the identity is published only when it is PROVABLY this load's", () => {
   // THE PROPERTY THAT MATTERS, and the one review had to force. Reading "whatever is
   // active now" after the await is the SAME wrong-graph hazard the orchestrator-side

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -341,6 +341,31 @@ test("#1668 does not wait forever when animation frames are paused", async () =>
   }
 });
 
+test("#1668 skips the retry when the workflow changes during the settle wait", async () => {
+  let configured = 0;
+  let checks = 0;
+  const node = {
+    id: 122,
+    inputs: [{ link: 901 }],
+    outputs: [],
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
+    configure: () => {
+      configured += 1;
+    },
+  };
+  const result = await retryNodeRestores(
+    { getNodeById: () => node },
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+    { isCurrent: () => ++checks === 1 },
+  );
+  assert.equal(configured, 0, "the old node must not be configured after a workflow switch");
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.recovered, []);
+  assert.deepEqual(result.failed, [
+    { id: 122, type: "ImpactSwitch", error: "active workflow changed during restore retry", retry: "workflow-switched" },
+  ]);
+});
+
 test("#1668 cannot upgrade an unrelated initial failure from a link-shaped retry", async () => {
   const node = {
     id: 122,

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -71,6 +71,25 @@ test("#1260: a throw from one node's configure is contained — later nodes rest
   assert.deepEqual(nodes[2].configured, [infos[2]], "every later node restored normally");
 });
 
+test("the retry snapshot is not aliased to configure's mutable input", () => {
+  const LG = makeLiteGraph();
+  const original = LG.LGraphNode.prototype.configure;
+  LG.LGraphNode.prototype.configure = function (info) {
+    info.properties.p = "mutated before throw";
+    throw new Error("configure boom");
+  };
+  const isolation = installNodeConfigureIsolation(LG);
+  const info = { id: 15, type: "FaceDetailer", properties: { p: "original" } };
+  try {
+    new LG.LGraphNode(15).configure(info);
+  } finally {
+    isolation.restore();
+    LG.LGraphNode.prototype.configure = original;
+  }
+  assert.equal(info.properties.p, "mutated before throw");
+  assert.equal(isolation.failures[0].info.properties.p, "original");
+});
+
 test("the wrapper preserves a non-throwing configure's return value and `this`", () => {
   const LG = makeLiteGraph();
   const isolation = installNodeConfigureIsolation(LG);
@@ -191,6 +210,7 @@ test("#1668 records the narrow link-disconnect crash and verifies a linked-widge
   const isolation = installNodeConfigureIsolation(LG);
   const node = new LG.LGraphNode(122);
   node.type = "ImpactSwitch";
+  node.inputs = [{ name: "select", link: 901, widget: { name: "select" } }];
   node.widgets = [{ name: "select" }, { name: "other" }];
   const info = {
     id: 122,
@@ -245,6 +265,8 @@ test("#1668 does not verify a non-linked widget difference", () => {
 
 test("#1668 does not bless an unrelated exception on the retry", async () => {
   const node = {
+    inputs: [{ link: 901 }],
+    outputs: [],
     serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
     configure: () => {
       throw new Error("unrelated retry failure");
@@ -257,6 +279,44 @@ test("#1668 does not bless an unrelated exception on the retry", async () => {
   assert.deepEqual(result.restored, []);
   assert.deepEqual(result.recovered, []);
   assert.deepEqual(result.failed, [{ id: 122, type: "ImpactSwitch", error: "unrelated retry failure" }]);
+});
+
+test("#1668 does not bless a link-shaped retry without residual links", async () => {
+  const node = {
+    id: 122,
+    inputs: [],
+    outputs: [],
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
+    configure: () => {},
+  };
+  const result = await retryNodeRestores(
+    { getNodeById: () => node },
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+  );
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.recovered, []);
+  assert.deepEqual(result.failed, [
+    { id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", retry: "no-residual-links" },
+  ]);
+});
+
+test("#1668 cannot upgrade an unrelated initial failure from a link-shaped retry", async () => {
+  const node = {
+    id: 122,
+    inputs: [{ link: 901 }],
+    outputs: [],
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
+    configure: () => {
+      throw new TypeError("t.findInputSlot is not a function");
+    },
+  };
+  const result = await retryNodeRestores(
+    { getNodeById: () => node },
+    [{ id: 122, type: "ImpactSwitch", error: "first failure", linkDisconnectCrash: false, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+  );
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.recovered, []);
+  assert.deepEqual(result.failed, [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function" }]);
 });
 
 test("#1668 does not equate JSON null with a live NaN widget value", () => {

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -207,11 +207,16 @@ test("#1668 records the narrow link-disconnect crash and verifies a linked-widge
     if (info.id === 122) throw new TypeError("t.findInputSlot is not a function");
     return base.call(this, info);
   };
-  const isolation = installNodeConfigureIsolation(LG);
   const node = new LG.LGraphNode(122);
   node.type = "ImpactSwitch";
   node.inputs = [{ name: "select", link: 901, widget: { name: "select" } }];
   node.widgets = [{ name: "select" }, { name: "other" }];
+  const brokenFarEnd = { id: 321 };
+  const graph = {
+    _links: new Map([[901, { id: 901, origin_id: 321, target_id: 122 }]]),
+    getNodeById: (id) => (id === 122 ? node : id === 321 ? brokenFarEnd : null),
+  };
+  const isolation = installNodeConfigureIsolation(LG, graph);
   const info = {
     id: 122,
     type: "ImpactSwitch",
@@ -227,6 +232,7 @@ test("#1668 records the narrow link-disconnect crash and verifies a linked-widge
     isolation.restore();
   }
   assert.equal(isolation.failures[0].linkDisconnectCrash, true);
+  assert.equal(isolation.failures[0].linkDisconnectEvidence, true);
 
   node.serialize = () => ({
     ...info,
@@ -235,7 +241,6 @@ test("#1668 records the narrow link-disconnect crash and verifies a linked-widge
   node.configure = () => {
     // The second call is allowed to succeed after the link state settles.
   };
-  const graph = { getNodeById: (id) => (id === 122 ? node : null) };
   const result = await retryNodeRestores(graph, isolation.failures);
   assert.deepEqual(result.restored, [{ id: 122, type: "ImpactSwitch" }]);
   assert.deepEqual(result.failed, []);
@@ -274,7 +279,7 @@ test("#1668 does not bless an unrelated exception on the retry", async () => {
   };
   const result = await retryNodeRestores(
     { getNodeById: () => node },
-    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, linkDisconnectEvidence: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
   );
   assert.deepEqual(result.restored, []);
   assert.deepEqual(result.recovered, []);
@@ -292,7 +297,7 @@ test("#1668 does not bless the same link-disconnect exception on the retry", asy
   };
   const result = await retryNodeRestores(
     { getNodeById: () => node },
-    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, linkDisconnectEvidence: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
   );
   assert.deepEqual(result.restored, []);
   assert.deepEqual(result.recovered, []);
@@ -310,7 +315,7 @@ test("#1668 verifies against the untouched snapshot when retry configure mutates
   };
   const result = await retryNodeRestores(
     { getNodeById: () => node },
-    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, linkDisconnectEvidence: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
   );
   assert.deepEqual(result.restored, []);
   assert.deepEqual(result.recovered, []);
@@ -329,12 +334,30 @@ test("#1668 does not bless a link-shaped retry without residual links", async ()
   };
   const result = await retryNodeRestores(
     { getNodeById: () => node },
-    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, linkDisconnectEvidence: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
   );
   assert.deepEqual(result.restored, []);
   assert.deepEqual(result.recovered, []);
   assert.deepEqual(result.failed, [
     { id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", retry: "no-residual-links" },
+  ]);
+});
+
+test("#1668 does not treat the message alone as restore evidence", async () => {
+  const node = {
+    inputs: [{ link: 901 }],
+    outputs: [],
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
+    configure: () => {},
+  };
+  const result = await retryNodeRestores(
+    { getNodeById: () => node },
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+  );
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.recovered, []);
+  assert.deepEqual(result.failed, [
+    { id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", retry: "link-disconnect-unverified" },
   ]);
 });
 
@@ -351,7 +374,7 @@ test("#1668 does not wait forever when animation frames are paused", async () =>
   try {
     const result = await retryNodeRestores(
       { getNodeById: () => node },
-      [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+      [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, linkDisconnectEvidence: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
     );
     assert.deepEqual(result.restored, [{ id: 122, type: "ImpactSwitch" }]);
     assert.deepEqual(result.failed, []);
@@ -375,7 +398,7 @@ test("#1668 skips the retry when the workflow changes during the settle wait", a
   };
   const result = await retryNodeRestores(
     { getNodeById: () => node },
-    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+      [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, linkDisconnectEvidence: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
     { isCurrent: () => ++checks === 1 },
   );
   assert.equal(configured, 0, "the old node must not be configured after a workflow switch");

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -91,6 +91,33 @@ test("the retry snapshot is not aliased to configure's mutable input", () => {
   assert.equal(isolation.failures[0].info.properties.p, "original");
 });
 
+test("the retry snapshot preserves an own serialized __proto__ field", async () => {
+  const LG = makeLiteGraph();
+  const base = LG.LGraphNode.prototype.configure;
+  let first = true;
+  LG.LGraphNode.prototype.configure = function (info) {
+    if (first) {
+      first = false;
+      throw new Error("first configure failed");
+    }
+    return base.call(this, info);
+  };
+  const node = new LG.LGraphNode(22);
+  const graph = { getNodeById: (id) => (id === 22 ? node : null) };
+  const isolation = installNodeConfigureIsolation(LG, graph);
+  const info = JSON.parse('{"id":22,"properties":{"__proto__":{"x":1}}}');
+  try {
+    node.configure(info);
+  } finally {
+    isolation.restore();
+  }
+  const result = await retryNodeRestores(graph, isolation.failures);
+  assert.deepEqual(result.restored, [{ id: 22, type: null }]);
+  const retried = node.configured[0];
+  assert.equal(Object.prototype.hasOwnProperty.call(retried.properties, "__proto__"), true);
+  assert.deepEqual(retried.properties.__proto__, { x: 1 });
+});
+
 test("the wrapper preserves a non-throwing configure's return value and `this`", () => {
   const LG = makeLiteGraph();
   const isolation = installNodeConfigureIsolation(LG);

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -251,6 +251,31 @@ test("#1668 records the narrow link-disconnect crash and verifies a linked-widge
   assert.deepEqual(verifyNodeRestore(node, info).linkDrivenWidgetDifferences, ["select"]);
 });
 
+test("#1668 records mirror-write evidence when the far node is valid but its referenced slot is missing", () => {
+  const LG = makeLiteGraph();
+  const base = LG.LGraphNode.prototype.configure;
+  LG.LGraphNode.prototype.configure = function (info) {
+    if (info.id === 122) throw new TypeError("Cannot set properties of undefined (setting 'link')");
+    return base.call(this, info);
+  };
+  const node = new LG.LGraphNode(122);
+  node.inputs = [{ name: "select", link: 902, widget: { name: "select" } }];
+  node.widgets = [{ name: "select" }];
+  const farNode = { id: 321, findInputSlot: () => 0, findOutputSlot: () => 0, outputs: [] };
+  const graph = {
+    _links: new Map([[902, { id: 902, origin_id: 321, origin_slot: 0, target_id: 122, target_slot: 0 }]]),
+    getNodeById: (id) => (id === 122 ? node : id === 321 ? farNode : null),
+  };
+  const isolation = installNodeConfigureIsolation(LG, graph);
+  try {
+    node.configure({ id: 122, type: "ImpactSwitch" });
+  } finally {
+    isolation.restore();
+  }
+  assert.equal(isolation.failures[0].linkDisconnectCrash, true);
+  assert.equal(isolation.failures[0].linkDisconnectEvidence, true);
+});
+
 test("#1668 does not verify a non-linked widget difference", () => {
   const info = {
     id: 122,

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -300,6 +300,29 @@ test("#1668 does not bless a link-shaped retry without residual links", async ()
   ]);
 });
 
+test("#1668 does not wait forever when animation frames are paused", async () => {
+  const priorRequestAnimationFrame = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = () => {};
+  const node = {
+    id: 122,
+    inputs: [{ link: 901 }],
+    outputs: [],
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
+    configure: () => {},
+  };
+  try {
+    const result = await retryNodeRestores(
+      { getNodeById: () => node },
+      [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+    );
+    assert.deepEqual(result.restored, [{ id: 122, type: "ImpactSwitch" }]);
+    assert.deepEqual(result.failed, []);
+  } finally {
+    if (priorRequestAnimationFrame === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = priorRequestAnimationFrame;
+  }
+});
+
 test("#1668 cannot upgrade an unrelated initial failure from a link-shaped retry", async () => {
   const node = {
     id: 122,

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -281,6 +281,24 @@ test("#1668 does not bless an unrelated exception on the retry", async () => {
   assert.deepEqual(result.failed, [{ id: 122, type: "ImpactSwitch", error: "unrelated retry failure" }]);
 });
 
+test("#1668 does not bless the same link-disconnect exception on the retry", async () => {
+  const node = {
+    inputs: [{ link: 901 }],
+    outputs: [],
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
+    configure: () => {
+      throw new TypeError("t.findInputSlot is not a function");
+    },
+  };
+  const result = await retryNodeRestores(
+    { getNodeById: () => node },
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+  );
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.recovered, []);
+  assert.deepEqual(result.failed, [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function" }]);
+});
+
 test("#1668 does not bless a link-shaped retry without residual links", async () => {
   const node = {
     id: 122,

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -18,6 +18,7 @@ import assert from "node:assert/strict";
 
 import {
   installNodeConfigureIsolation,
+  loadRestoreCompleted,
   retryNodeRestores,
   verifyNodeRestore,
 } from "../../web/js/lib/load-restore-isolation.js";
@@ -359,6 +360,63 @@ test("#1668 does not treat the message alone as restore evidence", async () => {
   assert.deepEqual(result.failed, [
     { id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", retry: "link-disconnect-unverified" },
   ]);
+});
+
+test("#1668 retries a subgraph node in its owning graph when the id collides with a root node", async () => {
+  const info = { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] };
+  let rootConfigured = 0;
+  let definitionConfigured = 0;
+  const definitionNode = {
+    id: 122,
+    inputs: [{ link: 901 }],
+    outputs: [],
+    configure: () => {
+      definitionConfigured += 1;
+    },
+    serialize: () => ({ ...info }),
+  };
+  const rootNode = {
+    id: 122,
+    inputs: [],
+    outputs: [],
+    configure: () => {
+      rootConfigured += 1;
+    },
+    serialize: () => ({ ...info }),
+  };
+  const definitionGraph = { getNodeById: (id) => (id === 122 ? definitionNode : null) };
+  const rootGraph = { getNodeById: (id) => (id === 122 ? rootNode : null) };
+  const failure = {
+    id: 122,
+    type: "ImpactSwitch",
+    error: "t.findInputSlot is not a function",
+    linkDisconnectCrash: true,
+    linkDisconnectEvidence: true,
+    ownerGraph: definitionGraph,
+    info,
+  };
+
+  const result = await retryNodeRestores(rootGraph, [failure]);
+  assert.equal(definitionConfigured, 1, "the definition node receives the retry");
+  assert.equal(rootConfigured, 0, "the colliding root node is not retargeted");
+  assert.equal(result.failed.length, 0);
+  assert.equal(result.recovered[0].ownerGraph, definitionGraph);
+  assert.equal(
+    loadRestoreCompleted({
+      nodeIsolation: { failures: [failure] },
+      graphWatch: { throws: [], entered: 1 },
+      recoveredFailures: result.recovered,
+    }),
+    true,
+  );
+  assert.equal(
+    loadRestoreCompleted({
+      nodeIsolation: { failures: [failure] },
+      graphWatch: { throws: [], entered: 1 },
+      recoveredFailures: [{ id: 122, ownerGraph: rootGraph }],
+    }),
+    false,
+  );
 });
 
 test("#1668 does not wait forever when animation frames are paused", async () => {

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -400,7 +400,8 @@ test("#1668 retries a subgraph node in its owning graph when the id collides wit
   assert.equal(definitionConfigured, 1, "the definition node receives the retry");
   assert.equal(rootConfigured, 0, "the colliding root node is not retargeted");
   assert.equal(result.failed.length, 0);
-  assert.equal(result.recovered[0].ownerGraph, definitionGraph);
+  assert.equal(typeof result.recovered[0].ownerGraphToken, "number");
+  assert.doesNotThrow(() => JSON.stringify(result.recovered), "recovery receipts remain bridge-serializable");
   assert.equal(
     loadRestoreCompleted({
       nodeIsolation: { failures: [failure] },
@@ -413,7 +414,7 @@ test("#1668 retries a subgraph node in its owning graph when the id collides wit
     loadRestoreCompleted({
       nodeIsolation: { failures: [failure] },
       graphWatch: { throws: [], entered: 1 },
-      recoveredFailures: [{ id: 122, ownerGraph: rootGraph }],
+      recoveredFailures: [{ id: 122, ownerGraphToken: 999999 }],
     }),
     false,
   );

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -19,6 +19,7 @@ import assert from "node:assert/strict";
 import {
   installNodeConfigureIsolation,
   retryNodeRestores,
+  verifyNodeRestore,
 } from "../../web/js/lib/load-restore-isolation.js";
 
 /** A minimal LiteGraph/LGraphNode pair: configure dispatches through the
@@ -145,7 +146,7 @@ test("chained isolations: restoring the INNER one first does not drop the outer'
   assert.equal(node.configure({ id: 8, type: "Y" }), "configured", "non-throwing nodes are unaffected");
 });
 
-test("#1260 retry: a node whose widgets exist by retry time restores; a still-throwing node is disclosed with the NEW error", () => {
+test("#1260 retry: a node whose widgets exist by retry time restores; a still-throwing node is disclosed with the NEW error", async () => {
   const LG = makeLiteGraph();
   const healed = new LG.LGraphNode(15);
   healed.type = "FaceDetailer";
@@ -166,7 +167,7 @@ test("#1260 retry: a node whose widgets exist by retry time restores; a still-th
     { id: 21, type: "MarkdownNote", error: "first boom", info: { id: 21, widgets_values: ["hi"] } },
     { id: 99, type: "Ghost", error: "creation failed too", info: { id: 99 } },
   ];
-  const { restored, failed } = retryNodeRestores(graph, failures);
+  const { restored, failed } = await retryNodeRestores(graph, failures);
   assert.deepEqual(restored, [{ id: 15, type: "FaceDetailer" }]);
   assert.deepEqual(healed.configured, [{ id: 15, widgets_values: [768] }], "the serialized data was re-applied");
   assert.equal(failed.length, 2);
@@ -175,7 +176,93 @@ test("#1260 retry: a node whose widgets exist by retry time restores; a still-th
   assert.equal(failed[1].retry, "node-not-on-graph", "a node that never landed is told apart from a re-throw");
 });
 
-test("retry tolerates a missing graph and empty failures (nothing to heal, nothing to disclose)", () => {
-  assert.deepEqual(retryNodeRestores(null, []), { restored: [], failed: [] });
-  assert.deepEqual(retryNodeRestores(undefined, undefined), { restored: [], failed: [] });
+test("retry tolerates a missing graph and empty failures (nothing to heal, nothing to disclose)", async () => {
+  assert.deepEqual(await retryNodeRestores(null, []), { restored: [], failed: [], recovered: [] });
+  assert.deepEqual(await retryNodeRestores(undefined, undefined), { restored: [], failed: [], recovered: [] });
+});
+
+test("#1668 records the narrow link-disconnect crash and verifies a linked-widget normalization", async () => {
+  const LG = makeLiteGraph();
+  const base = LG.LGraphNode.prototype.configure;
+  LG.LGraphNode.prototype.configure = function (info) {
+    if (info.id === 122) throw new TypeError("t.findInputSlot is not a function");
+    return base.call(this, info);
+  };
+  const isolation = installNodeConfigureIsolation(LG);
+  const node = new LG.LGraphNode(122);
+  node.type = "ImpactSwitch";
+  node.widgets = [{ name: "select" }, { name: "other" }];
+  const info = {
+    id: 122,
+    type: "ImpactSwitch",
+    mode: 4,
+    flags: { collapsed: true },
+    inputs: [{ name: "select", link: 901, widget: { name: "select" } }],
+    outputs: [{ name: "out", links: [902] }],
+    widgets_values: ["saved-selection", "saved-other"],
+  };
+  try {
+    node.configure(info);
+  } finally {
+    isolation.restore();
+  }
+  assert.equal(isolation.failures[0].linkDisconnectCrash, true);
+
+  node.serialize = () => ({
+    ...info,
+    widgets_values: ["upstream-selection", "saved-other"],
+  });
+  node.configure = () => {
+    // The second call is allowed to succeed after the link state settles.
+  };
+  const graph = { getNodeById: (id) => (id === 122 ? node : null) };
+  const result = await retryNodeRestores(graph, isolation.failures);
+  assert.deepEqual(result.restored, [{ id: 122, type: "ImpactSwitch" }]);
+  assert.deepEqual(result.failed, []);
+  assert.deepEqual(result.recovered, [
+    { id: 122, type: "ImpactSwitch", linkDrivenWidgetDifferences: ["select"] },
+  ]);
+  assert.deepEqual(verifyNodeRestore(node, info).linkDrivenWidgetDifferences, ["select"]);
+});
+
+test("#1668 does not verify a non-linked widget difference", () => {
+  const info = {
+    id: 122,
+    type: "ImpactSwitch",
+    inputs: [{ name: "select", link: 901, widget: { name: "select" } }],
+    widgets_values: ["saved-selection", "saved-other"],
+  };
+  const node = {
+    inputs: info.inputs,
+    widgets: [{ name: "select" }, { name: "other" }],
+    serialize: () => ({ ...info, widgets_values: ["upstream-selection", "lost-other"] }),
+  };
+  const result = verifyNodeRestore(node, info);
+  assert.equal(result.verified, false);
+  assert.deepEqual(result.differences, ["widgets_values.other"]);
+  assert.deepEqual(result.linkDrivenWidgetDifferences, ["select"]);
+});
+
+test("#1668 does not bless an unrelated exception on the retry", async () => {
+  const node = {
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
+    configure: () => {
+      throw new Error("unrelated retry failure");
+    },
+  };
+  const result = await retryNodeRestores(
+    { getNodeById: () => node },
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+  );
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.recovered, []);
+  assert.deepEqual(result.failed, [{ id: 122, type: "ImpactSwitch", error: "unrelated retry failure" }]);
+});
+
+test("#1668 does not equate JSON null with a live NaN widget value", () => {
+  const info = { id: 122, type: "ImpactSwitch", widgets_values: [null] };
+  const node = { widgets: [{ name: "value" }], serialize: () => ({ ...info, widgets_values: [Number.NaN] }) };
+  const result = verifyNodeRestore(node, info);
+  assert.equal(result.verified, false);
+  assert.deepEqual(result.differences, ["widgets_values.value"]);
 });

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -472,6 +472,37 @@ test("#1668 retries a subgraph node in its owning graph when the id collides wit
   );
 });
 
+test("#1668 refuses a failure whose owning graph was detached by the load", async () => {
+  let configured = 0;
+  const oldNode = {
+    id: 122,
+    inputs: [{ link: 901 }],
+    outputs: [],
+    configure: () => {
+      configured += 1;
+    },
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["saved"] }),
+  };
+  const oldGraph = { getNodeById: () => oldNode };
+  const currentGraph = { getNodeById: () => null };
+  const result = await retryNodeRestores(
+    currentGraph,
+    [{
+      id: 122,
+      type: "ImpactSwitch",
+      error: "t.findInputSlot is not a function",
+      linkDisconnectCrash: true,
+      linkDisconnectEvidence: true,
+      ownerGraph: oldGraph,
+      info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] },
+    }],
+    { isGraphCurrent: () => false },
+  );
+  assert.equal(configured, 0, "a detached node must never receive the retry");
+  assert.deepEqual(result.recovered, []);
+  assert.deepEqual(result.failed, [{ id: 122, type: "ImpactSwitch", error: "restore graph changed during retry", retry: "graph-switched" }]);
+});
+
 test("#1668 does not wait forever when animation frames are paused", async () => {
   const priorRequestAnimationFrame = globalThis.requestAnimationFrame;
   globalThis.requestAnimationFrame = () => {};

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -299,6 +299,26 @@ test("#1668 does not bless the same link-disconnect exception on the retry", asy
   assert.deepEqual(result.failed, [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function" }]);
 });
 
+test("#1668 verifies against the untouched snapshot when retry configure mutates its input", async () => {
+  const node = {
+    inputs: [{ link: 901 }],
+    outputs: [],
+    configure: (info) => {
+      info.widgets_values[0] = "wrong";
+    },
+    serialize: () => ({ id: 122, type: "ImpactSwitch", widgets_values: ["wrong"] }),
+  };
+  const result = await retryNodeRestores(
+    { getNodeById: () => node },
+    [{ id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", linkDisconnectCrash: true, info: { id: 122, type: "ImpactSwitch", widgets_values: ["saved"] } }],
+  );
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.recovered, []);
+  assert.deepEqual(result.failed, [
+    { id: 122, type: "ImpactSwitch", error: "t.findInputSlot is not a function", widgetDifferences: ["widgets_values.#0"] },
+  ]);
+});
+
 test("#1668 does not bless a link-shaped retry without residual links", async () => {
   const node = {
     id: 122,

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -457,6 +457,35 @@ test("panel#1283 the fold is true only when BOTH halves looked and neither saw a
   assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: watched(["x"]) }), false);
 });
 
+test("panel#1668 a verified link-disconnect recovery can license the completed-load ground", () => {
+  const watched = { throws: [], entered: 1 };
+  const failure = { id: 122, linkDisconnectCrash: true };
+  assert.equal(
+    loadRestoreCompleted({
+      nodeIsolation: { failures: [failure] },
+      graphWatch: watched,
+      recoveredFailures: [{ id: 122 }],
+    }),
+    true,
+  );
+  assert.equal(
+    loadRestoreCompleted({
+      nodeIsolation: { failures: [{ id: 122, linkDisconnectCrash: false }] },
+      graphWatch: watched,
+      recoveredFailures: [{ id: 122 }],
+    }),
+    false,
+  );
+  assert.equal(
+    loadRestoreCompleted({
+      nodeIsolation: { failures: [failure] },
+      graphWatch: watched,
+      recoveredFailures: [],
+    }),
+    false,
+  );
+});
+
 test("panel#1283 both wraps compose: a node throw is contained, the graph throw is not", () => {
   const LG = fakeLG();
   LG.LGraphNode.prototype.configure = function () {
@@ -624,7 +653,7 @@ test("panel#1283 wiring: the observation is FOLDED and reaches the proof and the
   const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
   assert.match(
     repaint,
-    /const loadRanToCompletion = loadRestoreCompleted\(\{ nodeIsolation, graphWatch \}\);/,
+    /const loadRanToCompletion = loadRestoreCompleted\(\{[\s\S]{0,180}?recoveredFailures: openRestoreRecovered,[\s\S]{0,80}?\}\);/,
     "the two observations must be folded by the helper that keeps `unknown` representable",
   );
   // It must reach the PROOF — this is the one line whose deletion silently restores the
@@ -726,6 +755,7 @@ test("panel#1283 wiring: a node the retry could not heal is still disclosed on t
   const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
   assert.match(repaint, /retryNodeRestores\(app\?\.graph, containedNodeFailureList\)/);
   assert.match(repaint, /openRestoreFailures = retry\.failed;/);
+  assert.match(repaint, /openRestoreRecovered = retry\.recovered/);
 });
 
 // ── F1: INSTALLED IS NOT ENTERED (post-merge review of #1358) ────────────────

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -459,7 +459,7 @@ test("panel#1283 the fold is true only when BOTH halves looked and neither saw a
 
 test("panel#1668 a verified link-disconnect recovery can license the completed-load ground", () => {
   const watched = { throws: [], entered: 1 };
-  const failure = { id: 122, linkDisconnectCrash: true };
+  const failure = { id: 122, linkDisconnectCrash: true, linkDisconnectEvidence: true };
   assert.equal(
     loadRestoreCompleted({
       nodeIsolation: { failures: [failure] },
@@ -630,7 +630,7 @@ test("panel#1283 wiring: workflow_open installs BOTH wraps around its own load",
   const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
   // The wraps must be installed BEFORE the load — a wrapper installed afterwards
   // observes nothing, and the whole ground rests on this ordering.
-  const nodeWrapAt = repaint.indexOf("installNodeConfigureIsolation(LGForOpen)");
+  const nodeWrapAt = repaint.indexOf("installNodeConfigureIsolation(LGForOpen, app?.graph)");
   const graphWrapAt = repaint.indexOf("installGraphConfigureWatch(LGForOpen)");
   const loadAt = repaint.indexOf("await app.loadGraphData(repaintState, true, true, target);");
   assert.notEqual(nodeWrapAt, -1, "the node-configure isolation must be installed on the open path");
@@ -754,7 +754,7 @@ test("panel#1283 wiring: a node the retry could not heal is still disclosed on t
   const repaintAt = src.indexOf("const targetUuid = workflowStableUuid", openAt);
   const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
   assert.match(repaint, /retryNodeRestores\(app\?\.graph, containedNodeFailureList, \{/);
-  assert.match(repaint, /isCurrent: \(\) => sameWorkflowObject\(activeWorkflowRef\(\), target\)/);
+  assert.match(repaint, /isCurrent: \(\) =>[\s\S]{0,160}sameWorkflowObject\(activeWorkflowRef\(\), target\)/);
   assert.match(repaint, /openRestoreFailures = retry\.failed;/);
   assert.match(repaint, /openRestoreRecovered = retry\.recovered/);
 });

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -486,6 +486,27 @@ test("panel#1668 a verified link-disconnect recovery can license the completed-l
   );
 });
 
+test("panel#1668 each duplicate failure needs its own recovery receipt", () => {
+  const watched = { throws: [], entered: 1 };
+  const failure = { id: 122, linkDisconnectCrash: true, linkDisconnectEvidence: true };
+  assert.equal(
+    loadRestoreCompleted({
+      nodeIsolation: { failures: [failure, { ...failure }] },
+      graphWatch: watched,
+      recoveredFailures: [{ id: 122 }],
+    }),
+    false,
+  );
+  assert.equal(
+    loadRestoreCompleted({
+      nodeIsolation: { failures: [failure, { ...failure }] },
+      graphWatch: watched,
+      recoveredFailures: [{ id: 122 }, { id: 122 }],
+    }),
+    true,
+  );
+});
+
 test("panel#1283 both wraps compose: a node throw is contained, the graph throw is not", () => {
   const LG = fakeLG();
   LG.LGraphNode.prototype.configure = function () {

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -753,7 +753,8 @@ test("panel#1283 wiring: a node the retry could not heal is still disclosed on t
   const openAt = src.indexOf("async workflow_open({");
   const repaintAt = src.indexOf("const targetUuid = workflowStableUuid", openAt);
   const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
-  assert.match(repaint, /retryNodeRestores\(app\?\.graph, containedNodeFailureList\)/);
+  assert.match(repaint, /retryNodeRestores\(app\?\.graph, containedNodeFailureList, \{/);
+  assert.match(repaint, /isCurrent: \(\) => sameWorkflowObject\(activeWorkflowRef\(\), target\)/);
   assert.match(repaint, /openRestoreFailures = retry\.failed;/);
   assert.match(repaint, /openRestoreRecovered = retry\.recovered/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14337,7 +14337,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // asynchronously-built widgets usually exist. A node that still throws is
     // DISCLOSED below — never folded into a clean `loaded: true`.
     const { restored: retriedNodes, failed: unrestoredNodes } = isolation?.failures?.length
-      ? retryNodeRestores(app?.graph, isolation.failures)
+      ? await retryNodeRestores(app?.graph, isolation.failures)
       : { restored: [], failed: [] };
     // #874 remaining load path — SubgraphNode.configure seeds host rails from
     // INNER definition widgets, so a saved subgraph host lands at defaults
@@ -18588,6 +18588,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // node threw and never got its values".
     let openRestoreFailures = [];
     let openRestoreRetried = [];
+    let openRestoreRecovered = [];
     // Hold the switch+reload critical section across the WHOLE mutating sequence. The canvas
     // freeze keeps the USER out; this keeps the BRIDGE out, so a concurrent graph_* command
     // can neither be overwritten by the reload nor be silently re-baselined as clean.
@@ -19017,14 +19018,19 @@ const GRAPH_TOOL_EXECUTORS = {
               // workflow-SERVICE dependency. Same reason `canvasView` exists below.
               const containedNodeFailureList = nodeIsolation?.failures ?? [];
               if (containedNodeFailureList.length) {
-                const retry = retryNodeRestores(app?.graph, containedNodeFailureList);
+                const retry = await retryNodeRestores(app?.graph, containedNodeFailureList);
                 openRestoreRetried = retry.restored;
                 openRestoreFailures = retry.failed;
+                openRestoreRecovered = retry.recovered ?? [];
               }
               // THREE states, and the null one is the point: `loadRestoreCompleted`
               // answers null when either wrap could not be installed, i.e. the question
               // was never asked. Only an explicit `true` may license anything below.
-              const loadRanToCompletion = loadRestoreCompleted({ nodeIsolation, graphWatch });
+              const loadRanToCompletion = loadRestoreCompleted({
+                nodeIsolation,
+                graphWatch,
+                recoveredFailures: openRestoreRecovered,
+              });
               // A successful promise alone is not a binding receipt: old/partial frontend
               // implementations can resolve while leaving app.canvas on the previous root.
               // Demand the positive, attempt-specific marker even for dirty workflows —
@@ -19625,10 +19631,25 @@ const GRAPH_TOOL_EXECUTORS = {
             nodes_restored_on_retry: openRestoreRetried,
             nodes_restored_on_retry_note:
               `${openRestoreRetried.length} node(s) threw while their saved state was being applied ` +
-              `during this open, and were re-applied successfully after the load settled — their ` +
-              `widgets are built asynchronously by their own pack. Nothing is missing because of ` +
-              `it. That failure came from the node's own frontend code, not from the open; if it ` +
-              `recurs, update or report the pack.`,
+              `during this open, and were re-applied successfully after the load settled. ` +
+              (openRestoreRecovered.length
+                ? `A recognized LiteGraph link-disconnect crash was recovered and the affected ` +
+                  `node's serialized state was verified; any named linked-widget difference is ` +
+                  `reported separately. `
+                : `Their widgets are built asynchronously by their own pack. `) +
+              `Nothing is missing because of it. That failure came from the node's own frontend ` +
+              `code, not from the open; if it recurs, update or report the pack.`,
+          }
+        : {}),
+      ...(openRestoreRecovered.length
+        ? {
+            link_disconnect_recovered: openRestoreRecovered,
+            link_disconnect_recovered_note:
+              `The panel recognized a LiteGraph far-end slot lookup crash during restore, waited ` +
+              `for the link state to settle, retried the node once, and verified its serialized ` +
+              `state before allowing this open to proceed. A linked widget may display the ` +
+              `upstream value rather than the file's saved widget value; saving preserves the ` +
+              `verified live graph, so inspect that widget if its exact value matters.`,
           }
         : {}),
       ...(openDefinitionsUnverified
@@ -19648,8 +19669,12 @@ const GRAPH_TOOL_EXECUTORS = {
             content_normalized: openContentNormalized,
             content_normalized_note:
               `Every node in this workflow came back with the same id and type, nothing extra ` +
-              `appeared, and the panel WATCHED this load: no node's configure threw and the graph ` +
-              `restore ran to completion. So the load did not stop part-way — the failure mode ` +
+              `appeared, and the panel WATCHED this load: ` +
+              (openRestoreRecovered.length
+                ? `a recognized LiteGraph link-disconnect crash was repaired and the affected ` +
+                  `node's serialized state was verified after the post-load retry. `
+                : `no node's configure threw and the graph restore ran to completion. `) +
+              `So the load did not stop part-way — the failure mode ` +
               `that leaves a full node set over nodes that lost their values — and that is why ` +
               `the open is reported APPLIED and the workflow_uuid published rather than refused. ` +
               `What differs from the file is per-node ${openContentNormalized.join(", ")}. The ` +

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14308,9 +14308,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // reload left graph routing stranded on a frozen Unsaved tab.
     const activeWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
     let retryTargetWorkflow = activeWorkflow;
-    const retryTargetGraph = app?.graph;
+    let retryTargetGraph = app?.graph;
     const loadStillTargetsWorkflow = () => {
       const currentWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
+      if (app?.graph !== retryTargetGraph) return false;
       if (retryTargetWorkflow) return sameWorkflowObject(currentWorkflow, retryTargetWorkflow);
       return currentWorkflow == null && app?.graph === retryTargetGraph;
     };
@@ -14330,7 +14331,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // construction defaults and links/groups are never applied, while the load
     // reports a clean success. With the throw contained, the sequence
     // completes and only the throwing node needs the post-load retry below.
-    const isolation = installNodeConfigureIsolation(LG);
+    const isolation = installNodeConfigureIsolation(LG, app?.graph);
     try {
       if (activeWorkflow && typeof activeWorkflow === "object") {
         await app.loadGraphData(...loadArgs, { __cmcpKeepInstance: true });
@@ -14346,6 +14347,7 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!retryTargetWorkflow) {
       retryTargetWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
     }
+    retryTargetGraph = app?.graph;
     // Retry each contained node ONCE, now that the load has settled and its
     // asynchronously-built widgets usually exist. A node that still throws is
     // DISCLOSED below — never folded into a clean `loaded: true`.
@@ -19010,7 +19012,7 @@ const GRAPH_TOOL_EXECUTORS = {
             // handled: both wraps answer null, the fold answers UNKNOWN, and the open
             // behaves exactly as it did before this change.
             const LGForOpen = liteGraphGlobal();
-            const nodeIsolation = installNodeConfigureIsolation(LGForOpen);
+            const nodeIsolation = installNodeConfigureIsolation(LGForOpen, app?.graph);
             const graphWatch = installGraphConfigureWatch(LGForOpen);
             // The load is INSIDE the try whose finally strips the marker: the payload
             // carrying the marker is handed over the moment this call starts, so a
@@ -19026,6 +19028,7 @@ const GRAPH_TOOL_EXECUTORS = {
                 nodeIsolation?.restore();
                 graphWatch?.restore();
               }
+              const restoreTargetGraph = app?.graph;
               // Retry each contained node ONCE now that the load has settled — the
               // asynchronously-built widgets that made it throw usually exist by then, and
               // a healed node makes the content comparison below honest rather than
@@ -19037,12 +19040,13 @@ const GRAPH_TOOL_EXECUTORS = {
               const containedNodeFailureList = nodeIsolation?.failures ?? [];
               if (containedNodeFailureList.length) {
                 const retry = await retryNodeRestores(app?.graph, containedNodeFailureList, {
-                  isCurrent: () => sameWorkflowObject(activeWorkflowRef(), target),
+                  isCurrent: () =>
+                    app?.graph === restoreTargetGraph && sameWorkflowObject(activeWorkflowRef(), target),
                 });
                 openRestoreRetried = retry.restored;
                 openRestoreFailures = retry.failed;
                 openRestoreRecovered = retry.recovered ?? [];
-                if (!sameWorkflowObject(activeWorkflowRef(), target)) {
+                if (app?.graph !== restoreTargetGraph || !sameWorkflowObject(activeWorkflowRef(), target)) {
                   throw failOpenRebindUnknown(
                     new Error(
                       "workflow_open target workflow changed while restore retry was settling; the retry was skipped",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19037,8 +19037,10 @@ const GRAPH_TOOL_EXECUTORS = {
                 openRestoreFailures = retry.failed;
                 openRestoreRecovered = retry.recovered ?? [];
                 if (!sameWorkflowObject(activeWorkflowRef(), target)) {
-                  throw new Error(
-                    "workflow_open target workflow changed while restore retry was settling; the retry was skipped",
+                  throw failOpenRebindUnknown(
+                    new Error(
+                      "workflow_open target workflow changed while restore retry was settling; the retry was skipped",
+                    ),
                   );
                 }
               }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14307,7 +14307,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // same active tab twice, and a later save 409'd), and a soft-reload-then-
     // reload left graph routing stranded on a frozen Unsaved tab.
     const activeWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
-    const retryTargetWorkflow = activeWorkflow;
+    let retryTargetWorkflow = activeWorkflow;
     const retryTargetGraph = app?.graph;
     const loadStillTargetsWorkflow = () => {
       const currentWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
@@ -14339,6 +14339,12 @@ const GRAPH_TOOL_EXECUTORS = {
       }
     } finally {
       isolation?.restore();
+    }
+    // A blank-canvas load has no workflow object before the call: the frontend
+    // creates its active workflow as part of loadGraphData. Bind that newly
+    // created target before the asynchronous retry can yield.
+    if (!retryTargetWorkflow) {
+      retryTargetWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
     }
     // Retry each contained node ONCE, now that the load has settled and its
     // asynchronously-built widgets usually exist. A node that still throws is

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14307,6 +14307,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // same active tab twice, and a later save 409'd), and a soft-reload-then-
     // reload left graph routing stranded on a frozen Unsaved tab.
     const activeWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
+    const retryTargetWorkflow = activeWorkflow;
+    const retryTargetGraph = app?.graph;
+    const loadStillTargetsWorkflow = () => {
+      const currentWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
+      if (retryTargetWorkflow) return sameWorkflowObject(currentWorkflow, retryTargetWorkflow);
+      return currentWorkflow == null && app?.graph === retryTargetGraph;
+    };
     // #570 P0b — this replaces the ACTIVE canvas with UNTRUSTED external JSON in place. Keep
     // the live workflow instance's identity (so the agent's live session/fence stays intact —
     // re-minting here would reject the agent's own follow-up commands and reset the very
@@ -14337,8 +14344,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // asynchronously-built widgets usually exist. A node that still throws is
     // DISCLOSED below — never folded into a clean `loaded: true`.
     const { restored: retriedNodes, failed: unrestoredNodes } = isolation?.failures?.length
-      ? await retryNodeRestores(app?.graph, isolation.failures)
+      ? await retryNodeRestores(app?.graph, isolation.failures, { isCurrent: loadStillTargetsWorkflow })
       : { restored: [], failed: [] };
+    if (isolation?.failures?.length && !loadStillTargetsWorkflow()) {
+      throw new Error(
+        "graph_load target workflow changed while restore retry was settling; the retry was skipped",
+      );
+    }
     // #874 remaining load path — SubgraphNode.configure seeds host rails from
     // INNER definition widgets, so a saved subgraph host lands at defaults
     // (prompt, dimensions, length, selectors) while the file still holds the
@@ -19018,10 +19030,17 @@ const GRAPH_TOOL_EXECUTORS = {
               // workflow-SERVICE dependency. Same reason `canvasView` exists below.
               const containedNodeFailureList = nodeIsolation?.failures ?? [];
               if (containedNodeFailureList.length) {
-                const retry = await retryNodeRestores(app?.graph, containedNodeFailureList);
+                const retry = await retryNodeRestores(app?.graph, containedNodeFailureList, {
+                  isCurrent: () => sameWorkflowObject(activeWorkflowRef(), target),
+                });
                 openRestoreRetried = retry.restored;
                 openRestoreFailures = retry.failed;
                 openRestoreRecovered = retry.recovered ?? [];
+                if (!sameWorkflowObject(activeWorkflowRef(), target)) {
+                  throw new Error(
+                    "workflow_open target workflow changed while restore retry was settling; the retry was skipped",
+                  );
+                }
               }
               // THREE states, and the null one is the point: `loadRestoreCompleted`
               // answers null when either wrap could not be installed, i.e. the question

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14351,9 +14351,31 @@ const GRAPH_TOOL_EXECUTORS = {
     // Retry each contained node ONCE, now that the load has settled and its
     // asynchronously-built widgets usually exist. A node that still throws is
     // DISCLOSED below — never folded into a clean `loaded: true`.
-    const { restored: retriedNodes, failed: unrestoredNodes } = isolation?.failures?.length
-      ? await retryNodeRestores(app?.graph, isolation.failures, { isCurrent: loadStillTargetsWorkflow })
-      : { restored: [], failed: [] };
+    let retriedNodes = [];
+    let unrestoredNodes = [];
+    if (isolation?.failures?.length) {
+      // The retry waits for link state to settle. Freeze the user canvas across
+      // that await so a same-workflow edit cannot be overwritten by the saved
+      // node snapshot. If this frontend exposes no reliable interaction lock,
+      // disclose the failed nodes instead of attempting an unsafe retry.
+      const retryInteractionToken = acquireCanvasInteractionLock(app?.canvas);
+      if (retryInteractionToken === null) {
+        unrestoredNodes = isolation.failures.map(({ id, type, error }) => ({
+          id,
+          type,
+          error,
+          retry: "no-interaction-lock",
+        }));
+      } else {
+        try {
+          ({ restored: retriedNodes, failed: unrestoredNodes } = await retryNodeRestores(app?.graph, isolation.failures, {
+            isCurrent: loadStillTargetsWorkflow,
+          }));
+        } finally {
+          releaseCanvasInteractionLock(retryInteractionToken, app?.canvas);
+        }
+      }
+    }
     if (isolation?.failures?.length && !loadStillTargetsWorkflow()) {
       throw new Error(
         "graph_load target workflow changed while restore retry was settling; the retry was skipped",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14341,12 +14341,10 @@ const GRAPH_TOOL_EXECUTORS = {
     } finally {
       isolation?.restore();
     }
-    // A blank-canvas load has no workflow object before the call: the frontend
-    // creates its active workflow as part of loadGraphData. Bind that newly
-    // created target before the asynchronous retry can yield.
-    if (!retryTargetWorkflow) {
-      retryTargetWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
-    }
+    // A blank-canvas load has no workflow object before the call. The frontend
+    // may create one as part of loadGraphData, but a tab switch during that await
+    // is indistinguishable from the workflow the load created. Do not retry a
+    // failed node without a pre-load identity that can fence the target.
     retryTargetGraph = app?.graph;
     // Retry each contained node ONCE, now that the load has settled and its
     // asynchronously-built widgets usually exist. A node that still throws is
@@ -14354,29 +14352,39 @@ const GRAPH_TOOL_EXECUTORS = {
     let retriedNodes = [];
     let unrestoredNodes = [];
     if (isolation?.failures?.length) {
-      // The retry waits for link state to settle. Freeze the user canvas across
-      // that await so a same-workflow edit cannot be overwritten by the saved
-      // node snapshot. If this frontend exposes no reliable interaction lock,
-      // disclose the failed nodes instead of attempting an unsafe retry.
-      const retryInteractionToken = acquireCanvasInteractionLock(app?.canvas);
-      if (retryInteractionToken === null) {
+      if (!retryTargetWorkflow) {
         unrestoredNodes = isolation.failures.map(({ id, type, error }) => ({
           id,
           type,
           error,
-          retry: "no-interaction-lock",
+          retry: "blank-load-target-unverified",
         }));
       } else {
-        try {
-          ({ restored: retriedNodes, failed: unrestoredNodes } = await retryNodeRestores(app?.graph, isolation.failures, {
-            isCurrent: loadStillTargetsWorkflow,
+        // The retry waits for link state to settle. Freeze the user canvas across
+        // that await so a same-workflow edit cannot be overwritten by the saved
+        // node snapshot. If this frontend exposes no reliable interaction lock,
+        // disclose the failed nodes instead of attempting an unsafe retry.
+        const retryCanvas = app?.canvas;
+        const retryInteractionToken = acquireCanvasInteractionLock(retryCanvas);
+        if (retryInteractionToken === null) {
+          unrestoredNodes = isolation.failures.map(({ id, type, error }) => ({
+            id,
+            type,
+            error,
+            retry: "no-interaction-lock",
           }));
-        } finally {
-          releaseCanvasInteractionLock(retryInteractionToken, app?.canvas);
+        } else {
+          try {
+            ({ restored: retriedNodes, failed: unrestoredNodes } = await retryNodeRestores(app?.graph, isolation.failures, {
+              isCurrent: loadStillTargetsWorkflow,
+            }));
+          } finally {
+            releaseCanvasInteractionLock(retryInteractionToken, retryCanvas);
+          }
         }
       }
     }
-    if (isolation?.failures?.length && !loadStillTargetsWorkflow()) {
+    if (isolation?.failures?.length && retryTargetWorkflow && !loadStillTargetsWorkflow()) {
       throw new Error(
         "graph_load target workflow changed while restore retry was settling; the retry was skipped",
       );

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14377,6 +14377,11 @@ const GRAPH_TOOL_EXECUTORS = {
           try {
             ({ restored: retriedNodes, failed: unrestoredNodes } = await retryNodeRestores(app?.graph, isolation.failures, {
               isCurrent: loadStillTargetsWorkflow,
+              isGraphCurrent: (ownerGraph) =>
+                ownerGraph == null ||
+                ownerGraph === retryTargetGraph ||
+                !!findSubgraphOwner(retryTargetGraph, ownerGraph) ||
+                isSubgraphInRoot(retryTargetGraph, ownerGraph),
             }));
           } finally {
             releaseCanvasInteractionLock(retryInteractionToken, retryCanvas);
@@ -19072,6 +19077,11 @@ const GRAPH_TOOL_EXECUTORS = {
                 const retry = await retryNodeRestores(app?.graph, containedNodeFailureList, {
                   isCurrent: () =>
                     app?.graph === restoreTargetGraph && sameWorkflowObject(activeWorkflowRef(), target),
+                  isGraphCurrent: (ownerGraph) =>
+                    ownerGraph == null ||
+                    ownerGraph === restoreTargetGraph ||
+                    !!findSubgraphOwner(restoreTargetGraph, ownerGraph) ||
+                    isSubgraphInRoot(restoreTargetGraph, ownerGraph),
                 });
                 openRestoreRetried = retry.restored;
                 openRestoreFailures = retry.failed;

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -2206,7 +2206,16 @@ function abortedRestoreClause(observed = {}) {
   // not grow this clause without bound. The cap trims the LIST, never the claim.
   const named = failures
     .slice(0, 10)
-    .map((f) => `${f?.type ?? "node"} (id ${f?.id ?? "?"})${f?.error ? `: ${f.error}` : ""}`)
+    .map((f) => {
+      const widgets = Array.isArray(f?.widgetDifferences) && f.widgetDifferences.length
+        ? `; widgets not verified: ${f.widgetDifferences.join(", ")}`
+        : "";
+      const linkDriven =
+        Array.isArray(f?.linkDrivenWidgetDifferences) && f.linkDrivenWidgetDifferences.length
+          ? `; link-driven widgets observed: ${f.linkDrivenWidgetDifferences.join(", ")}`
+          : "";
+      return `${f?.type ?? "node"} (id ${f?.id ?? "?"})${f?.error ? `: ${f.error}` : ""}${widgets}${linkDriven}`;
+    })
     .join("; ");
   if (!named) {
     // Something threw, and nothing is still broken that the panel can name — a node

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -42,6 +42,19 @@ function sameNodeId(left, right) {
   return left === right || (left != null && right != null && String(left) === String(right));
 }
 
+const graphIdentityTokens = new WeakMap();
+let nextGraphIdentityToken = 1;
+
+function graphIdentityToken(graph) {
+  if ((typeof graph !== "object" || graph === null) && typeof graph !== "function") return null;
+  let token = graphIdentityTokens.get(graph);
+  if (token == null) {
+    token = nextGraphIdentityToken++;
+    graphIdentityTokens.set(graph, token);
+  }
+  return token;
+}
+
 function graphLinkEntries(graph) {
   const map = graph?._links;
   if (map && typeof map.entries === "function") return [...map.entries()];
@@ -226,6 +239,7 @@ export function installNodeConfigureIsolation(LG, graph = null) {
         // graph that owned the failed configure so the retry cannot retarget
         // the root graph by id alone.
         ownerGraph,
+        ownerGraphToken: graphIdentityToken(ownerGraph),
         // configure implementations can mutate their input before throwing;
         // retain an independent serialized snapshot for the retry/verification.
         info: serializedSnapshot,
@@ -354,10 +368,11 @@ export async function retryNodeRestores(graph, failures, options = {}) {
       const verification = verifyNodeRestore(node, failure.info);
       if (verification.verified) {
         restored.push({ id: failure.id, type: failure.type });
+        const ownerGraphToken = failure.ownerGraphToken ?? graphIdentityToken(failure.ownerGraph);
         recovered.push({
           id: failure.id,
           type: failure.type,
-          ...(failure.ownerGraph ? { ownerGraph: failure.ownerGraph } : {}),
+          ...(ownerGraphToken != null ? { ownerGraphToken } : {}),
           linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences,
         });
         continue;
@@ -558,10 +573,11 @@ export function loadRestoreCompleted({ nodeIsolation, graphWatch, recoveredFailu
   return nodeFailures.every(
     (failure) => {
       if (failure?.linkDisconnectCrash !== true || failure?.linkDisconnectEvidence !== true) return false;
+      const ownerGraphToken = failure?.ownerGraphToken ?? graphIdentityToken(failure?.ownerGraph);
       return recovered.some(
         (candidate) =>
           sameNodeId(candidate?.id, failure?.id) &&
-          (failure?.ownerGraph == null || candidate?.ownerGraph === failure.ownerGraph),
+          (ownerGraphToken == null || candidate?.ownerGraphToken === ownerGraphToken),
       );
     },
   );

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -263,11 +263,10 @@ export async function retryNodeRestores(graph, failures) {
       retryError = err;
     }
     if (linkDisconnectCrash) {
-      // The initial crash makes the retry worth attempting, but it does not
-      // bless a DIFFERENT exception from the retry. That is a new failure and
-      // must remain fail-closed even if the node happened to serialize cleanly
-      // after partially mutating itself.
-      if (retryError && !isLinkDisconnectCrash(retryError)) {
+      // The initial crash makes the retry worth attempting, but ANY exception
+      // from that retry means configure still failed. Serialization after a
+      // throwing configure is not proof that the node was restored.
+      if (retryError) {
         failed.push({ id: failure.id, type: failure.type, error: errorText(retryError) });
         continue;
       }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -38,6 +38,33 @@ function cloneSerializedValue(value, seen = new Map()) {
   return clone;
 }
 
+function sameNodeId(left, right) {
+  return left === right || (left != null && right != null && String(left) === String(right));
+}
+
+function graphLinkEntries(graph) {
+  const map = graph?._links;
+  if (map && typeof map.entries === "function") return [...map.entries()];
+  const links = graph?.links;
+  if (links && typeof links === "object") return Object.keys(links).map((key) => [key, links[key]]);
+  return [];
+}
+
+function hasBrokenLinkEndpoint(graph, node, err) {
+  const nodeId = node?.id;
+  if (nodeId == null || typeof graph?.getNodeById !== "function") return false;
+  const message = String(err?.message ?? "");
+  const method = /findOutputSlot/.test(message) ? "findOutputSlot" : "findInputSlot";
+  for (const [, link] of graphLinkEntries(graph)) {
+    if (!link) continue;
+    const farId = sameNodeId(link.origin_id, nodeId) ? link.target_id : sameNodeId(link.target_id, nodeId) ? link.origin_id : null;
+    if (farId == null) continue;
+    const far = graph.getNodeById(farId);
+    if (far != null && typeof far[method] !== "function") return true;
+  }
+  return false;
+}
+
 function sameSerializedValue(a, b) {
   const seen = new Map();
   const equal = (left, right) => {
@@ -167,7 +194,7 @@ function waitForLinkStateToSettle() {
  * on it; `loadRestoreCompleted` explains why the graph-level count is the one
  * that licenses the verdict and this one must not.
  */
-export function installNodeConfigureIsolation(LG) {
+export function installNodeConfigureIsolation(LG, graph = null) {
   const proto = LG?.LGraphNode?.prototype;
   if (!proto || typeof proto.configure !== "function") return null;
   const original = proto.configure;
@@ -192,6 +219,7 @@ export function installNodeConfigureIsolation(LG) {
         type: info?.type ?? this?.type ?? null,
         error: errorText(err),
         linkDisconnectCrash: isLinkDisconnectCrash(err),
+        linkDisconnectEvidence: isLinkDisconnectCrash(err) && hasBrokenLinkEndpoint(graph, this, err),
         // configure implementations can mutate their input before throwing;
         // retain an independent serialized snapshot for the retry/verification.
         info: serializedSnapshot,
@@ -262,6 +290,15 @@ export async function retryNodeRestores(graph, failures, options = {}) {
       continue;
     }
     const linkDisconnectCrash = failure.linkDisconnectCrash === true;
+    if (linkDisconnectCrash && failure.linkDisconnectEvidence !== true) {
+      failed.push({
+        id: failure.id,
+        type: failure.type,
+        error: failure.error ?? "link-disconnect restore failure",
+        retry: "link-disconnect-unverified",
+      });
+      continue;
+    }
     // Check the same discriminator safeRemoveNode uses while the failed
     // restore's residual link state is still observable. Do not let configure
     // manufacture links during the retry and then use those as proof.
@@ -513,6 +550,9 @@ export function loadRestoreCompleted({ nodeIsolation, graphWatch, recoveredFailu
     (Array.isArray(recoveredFailures) ? recoveredFailures : []).map((failure) => String(failure?.id)),
   );
   return nodeFailures.every(
-    (failure) => failure?.linkDisconnectCrash === true && recoveredIds.has(String(failure?.id)),
+    (failure) =>
+      failure?.linkDisconnectCrash === true &&
+      failure?.linkDisconnectEvidence === true &&
+      recoveredIds.has(String(failure?.id)),
   );
 }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -214,12 +214,18 @@ export function installNodeConfigureIsolation(LG, graph = null) {
     try {
       return original.call(this, info);
     } catch (err) {
+      const ownerGraph = this?.graph ?? null;
+      const evidenceGraph = this?.graph ?? graph ?? null;
       failures.push({
         id: info?.id ?? this?.id ?? null,
         type: info?.type ?? this?.type ?? null,
         error: errorText(err),
         linkDisconnectCrash: isLinkDisconnectCrash(err),
-        linkDisconnectEvidence: isLinkDisconnectCrash(err) && hasBrokenLinkEndpoint(graph, this, err),
+        linkDisconnectEvidence: isLinkDisconnectCrash(err) && hasBrokenLinkEndpoint(evidenceGraph, this, err),
+        // A node inside a subgraph can share an id with a root node. Keep the
+        // graph that owned the failed configure so the retry cannot retarget
+        // the root graph by id alone.
+        ownerGraph,
         // configure implementations can mutate their input before throwing;
         // retain an independent serialized snapshot for the retry/verification.
         info: serializedSnapshot,
@@ -276,9 +282,10 @@ export async function retryNodeRestores(graph, failures, options = {}) {
       });
       continue;
     }
+    const retryGraph = failure?.ownerGraph ?? graph;
     const node =
-      failure?.id != null && typeof graph?.getNodeById === "function"
-        ? graph.getNodeById(failure.id)
+      failure?.id != null && typeof retryGraph?.getNodeById === "function"
+        ? retryGraph.getNodeById(failure.id)
         : null;
     if (!node || !failure.info || typeof node.configure !== "function") {
       failed.push({
@@ -302,7 +309,7 @@ export async function retryNodeRestores(graph, failures, options = {}) {
     // Check the same discriminator safeRemoveNode uses while the failed
     // restore's residual link state is still observable. Do not let configure
     // manufacture links during the retry and then use those as proof.
-    if (linkDisconnectCrash && !nodeHasResidualLinks(graph, node)) {
+    if (linkDisconnectCrash && !nodeHasResidualLinks(retryGraph, node)) {
       failed.push({
         id: failure.id,
         type: failure.type,
@@ -350,6 +357,7 @@ export async function retryNodeRestores(graph, failures, options = {}) {
         recovered.push({
           id: failure.id,
           type: failure.type,
+          ...(failure.ownerGraph ? { ownerGraph: failure.ownerGraph } : {}),
           linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences,
         });
         continue;
@@ -546,13 +554,15 @@ export function loadRestoreCompleted({ nodeIsolation, graphWatch, recoveredFailu
   if (typeof graphEntered !== "number" || !(graphEntered >= 1)) return null;
   if (graphThrows.length !== 0) return false;
   if (nodeFailures.length === 0) return true;
-  const recoveredIds = new Set(
-    (Array.isArray(recoveredFailures) ? recoveredFailures : []).map((failure) => String(failure?.id)),
-  );
+  const recovered = Array.isArray(recoveredFailures) ? recoveredFailures : [];
   return nodeFailures.every(
-    (failure) =>
-      failure?.linkDisconnectCrash === true &&
-      failure?.linkDisconnectEvidence === true &&
-      recoveredIds.has(String(failure?.id)),
+    (failure) => {
+      if (failure?.linkDisconnectCrash !== true || failure?.linkDisconnectEvidence !== true) return false;
+      return recovered.some(
+        (candidate) =>
+          sameNodeId(candidate?.id, failure?.id) &&
+          (failure?.ownerGraph == null || candidate?.ownerGraph === failure.ownerGraph),
+      );
+    },
   );
 }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -122,12 +122,23 @@ export function verifyNodeRestore(node, info) {
 
 function waitForLinkStateToSettle() {
   return new Promise((resolve) => {
-    if (typeof requestAnimationFrame === "function") {
-      requestAnimationFrame(() => resolve());
-    } else if (typeof setTimeout === "function") {
-      setTimeout(resolve, 0);
-    } else {
+    let settled = false;
+    let timer = null;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      if (timer != null && typeof clearTimeout === "function") clearTimeout(timer);
       resolve();
+    };
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(finish);
+      // requestAnimationFrame may be paused indefinitely for a hidden tab;
+      // retain a bounded recovery path for background graph loads.
+      if (typeof setTimeout === "function") timer = setTimeout(finish, 100);
+    } else if (typeof setTimeout === "function") {
+      timer = setTimeout(finish, 0);
+    } else {
+      finish();
     }
   });
 }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -34,7 +34,14 @@ function cloneSerializedValue(value, seen = new Map()) {
   if (prior) return prior;
   const clone = Array.isArray(value) ? [] : {};
   seen.set(value, clone);
-  for (const key of Object.keys(value)) clone[key] = cloneSerializedValue(value[key], seen);
+  for (const key of Object.keys(value)) {
+    Object.defineProperty(clone, key, {
+      configurable: true,
+      enumerable: true,
+      value: cloneSerializedValue(value[key], seen),
+      writable: true,
+    });
+  }
   return clone;
 }
 

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -606,15 +606,20 @@ export function loadRestoreCompleted({ nodeIsolation, graphWatch, recoveredFailu
   if (graphThrows.length !== 0) return false;
   if (nodeFailures.length === 0) return true;
   const recovered = Array.isArray(recoveredFailures) ? recoveredFailures : [];
+  const usedRecovered = new Set();
   return nodeFailures.every(
     (failure) => {
       if (failure?.linkDisconnectCrash !== true || failure?.linkDisconnectEvidence !== true) return false;
       const ownerGraphToken = failure?.ownerGraphToken ?? graphIdentityToken(failure?.ownerGraph);
-      return recovered.some(
-        (candidate) =>
+      const recoveredIndex = recovered.findIndex(
+        (candidate, index) =>
+          !usedRecovered.has(index) &&
           sameNodeId(candidate?.id, failure?.id) &&
           (ownerGraphToken == null || candidate?.ownerGraphToken === ownerGraphToken),
       );
+      if (recoveredIndex < 0) return false;
+      usedRecovered.add(recoveredIndex);
+      return true;
     },
   );
 }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -289,6 +289,9 @@ export function installNodeConfigureIsolation(LG, graph = null) {
  * again" with "there is nothing to restore onto". Callers that can observe
  * workflow identity may pass `{ isCurrent }`; the check runs before configure
  * and again after the settle wait so a tab switch cannot retarget the retry.
+ * Callers whose root graph can be replaced may also pass `{ isGraphCurrent }`;
+ * it receives the graph selected for this failure and must prove that graph is
+ * still owned by the caller's post-load root before configure runs.
  */
 export async function retryNodeRestores(graph, failures, options = {}) {
   const restored = [];
@@ -313,6 +316,23 @@ export async function retryNodeRestores(graph, failures, options = {}) {
       continue;
     }
     const retryGraph = failure?.ownerGraph ?? graph;
+    if (typeof options?.isGraphCurrent === "function") {
+      let graphCurrent = false;
+      try {
+        graphCurrent = options.isGraphCurrent(retryGraph, failure) === true;
+      } catch {
+        graphCurrent = false;
+      }
+      if (!graphCurrent) {
+        failed.push({
+          id: failure?.id ?? null,
+          type: failure?.type ?? null,
+          error: "restore graph changed during retry",
+          retry: "graph-switched",
+        });
+        continue;
+      }
+    }
     const node =
       failure?.id != null && typeof retryGraph?.getNodeById === "function"
         ? retryGraph.getNodeById(failure.id)

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -1,6 +1,6 @@
 // #1260 — one node's restore must not abort the rest of the load.
 //
-import { isLinkDisconnectCrash } from "./safe-remove-node.js";
+import { isLinkDisconnectCrash, nodeHasResidualLinks } from "./safe-remove-node.js";
 
 // LiteGraph restores a serialized graph in passes: every node is CREATED
 // first, then each node is configured in `nodes` order through the PROTOTYPE's
@@ -26,6 +26,16 @@ function errorText(err) {
   } catch {
     return "an unprintable error";
   }
+}
+
+function cloneSerializedValue(value, seen = new Map()) {
+  if (value === null || typeof value !== "object") return value;
+  const prior = seen.get(value);
+  if (prior) return prior;
+  const clone = Array.isArray(value) ? [] : {};
+  seen.set(value, clone);
+  for (const key of Object.keys(value)) clone[key] = cloneSerializedValue(value[key], seen);
+  return clone;
 }
 
 function sameSerializedValue(a, b) {
@@ -156,6 +166,13 @@ export function installNodeConfigureIsolation(LG) {
   const wrapped = function (info) {
     if (!active) return original.call(this, info);
     entered += 1;
+    let serializedSnapshot = null;
+    try {
+      serializedSnapshot = info == null ? null : cloneSerializedValue(info);
+    } catch {
+      // An uncloneable payload cannot be safely verified after a throw.
+      serializedSnapshot = null;
+    }
     try {
       return original.call(this, info);
     } catch (err) {
@@ -164,7 +181,9 @@ export function installNodeConfigureIsolation(LG) {
         type: info?.type ?? this?.type ?? null,
         error: errorText(err),
         linkDisconnectCrash: isLinkDisconnectCrash(err),
-        info: info ?? null,
+        // configure implementations can mutate their input before throwing;
+        // retain an independent serialized snapshot for the retry/verification.
+        info: serializedSnapshot,
       });
       return undefined;
     }
@@ -212,21 +231,32 @@ export async function retryNodeRestores(graph, failures) {
       });
       continue;
     }
-    if (failure.linkDisconnectCrash) await waitForLinkStateToSettle();
+    const linkDisconnectCrash = failure.linkDisconnectCrash === true;
+    // Check the same discriminator safeRemoveNode uses while the failed
+    // restore's residual link state is still observable. Do not let configure
+    // manufacture links during the retry and then use those as proof.
+    if (linkDisconnectCrash && !nodeHasResidualLinks(graph, node)) {
+      failed.push({
+        id: failure.id,
+        type: failure.type,
+        error: failure.error ?? "link-disconnect restore failure",
+        retry: "no-residual-links",
+      });
+      continue;
+    }
+    if (linkDisconnectCrash) await waitForLinkStateToSettle();
     let retryError = null;
     try {
       node.configure(failure.info);
     } catch (err) {
       retryError = err;
     }
-    const retryLinkDisconnectCrash = isLinkDisconnectCrash(retryError);
-    const linkDisconnectCrash = failure.linkDisconnectCrash || retryLinkDisconnectCrash;
     if (linkDisconnectCrash) {
       // The initial crash makes the retry worth attempting, but it does not
       // bless a DIFFERENT exception from the retry. That is a new failure and
       // must remain fail-closed even if the node happened to serialize cleanly
       // after partially mutating itself.
-      if (retryError && !retryLinkDisconnectCrash) {
+      if (retryError && !isLinkDisconnectCrash(retryError)) {
         failed.push({ id: failure.id, type: failure.type, error: errorText(retryError) });
         continue;
       }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -284,9 +284,18 @@ export async function retryNodeRestores(graph, failures, options = {}) {
       });
       continue;
     }
+    let retryInfo;
+    try {
+      // configure may mutate its input too; keep the failure's independent
+      // snapshot untouched for verification after this retry.
+      retryInfo = cloneSerializedValue(failure.info);
+    } catch {
+      failed.push({ id: failure.id, type: failure.type, error: "restore payload could not be cloned", retry: "uncloneable-info" });
+      continue;
+    }
     let retryError = null;
     try {
-      node.configure(failure.info);
+      node.configure(retryInfo);
     } catch (err) {
       retryError = err;
     }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -67,12 +67,21 @@ function hasBrokenLinkEndpoint(graph, node, err) {
   const nodeId = node?.id;
   if (nodeId == null || typeof graph?.getNodeById !== "function") return false;
   const message = String(err?.message ?? "");
+  const mirrorWrite = /Cannot set propert(?:y|ies) of (?:undefined|null) \(setting ['\"](?:link|links)['\"]\)|Cannot set property ['\"](?:link|links)['\"] of (?:undefined|null)/.test(message);
   const method = /findOutputSlot/.test(message) ? "findOutputSlot" : "findInputSlot";
   for (const [, link] of graphLinkEntries(graph)) {
     if (!link) continue;
-    const farId = sameNodeId(link.origin_id, nodeId) ? link.target_id : sameNodeId(link.target_id, nodeId) ? link.origin_id : null;
+    const nodeIsOrigin = sameNodeId(link.origin_id, nodeId);
+    const nodeIsTarget = sameNodeId(link.target_id, nodeId);
+    const farId = nodeIsOrigin ? link.target_id : nodeIsTarget ? link.origin_id : null;
     if (farId == null) continue;
     const far = graph.getNodeById(farId);
+    if (mirrorWrite) {
+      const farSlot = nodeIsOrigin ? link.target_slot : link.origin_slot;
+      const farSlots = nodeIsOrigin ? far?.inputs : far?.outputs;
+      if (far != null && farSlot != null && (!Array.isArray(farSlots) || farSlots[Number(farSlot)] == null)) return true;
+      continue;
+    }
     if (far != null && typeof far[method] !== "function") return true;
   }
   return false;

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -1,5 +1,7 @@
 // #1260 — one node's restore must not abort the rest of the load.
 //
+import { isLinkDisconnectCrash } from "./safe-remove-node.js";
+
 // LiteGraph restores a serialized graph in passes: every node is CREATED
 // first, then each node is configured in `nodes` order through the PROTOTYPE's
 // `LGraphNode.prototype.configure`, and only afterwards are links and groups
@@ -24,6 +26,100 @@ function errorText(err) {
   } catch {
     return "an unprintable error";
   }
+}
+
+function sameSerializedValue(a, b) {
+  const seen = new Map();
+  const equal = (left, right) => {
+    if (Object.is(left, right)) return true;
+    if (left === null || right === null || typeof left !== typeof right) return false;
+    if (typeof left !== "object") return false;
+    const prior = seen.get(left);
+    if (prior) return prior === right;
+    seen.set(left, right);
+    if (Array.isArray(left) || Array.isArray(right)) {
+      if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+      return left.every((value, index) => equal(value, right[index]));
+    }
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    if (leftKeys.length !== rightKeys.length || leftKeys.some((key) => !Object.prototype.hasOwnProperty.call(right, key))) {
+      return false;
+    }
+    return leftKeys.every((key) => equal(left[key], right[key]));
+  };
+  try {
+    return equal(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify the state of one node after a link-disconnect configure failure.
+ *
+ * A linked widget is allowed to differ: ComfyUI's connection propagation can
+ * replace its displayed value while the link, mode, flags, properties, and
+ * every other widget remain the serialized values. That is an explicit,
+ * inspectable warning, not a general normalization exemption. Every other
+ * serialized field must match, including the node's position and topology.
+ */
+export function verifyNodeRestore(node, info) {
+  try {
+    const actual = node?.serialize?.();
+    if (!actual || !info || typeof actual !== "object" || typeof info !== "object") {
+      return { comparable: false, verified: false, differences: [], linkDrivenWidgetDifferences: [] };
+    }
+    const linkedWidgetNames = new Set();
+    for (const input of [...(info.inputs ?? []), ...(node.inputs ?? [])]) {
+      if (input?.link != null && typeof input?.widget?.name === "string") {
+        linkedWidgetNames.add(input.widget.name);
+      }
+    }
+    const serializedWidgets = (node.widgets ?? []).filter((widget) => widget && widget.serialize !== false);
+    const widgetNames = serializedWidgets.map((widget) => widget.name);
+    const differences = [];
+    const linkDrivenWidgetDifferences = [];
+    const fields = new Set([...Object.keys(info), ...Object.keys(actual)]);
+    for (const field of fields) {
+      const expectedHas = Object.prototype.hasOwnProperty.call(info, field) && info[field] !== undefined;
+      const actualHas = Object.prototype.hasOwnProperty.call(actual, field) && actual[field] !== undefined;
+      if (!expectedHas && !actualHas) continue;
+      if (field === "widgets_values" && Array.isArray(info[field]) && Array.isArray(actual[field])) {
+        const length = Math.max(info[field].length, actual[field].length);
+        for (let index = 0; index < length; index += 1) {
+          if (sameSerializedValue(info[field][index], actual[field][index])) continue;
+          const name = widgetNames[index] ?? `#${index}`;
+          if (linkedWidgetNames.has(name)) linkDrivenWidgetDifferences.push(name);
+          else differences.push(`widgets_values.${name}`);
+        }
+        continue;
+      }
+      if (expectedHas !== actualHas || !sameSerializedValue(info[field], actual[field])) {
+        differences.push(field);
+      }
+    }
+    return {
+      comparable: true,
+      verified: differences.length === 0,
+      differences: [...new Set(differences)],
+      linkDrivenWidgetDifferences: [...new Set(linkDrivenWidgetDifferences)],
+    };
+  } catch {
+    return { comparable: false, verified: false, differences: [], linkDrivenWidgetDifferences: [] };
+  }
+}
+
+function waitForLinkStateToSettle() {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => resolve());
+    } else if (typeof setTimeout === "function") {
+      setTimeout(resolve, 0);
+    } else {
+      resolve();
+    }
+  });
 }
 
 /**
@@ -67,6 +163,7 @@ export function installNodeConfigureIsolation(LG) {
         id: info?.id ?? this?.id ?? null,
         type: info?.type ?? this?.type ?? null,
         error: errorText(err),
+        linkDisconnectCrash: isLinkDisconnectCrash(err),
         info: info ?? null,
       });
       return undefined;
@@ -97,9 +194,10 @@ export function installNodeConfigureIsolation(LG) {
  * `retry: "node-not-on-graph"` so the caller does not confuse "restore threw
  * again" with "there is nothing to restore onto".
  */
-export function retryNodeRestores(graph, failures) {
+export async function retryNodeRestores(graph, failures) {
   const restored = [];
   const failed = [];
+  const recovered = [];
   for (const failure of failures ?? []) {
     const node =
       failure?.id != null && typeof graph?.getNodeById === "function"
@@ -114,14 +212,49 @@ export function retryNodeRestores(graph, failures) {
       });
       continue;
     }
+    if (failure.linkDisconnectCrash) await waitForLinkStateToSettle();
+    let retryError = null;
     try {
       node.configure(failure.info);
-      restored.push({ id: failure.id, type: failure.type });
     } catch (err) {
-      failed.push({ id: failure.id, type: failure.type, error: errorText(err) });
+      retryError = err;
     }
+    const retryLinkDisconnectCrash = isLinkDisconnectCrash(retryError);
+    const linkDisconnectCrash = failure.linkDisconnectCrash || retryLinkDisconnectCrash;
+    if (linkDisconnectCrash) {
+      // The initial crash makes the retry worth attempting, but it does not
+      // bless a DIFFERENT exception from the retry. That is a new failure and
+      // must remain fail-closed even if the node happened to serialize cleanly
+      // after partially mutating itself.
+      if (retryError && !retryLinkDisconnectCrash) {
+        failed.push({ id: failure.id, type: failure.type, error: errorText(retryError) });
+        continue;
+      }
+      const verification = verifyNodeRestore(node, failure.info);
+      if (verification.verified) {
+        restored.push({ id: failure.id, type: failure.type });
+        recovered.push({
+          id: failure.id,
+          type: failure.type,
+          linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences,
+        });
+        continue;
+      }
+      failed.push({
+        id: failure.id,
+        type: failure.type,
+        error: errorText(retryError ?? new TypeError(failure.error ?? "link-disconnect restore failure")),
+        ...(verification.differences.length ? { widgetDifferences: verification.differences } : {}),
+        ...(verification.linkDrivenWidgetDifferences.length
+          ? { linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences }
+          : {}),
+      });
+      continue;
+    }
+    if (!retryError) restored.push({ id: failure.id, type: failure.type });
+    else failed.push({ id: failure.id, type: failure.type, error: errorText(retryError) });
   }
-  return { restored, failed };
+  return { restored, failed, recovered };
 }
 
 /**
@@ -286,7 +419,7 @@ export function installGraphConfigureWatch(LG) {
  *    that node; it does not lose the OBSERVATION. An unentered graph watch loses
  *    the observation outright, which is why only that one may answer null.
  */
-export function loadRestoreCompleted({ nodeIsolation, graphWatch } = {}) {
+export function loadRestoreCompleted({ nodeIsolation, graphWatch, recoveredFailures = [] } = {}) {
   if (!nodeIsolation || !graphWatch) return null;
   const nodeFailures = Array.isArray(nodeIsolation.failures) ? nodeIsolation.failures : null;
   const graphThrows = Array.isArray(graphWatch.throws) ? graphWatch.throws : null;
@@ -297,5 +430,12 @@ export function loadRestoreCompleted({ nodeIsolation, graphWatch } = {}) {
   // `>= 1` and not `< 1`: NaN fails every comparison, so a `< 1` test would let it
   // through as "entered" — the same fold, hiding in an operator.
   if (typeof graphEntered !== "number" || !(graphEntered >= 1)) return null;
-  return nodeFailures.length === 0 && graphThrows.length === 0;
+  if (graphThrows.length !== 0) return false;
+  if (nodeFailures.length === 0) return true;
+  const recoveredIds = new Set(
+    (Array.isArray(recoveredFailures) ? recoveredFailures : []).map((failure) => String(failure?.id)),
+  );
+  return nodeFailures.every(
+    (failure) => failure?.linkDisconnectCrash === true && recoveredIds.has(String(failure?.id)),
+  );
 }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -222,13 +222,32 @@ export function installNodeConfigureIsolation(LG) {
  * A recorded failure whose node never landed on the graph (creation failed
  * too, not just configure) cannot be retried; it is disclosed with
  * `retry: "node-not-on-graph"` so the caller does not confuse "restore threw
- * again" with "there is nothing to restore onto".
+ * again" with "there is nothing to restore onto". Callers that can observe
+ * workflow identity may pass `{ isCurrent }`; the check runs before configure
+ * and again after the settle wait so a tab switch cannot retarget the retry.
  */
-export async function retryNodeRestores(graph, failures) {
+export async function retryNodeRestores(graph, failures, options = {}) {
   const restored = [];
   const failed = [];
   const recovered = [];
+  const isCurrent = () => {
+    if (typeof options?.isCurrent !== "function") return true;
+    try {
+      return options.isCurrent() === true;
+    } catch {
+      return false;
+    }
+  };
   for (const failure of failures ?? []) {
+    if (!isCurrent()) {
+      failed.push({
+        id: failure?.id ?? null,
+        type: failure?.type ?? null,
+        error: "active workflow changed during restore retry",
+        retry: "workflow-switched",
+      });
+      continue;
+    }
     const node =
       failure?.id != null && typeof graph?.getNodeById === "function"
         ? graph.getNodeById(failure.id)
@@ -256,6 +275,15 @@ export async function retryNodeRestores(graph, failures) {
       continue;
     }
     if (linkDisconnectCrash) await waitForLinkStateToSettle();
+    if (!isCurrent()) {
+      failed.push({
+        id: failure.id,
+        type: failure.type,
+        error: "active workflow changed during restore retry",
+        retry: "workflow-switched",
+      });
+      continue;
+    }
     let retryError = null;
     try {
       node.configure(failure.info);


### PR DESCRIPTION
## Summary
- contain link-disconnect configure crashes and retry once after link state settles
- require endpoint evidence, strict serialized verification, residual links, current workflow/graph ownership, and serializable recovery receipts
- fence graph-load retries against same-workflow edits and fail closed for unverified blank-load targets

## Validation
- independent Codex gate: SHIP (r17)
- npm.cmd run test:unit: 6583 tests, 6582 passed, 1 todo, 0 failures
- npm.cmd run typecheck: passed