### PR TITLE
fix(1539): refuse arbitrary Manager v4 git installs

### DIFF
--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -1139,6 +1139,68 @@ test("#671 nodes_install (real panel source) happy path still verifies inside th
   assert.deepEqual(calls, ["manager/queue/task"], "exactly one submit, on the v2 task route");
 });
 
+test("#1539 v4 refuses a Git-routed target before any Manager mutation", async () => {
+  const calls = [];
+  const nodes_install = loadNodesInstall({
+    budgetMs: 2500,
+    detect: async () => "v2",
+    managerV2: async (...args) => { calls.push(["v2", ...args]); },
+    managerCall: async (...args) => { calls.push(["legacy", ...args]); },
+    managerQueueControl: async (...args) => { calls.push(["start", ...args]); },
+    verifyInstalled: async (...args) => { calls.push(["verify", ...args]); },
+  });
+  const err = await nodes_install({
+    repository: "https://github.com/example/arbitrary-node.git",
+  }).then(() => null, (e) => e);
+
+  assert.ok(err, "an arbitrary Git URL must be refused on real v4");
+  assert.match(err.message, /Manager v4 does not clone the supplied arbitrary URL/);
+  assert.match(err.message, /no install was queued/i);
+  assert.match(err.message, /Manager registry id/);
+  assert.match(err.message, /ComfyUI host/);
+  assert.match(err.message, /local verified path/);
+  assert.deepEqual(calls, [], "v4 Git rejection must send no submit, start, or verification mutation");
+});
+
+for (const dialect of ["v2-batch", "legacy"]) {
+  test(`#1539 ${dialect} keeps the direct-URL files path`, async () => {
+    const url = "https://github.com/example/arbitrary-node.git";
+    const calls = [];
+    const managerV2 = async (route, opts) => {
+      calls.push(["v2", route, opts]);
+      return { failed: [] };
+    };
+    const managerCall = async (route, opts) => {
+      calls.push(["legacy", route, opts]);
+      return null;
+    };
+    const nodes_install = loadNodesInstall({
+      budgetMs: 2500,
+      detect: async () => dialect,
+      managerV2,
+      managerCall,
+      managerQueueControl: async (_call, route) => {
+        calls.push(["start", route]);
+      },
+      verifyInstalled: async (target, actualDialect) => {
+        assert.equal(actualDialect, dialect);
+        return { state: "installed" };
+      },
+    });
+    const result = await nodes_install({ repository: url });
+
+    assert.equal(result.installed, true);
+    const submit = calls.find(([kind, route]) =>
+      kind === (dialect === "v2-batch" ? "v2" : "legacy") &&
+      route === (dialect === "v2-batch" ? "manager/queue/batch" : "manager/queue/install"),
+    );
+    assert.ok(submit, `${dialect} must still submit the install`);
+    const body = dialect === "v2-batch" ? submit[2].body.install[0] : submit[2].body;
+    assert.deepEqual(body.files, [url], `${dialect} must preserve files:[url] direct-URL routing`);
+    assert.ok(calls.some(([kind, route]) => kind === "start" && route === "manager/queue/start"));
+  });
+}
+
 test("#671 nodes_install a stalled dialect detection reports NOTHING queued (a retry is safe)", async () => {
   // Detection hangs (signal-aware); NO mutation may run. The budget error must
   // say so — this phase can vouch for it (codex r2 P2).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22508,6 +22508,16 @@ const GRAPH_TOOL_EXECUTORS = {
       const detected = await detectManagerDialect({
         signal: AbortSignal.timeout(bounded(MANAGER_FETCH_TIMEOUT_MS)),
       });
+      // #1539 — real Manager v4's v2 install handler does not clone arbitrary
+      // URLs. Refuse before creating or submitting a task; the v2-batch/legacy
+      // dialects intentionally keep their measured files:[url] escape hatch.
+      if (detected === "v2" && installGitUrl(args)) {
+        throw new Error(
+          "Manager v4 does not clone the supplied arbitrary URL; no install was queued. " +
+            "Use a Manager registry id, or install the repository on the ComfyUI host " +
+            "from a local verified path.",
+        );
+      }
       const ui_id = crypto.randomUUID();
       const client_id = api.clientId ?? api.initialClientId ?? "comfyui-mcp-panel";
       // A git URL or an owner/repo id can install under a directory name that
@@ -22616,8 +22626,8 @@ const GRAPH_TOOL_EXECUTORS = {
       // draws on whatever the command budget has LEFT (#671).
       phase = "verify";
       // #1539 — `ui_id` is what makes the Manager's own terminal verdict for THIS
-      // task readable. Without it the verifier is back to drain + name-presence,
-      // and a v4 registry rejection of a git URL reports queued/pending.
+      // registry task readable. Git-routed targets on real v4 are refused above;
+      // v2-batch/legacy retain their direct-URL files:[url] path.
       const outcome = await verifyInstalled(target, dialect, {
         batchFailed, renameProne, budgetMs: remaining(), ui_id,
       });


### PR DESCRIPTION
## Summary\n- Refuse Git-routed nodes_install requests on Manager v4 before any task is submitted.\n- Keep the measured files:[url] direct-URL path for v2-batch and legacy Manager dialects.\n- Add no-mutation and legacy-preservation regressions.\n\nManager v4 ignores the supplied repository URL and resolves by bare name, so accepting the request can install another repository or remain unverifiable. The MCP contract update is in the paired comfyui-mcp PR.\n\nIssue: artokun/comfyui-mcp#1539\n\n## Validation\n- node --test browser_tests/unit/manager-install.test.mjs browser_tests/unit/install-terminal-failure.test.mjs (140 passed)\n- git diff --check\n\nCo-authored-by: Codex <codex@openai.com>