### PR TITLE
fix(2099): treat VHS date prefixes as queue-time volatile

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -474,6 +474,103 @@ test("#1273 promptContentHash: an untouched UE graph stamps EQUAL to its dispatc
 });
 
 // ---------------------------------------------------------------------------
+// #2099 — VHS_VideoCombine resolves Comfy save-file date templates in
+// filename_prefix as the prompt is queued. That queue-time clock substitution is
+// not graph drift, but only the exact VHS filename_prefix date-template input is
+// volatile; ordinary prefixes and every other input stay covered.
+// ---------------------------------------------------------------------------
+
+const vhsNode = (id, filenamePrefix, extra = {}) => ({
+  id,
+  type: "VHS_VideoCombine",
+  widgets: [
+    { name: "frame_rate", value: 24 },
+    { name: "filename_prefix", value: filenamePrefix },
+    { name: "format", value: "video/h264-mp4" },
+  ],
+  ...extra,
+});
+
+test("#2099 collectVolatileInputs: only VHS_VideoCombine filename_prefix with a recognized date template is volatile", () => {
+  const root = {
+    _nodes: [
+      vhsNode(223, "video/%date:yyyyMMdd_hhmmss%"),
+      vhsNode(224, "video/fixed_prefix"),
+      vhsNode(225, "video/%not_a_date_template%"),
+      vhsNode(226, "video/%date:folder%"),
+      vhsNode(227, "video/%date:yyyy-MM-ddThh:mm:ss%"),
+      { id: 9, type: "SaveImage", widgets: [{ name: "filename_prefix", value: "%date:yyyyMMdd_hhmmss%" }] },
+      { id: 10, widgets: [], subgraph: { _nodes: [vhsNode(15, "nested/%date:yyyy-MM-dd%")] } },
+    ],
+  };
+  const pairs = collectVolatileInputs(root);
+  assert.deepEqual(
+    [...pairs].sort(),
+    ["10:15 filename_prefix", "223 filename_prefix", "227 filename_prefix"],
+    "exact VHS node + exact input + recognized date template; nested execIds are preserved",
+  );
+});
+
+test("#2099 promptContentHash: VHS date-template substitution is stable, ordinary prefixes and sibling edits are still drift", () => {
+  const graph = { _nodes: [vhsNode(223, "video/%date:yyyyMMdd_hhmmss%")] };
+  const volatileInputs = collectVolatileInputs(graph);
+  const stamped = {
+    "223": {
+      class_type: "VHS_VideoCombine",
+      inputs: { images: ["1000", 0], filename_prefix: "video/%date:yyyyMMdd_hhmmss%", frame_rate: 24 },
+    },
+    "14": { class_type: "PreviewAny", inputs: {} },
+  };
+  const atHash = promptContentHash(stamped, volatileInputs);
+  const body = (inputs) => JSON.stringify({
+    prompt: {
+      "223": { class_type: "VHS_VideoCombine", inputs },
+      "14": { class_type: "PreviewAny", inputs: {} },
+    },
+  });
+  assert.equal(
+    promptContentHashFromBody(
+      body({ images: ["1000", 0], filename_prefix: "video/20260823_142233", frame_rate: 24 }),
+      volatileInputs,
+    ),
+    atHash,
+    "the queue-time clock substitution is the exclusion's purpose",
+  );
+  assert.notEqual(
+    promptContentHashFromBody(
+      body({ images: ["1000", 0], filename_prefix: "video/20260823_142233", frame_rate: 30 }),
+      volatileInputs,
+    ),
+    atHash,
+    "a sibling input on the same VHS node is still drift-covered",
+  );
+
+  const ordinaryVolatileInputs = collectVolatileInputs({ _nodes: [vhsNode(223, "video/fixed_prefix")] });
+  const ordinaryStamped = {
+    "223": {
+      class_type: "VHS_VideoCombine",
+      inputs: { images: ["1000", 0], filename_prefix: "video/fixed_prefix", frame_rate: 24 },
+    },
+  };
+  assert.equal(ordinaryVolatileInputs.size, 0, "an ordinary VHS prefix excludes nothing");
+  assert.notEqual(
+    promptContentHashFromBody(
+      JSON.stringify({
+        prompt: {
+          "223": {
+            class_type: "VHS_VideoCombine",
+            inputs: { images: ["1000", 0], filename_prefix: "video/changed_prefix", frame_rate: 24 },
+          },
+        },
+      }),
+      ordinaryVolatileInputs,
+    ),
+    promptContentHash(ordinaryStamped, ordinaryVolatileInputs),
+    "ordinary filename_prefix edits remain drift-covered",
+  );
+});
+
+// ---------------------------------------------------------------------------
 // #1331 — the FOURTH volatility mechanism: after reconnect, leftover values of
 // link-driven converted widgets (MiniMax H3 clip/vae/model/length, …) settle
 // between the pre-dispatch stamp and the POST body. The #1050 single retry
