### PR TITLE
fix/1682 refresh join

### DIFF
--- a/browser_tests/unit/get-errors-budget.test.mjs
+++ b/browser_tests/unit/get-errors-budget.test.mjs
@@ -120,8 +120,8 @@ test("graph_get_errors spends the shared budget and the old 4 s constant is gone
   );
   assert.match(
     PANEL_SOURCE,
-    /withRefreshTimeout\(\s*refreshComfyNodeDefs\(undefined, \{ force: true \}\),\s*refreshBudgetMs,?\s*\)/,
-    "the forced refresh race must RECEIVE that budget (an unpassed budget silently reverts #610)",
+    /refreshMissingAssetTrust\(\{[\s\S]*?refreshBudgetMs,[\s\S]*?withRefreshTimeout,[\s\S]*?\}\)/,
+    "the graph_get_errors refresh seam must RECEIVE the shared budget and timeout",
   );
   assert.match(
     PANEL_SOURCE,

--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -115,6 +115,61 @@ test("#1680: a forced payload-less caller can explicitly join an in-flight refre
   assert.equal(registered.length, 1, "the opt-in joins the existing run without a trailing pass");
 });
 
+test("#1682: an acknowledgement join observes an already-queued fresh trailing run", async () => {
+  const firstGate = deferred();
+  let run = 0;
+  const { coalescer } = makeHarnessReturning(async () => {
+    run += 1;
+    if (run === 1) await firstGate.promise;
+    return { refreshed: run === 2, generation: run };
+  });
+
+  const current = coalescer(undefined, { force: true });
+  const trailing = coalescer(undefined, { force: true });
+  const acknowledgement = coalescer(undefined, {
+    force: true,
+    joinInFlight: true,
+    joinMs: 500,
+  });
+
+  firstGate.resolve();
+  assert.deepEqual(
+    await acknowledgement,
+    { refreshed: true, generation: 2 },
+    "the acknowledgement must report the fresh trailing generation, not the stale current run",
+  );
+  await Promise.all([current, trailing]);
+});
+
+test("#1682: the completion chain remains bounded when its fresh trailing run stalls", async () => {
+  const firstGate = deferred();
+  const trailingGate = deferred();
+  let run = 0;
+  const { coalescer } = makeHarnessReturning(async () => {
+    run += 1;
+    if (run === 1) await firstGate.promise;
+    if (run === 2) await trailingGate.promise;
+    return { refreshed: true };
+  });
+
+  const current = coalescer(undefined, { force: true });
+  const trailing = coalescer(undefined, { force: true });
+  const acknowledgement = coalescer(undefined, {
+    force: true,
+    joinInFlight: true,
+    joinMs: 25,
+  });
+
+  firstGate.resolve();
+  assert.equal(
+    await acknowledgement,
+    REFRESH_JOIN_ABANDONED,
+    "a queued refresh that does not settle stays a bounded, retryable refusal",
+  );
+  trailingGate.resolve();
+  await Promise.all([current, trailing]);
+});
+
 test("#1680: a failed joined refresh returns no freshness verdict", async () => {
   const gate = deferred();
   const { coalescer } = makeHarnessReturning(async () => {

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -18,6 +18,7 @@ import assert from "node:assert/strict";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { makeRefreshCoalescer } from "../../web/js/lib/refresh-coalesce.js";
 import { NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
+import { isStaleAssetCandidate } from "../../web/js/lib/asset-staleness.js";
 import {
   PANEL_SRC,
   ADD_NODE_COMMAND_BUDGET_MS,
@@ -139,6 +140,48 @@ test("#1680: refresh_nodes returns the completed verdict from an already-running
   assert.deepEqual(value, { ok: true, refreshed: true });
   assert.equal(built.runs.length, 1, "joining the completion must not queue a trailing refresh");
   await built.inFlightStarted?.catch(() => {});
+});
+
+test("#1682: refresh_nodes waits through a queued freshness run before the missing-asset scan", async () => {
+  const gate = deferred();
+  const node = {
+    id: 7,
+    widgets: [{ name: "model", value: "taeh3.safetensors", options: { values: [] } }],
+  };
+  const rootGraph = { _nodes: [node] };
+  const built = realRefreshNodes({
+    holdFirstRun: gate.promise,
+    budgetMs: 500,
+    runHook: async ({ index }) => {
+      if (index === 1) node.widgets[0].options.values = ["taeh3.safetensors"];
+      return { refreshed: index === 1, reason: index === 1 ? "refreshed" : "object_info_fetch_failed" };
+    },
+  });
+
+  // The first run represents a refresh already started by a background missing-asset check.
+  // The second is its forced trailing fetch, which is the one that can observe the file copied
+  // into the configured model directory after the first /object_info request began.
+  const trailing = built.refreshComfyNodeDefs(undefined, { force: true });
+  const reply = built.refresh_nodes();
+  gate.resolve();
+
+  const { value } = await withWatchdog(
+    () => reply,
+    1500,
+    "refresh_nodes did not observe the queued freshness run",
+  );
+  assert.equal(value.refreshed, true, "the acknowledgement reports the run that saw the new file");
+  assert.equal(built.runs.length, 2, "the background refresh and its one trailing freshness run completed");
+  assert.equal(
+    isStaleAssetCandidate(rootGraph, {
+      nodeId: 7,
+      name: "taeh3.safetensors",
+      widgetName: "model",
+    }, { trustCombo: true }),
+    true,
+    "the post-refresh missing-asset scan clears the candidate from the refreshed combo",
+  );
+  await Promise.all([built.inFlightStarted, trailing]);
 });
 
 test("#1680: refresh_nodes replies at its budget instead of waiting for the joined run", async () => {

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -18,7 +18,13 @@ import assert from "node:assert/strict";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { makeRefreshCoalescer } from "../../web/js/lib/refresh-coalesce.js";
 import { NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
-import { isStaleAssetCandidate } from "../../web/js/lib/asset-staleness.js";
+import {
+  collectAllGraphs,
+  isStaleAssetCandidate as isStaleAssetCandidateLib,
+  resolveMissingModelDirectory,
+} from "../../web/js/lib/asset-staleness.js";
+import { withoutFrontendVirtualTypes } from "../../web/js/lib/frontend-virtual-nodes.js";
+import { refreshMissingAssetTrust } from "../../web/js/lib/missing-asset-refresh.js";
 import {
   PANEL_SRC,
   ADD_NODE_COMMAND_BUDGET_MS,
@@ -28,6 +34,77 @@ import {
 
 const refreshNodesMatch = PANEL_SRC.match(/\n {2}async refresh_nodes\(\) \{[\s\S]*?\n {2}\},/);
 assert.ok(refreshNodesMatch, "could not locate refresh_nodes in panel source");
+
+function extractPanelFn(sig) {
+  const start = PANEL_SRC.indexOf(sig);
+  assert.notEqual(start, -1, `${sig} not found in the panel source`);
+  const open = PANEL_SRC.indexOf(") {", start) + 1;
+  let depth = 0;
+  for (let i = open; i < PANEL_SRC.length; i += 1) {
+    const ch = PANEL_SRC[i];
+    if (ch === "/" && PANEL_SRC[i + 1] === "/") {
+      i = PANEL_SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && PANEL_SRC[i + 1] === "*") {
+      i = PANEL_SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < PANEL_SRC.length; i += 1) {
+        if (PANEL_SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (PANEL_SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return PANEL_SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated: ${sig}`);
+}
+
+// Execute the shipped local wrapper and collector together. This keeps the regression at
+// the production consumer boundary: a refresh verdict changes the trust supplied to the
+// same `collectMissingAssets` body graph_get_errors and validationBanner use.
+const STALE_ASSET_BODY = extractPanelFn("function isStaleAssetCandidate(c, trustComboOverride) {");
+const COLLECTOR_BODY = extractPanelFn("function collectMissingAssets(trustComboOverride) {");
+const WITH_REFRESH_TIMEOUT_BODY = extractPanelFn("function withRefreshTimeout(promise, timeoutMs) {");
+const productionWithRefreshTimeout = new Function(
+  `${WITH_REFRESH_TIMEOUT_BODY}; return withRefreshTimeout;`,
+)();
+
+function makeProductionMissingAssetCollector({ stores, rootGraph }) {
+  const factory = new Function(
+    "getPiniaStore",
+    "isStaleAssetCandidateLib",
+    "resolveMissingModelDirectory",
+    "withoutFrontendVirtualTypes",
+    "collectAllGraphs",
+    "getGraphCtx",
+    `let nodeDefsRefreshConfirmed = false;
+     ${STALE_ASSET_BODY}
+     ${COLLECTOR_BODY}
+     return {
+       collectMissingAssets,
+       setRefreshConfirmed: (value) => { nodeDefsRefreshConfirmed = value === true; },
+     };`,
+  );
+  return factory(
+    (name) => stores[name],
+    isStaleAssetCandidateLib,
+    resolveMissingModelDirectory,
+    withoutFrontendVirtualTypes,
+    collectAllGraphs,
+    () => ({ rootGraph }),
+  );
+}
 
 /** A tiny deferred so a test can hold the in-flight refresh open until it chooses. */
 function deferred() {
@@ -144,11 +221,29 @@ test("#1680: refresh_nodes returns the completed verdict from an already-running
 
 test("#1682: refresh_nodes waits through a queued freshness run before the missing-asset scan", async () => {
   const gate = deferred();
+  const candidate = {
+    nodeId: 7,
+    name: "taeh3.safetensors",
+    widgetName: "model",
+    directory: "checkpoints",
+    isMissing: true,
+  };
   const node = {
     id: 7,
     widgets: [{ name: "model", value: "taeh3.safetensors", options: { values: [] } }],
   };
-  const rootGraph = { _nodes: [node] };
+  const rootGraph = {
+    _nodes: [node],
+    getNodeById: (id) => node.id === id || String(node.id) === String(id) ? node : null,
+  };
+  const productionCollector = makeProductionMissingAssetCollector({
+    stores: {
+      missingModel: { missingModelCandidates: [candidate] },
+      missingMedia: { missingMediaCandidates: [] },
+      missingNodesError: { hasMissingNodes: false, missingNodeCount: 0, missingNodesError: [] },
+    },
+    rootGraph,
+  });
   const built = realRefreshNodes({
     holdFirstRun: gate.promise,
     budgetMs: 500,
@@ -172,17 +267,144 @@ test("#1682: refresh_nodes waits through a queued freshness run before the missi
   );
   assert.equal(value.refreshed, true, "the acknowledgement reports the run that saw the new file");
   assert.equal(built.runs.length, 2, "the background refresh and its one trailing freshness run completed");
+  productionCollector.setRefreshConfirmed(value.refreshed);
+  const assets = productionCollector.collectMissingAssets();
   assert.equal(
-    isStaleAssetCandidate(rootGraph, {
+    assets.models.length,
+    0,
+    "the shipped collectMissingAssets path clears the candidate from the refreshed combo",
+  );
+  assert.equal(assets.any, false, "the shipped collector reports no stale missing-asset error");
+  await Promise.all([built.inFlightStarted, trailing]);
+});
+
+test("#1682: graph_get_errors refresh seam scans with the completed trailing combo", async () => {
+  const gate = deferred();
+  const node = {
+    id: 7,
+    widgets: [{ name: "model", value: "taeh3.safetensors", options: { values: [] } }],
+  };
+  const rootGraph = {
+    _nodes: [node],
+    getNodeById: (id) => node.id === id || String(node.id) === String(id) ? node : null,
+  };
+  const candidate = {
+    nodeId: 7,
+    name: "taeh3.safetensors",
+    widgetName: "model",
+    directory: "checkpoints",
+    isMissing: true,
+  };
+  const productionCollector = makeProductionMissingAssetCollector({
+    stores: {
+      missingModel: { missingModelCandidates: [candidate] },
+      missingMedia: { missingMediaCandidates: [] },
+      missingNodesError: { hasMissingNodes: false, missingNodeCount: 0, missingNodesError: [] },
+    },
+    rootGraph,
+  });
+  const built = realRefreshNodes({
+    holdFirstRun: gate.promise,
+    budgetMs: 500,
+    runHook: async ({ index }) => {
+      if (index === 1) node.widgets[0].options.values = ["taeh3.safetensors"];
+      return { refreshed: index === 1, reason: index === 1 ? "refreshed" : "object_info_fetch_failed" };
+    },
+  });
+
+  // This is the exact refresh/scan boundary used by graph_get_errors. The first refresh
+  // started before the scan cannot see the file; the forced call queues the one that can.
+  const trustPromise = refreshMissingAssetTrust({
+    refreshBudgetMs: 500,
+    refreshComfyNodeDefs: built.refreshComfyNodeDefs,
+    withRefreshTimeout: productionWithRefreshTimeout,
+    getRefreshInFlight: built.getInFlight,
+  });
+  gate.resolve();
+
+  const trusted = await withWatchdog(
+    () => trustPromise,
+    1500,
+    "graph_get_errors refresh seam did not complete the trailing refresh",
+  );
+  assert.equal(trusted.value, true, "only the refresh that saw the new combo may grant trust");
+  productionCollector.setRefreshConfirmed(trusted.value);
+  const assets = productionCollector.collectMissingAssets();
+  assert.equal(assets.models.length, 0, "graph_get_errors' shipped collector clears the stale error");
+  assert.equal(assets.any, false, "the production scan is clean after the trailing refresh");
+  assert.equal(built.runs.length, 2, "the graph error refresh used one trailing run");
+  await built.inFlightStarted;
+});
+
+for (const [label, runHook, release] of [
+  [
+    "timeout",
+    async ({ index }) => {
+      if (index === 1) await release.promise;
+      return { refreshed: index === 0, reason: index === 0 ? "refreshed" : "object_info_fetch_failed" };
+    },
+    deferred(),
+  ],
+  [
+    "rejection",
+    async ({ index }) => {
+      if (index === 1) throw new Error("trailing refresh failed");
+      return { refreshed: index === 0, reason: index === 0 ? "refreshed" : "object_info_fetch_failed" };
+    },
+    null,
+  ],
+]) {
+  test(`#1682: graph_get_errors keeps a trailing ${label} fail-closed`, async () => {
+    const gate = deferred();
+    const node = {
+      id: 7,
+      widgets: [{ name: "model", value: "taeh3.safetensors", options: { values: [] } }],
+    };
+    const rootGraph = {
+      _nodes: [node],
+      getNodeById: (id) => node.id === id || String(node.id) === String(id) ? node : null,
+    };
+    const candidate = {
       nodeId: 7,
       name: "taeh3.safetensors",
       widgetName: "model",
-    }, { trustCombo: true }),
-    true,
-    "the post-refresh missing-asset scan clears the candidate from the refreshed combo",
-  );
-  await Promise.all([built.inFlightStarted, trailing]);
-});
+      directory: "checkpoints",
+      isMissing: true,
+    };
+    const productionCollector = makeProductionMissingAssetCollector({
+      stores: {
+        missingModel: { missingModelCandidates: [candidate] },
+        missingMedia: { missingMediaCandidates: [] },
+        missingNodesError: { hasMissingNodes: false, missingNodeCount: 0, missingNodesError: [] },
+      },
+      rootGraph,
+    });
+    const built = realRefreshNodes({ holdFirstRun: gate.promise, budgetMs: 500, runHook });
+    const trustPromise = refreshMissingAssetTrust({
+      refreshBudgetMs: 25,
+      refreshComfyNodeDefs: built.refreshComfyNodeDefs,
+      withRefreshTimeout: productionWithRefreshTimeout,
+      getRefreshInFlight: built.getInFlight,
+    });
+    gate.resolve();
+
+    const trusted = await withWatchdog(
+      () => trustPromise,
+      1500,
+      `graph_get_errors trailing ${label} case did not return`,
+    );
+    assert.equal(trusted.value, false, `a trailing ${label} must not grant combo trust`);
+    productionCollector.setRefreshConfirmed(trusted.value);
+    const assets = productionCollector.collectMissingAssets();
+    assert.equal(assets.models.length, 1, `a trailing ${label} keeps the raw missing candidate`);
+    assert.equal(assets.any, true, `a trailing ${label} remains visible to graph_get_errors`);
+
+    release?.resolve();
+    await built.inFlightStarted?.catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(built.getInFlight(), null, `the trailing ${label} eventually releases its slot`);
+  });
+}
 
 test("#1680: refresh_nodes replies at its budget instead of waiting for the joined run", async () => {
   const gate = deferred();

--- a/browser_tests/unit/stale-placeholders.test.mjs
+++ b/browser_tests/unit/stale-placeholders.test.mjs
@@ -375,10 +375,10 @@ test("#1332 source guard: get_errors adjudicates AFTER the node-def refresh, aga
   const end = src.indexOf("async workflow_save(", at);
   assert.ok(end > at, "the executor's end must still be recognisable");
   const body = src.slice(at, end);
-  const refreshAt = body.indexOf("refreshComfyNodeDefs(undefined, { force: true })");
+  const refreshAt = body.indexOf("refreshMissingAssetTrust({");
   const adjudicateAt = body.indexOf("adjudicateRecordedMissingNodeTypes(");
   const reasonsAt = body.indexOf("collectMissingNodeTypeReasons(nodes, missingNodeTypes)");
-  assert.ok(refreshAt > 0, "get_errors still force-refreshes node defs");
+  assert.ok(refreshAt > 0, "get_errors still reaches the forced node-def refresh seam");
   assert.ok(adjudicateAt > refreshAt, "adjudication must run AFTER the refresh so LiteGraph is current");
   assert.ok(reasonsAt > adjudicateAt, "per-node missing_node_type blame uses the FILTERED list");
   assert.match(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -268,6 +268,7 @@ import {
 } from "./lib/bridge-defaults.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "./lib/refresh-coalesce.js";
+import { refreshMissingAssetTrust } from "./lib/missing-asset-refresh.js";
 import {
   NODE_DEF_REFRESH_REASONS,
   describeNodeDefRefresh,
@@ -17491,29 +17492,16 @@ const GRAPH_TOOL_EXECUTORS = {
       const refreshBudgetMs = hasRawMissingAssetCandidates()
         ? errorsStepBudget(GET_ERRORS_REFRESH_CAP_MS)
         : 0;
-      if (refreshBudgetMs > 0) {
-        // force:true so we never JOIN an /object_info fetch that began BEFORE the current
-        // asset state (a joined stale run would trust a combo snapshot predating a just-
-        // deleted asset and suppress the now-genuine miss). The coalescer guarantees a
-        // trailing fetch that STARTS after the in-flight run settles and dedups concurrent
-        // forced calls into one (#396 / codex round-4 P0), and FORWARDS that trailing run's
-        // own freshness verdict back here — so the value below reflects the fetch THIS call
-        // triggered, not any concurrent run's global write.
-        comboTrustedForQuery = await withRefreshTimeout(
-          refreshComfyNodeDefs(undefined, { force: true }),
-          refreshBudgetMs,
-        );
-        // …AND only if no OTHER refresh is still in flight at this synchronous point. The
-        // shared coalescer lets a concurrent PAYLOAD refresh (graph_add_node) run its own
-        // registration alongside our forced one; if that payload carries an older combo
-        // snapshot and its refreshComboInNodes lands LAST, the live combos are stale even
-        // though our forced refresh returned true. When the slot still holds a run after
-        // ours settled, it points at that other in-flight registration — distrust and keep
-        // the raw candidate reported rather than risk suppressing a genuine miss off a
-        // combo another run may still overwrite (codex round-10 P0). Read synchronously,
-        // no intervening await, so the value is current for the collect below.
-        comboTrustedForQuery = comboTrustedForQuery && nodeDefRefreshInFlight === null;
-      }
+      // force:true so we never JOIN an /object_info fetch that began BEFORE the current
+      // asset state. The seam guarantees a trailing fetch, returns its own freshness
+      // verdict, and rejects trust if another refresh still owns the slot at the exact
+      // handoff into collectMissingAssets.
+      comboTrustedForQuery = await refreshMissingAssetTrust({
+        refreshBudgetMs,
+        refreshComfyNodeDefs,
+        withRefreshTimeout,
+        getRefreshInFlight: () => nodeDefRefreshInFlight,
+      });
     } catch {
       // best-effort; on any failure distrust the combo and keep raw candidates reported.
       comboTrustedForQuery = false;

--- a/web/js/lib/missing-asset-refresh.js
+++ b/web/js/lib/missing-asset-refresh.js
@@ -1,0 +1,32 @@
+// The graph error path refreshes node definitions before it trusts live combo
+// membership. Keep that small ordering decision independently executable so its
+// production consumer can be tested without evaluating the whole panel IIFE.
+
+/**
+ * Return whether this graph-error scan may trust the live combo lists.
+ *
+ * The caller owns the shared graph-error budget. A refresh that fails, times out,
+ * or leaves another refresh in the single-flight slot is deliberately not trusted:
+ * the collector must keep the raw missing candidate visible.
+ */
+export async function refreshMissingAssetTrust({
+  refreshBudgetMs,
+  refreshComfyNodeDefs,
+  withRefreshTimeout,
+  getRefreshInFlight,
+}) {
+  let comboTrustedForQuery = false;
+  try {
+    if (refreshBudgetMs > 0) {
+      comboTrustedForQuery = await withRefreshTimeout(
+        refreshComfyNodeDefs(undefined, { force: true }),
+        refreshBudgetMs,
+      );
+      comboTrustedForQuery = comboTrustedForQuery && getRefreshInFlight() === null;
+    }
+  } catch {
+    // A timeout or rejection must fail closed and leave the raw candidate reported.
+    comboTrustedForQuery = false;
+  }
+  return comboTrustedForQuery === true;
+}

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -177,6 +177,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
   let trailing = null;
   const startRun = (preloadedDefs, runOpts, abandonBeforeLocalWork) => {
     let yieldBeforeLocalWork = !!abandonBeforeLocalWork;
+    let nextCompletion = null;
     let announceBeforeLocalWork;
     const beforeLocalWork = new Promise((resolve) => {
       announceBeforeLocalWork = resolve;
@@ -212,11 +213,37 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     // no later caller can safely interrupt that JavaScript turn.
     const requestEarlyYield = () => {
       yieldBeforeLocalWork = true;
+      nextCompletion?.requestEarlyYield?.();
     };
+    const attachNextCompletion = (next) => {
+      nextCompletion = next;
+      if (yieldBeforeLocalWork) next?.requestEarlyYield?.();
+    };
+    // A forced freshness caller may queue one trailing run while this run is still active.
+    // Keep that successor in the acknowledgement handle's completion chain: joining only
+    // `p` can report the older /object_info generation as complete while the fresh combo
+    // rebuild is still pending (#1682). The chain is bounded once by the caller, so it cannot
+    // turn a queued refresh into an unbounded acknowledgement wait.
+    const completion = p.then(
+      (value) => (nextCompletion ? nextCompletion.promise : value),
+      (err) => (nextCompletion ? nextCompletion.promise : Promise.reject(err)),
+    );
+    // The completion chain is an optional observation handle. Mark its rejection handled
+    // until an acknowledgement caller elects to await it; the original run promise still
+    // preserves the caller-visible rejection semantics for ordinary/coalesced paths.
+    completion.catch(() => {});
+    const handle = { promise: p, beforeLocalWork, requestEarlyYield };
+    handle.completion = {
+      promise: completion,
+      requestEarlyYield,
+    };
+    handle.attachNextCompletion = attachNextCompletion;
     p.beforeLocalWork = beforeLocalWork;
     p.requestEarlyYield = requestEarlyYield;
+    p.completion = handle.completion;
+    p.attachNextCompletion = attachNextCompletion;
     setInFlight(p);
-    return { promise: p, beforeLocalWork, requestEarlyYield };
+    return handle;
   };
   return async function refresh(preloadedDefs, opts) {
     const force = !!(opts && opts.force);
@@ -250,15 +277,20 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         // acknowledgement, so its local work cannot consume the acknowledgement's deadline.
         // The opt-in is intentionally limited to this join path; default forced callers still
         // queue the trailing freshness run below.
-        if (joinInFlight) current.requestEarlyYield?.();
-        if (!(await joinBounded(current, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
+        const joined = joinInFlight ? current.completion ?? current : current;
+        if (joinInFlight) {
+          current.requestEarlyYield?.();
+          joined.requestEarlyYield?.();
+        }
+        const joinedPromise = joined.promise ?? joined;
+        if (!(await joinBounded(joinedPromise, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
         // #1680 — an acknowledgement caller needs the run's freshness verdict, not just
         // proof that the promise settled. Ordinary payload-less joins intentionally retain
         // their historical undefined result because their callers only use the completion
         // as a synchronization point.
         if (joinInFlight) {
           try {
-            return await current;
+            return await joinedPromise;
           } catch {
             // A failed joined run is settled but has no freshness verdict. Preserve the
             // fail-closed undefined result so the caller reports a non-fresh outcome.
@@ -318,6 +350,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
             earlyYieldRequested = true;
           },
         };
+        current.attachNextCompletion?.(trailing);
       }
       return waitForRun(trailing, joinMs, withTimeout, abandonBeforeLocalWork);
     }


### PR DESCRIPTION
Fixes #1682. Joins trailing node-definition refresh completion under the existing bounded deadline and wires a production missing-asset refresh seam into graph_get_errors so newly present combo files clear stale errors while timeout/rejection remains fail-closed. Independently reviewed SHIP. Validation: 279 focused tests, typecheck, scope check, and diff check. 
