### PR TITLE
fix: preserve raw string matching in panel_find_nodes (#1678)

### DIFF
--- a/browser_tests/unit/graph-find-nodes.test.mjs
+++ b/browser_tests/unit/graph-find-nodes.test.mjs
@@ -1,41 +1,153 @@
+// #1678 — graph_find_nodes must search the values that the live node exposes,
+// while returning the normal summarizeNode-shaped result.
+//
+// This deliberately extracts and runs the shipped executor method. Testing a
+// safe-stringify helper alone would miss the production seam where the method
+// gets widget values from summarizeNode and projects the match into `matches`.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
-const PANEL_JS = new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url);
+import { displayLabel, boundaryInputLabel, widgetLabelMap } from "../../web/js/lib/slot-labels.js";
+import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
+import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
+import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
+import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
 
-function graphFindNodesBody(source) {
-  const start = source.indexOf("  graph_find_nodes({");
-  assert.ok(start >= 0, "graph_find_nodes handler must exist");
-  const next = source.slice(start).match(/\n  (?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
-  return source.slice(start, next ? start + next.index : source.length);
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+/** Brace-balanced extraction of a top-level function from the shipped panel. */
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  const open = src.indexOf(") {", start) + 2;
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
 }
 
-function productionSafeJson() {
-  const body = graphFindNodesBody(readFileSync(PANEL_JS, "utf8"));
-  const match = body.match(/    const safeJson = \(v\) => \{[\s\S]*?^    \};/m);
-  assert.ok(match, "graph_find_nodes must define safeJson");
-  return new Function(`${match[0]}\nreturn safeJson;`)();
+/** Extract one executor method, stopping at the next sibling method. */
+function handlerBody(src, signature) {
+  const start = src.indexOf(signature);
+  if (start === -1) return null;
+  const after = start + signature.length;
+  const next = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  const end = next ? after + next.index : src.length;
+  return src.slice(start, end);
 }
 
-const includes = (safeJson, value, query) =>
-  String(safeJson(value) ?? "")
-    .toLowerCase()
-    .includes(query.toLowerCase());
+const PANEL_SOURCE = readFileSync(PANEL_JS, "utf8");
 
-test("#1678 graph_find_nodes matches raw embedded quotes in string widget values", () => {
-  const safeJson = productionSafeJson();
-  const value = 'say "hello" to the model';
+const summarizeNode = (() => {
+  const source = namedFunctionSource(PANEL_SOURCE, "summarizeNode");
+  assert.ok(source, "summarizeNode must remain present in the shipped panel");
+  // eslint-disable-next-line no-new-func -- this runs the shipped production function.
+  return new Function(
+    "virtualFedInputs",
+    "boundaryInputLabel",
+    "displayLabel",
+    "widgetLabelMap",
+    "duplicateWidgetRows",
+    "controlAfterGenerateModes",
+    "drivenWidgetsFor",
+    `${source}; return summarizeNode;`,
+  )(
+    virtualFedInputs,
+    boundaryInputLabel,
+    displayLabel,
+    widgetLabelMap,
+    duplicateWidgetRows,
+    controlAfterGenerateModes,
+    drivenWidgetsFor,
+  );
+})();
 
-  assert.equal(safeJson(value), value, "strings must not be JSON-escaped before matching");
-  assert.equal(includes(safeJson, value, '"hello"'), true);
+const graphFindNodes = (() => {
+  const source = handlerBody(PANEL_SOURCE, "  graph_find_nodes({");
+  assert.ok(source, "graph_find_nodes executor method must remain present");
+  // eslint-disable-next-line no-new-func -- this runs the shipped production method.
+  return new Function(
+    "getGraphCtx",
+    "LIMIT_CEILING",
+    "summarizeNode",
+    "nodeDescription",
+    "describeActiveGraph",
+    `return ({ ${source} }).graph_find_nodes;`,
+  );
+})();
+
+function makeNode(id, value, { description = "", type = "MiniMaxH3Director" } = {}) {
+  return {
+    id,
+    type,
+    title: type,
+    widgets: [{ name: "timeline_data", value }],
+    inputs: [],
+    outputs: [],
+    constructor: { nodeData: { description } },
+  };
+}
+
+function runFind(nodes, args) {
+  const graph = { _nodes: nodes };
+  const method = graphFindNodes(
+    () => ({ graph }),
+    200,
+    summarizeNode,
+    (node) => String(node?.constructor?.nodeData?.description ?? node?.description ?? ""),
+    () => ({ scope: "root" }),
+  );
+  return method(args);
+}
+
+test("#1678 searches a raw STRING widget for a quoted substring", () => {
+  const raw = '{"clips":[{"slot":2,"name":"Picture 2"}]}';
+  const result = runFind([makeNode(1, raw)], {
+    query: 'slot":2',
+    widget_value: 'slot":2',
+  });
+
+  assert.equal(result.count, 1);
+  assert.equal(result.matches.length, 1);
+  assert.equal(result.matches[0].widgets.timeline_data, raw);
+  assert.deepEqual(
+    result.matches[0].matched_on,
+    [
+      `widget_value:timeline_data=${raw}`,
+      `widget_value:timeline_data=${raw}`,
+    ],
+  );
 });
 
-test("#1678 graph_find_nodes keeps JSON matching for non-string widget values", () => {
-  const safeJson = productionSafeJson();
+test("#1678 keeps JSON object and array widget values searchable", () => {
+  const objectValue = { slot: 2, name: "object" };
+  const arrayValue = [{ slot: 2, name: "array" }];
+  const objectResult = runFind([makeNode(2, objectValue)], { query: 'slot":2' });
+  const arrayResult = runFind([makeNode(3, arrayValue)], { widget_value: 'slot":2' });
 
-  assert.equal(safeJson(42), "42");
-  assert.equal(safeJson(false), "false");
-  assert.equal(safeJson({ mode: "fast" }), '{"mode":"fast"}');
-  assert.equal(includes(safeJson, { mode: "fast" }, '"mode":"fast"'), true);
+  assert.equal(objectResult.count, 1);
+  assert.deepEqual(objectResult.matches[0].widgets.timeline_data, objectValue);
+  assert.equal(arrayResult.count, 1);
+  assert.deepEqual(arrayResult.matches[0].widgets.timeline_data, arrayValue);
+});
+
+test("#1678 searches the complete large STRING before projecting the result", () => {
+  const needle = '"slot":2';
+  const raw = `${"x".repeat(9000)}${needle}`;
+  const result = runFind(
+    [makeNode(4, raw, { description: "d".repeat(400) })],
+    { query: needle },
+  );
+
+  assert.equal(result.count, 1, "a match after the large-value prefix must not be lost");
+  assert.equal(result.matches[0].description.length, 240, "description projection remains bounded");
+  assert.deepEqual(
+    result.matches[0].matched_on,
+    [`widget_value:timeline_data=${"x".repeat(60)}`],
+    "matched_on remains a short projection even when the full value was searched",
+  );
 });

--- a/browser_tests/unit/graph-find-nodes.test.mjs
+++ b/browser_tests/unit/graph-find-nodes.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const PANEL_JS = new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url);
+
+function graphFindNodesBody(source) {
+  const start = source.indexOf("  graph_find_nodes({");
+  assert.ok(start >= 0, "graph_find_nodes handler must exist");
+  const next = source.slice(start).match(/\n  (?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  return source.slice(start, next ? start + next.index : source.length);
+}
+
+function productionSafeJson() {
+  const body = graphFindNodesBody(readFileSync(PANEL_JS, "utf8"));
+  const match = body.match(/    const safeJson = \(v\) => \{[\s\S]*?^    \};/m);
+  assert.ok(match, "graph_find_nodes must define safeJson");
+  return new Function(`${match[0]}\nreturn safeJson;`)();
+}
+
+const includes = (safeJson, value, query) =>
+  String(safeJson(value) ?? "")
+    .toLowerCase()
+    .includes(query.toLowerCase());
+
+test("#1678 graph_find_nodes matches raw embedded quotes in string widget values", () => {
+  const safeJson = productionSafeJson();
+  const value = 'say "hello" to the model';
+
+  assert.equal(safeJson(value), value, "strings must not be JSON-escaped before matching");
+  assert.equal(includes(safeJson, value, '"hello"'), true);
+});
+
+test("#1678 graph_find_nodes keeps JSON matching for non-string widget values", () => {
+  const safeJson = productionSafeJson();
+
+  assert.equal(safeJson(42), "42");
+  assert.equal(safeJson(false), "false");
+  assert.equal(safeJson({ mode: "fast" }), '{"mode":"fast"}');
+  assert.equal(includes(safeJson, { mode: "fast" }, '"mode":"fast"'), true);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13328,9 +13328,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // can never quote a ceiling the runtime does not enforce.
     const cap = Math.min(Math.max(Number(limit ?? 40), 1), LIMIT_CEILING);
     const lc = (s) => String(s ?? "").toLowerCase();
-    // Safe stringify for widget values — a BigInt or circular/custom value would
-    // throw in JSON.stringify and fail the whole find call; fall back to String().
+    // Preserve string widget values exactly so searches can match embedded quotes. Non-string
+    // values still use JSON for readable matching, while exotic values stay non-fatal.
     const safeJson = (v) => {
+      if (typeof v === "string") return v;
       try {
         return JSON.stringify(v) ?? String(v);
       } catch {


### PR DESCRIPTION
## Summary\n- preserve raw STRING widget contents during panel_find_nodes matching\n- retain JSON matching for objects, arrays, and other non-string values\n- add production-seam regression coverage for quoted substrings, large values, and projection/truncation\n\n## Verification\n- node --test browser_tests/unit/graph-find-nodes.test.mjs browser_tests/unit/outline-coverage.test.mjs\n- 23 passed\n- full panel unit gate: 6,592 passed, 1 todo, 0 failures\n- independent review: SHIP\n\nFixes #1678