@@ -2490,6 +2587,82 @@ test("#1124 integration: the exclusion is ONE input — an armed rgthree Seed do
       // the refusal names the REAL change instead of the red herring the reporter
       // was handed.
       assert.doesNotMatch(result.error, /47 seed/, `${label}: the substituted seed is no longer blamed`);
+    }
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #2099 integration — VHS_VideoCombine's filename_prefix date-template
+// substitution is driven through dispatchScopedRun, while another changed input
+// in the same queued body still trips the graph-drift refusal.
+// ---------------------------------------------------------------------------
+
+const VHS_STAMP = {
+  "1000": { class_type: "VAEDecode", inputs: { samples: ["4", 0] } },
+  "223": {
+    class_type: "VHS_VideoCombine",
+    inputs: { images: ["1000", 0], filename_prefix: "video/%date:yyyyMMdd_hhmmss%", frame_rate: 24 },
+  },
+};
+
+function makeVhsDateFrontend({ apiTarget, alsoEdit = null } = {}) {
+  const app = {
+    queueItems: [],
+    posted: [],
+    graph: { _nodes: [vhsNode(223, "video/%date:yyyyMMdd_hhmmss%")] },
+    graphToPrompt: async () => ({ output: structuredClone(VHS_STAMP), workflow: {} }),
+    queuePrompt: async (number, batch, arg) => {
+      const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+      const output = structuredClone(VHS_STAMP);
+      output["223"].inputs.filename_prefix = "video/20260823_142233";
+      if (alsoEdit) alsoEdit(output);
+      const body = frontendBody({ output, number, targets: targets?.length ? targets : null });
+      app.posted.push(body);
+      await apiTarget.fetchApi(...promptPost(body));
+      return true;
+    },
+  };
+  return app;
+}
+
+test("#2099 integration: VHS_VideoCombine date-template filename_prefix substitution is OUR dispatch", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeVhsDateFrontend({ apiTarget });
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["223"], batch: 1, toNodeId: 223, verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "dispatched", "the date substitution is not treated as graph drift");
+    assert.equal(server.calls.length, 1, "the scoped prompt reached ComfyUI");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["223"]);
+    assert.deepEqual(result.volatileInputs, ["223 filename_prefix"], "the coverage gap is disclosed");
+  } finally {
+    stop();
+  }
+});
+
+test("#2099 integration: VHS date-template exclusion does NOT let real edits elsewhere ride along", async () => {
+  const stop = keepAlive();
+  try {
+    for (const [label, edit, token] of [
+      ["a sibling VHS input", (output) => { output["223"].inputs.frame_rate = 30; }, /223 frame_rate/],
+      ["an upstream node input", (output) => { output["1000"].inputs.samples = ["5", 0]; }, /1000 samples/],
+    ]) {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const app = makeVhsDateFrontend({ apiTarget, alsoEdit: edit });
+      const result = await dispatchScopedRun({
+        app, apiTarget, execIds: ["223"], batch: 1, toNodeId: 223, verifyTimeoutMs: 500,
+      });
+      assert.equal(result.outcome, "refused", `${label} edit is still drift`);
+      assert.match(result.error, /graph CHANGED/i);
+      assert.match(result.error, token);
+      assert.doesNotMatch(result.error, /223 filename_prefix/, "the volatile date template is not blamed");
+      assert.equal(server.calls.length, 0, `${label}: the edited workflow never left the tab`);
     }
   } finally {
     stop();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17199,14 +17199,15 @@ const GRAPH_TOOL_EXECUTORS = {
       accept.fixed_seed_nodes = repeatingRgthreeSeeds(rgthreeSeeds);
       accept.fixed_seed_note = fixedSeedNote;
     }
-    // #572/#1124/#1331 — TRUTHFUL drift-coverage note for a scoped run: the drift
+    // #572/#1124/#1331/#2099 — TRUTHFUL drift-coverage note for a scoped run: the drift
     // hash excluded the inputs that mutate at queue time by the known
     // mechanisms — beforeQueued carriers + their linked, serialized targets
     // (e.g. a control_after_generate seed reroll), the seed of an ARMED
     // rgthree Seed node (no hook: rgthree substitutes inside its own
     // api.queuePrompt patch), leftover values of link-driven converted
-    // widgets (clip/vae/model settling after reconnect), and UE broadcast
-    // targets. A user edit to exactly THOSE inputs during the queue window
+    // widgets (clip/vae/model settling after reconnect), UE broadcast targets,
+    // and VHS date-template filename_prefix values. A user edit to exactly THOSE
+    // inputs during the queue window
     // is indistinguishable from the queue-time mutation (accepted residual),
     // so the result names the uncovered inputs instead of implying full-graph
     // drift proof. Every other input was covered.
@@ -17222,8 +17223,9 @@ const GRAPH_TOOL_EXECUTORS = {
         note:
           "These inputs mutate at queue time — a beforeQueued hook (e.g. a " +
           "control_after_generate seed reroll), an extension that rewrites the prompt in " +
-          "its own api.queuePrompt patch (an armed Seed (rgthree) node), or a leftover " +
-          "link-driven widget value settling after reconnect (clip/vae/model) — so they were " +
+          "its own api.queuePrompt patch (an armed Seed (rgthree) node), a leftover " +
+          "link-driven widget value settling after reconnect (clip/vae/model), or a " +
+          "VHS_VideoCombine date-template filename_prefix — so they were " +
           "excluded from this run's graph-drift check: a user edit to exactly these inputs " +
           "during the queue window is indistinguishable from that mutation and would NOT " +
           "have been caught. Every other input was drift-covered.",

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -427,7 +427,7 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
 /**
  * The "execId inputName" pairs whose values MUTATE AT QUEUE TIME — after our
  * pre-dispatch stamp and before the POST body is built — collected from the live
- * root graph and every nested subgraph. FOUR signals, one per mechanism: a
+ * root graph and every nested subgraph. FIVE signals, one per mechanism: a
  * widget-level `beforeQueued` hook (#572), an extension that patches
  * `api.queuePrompt` and rewrites the outgoing prompt directly (rgthree's armed
  * Seed node, #1124 — invisible to any widget scan, matched by node identity),
@@ -436,7 +436,9 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
  * record, see ueQueueTimeLinkPairs), and a leftover widget value whose
  * SAME-NAMED input is already link-connected (#1331 — after reconnect the
  * serialized form flips from the stale widget default to the incoming link,
- * or the leftover filename itself settles, while the canvas is idle).
+ * or the leftover filename itself settles, while the canvas is idle), plus
+ * VHS_VideoCombine filename_prefix date templates (#2099), which the frontend
+ * resolves at queue time.
  * execId is the flattened prompt id: String(node.id) at root, the
  * colon-joined subgraph-instance path for nested nodes ("10:15:359") — the
  * same path buildNodeExecutionId produces, so pairs line up with the keys of
@@ -497,6 +499,24 @@ function linkDrivenWidgetInputNames(node) {
     /* a malformed node contributes no pairs — fail toward detecting drift */
   }
   return names;
+}
+
+function hasRecognizedDateFilenameTemplate(value) {
+  if (typeof value !== "string") return false;
+  // Comfy save-file formatting documents `%date:FORMAT%`; the recognized date
+  // format specifiers are d, M, y, h, m, and s. Accept only those plus common
+  // filename/path separators so arbitrary percent strings stay drift-covered.
+  return /%date:[dMyhms][-dMyhms ._:/\\T]*%/.test(value);
+}
+
+function vhsQueueTimeFilenamePrefixInput(node) {
+  if (node?.type !== "VHS_VideoCombine") return null;
+  for (const w of node?.widgets ?? []) {
+    if (w?.name === "filename_prefix" && hasRecognizedDateFilenameTemplate(w.value)) {
+      return "filename_prefix";
+    }
+  }
+  return null;
 }
 
 export function collectVolatileInputs(rootGraph) {
@@ -577,6 +597,17 @@ export function collectVolatileInputs(rootGraph) {
         addPair(execId, entry.widget);
         if (entry.control !== entry.widget) addPair(execId, entry.control);
       }
+      // #2099 — THE FIFTH VOLATILITY SIGNAL. VHS_VideoCombine applies Comfy's
+      // save-file date templates in its filename_prefix as the prompt is queued:
+      // `%date:yyyyMMdd_hhmmss%` in the stamped graph becomes the current clock
+      // value in the POST body. That is queue-time substitution, not graph drift.
+      //
+      // NARROW BY CONSTRUCTION: exact node class, exact input name, and a
+      // recognized `%date:FORMAT%` token only. Ordinary VHS prefixes, arbitrary
+      // percent strings, other VHS inputs, and every other node class keep full
+      // drift coverage.
+      const vhsFilenamePrefixInput = vhsQueueTimeFilenamePrefixInput(node);
+      if (vhsFilenamePrefixInput != null) addPair(execId, vhsFilenamePrefixInput);
       if (node.subgraph) walk(node.subgraph, execId);
     }
   };


### PR DESCRIPTION
## Summary
- treat VHS_VideoCombine filename_prefix values containing documented %date:FORMAT% templates as queue-time volatile for scoped graph hashing
- keep ordinary prefixes, arbitrary percent strings, other VHS inputs, and other node classes drift-covered
- disclose the VHS exclusion in drift_coverage and add pure/integration regressions, including nested exec IDs and the documented ISO T separator

## Verification
- node --test browser_tests/unit/run-scope-guard.test.mjs (122 passed)
- npm.cmd run test:unit (5781 passed, 1 existing todo)
- git diff --check

Fixes artokun/comfyui#2099