### PR TITLE
fix/1681 widget detail budget

### DIFF
--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -1,0 +1,183 @@
+// #1681 — execute the shipped graph_query handler at its production seam. The test
+// extracts the method from the panel bundle, then injects only the unrelated canvas
+// binding/read dependencies so the real filtering, projection, capping, and response
+// assembly run against a synthetic live graph.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  WIDGET_VALUE_CAP,
+  DETAIL_WIDGET_VALUE_CEILING,
+  COMPACT_VALUE_CLIP,
+  clampDetailWidgetCap,
+  capSummaryWidgets,
+  clipCompactValue,
+  compactClipNote,
+  drivenTag,
+  drivenWidgetsFor,
+  fitDetailLine,
+  isLineProtected,
+  truncationTail,
+} from "../../web/js/lib/graph-read.js";
+
+const PANEL_JS = join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js");
+const source = readFileSync(PANEL_JS, "utf8");
+
+/** Extract the shipped graph_query method from its object-literal seam. */
+function methodSource(src, marker) {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `missing shipped method: ${marker}`);
+  const nextMethod = src.indexOf("\n  // Domain-aware, READ-ONLY audit", start);
+  assert.ok(nextMethod > start, `missing method boundary: ${marker}`);
+  const end = src.lastIndexOf("\n  },", nextMethod);
+  assert.ok(end > start, `missing method close: ${marker}`);
+  // Exclude the object-literal comma; the extracted method is reinserted into a
+  // fresh object literal below. This boundary is deliberately anchored on the next
+  // shipped executor rather than attempting to parse nested template expressions.
+  return src.slice(start, end + 4);
+}
+
+const graph = {
+  _groups: [],
+  _nodes: [
+    {
+      id: 78,
+      type: "MarkdownNote",
+      title: "Clothing library",
+      widgets: [{ name: "text", value: "prompt-" + "x".repeat(5000) }],
+      inputs: [],
+      outputs: [],
+    },
+    {
+      id: 79,
+      type: "MarkdownNote",
+      title: "Second note",
+      widgets: [{ name: "text", value: "second-" + "y".repeat(5000) }],
+      inputs: [],
+      outputs: [],
+    },
+    {
+      id: 80,
+      type: "MarkdownNote",
+      title: "Ceiling note",
+      widgets: [{ name: "text", value: "ceiling-" + "z".repeat(40000) }],
+      inputs: [],
+      outputs: [],
+    },
+  ],
+};
+
+// summarizeNode is kept deliberately small because its own production dependencies are
+// unrelated to this budget seam. The graph_query method itself is the shipped source.
+const summarizeNode = (node) => ({
+  id: node.id,
+  type: node.type,
+  title: node.title,
+  widgets: Object.fromEntries((node.widgets ?? []).map((w) => [w.name, w.value])),
+});
+
+const graphQuerySource = methodSource(source, "graph_query({");
+const dependencyNames = [
+  "getGraphCtx",
+  "syncGraphNodeAreas",
+  "readStoredLink",
+  "summarizeNode",
+  "summarizeGroup",
+  "GROUPS_RIDER_CAP",
+  "describeActiveGraph",
+  "describeRails",
+  "manualChangeSupersededRider",
+  "clampDetailWidgetCap",
+  "WIDGET_VALUE_CAP",
+  "COMPACT_VALUE_CLIP",
+  "MAX_CHARS_CEILING",
+  "drivenWidgetsFor",
+  "drivenTag",
+  "virtualFedInputs",
+  "virtualSourceTag",
+  "capSummaryWidgets",
+  "fitDetailLine",
+  "isLineProtected",
+  "truncationTail",
+  "clipCompactValue",
+  "compactClipNote",
+];
+const graphQuery = new Function(
+  ...dependencyNames,
+  `return ({ ${graphQuerySource} }).graph_query;`,
+)(
+  () => ({ graph, rootGraph: graph }),
+  () => {},
+  () => null,
+  summarizeNode,
+  () => ({}),
+  200,
+  () => ({ scope: "root" }),
+  () => ({}),
+  () => ({}),
+  clampDetailWidgetCap,
+  WIDGET_VALUE_CAP,
+  COMPACT_VALUE_CLIP,
+  60000,
+  drivenWidgetsFor,
+  drivenTag,
+  () => ({}),
+  () => "",
+  capSummaryWidgets,
+  fitDetailLine,
+  isLineProtected,
+  truncationTail,
+  clipCompactValue,
+  compactClipNote,
+);
+
+function detailRows(result) {
+  return result.text
+    .slice(result.text.indexOf("\n") + 1)
+    .split("\n")
+    .filter((line) => line.startsWith("{"))
+    .map((line) => JSON.parse(line));
+}
+
+function query(args) {
+  return graphQuery({ max_chars: 20000, ...args });
+}
+
+test("#1681 shipped graph_query keeps default detail at 2048 and raises one explicit id", () => {
+  const defaultRead = query({ ids: [78], fields: "detail" });
+  const raisedRead = query({ ids: [78], fields: "detail", widget_max_chars: 8192 });
+
+  const defaultRow = detailRows(defaultRead)[0];
+  const raisedRow = detailRows(raisedRead)[0];
+  assert.match(defaultRow.widgets.text, /2048-char per-widget cap/);
+  assert.equal(raisedRow.widgets.text, graph._nodes[0].widgets[0].value);
+  assert.equal(Object.keys(defaultRead).join(","), Object.keys(raisedRead).join(","), "reply shape is unchanged");
+  assert.equal(Object.keys(defaultRow).join(","), Object.keys(raisedRow).join(","), "detail row shape is unchanged");
+});
+
+test("#1681 shipped graph_query ignores the raised cap for broad and multi-ID detail", () => {
+  const broad = query({ fields: "detail", widget_max_chars: 8192 });
+  const multi = query({ ids: [78, 79], fields: "detail", widget_max_chars: 8192 });
+  assert.match(detailRows(broad)[0].widgets.text, /2048-char per-widget cap/);
+  assert.deepEqual(
+    detailRows(multi).map((row) => /2048-char per-widget cap/.test(row.widgets.text)),
+    [true, true],
+  );
+});
+
+test("#1681 shipped graph_query normalizes invalid/ceiling caps and keeps max_chars authoritative", () => {
+  assert.match(
+    detailRows(query({ ids: [78], fields: "detail", widget_max_chars: "bad" }))[0].widgets.text,
+    /2048-char per-widget cap/,
+  );
+  const ceiling = detailRows(query({ ids: [80], fields: "detail", widget_max_chars: 1e9, max_chars: 60000 }))[0].widgets.text;
+  assert.match(ceiling, new RegExp(`${DETAIL_WIDGET_VALUE_CEILING}-char per-widget cap`));
+
+  const budgeted = query({ ids: [78], fields: "detail", widget_max_chars: 32768, max_chars: 5000 });
+  assert.ok(budgeted.text.length <= 5000, `text must remain within max_chars, got ${budgeted.text.length}`);
+  assert.match(budgeted.text, /over the `max_chars` budget/);
+  assert.doesNotMatch(budgeted.text, /32768-char per-widget cap/);
+});

