### PR TITLE
fix(widget): fence live widget write targets

### DIFF
--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -13,8 +13,10 @@ test("graph_set_widget enforces expected_node_type at the synchronous write boun
 
   const expectedArg = handler.indexOf("expected_node_type");
   const targetCheck = handler.indexOf("liveTarget.type !== expected_node_type");
+  const identityCheck = handler.indexOf("liveTarget !== node");
   const runSet = handler.indexOf("runSetWidget(node, widget, value, setWidgetOpts)");
   assert.ok(expectedArg >= 0, "handler does not accept expected_node_type");
   assert.ok(targetCheck >= 0, "handler does not verify the live target type");
+  assert.ok(identityCheck >= 0, "handler does not reject a same-type replacement object");
   assert.ok(runSet > targetCheck, "target type must be checked before runSetWidget");
 });

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -19,4 +19,54 @@ test("graph_set_widget enforces expected_node_type at the synchronous write boun
   assert.ok(targetCheck >= 0, "handler does not verify the live target type");
   assert.ok(identityCheck >= 0, "handler does not reject a same-type replacement object");
   assert.ok(runSet > targetCheck, "target type must be checked before runSetWidget");
+  assert.ok(runSet > identityCheck, "target identity must be checked before runSetWidget");
+});
+
+test("the shipped target fence rejects replacement objects and preserves qualified ids", () => {
+  const start = PANEL_SRC.indexOf("async graph_set_widget({");
+  const end = PANEL_SRC.indexOf("\n  // artokun/comfyui-mcp#938", start);
+  const handler = PANEL_SRC.slice(start, end);
+  const fenceStart = handler.indexOf("assertTargetStillCurrent: () => {");
+  const fenceTail = handler.slice(fenceStart).match(/\r?\n      \},\r?\n      \/\/ Stale-combo retry/);
+  const fenceEnd = fenceTail?.index == null ? -1 : fenceStart + fenceTail.index;
+  assert.ok(fenceStart >= 0, "production target fence not found");
+  assert.ok(fenceEnd > fenceStart, "production target fence boundary not found");
+  const fenceProperty = handler.slice(fenceStart, fenceEnd) + "\n      }";
+
+  const original = { id: 7, type: "OtherLoraLoader" };
+  let liveTarget = original;
+  let resolvedId;
+  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, node) {
+      return ({ ${fenceProperty} }).assertTargetStillCurrent;
+    };`;
+  let makeFence;
+  try {
+    makeFence = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "assertActiveWorkflowCommandTarget",
+    "WORKFLOW_UUID_FIELD",
+    factorySource,
+    );
+  } catch (err) {
+    throw new Error(`${err}\n${factorySource}`);
+  }
+  const fence = makeFence(
+    () => ({ graph: {} }),
+    (_graph, id) => {
+      resolvedId = id;
+      return liveTarget;
+    },
+    () => {},
+    "workflow_uuid",
+  )("7:subgraph", "OtherLoraLoader", undefined, original);
+
+  fence();
+  assert.equal(resolvedId, "7:subgraph");
+
+  liveTarget = { id: 7, type: "OtherLoraLoader" };
+  assert.throws(() => fence(), /target changed before dispatch/);
+
+  liveTarget = { id: 7, type: "KSampler" };
+  assert.throws(() => fence(), /target changed before dispatch/);
 });

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+test("graph_set_widget enforces expected_node_type at the synchronous write boundary", () => {
+  const start = PANEL_SRC.indexOf("async graph_set_widget({");
+  const end = PANEL_SRC.indexOf("\n  // artokun/comfyui-mcp#938", start);
+  assert.ok(start >= 0, "graph_set_widget handler not found");
+  assert.ok(end > start, "graph_set_widget handler boundary not found");
+  const handler = PANEL_SRC.slice(start, end);
+
+  const expectedArg = handler.indexOf("expected_node_type");
+  const targetCheck = handler.indexOf("liveTarget.type !== expected_node_type");
+  const runSet = handler.indexOf("runSetWidget(node, widget, value, setWidgetOpts)");
+  assert.ok(expectedArg >= 0, "handler does not accept expected_node_type");
+  assert.ok(targetCheck >= 0, "handler does not verify the live target type");
+  assert.ok(runSet > targetCheck, "target type must be checked before runSetWidget");
+});

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -538,6 +538,28 @@ test("set_widget e2e: unreachable ⇒ REFUSE even for a would-be-core type, no m
   assert.equal(node.widgets[0].value, "");
 });
 
+test("#2107: the real runSetWidget refuses a replacement object before mutation", async () => {
+  const reg = loadedRegistry();
+  const node = regNode("KSampler", [{ name: "steps", type: "INT", value: 0 }]);
+  const replacement = regNode("KSampler", [{ name: "steps", type: "INT", value: 99 }]);
+  let liveTarget = replacement;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 20, {
+        registry: reg,
+        getFreshObjectInfo: async () => FRESH_ALL,
+        resolveSource: () => null,
+        ...HOOKS,
+        assertTargetStillCurrent: () => {
+          if (liveTarget !== node) throw new Error("panel_set_widget target changed before dispatch");
+        },
+      }),
+    /target changed before dispatch/,
+  );
+  assert.equal(node.widgets[0].value, 0, "the captured stale object was not mutated");
+  liveTarget = node;
+});
+
 // ---- HANDLER ORDERING through the REAL runSetWidget (#458) -------------------
 // reconcileUnknownWidgetNames RENAMES widgets in place. The handler must preflight
 // (refuse a placeholder) BEFORE reconcile, and reconcile only a resolved direct

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1277,7 +1277,7 @@ test("#757 the created row is disclosed on its own field, not in `warning`", () 
 // implementation is verified, never a copy of it.
 
 const SET_WIDGET_SRC = (() => {
-  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid, builder_state \}\) \{[\s\S]*?\n {2}\},/);
+  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid, builder_state(?:, expected_node_type)? \}\) \{[\s\S]*?\n {2}\},/);
   assert.ok(m, "could not locate graph_set_widget in the panel source");
   return m[0];
 })();

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -270,12 +270,17 @@ test("#570/#718: hello ALWAYS advertises both workflow-stamp fences so the orche
   // server never treats this build like an older unsafe bundle.
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp_at_write, true);
+  assert.equal(buildHelloPayload({ tabId: "t" }).enforces_expected_node_type_at_write, true);
   assert.equal(
     buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_workflow_stamp,
     true,
   );
   assert.equal(
     buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_workflow_stamp_at_write,
+    true,
+  );
+  assert.equal(
+    buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_expected_node_type_at_write,
     true,
   );
 });

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -238,7 +238,7 @@ test("#718 wiring: graph_set_widget passes the execution-time workflow fence int
   const body = src.slice(start, end);
   assert.match(
     body,
-    /assertTargetStillCurrent:\s*\(\)\s*=>\s*assertActiveWorkflowCommandTarget\([\s\S]*workflow_uuid/,
+    /assertTargetStillCurrent:\s*\(\)\s*=>\s*\{[\s\S]*assertActiveWorkflowCommandTarget\([\s\S]*workflow_uuid/,
     "the post-await write boundary must recheck the exact command stamp",
   );
 });

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -167,7 +167,7 @@ test("#1418 a never-started recovery says NOTHING IS RUNNING — never 'still ru
 // shipped body with the real coalescer answers that.
 
 const SET_WIDGET_SRC = (() => {
-  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid, builder_state \}\) \{[\s\S]*?\n {2}\},/);
+  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid, builder_state(?:, expected_node_type)? \}\) \{[\s\S]*?\n {2}\},/);
   assert.ok(m, "could not locate graph_set_widget in the panel source");
   return m[0];
 })();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15463,7 +15463,7 @@ const GRAPH_TOOL_EXECUTORS = {
         }
         const current = getGraphCtx();
         const liveTarget = resolveNode(current.graph, node_id);
-        if (!liveTarget || liveTarget.type !== expected_node_type) {
+        if (!liveTarget || liveTarget !== node || liveTarget.type !== expected_node_type) {
           throw new Error(
             `panel_set_widget target changed before dispatch: expected ${expected_node_type}, ` +
               `found ${liveTarget?.type ?? "missing"}`,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14947,7 +14947,7 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
-  async graph_set_widget({ node_id, widget, value, workflow_uuid, builder_state }) {
+  async graph_set_widget({ node_id, widget, value, workflow_uuid, builder_state, expected_node_type }) {
     // #1413 — ONE deadline for the whole command, taken BEFORE anything awaits, so the
     // bounded steps inside it compose instead of adding (#1192, #671). The step this
     // exists for is the stale-combo recovery's refresh join below: reached only after
@@ -15452,11 +15452,24 @@ const GRAPH_TOOL_EXECUTORS = {
       // and the fresh /object_info request. A user can switch workflows while either
       // promise is pending, so re-read the ACTIVE uuid at the exact shared write
       // boundary. runSetWidget calls this synchronously before every write path.
-      assertTargetStillCurrent: () =>
+      assertTargetStillCurrent: () => {
         assertActiveWorkflowCommandTarget({
           cmd: "graph_set_widget",
           [WORKFLOW_UUID_FIELD]: workflow_uuid,
-        }),
+        });
+        if (expected_node_type === undefined) return;
+        if (typeof expected_node_type !== "string" || !expected_node_type) {
+          throw new Error("graph_set_widget expected_node_type must be a non-empty string");
+        }
+        const current = getGraphCtx();
+        const liveTarget = resolveNode(current.graph, node_id);
+        if (!liveTarget || liveTarget.type !== expected_node_type) {
+          throw new Error(
+            `panel_set_widget target changed before dispatch: expected ${expected_node_type}, ` +
+              `found ${liveTarget?.type ?? "missing"}`,
+          );
+        }
+      },
       // Stale-combo retry: reuse the /object_info already fetched for authorization
       // (passed by runSetWidget) to refresh THIS target's combo option lists in place
       // — a single fetch total (#458 P2). When a payload IS present we NEVER re-fetch,

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -722,6 +722,10 @@ export function buildHelloPayload({
     // newer orchestrator fail closed for an older bundle that only fences at
     // initial dispatch.
     enforces_workflow_stamp_at_write: true,
+    // #2107: graph_set_widget honors optional expected_node_type at the
+    // synchronous write boundary, so the orchestrator can fence a node
+    // replacement between its final identity probe and mutation.
+    enforces_expected_node_type_at_write: true,
     // Advertise that this build understands `agent_note` — an orchestrator frame that is
     // delivered to the AGENT ONLY and never rendered as a chat bubble.
     //


### PR DESCRIPTION
Addresses #2107.

Adds the expected_node_type capability handshake and enforces live target type plus object identity immediately before widget mutation. Includes production-callback and replacement-object regression coverage.

Validation: direct unit suite 6595 passed, 1 todo, 0 failed; targeted fence tests 130 passed; typecheck passed.