### PR TITLE
fix/1680 refresh completion handle

### DIFF
--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -100,6 +100,36 @@ test("#396 a FORCED payload-less call while a refresh is in flight runs a TRAILI
   assert.equal(registered.length, 2, "the forced call ran its OWN trailing refresh, not just a join");
 });
 
+test("#1680: a forced payload-less caller can explicitly join an in-flight refresh", async () => {
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async () => {
+    if (registered.length === 1) await gate.promise;
+  });
+
+  const inFlight = coalescer();
+  const joined = coalescer(undefined, { force: true, joinInFlight: true, joinMs: 500 });
+
+  gate.resolve();
+  await Promise.all([inFlight, joined]);
+
+  assert.equal(registered.length, 1, "the opt-in joins the existing run without a trailing pass");
+});
+
+test("#1680: a failed joined refresh returns no freshness verdict", async () => {
+  const gate = deferred();
+  const { coalescer } = makeHarnessReturning(async () => {
+    await gate.promise;
+    throw new Error("refresh failed");
+  });
+
+  const inFlight = coalescer();
+  const joined = coalescer(undefined, { force: true, joinInFlight: true, joinMs: 500 });
+  gate.resolve();
+
+  await inFlight.catch(() => {});
+  assert.equal(await joined, undefined, "a rejected run must fail closed instead of claiming fresh");
+});
+
 test("#396 many FORCED calls during one in-flight run coalesce into ONE trailing run", async () => {
   const gate = deferred();
   const { coalescer, registered } = makeHarness(async () => {

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -1,22 +1,17 @@
-// panel#1404 — `panel_refresh_nodes` timed out with no acknowledgement for 30 s against a
-// ComfyUI that stayed healthy and idle, and the IDENTICAL call succeeded on the retry.
-//
-// The reply was not lost in transit. It was never COMPOSED inside the window: `refresh_nodes`
-// is relayed at comfyui-mcp's `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` (30,000 ms) and was the
-// only command relayed there that never took a command budget, so its forced coalescer call
-// waited unbounded on an in-flight run AND on the trailing run queued behind it. Each run is
-// ~14.5 s wall clock on the #610 install (NODE_DEFS_RUN_BUDGET_MS bounds only the WAITING it
-// controls and stops its clock across `registerNodesFromDefs`), and two of them do not fit.
-// The retry succeeds because by then the trailing run has settled and it pays for ONE.
+// panel#1680 — `panel_refresh_nodes` must observe an already-running node-definition refresh
+// instead of queueing a second forced run behind it. The command is an acknowledgement
+// surface: it joins the existing single-flight promise up to its command budget, returns the
+// completed freshness verdict when that promise settles, and reports a bounded retryable
+// status when it does not. When no run exists, it still starts its own forced refresh.
 //
 // THE HARNESS RUNS THE SHIPPED `refresh_nodes` BODY, extracted from the panel source and
 // given injected collaborators, over the REAL coalescer with a REAL in-flight run — the same
 // technique as add-node-command-budget.test.mjs, and for the same reason. A helper-level test
-// cannot reach this defect: `makeRefreshCoalescer` already accepts `joinMs` and already
-// implements it correctly (#1192/#1351), and `refresh_nodes` already handled a non-fresh
-// verdict. The whole bug was that the call site passed no bound. Only an assertion on THAT
-// CALL SITE can see it — which is why every test below drives the extracted executor rather
-// than the coalescer directly, and why deleting `joinMs` from the panel makes them fail.
+// cannot reach the whole defect: the coalescer's opt-in join and the existing budget are
+// individually testable, but only an assertion on THAT CALL SITE can prove that
+// `refresh_nodes` both opts into joining and preserves its idle forced-refresh behavior.
+// Every production-path case below therefore drives the extracted executor rather than
+// relying on a helper-only test.
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -123,19 +118,35 @@ async function withWatchdog(run, ms, what) {
 }
 
 // ---------------------------------------------------------------------------
-// 1. The reported shape: a run already in flight, and the tool call behind it.
+// 1. The reported shape: a run already in flight, and the tool call subscribed to it.
 // ---------------------------------------------------------------------------
 
-test("#1404: refresh_nodes REPLIES at its budget instead of waiting two runs out", async () => {
+test("#1680: refresh_nodes returns the completed verdict from an already-running refresh", async () => {
+  const gate = deferred();
+  const built = realRefreshNodes({ holdFirstRun: gate.promise, budgetMs: 500 });
+  const pending = built.refresh_nodes();
+
+  assert.equal(built.runs.length, 1, "the existing refresh owns the single-flight slot");
+  gate.resolve();
+
+  const { value } = await withWatchdog(
+    () => pending,
+    1500,
+    "refresh_nodes did not return after the already-running refresh settled",
+  );
+  assert.deepEqual(value, { ok: true, refreshed: true });
+  assert.equal(built.runs.length, 1, "joining the completion must not queue a trailing refresh");
+  await built.inFlightStarted?.catch(() => {});
+});
+
+test("#1680: refresh_nodes replies at its budget instead of waiting for the joined run", async () => {
   const gate = deferred();
   const built = realRefreshNodes({ holdFirstRun: gate.promise, budgetMs: 150 });
 
   const { value, elapsed } = await withWatchdog(
     () => built.refresh_nodes(),
     1500,
-    "refresh_nodes never replied: the command budget is not reaching the coalescer, so the " +
-      "forced call is waiting for a run someone else started PLUS its own — the composition " +
-      "that does not fit the 30,000 ms relay window",
+    "refresh_nodes never replied: the command budget did not reach the in-flight completion",
   );
 
   assert.equal(value.ok, true, "nothing failed, so the command still succeeds");
@@ -147,9 +158,11 @@ test("#1404: refresh_nodes REPLIES at its budget instead of waiting two runs out
 
   gate.resolve();
   await built.inFlightStarted?.catch(() => {});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(built.runs.length, 1, "a timed-out join must not create a trailing refresh");
 });
 
-test("#1404: the reply NAMES the cause instead of collapsing it into 'unknown'", async () => {
+test("#1680: the bounded status names the still-running refresh and its remedy", async () => {
   const gate = deferred();
   const built = realRefreshNodes({ holdFirstRun: gate.promise, budgetMs: 150 });
 
@@ -183,9 +196,8 @@ test("#1404: the reply NAMES the cause instead of collapsing it into 'unknown'",
     /[Nn]othing failed/,
     "the caller must know nothing was left half-done before it retries",
   );
-  // BOTH runs. The coalescer returns one symbol whether the budget went on a run someone
-  // else started or on this command's own, so a detail naming only the first would be
-  // flatly wrong on an uncontended big install — the case with no concurrency at all.
+  // The status remains compatible with the existing bounded own-run path: the same
+  // structured token is used whether the command joined an existing run or started one.
   assert.match(value.detail, /something else started/, "the contended case");
   assert.match(value.detail, /own registration/, "…and this command's own run");
 
@@ -193,7 +205,7 @@ test("#1404: the reply NAMES the cause instead of collapsing it into 'unknown'",
   await built.inFlightStarted?.catch(() => {});
 });
 
-test("#1404: the abandoned run is NOT cancelled, and the retry it asks for succeeds", async () => {
+test("#1680: a timed-out joined refresh is not cancelled and a later call can refresh", async () => {
   // This is why the remedy is honest rather than hopeful, and it is also the reporter's
   // observation: the identical call succeeded on the second attempt. The coalescer does not
   // cancel what it stopped waiting for, so the retry pays for ONE run rather than two.
@@ -210,6 +222,8 @@ test("#1404: the abandoned run is NOT cancelled, and the retry it asks for succe
 
   gate.resolve();
   await built.inFlightStarted?.catch(() => {});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(built.runs.length, 1, "the abandoned join did not start a competing refresh");
 
   const second = await withWatchdog(
     () => built.refresh_nodes(),
@@ -217,6 +231,18 @@ test("#1404: the abandoned run is NOT cancelled, and the retry it asks for succe
     "the retry the remedy prescribes never replied either",
   );
   assert.deepEqual(second.value, { ok: true, refreshed: true });
+  assert.equal(built.runs.length, 2, "the later idle call starts exactly one new refresh");
+});
+
+test("#1680: with no refresh in flight, refresh_nodes starts its own forced run", async () => {
+  const built = realRefreshNodes({ startInFlight: false, budgetMs: 500 });
+  const { value } = await withWatchdog(
+    () => built.refresh_nodes(),
+    1500,
+    "refresh_nodes did not start an idle refresh",
+  );
+  assert.deepEqual(value, { ok: true, refreshed: true });
+  assert.equal(built.runs.length, 1, "an idle call starts one forced refresh");
 });
 
 test("#1404: an UNCONTENDED run that outlives the budget lands on the same named verdict", async () => {
@@ -331,7 +357,7 @@ test("#1404: the shipped call site passes the budget — the helper alone cannot
   // but BOTH options are required by name.
   assert.match(
     refreshNodesMatch[0],
-    /refreshComfyNodeDefs\(undefined, \{[\s\S]*?force: true,[\s\S]*?joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,[\s\S]*?runBudgetMs: REFRESH_NODES_RUN_BUDGET_MS,\s*\}\)/,
-    "refresh_nodes must bound its own wait on the coalescer AND state the run's allowance",
+    /refreshComfyNodeDefs\(undefined, \{[\s\S]*?force: true,[\s\S]*?joinInFlight: true,[\s\S]*?joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,[\s\S]*?runBudgetMs: REFRESH_NODES_RUN_BUDGET_MS,\s*\}\)/,
+    "refresh_nodes must join an existing run, bound its wait, and state the run's allowance",
   );
 });

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -54,6 +54,7 @@ function realRefreshNodes({
   startInFlight = true,
   budgetMs = 150,
   verdicts = [{ refreshed: true, reason: "refreshed" }],
+  runHook = null,
 } = {}) {
   let inFlight = null;
   const runs = [];
@@ -62,10 +63,11 @@ function realRefreshNodes({
     setInFlight: (p) => {
       inFlight = p;
     },
-    runRegister: async () => {
+    runRegister: async (_defs, _runOpts, control) => {
       const index = runs.length;
       runs.push(index);
       if (index === 0 && holdFirstRun) await holdFirstRun;
+      if (runHook) return runHook({ index, control });
       return verdicts[Math.min(index, verdicts.length - 1)];
     },
     withTimeout,
@@ -160,6 +162,63 @@ test("#1680: refresh_nodes replies at its budget instead of waiting for the join
   await built.inFlightStarted?.catch(() => {});
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(built.runs.length, 1, "a timed-out join must not create a trailing refresh");
+});
+
+test("#1680: a joined acknowledgement yields before delayed synchronous registration", async () => {
+  const gate = deferred();
+  const localWorkMs = 100;
+  const built = realRefreshNodes({
+    holdFirstRun: gate.promise,
+    budgetMs: 1,
+    runHook: async ({ control }) => {
+      const handoff = control.beforeLocalWork?.();
+      if (handoff) await handoff;
+      const end = Date.now() + localWorkMs;
+      while (Date.now() < end) {}
+      return { refreshed: true, reason: "refreshed" };
+    },
+  });
+
+  const pending = built.refresh_nodes();
+  // Let the acknowledgement arm its one-millisecond join timer before releasing the
+  // external refresh toward the synchronous section that used to block that timer.
+  await Promise.resolve();
+  gate.resolve();
+
+  const { value, elapsed } = await withWatchdog(
+    () => pending,
+    500,
+    "refresh_nodes waited through the joined refresh's synchronous work",
+  );
+  assert.equal(value.reason, "refresh_still_running");
+  assert.ok(
+    elapsed < localWorkMs,
+    `replied in ${elapsed}ms instead of blocking through ${localWorkMs}ms of local work`,
+  );
+
+  await built.inFlightStarted?.catch(() => {});
+});
+
+test("#1680: a settled joined non-fresh verdict is forwarded truthfully", async () => {
+  const gate = deferred();
+  const verdict = {
+    refreshed: false,
+    reason: NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED,
+    remedy: "check that ComfyUI is running",
+  };
+  const built = realRefreshNodes({ holdFirstRun: gate.promise, budgetMs: 500, verdicts: [verdict] });
+  const pending = built.refresh_nodes();
+
+  gate.resolve();
+  const { value } = await withWatchdog(
+    () => pending,
+    1500,
+    "refresh_nodes did not return the joined non-fresh verdict",
+  );
+  assert.equal(value.refreshed, false);
+  assert.equal(value.reason, verdict.reason);
+  assert.equal(value.remedy, verdict.remedy);
+  await built.inFlightStarted?.catch(() => {});
 });
 
 test("#1680: the bounded status names the still-running refresh and its remedy", async () => {

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -178,15 +178,16 @@ test("#1562: refresh_nodes answers before synchronous reapply and keeps registra
     "the caller must reply before registerNodesFromDefs/reapply can block the main thread",
   );
 
-  // This retry sees the still-live first promise and queues one trailing forced run. Both
-  // runs may register eventually, but the coalescer must never let those passes overlap.
+  // This retry sees the still-live first promise and subscribes to its completion. The
+  // acknowledgement path must return that run's settled verdict without queueing a second
+  // forced pass.
   const retryReply = await refresh_nodes();
-  assert.equal(retryReply.reason, "refresh_still_running");
+  assert.equal(retryReply.refreshed, true, "the retry observes the completed first refresh");
   while (inFlight) {
     const current = inFlight;
     await current;
   }
-  assert.equal(registrationCalls, 2, "the retry joined/queued behind the first run, then refreshed once");
+  assert.equal(registrationCalls, 1, "the retry joined the first run instead of queueing another");
   assert.equal(maxConcurrentRegistrations, 1, "registration passes must remain single-flight");
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11852,9 +11852,13 @@ const GRAPH_TOOL_EXECUTORS = {
   // composition `graph_add_node`'s budget note describes — a forced call pays an in-flight
   // run AND its own, serially, which does not fit the 30,000 ms window this command is
   // relayed in. See REFRESH_NODES_COMMAND_BUDGET_MS.
+  // #1680 — when a refresh already owns the single-flight slot, this command is an
+  // acknowledgement of that work: subscribe to it instead of queueing a second
+  // trailing run. When the slot is empty, force:true still starts a fresh refresh.
   async refresh_nodes() {
     const verdict = await refreshComfyNodeDefs(undefined, {
       force: true,
+      joinInFlight: true,
       joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,
       // #1562 — the run announces this handoff after /object_info and yields one turn
       // before registration, so this caller can return its structured retryable verdict

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -21,6 +21,11 @@
 // combos. So a forced call GUARANTEES a fresh registration whose fetch begins
 // AFTER the current run settles. Multiple forced calls that arrive during one
 // in-flight run coalesce into a SINGLE trailing run (no /object_info stampede).
+// #1680 — an acknowledgement caller can opt into the opposite behavior with
+// `joinInFlight:true`: when a forced, payload-less call finds an existing run,
+// it subscribes to that run instead of queueing a trailing one. The opt-in is
+// deliberately narrow so freshness-triggered forced callers keep #396's
+// guarantee.
 //
 // #1192 / #1351 — A CALLER MAY BOUND ITS OWN WAIT. That wait is the whole invocation,
 // not just the join.
@@ -215,6 +220,11 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
   };
   return async function refresh(preloadedDefs, opts) {
     const force = !!(opts && opts.force);
+    // #1680 — panel_refresh_nodes forces a refresh when idle, but an already-running
+    // node-def refresh is the completion it needs to observe. This does not alter the
+    // default forced-refresh contract above; only callers that explicitly opt in join
+    // the current run instead of creating a trailing one.
+    const joinInFlight = !!(opts && opts.joinInFlight);
     // #1192 — a bound only when the caller asked for one AND a primitive was wired. Both
     // halves matter: `Number.isFinite` rejects the `Infinity`/`NaN` a caller can compute
     // from an unset budget, and an unwired `withTimeout` must leave today's unbounded wait
@@ -234,8 +244,21 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     const current = getInFlight();
     if (current) {
       // No payload, not forced ⇒ joining the settled refresh is enough.
-      if (preloadedDefs == null && !force) {
+      if (preloadedDefs == null && (!force || joinInFlight)) {
         if (!(await joinBounded(current, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
+        // #1680 — an acknowledgement caller needs the run's freshness verdict, not just
+        // proof that the promise settled. Ordinary payload-less joins intentionally retain
+        // their historical undefined result because their callers only use the completion
+        // as a synchronization point.
+        if (joinInFlight) {
+          try {
+            return await current;
+          } catch {
+            // A failed joined run is settled but has no freshness verdict. Preserve the
+            // fail-closed undefined result so the caller reports a non-fresh outcome.
+            return;
+          }
+        }
         return;
       }
       // Payload present ⇒ wait for the in-flight run, then register the NEWER

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -245,6 +245,12 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     if (current) {
       // No payload, not forced ⇒ joining the settled refresh is enough.
       if (preloadedDefs == null && (!force || joinInFlight)) {
+        // #1680 — an unbounded refresh may still be waiting at the explicit handoff before
+        // synchronous registration. Ask it to yield BEFORE arming/waiting on this bounded
+        // acknowledgement, so its local work cannot consume the acknowledgement's deadline.
+        // The opt-in is intentionally limited to this join path; default forced callers still
+        // queue the trailing freshness run below.
+        if (joinInFlight) current.requestEarlyYield?.();
         if (!(await joinBounded(current, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
         // #1680 — an acknowledgement caller needs the run's freshness verdict, not just
         // proof that the promise settled. Ordinary payload-less joins intentionally retain


### PR DESCRIPTION
Fixes #1680. panel_refresh_nodes joins an existing node-definition refresh within the command budget and returns its freshness verdict instead of queueing a second forced run. The explicit pre-registration yield lets bounded callers answer before synchronous registration; default forced trailing-refresh behavior remains unchanged. Validation: full unit suite 6608 pass and 1 todo, typecheck, focused refresh tests 39 pass, independent read-only review SHIP, diff check clean. 