--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -67,6 +67,14 @@ const graph = {
       inputs: [],
       outputs: [],
     },
+    {
+      id: 81,
+      type: "MarkdownNote",
+      title: "Escaped note",
+      widgets: [{ name: "text", value: { prompt: '"'.repeat(3000), items: ["\\", '"', "\n"] } }],
+      inputs: [],
+      outputs: [],
+    },
   ],
 };
 
@@ -180,4 +188,11 @@ test("#1681 shipped graph_query normalizes invalid/ceiling caps and keeps max_ch
   assert.ok(budgeted.text.length <= 5000, `text must remain within max_chars, got ${budgeted.text.length}`);
   assert.match(budgeted.text, /over the `max_chars` budget/);
   assert.doesNotMatch(budgeted.text, /32768-char per-widget cap/);
+});
+
+test("#1681 shipped graph_query preserves a fitting quote-heavy object at the opt-in cap", () => {
+  const row = detailRows(query({ ids: [81], fields: "detail", widget_max_chars: 8192 }))[0];
+  assert.equal(typeof row.widgets.text, "object");
+  assert.deepEqual(row.widgets.text, graph._nodes[3].widgets[0].value);
+  assert.equal(JSON.stringify(row.widgets.text), JSON.stringify(graph._nodes[3].widgets[0].value));
 });

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -13,6 +13,8 @@ import assert from "node:assert/strict";
 
 import {
   WIDGET_VALUE_CAP,
+  DETAIL_WIDGET_VALUE_CEILING,
+  clampDetailWidgetCap,
   COMPACT_VALUE_CLIP,
   linkDrivenWidgets,
   drivenWidgetsFor,
@@ -123,6 +125,28 @@ test("capWidgetValue clips an oversized string and reports the drop (#609)", () 
   assert.ok(out.startsWith("x".repeat(1000)), "keeps the head");
   assert.match(out, /…\(\+\d+ chars cut at the 2048-char per-widget cap, which `max_chars` does not raise\)$/, "#809: reports how much was dropped AND that max_chars cannot raise this cap");
   assert.ok(JSON.stringify(out).length <= WIDGET_VALUE_CAP, "ESCAPED size within the cap");
+});
+
+test("#1681 detail widget cap keeps the default and clamps opt-in requests", () => {
+  assert.equal(clampDetailWidgetCap(undefined), WIDGET_VALUE_CAP);
+  assert.equal(clampDetailWidgetCap(1024), WIDGET_VALUE_CAP, "the default cap is not lowered");
+  assert.equal(clampDetailWidgetCap(8192), 8192);
+  assert.equal(clampDetailWidgetCap(1e9), DETAIL_WIDGET_VALUE_CEILING);
+  assert.equal(clampDetailWidgetCap("not-a-number"), WIDGET_VALUE_CAP);
+});
+
+test("#1681 an explicit detail cap returns a long widget without changing its shape", () => {
+  const value = "prompt-" + "x".repeat(5000);
+  const summary = capSummaryWidgets({ id: 78, type: "MarkdownNote", widgets: { text: value } }, 8192, 12000);
+  assert.deepEqual(Object.keys(summary), ["id", "type", "widgets"]);
+  assert.equal(summary.widgets.text, value);
+  assert.equal(JSON.parse(JSON.stringify(summary)).widgets.text, value);
+});
+
+test("#1681 an opt-in cap still yields to the total max_chars budget", () => {
+  const capped = capSummaryWidgets({ id: 78, widgets: { text: "x".repeat(50000), other: 1 } }, 32768, 5000);
+  assert.ok(JSON.stringify(capped).length < 5000 * 2, "detail remains bounded by the total budget");
+  assert.match(capped.widgets.text, /over the `max_chars` budget/);
 });
 
 test("capWidgetValue bounds by ESCAPED size for control chars / surrogates (#609)", () => {

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -127,6 +127,18 @@ test("capWidgetValue clips an oversized string and reports the drop (#609)", () 
   assert.ok(JSON.stringify(out).length <= WIDGET_VALUE_CAP, "ESCAPED size within the cap");
 });
 
+test("capWidgetValue preserves a quote-heavy object whose single JSON encoding fits (#1681)", () => {
+  const value = { prompt: '"'.repeat(3000), items: ["\\", '"', "\n"] };
+  const serialized = JSON.stringify(value);
+  assert.ok(serialized.length < 8192, "the actual object encoding fits the explicit cap");
+  assert.ok(JSON.stringify(serialized).length > 8192, "double-escaping would incorrectly reject it");
+
+  const out = capWidgetValue(value, 8192);
+  assert.equal(out, value, "fitting non-string values keep identity");
+  assert.equal(typeof out, "object");
+  assert.equal(JSON.stringify(out), serialized, "JSON output is unchanged");
+});
+
 test("#1681 detail widget cap keeps the default and clamps opt-in requests", () => {
   assert.equal(clampDetailWidgetCap(undefined), WIDGET_VALUE_CAP);
   assert.equal(clampDetailWidgetCap(1024), WIDGET_VALUE_CAP, "the default cap is not lowered");

--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -106,6 +106,14 @@ test("#809 the query path fits its tail and footer INSIDE max_chars", () => {
   assert.match(body, /compactClipNote\(lineClips\.reduce\(/);
 });
 
+test("#1681 only an explicit detail query can raise the per-widget cap", () => {
+  const body = handlerBody(readFileSync(PANEL_JS, "utf8"), "graph_query({");
+  assert.match(body, /widget_max_chars/, "the opt-in cap is an argument to graph_query");
+  assert.match(body, /fields === "detail" \? clampDetailWidgetCap\(widget_max_chars\)/);
+  assert.match(body, /capSummaryWidgets\(summarizeNode\(n\), detailWidgetCap, maxChars\)/);
+  assert.match(body, /fitDetailLine\(line, \{ id: summary\.id, type: summary\.type, title: summary\.title \}, maxChars\)/);
+});
+
 // The `groups`/`rails` riders sit OUTSIDE the max_chars accounting (#807 owns that fix).
 // Until it lands they must at least be BOUNDED and MARKED, or the reply exceeds the very
 // budget the tool advertises no matter what the caller sets — and a silently short groups

--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -109,7 +109,8 @@ test("#809 the query path fits its tail and footer INSIDE max_chars", () => {
 test("#1681 only an explicit detail query can raise the per-widget cap", () => {
   const body = handlerBody(readFileSync(PANEL_JS, "utf8"), "graph_query({");
   assert.match(body, /widget_max_chars/, "the opt-in cap is an argument to graph_query");
-  assert.match(body, /fields === "detail" \? clampDetailWidgetCap\(widget_max_chars\)/);
+  assert.match(body, /fields === "detail" && Array\.isArray\(ids\) && ids\.length === 1/);
+  assert.match(body, /clampDetailWidgetCap\(widget_max_chars\)/);
   assert.match(body, /capSummaryWidgets\(summarizeNode\(n\), detailWidgetCap, maxChars\)/);
   assert.match(body, /fitDetailLine\(line, \{ id: summary\.id, type: summary\.type, title: summary\.title \}, maxChars\)/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12730,10 +12730,13 @@ const GRAPH_TOOL_EXECUTORS = {
     const total = nodes.length;
     const lim = Math.min(Math.max(Number(limit) || 40, 1), 200);
     const maxChars = Math.min(Math.max(Number(max_chars) || 12000, 500), 60000);
-    // #1681: detail is the explicit escape hatch for a named long widget. Keep the
-    // default and the outline/compact projections unchanged; the helper still applies
-    // the total max_chars budget and the final JSON-line guard.
-    const detailWidgetCap = fields === "detail" ? clampDetailWidgetCap(widget_max_chars) : WIDGET_VALUE_CAP;
+    // #1681: only a single explicitly named detail node gets the escape hatch for a
+    // long widget. Broad/multi-ID detail and the outline/compact projections retain the
+    // default cap; the helper still applies the total max_chars budget and final guard.
+    const detailWidgetCap =
+      fields === "detail" && Array.isArray(ids) && ids.length === 1
+        ? clampDetailWidgetCap(widget_max_chars)
+        : WIDGET_VALUE_CAP;
 
     // Adjacency over live links.
     const up = new Map();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -380,6 +380,7 @@ import {
   // #1634: the pinpoint per-value cap for an explicit-`ids` read is derived from these.
   WIDGET_VALUE_CAP,
   COMPACT_VALUE_CLIP,
+  clampDetailWidgetCap,
   // #1748: which frontend node types carry on-canvas prose as a widget value.
   NOTE_NODE_TYPES,
   OUTLINE_DETAIL_LEVELS,
@@ -12719,7 +12720,7 @@ const GRAPH_TOOL_EXECUTORS = {
   //   → group_by:"type" counts, or projection (ids | compact lines | detail =
   //     summarizeNode JSON rows), char-bounded with an explicit truncation tail.
   // graph_get_state stays registered for BACK-COMPAT with older orchestrators.
-  graph_query({ types, title, where, ids, upstream_of, downstream_of, depth, fields, group_by, limit, max_chars }) {
+  graph_query({ types, title, where, ids, upstream_of, downstream_of, depth, fields, group_by, limit, max_chars, widget_max_chars }) {
     const { graph, rootGraph } = getGraphCtx();
     // #429: resync cached node rects to live geometry before the `groups` block
     // recomputes geometric membership (summarizeGroup), so it never reports stale ids.
@@ -12729,6 +12730,10 @@ const GRAPH_TOOL_EXECUTORS = {
     const total = nodes.length;
     const lim = Math.min(Math.max(Number(limit) || 40, 1), 200);
     const maxChars = Math.min(Math.max(Number(max_chars) || 12000, 500), 60000);
+    // #1681: detail is the explicit escape hatch for a named long widget. Keep the
+    // default and the outline/compact projections unchanged; the helper still applies
+    // the total max_chars budget and the final JSON-line guard.
+    const detailWidgetCap = fields === "detail" ? clampDetailWidgetCap(widget_max_chars) : WIDGET_VALUE_CAP;
 
     // Adjacency over live links.
     const up = new Map();
@@ -12994,7 +12999,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // #609: bound each widget value AND the total widgets size so a
         // ResolutionMaster/LTXDirector/VHS blob (or a many-widget node) can't consume
         // the entire budget in one node's detail — even the protected first line.
-        const summary = capSummaryWidgets(summarizeNode(n), undefined, maxChars);
+        const summary = capSummaryWidgets(summarizeNode(n), detailWidgetCap, maxChars);
         line = JSON.stringify(summary);
         // Final guard: if the fully-capped detail STILL exceeds max_chars (a node with
         // very many/large slots, which capSummaryWidgets doesn't touch), degrade the

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -144,7 +144,11 @@ export function capWidgetValue(value, cap = WIDGET_VALUE_CAP, maxChars = Infinit
   const isString = typeof value === "string";
   const s = isString ? value : (() => { try { return JSON.stringify(value); } catch { return String(value); } })();
   if (typeof s !== "string") return value;
-  if (JSON.stringify(s).length <= cap) return value;
+  // Strings are emitted as JSON strings, so their quotes/escapes count twice. A
+  // non-string is emitted as its serialized JSON value, so serializing `s` again
+  // would double-count escapes and turn a fitting object/array into a string.
+  const serializedSize = isString ? JSON.stringify(s).length : s.length;
+  if (serializedSize <= cap) return value;
   // #809: name the lever that ACTUALLY applies. capSummaryWidgets() tightens the
   // per-value cap to the char budget only when the budget is smaller than the requested
   // fixed cap, so `cap < fixedCap` means max_chars is what cut this value and raising it

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -19,9 +19,19 @@
 //          inputs[].link backlink so the outline never renders an orphaned link
 //          against a slot it no longer feeds.
 
-/** Per-widget-value character cap for the `detail` projection (#609). Big enough
- *  to identify a value, small enough that one blob can't starve a whole query. */
+/** Default per-widget-value character cap for the `detail` projection (#609). Big
+ *  enough to identify a value, small enough that one blob can't starve a whole query.
+ *  An explicit detail read may opt into the bounded ceiling below. */
 export const WIDGET_VALUE_CAP = 2048;
+export const DETAIL_WIDGET_VALUE_CEILING = 32768;
+
+/** Normalize the optional detail-only per-widget cap without changing the default. */
+export function clampDetailWidgetCap(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > WIDGET_VALUE_CAP
+    ? Math.min(Math.floor(n), DETAIL_WIDGET_VALUE_CEILING)
+    : WIDGET_VALUE_CAP;
+}
 
 // #809: the REAL clamps for panel_query_graph / panel_graph_outline, exported so every
 // remedy string below quotes a ceiling the runtime actually enforces. A hint that names
@@ -129,21 +139,21 @@ export function drivenTag(src) {
  *  escape to 6 chars each, not 2. Returns the value unchanged when it already fits;
  *  otherwise the longest head prefix whose encoding fits `cap`, with an honest marker
  *  naming how many raw chars were dropped. */
-export function capWidgetValue(value, cap = WIDGET_VALUE_CAP, maxChars = Infinity) {
+export function capWidgetValue(value, cap = WIDGET_VALUE_CAP, maxChars = Infinity, fixedCap = cap) {
   if (value == null) return value;
   const isString = typeof value === "string";
   const s = isString ? value : (() => { try { return JSON.stringify(value); } catch { return String(value); } })();
   if (typeof s !== "string") return value;
   if (JSON.stringify(s).length <= cap) return value;
   // #809: name the lever that ACTUALLY applies. capSummaryWidgets() tightens the
-  // per-value cap to the char budget only when the budget is the smaller of the two, so
-  // `cap < WIDGET_VALUE_CAP` ⟺ max_chars is what cut this value and raising it helps. At
-  // the FIXED 2048 cap raising max_chars does nothing, and saying so stops the caller
-  // burning a retry on a parameter that cannot move this.
+  // per-value cap to the char budget only when the budget is smaller than the requested
+  // fixed cap, so `cap < fixedCap` means max_chars is what cut this value and raising it
+  // helps. At the fixed per-widget cap raising max_chars does nothing, and saying so stops
+  // the caller burning a retry on a parameter that cannot move this.
   const remedy =
-    cap < WIDGET_VALUE_CAP
+    cap < fixedCap
       ? `over the \`max_chars\` budget; ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)}`
-      : `at the ${WIDGET_VALUE_CAP}-char per-widget cap, which \`max_chars\` does not raise`;
+      : `at the ${fixedCap}-char per-widget cap, which \`max_chars\` does not raise`;
   const marker = (dropped) => `…(+${dropped} chars cut ${remedy})`;
   // Binary-search the longest raw prefix whose ESCAPED length fits, reserving EXACTLY
   // the marker's own worst-case size (its digit count is bounded by s.length) rather
@@ -198,7 +208,7 @@ export function capSummaryWidgets(summary, cap = WIDGET_VALUE_CAP, totalCap = In
     const [rawKey, v] = entries[i];
     const k = capKey(rawKey);
     if (k !== rawKey) changed = true;
-    const capped = capWidgetValue(v, perValueCap, totalCap);
+    const capped = capWidgetValue(v, perValueCap, totalCap, cap);
     if (capped !== v) changed = true;
     const size = entrySize(k, capped);
     // Keep at least one widget, then stop once the total would exceed the budget.
@@ -240,7 +250,7 @@ export function capSummaryWidgets(summary, cap = WIDGET_VALUE_CAP, totalCap = In
       if (k !== rawKey) changed = true;
       for (const row of Array.isArray(rows) ? rows : []) {
         if (stopped) { dOmitted++; continue; }
-        const value = capWidgetValue(row?.value, perValueCap, totalCap);
+        const value = capWidgetValue(row?.value, perValueCap, totalCap, cap);
         if (value !== row?.value) changed = true;
         const entry = { ...row, value };
         // Keep at least ONE occurrence, then stop once the total would exceed the


### PR DESCRIPTION
Fixes #1681. Adds a bounded widget_max_chars opt-in for exactly one graph_query detail node while preserving the 2048-char default and broad-query protections. Validated with the full Panel unit suite, focused detail-budget tests, typecheck, and git diff check. Paired with artokun/comfyui-mcp#2157. 
