### PR TITLE
fix(panel): preserve scoped execution errors

### DIFF
--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -444,12 +444,23 @@ function makeScopedErrorGraph() {
   const host = { id: 140, type: "Subgraph", subgraph: innerGraph };
   const siblingHost = { id: 141, type: "Subgraph", subgraph: siblingGraph };
   const rootNode = { id: 900, type: "SamplerCustomAdvanced" };
+  const collidingRootNode = { id: 125, type: "SamplerCustomAdvanced" };
   const rootGraph = {
-    _nodes: [host, siblingHost, rootNode],
+    _nodes: [host, siblingHost, rootNode, collidingRootNode],
     getNodeById: (id) =>
-      ({ 140: host, 141: siblingHost, 900: rootNode })[String(id)] ?? null,
+      ({ 140: host, 141: siblingHost, 900: rootNode, 125: collidingRootNode })[String(id)] ?? null,
   };
-  return { inner, innerGraph, host, siblingInner, siblingGraph, siblingHost, rootNode, rootGraph };
+  return {
+    inner,
+    innerGraph,
+    host,
+    siblingInner,
+    siblingGraph,
+    siblingHost,
+    rootNode,
+    collidingRootNode,
+    rootGraph,
+  };
 }
 
 async function runProductionGraphGetErrors({ graph, rootGraph, lastExecFailure }) {
@@ -565,6 +576,26 @@ test("#1685 production graph_get_errors omits same-type errors outside the visib
     assert.equal(result.last_execution_error, null, `foreign ${node_id} must be omitted`);
     assert.equal(result.note, "no errors recorded since the last execution start");
   }
+});
+
+test("#1685 production graph_get_errors rejects an ambiguous plain id colliding with the visible inner node", async () => {
+  const { inner, innerGraph, rootGraph, collidingRootNode } = makeScopedErrorGraph();
+  assert.equal(inner.id, collidingRootNode.id, "the fixture must reproduce the root/inner id collision");
+  assert.equal(inner.type, collidingRootNode.type, "the fixture must reproduce the same-type collision");
+  const result = await runProductionGraphGetErrors({
+    graph: innerGraph,
+    rootGraph,
+    lastExecFailure: {
+      node_id: String(collidingRootNode.id),
+      node_type: collidingRootNode.type,
+      exception_message: "root collision failure",
+    },
+  });
+
+  assert.equal(result.errored_count, 0);
+  assert.deepEqual(result.nodes, []);
+  assert.equal(result.last_execution_error, null);
+  assert.equal(result.note, "no errors recorded since the last execution start");
 });
 
 test("#1685 production graph_get_errors still rejects a type-mismatched scoped failure", async () => {

--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -25,6 +25,7 @@ import {
   executionErrorMatchesCurrentGraph,
   applyRuntimeExecFailure,
 } from "../../web/js/lib/exec-error-bounds.js";
+import { findNodeByScopedId, findVisibleNodeByScopedId } from "../../web/js/lib/asset-staleness.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PANEL_SOURCE = readFileSync(
@@ -341,4 +342,216 @@ test("graph_get_errors correlates runtime failures through applyRuntimeExecFailu
     !/const clean =\s*!nodeErrors &&\s*!lastExecFailure &&/.test(PANEL_SOURCE),
     "clean must not be dirtied by a stale lastExecFailure from another workflow",
   );
+});
+
+// #1685: the regression is in the shipped graph_get_errors executor, not in the
+// standalone correlation helper. Run that executor against a root graph with a
+// native subgraph so a scoped execution_error must survive the complete scan.
+function extractExecutorMethod(source, signature) {
+  const start = source.indexOf(signature);
+  assert.notEqual(start, -1, `${signature} not found in panel source`);
+  const open = source.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "/" && source[i + 1] === "/") {
+      i = source.indexOf("\n", i + 2);
+      continue;
+    }
+    if (ch === "/" && source[i + 1] === "*") {
+      i = source.indexOf("*/", i + 2) + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < source.length; i += 1) {
+        if (source[i] === "\\") i += 1;
+        else if (source[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`unterminated ${signature}`);
+}
+
+const GRAPH_GET_ERRORS_SOURCE = extractExecutorMethod(PANEL_SOURCE, "  async graph_get_errors() {");
+const GRAPH_GET_ERRORS_DEPS = [
+  "monotonicNow",
+  "getErrorsStepBudgetMs",
+  "hasRawMissingAssetCandidates",
+  "GET_ERRORS_REFRESH_CAP_MS",
+  "refreshMissingAssetTrust",
+  "refreshComfyNodeDefs",
+  "withRefreshTimeout",
+  "getRefreshInFlight",
+  "nodeDefRefreshInFlight",
+  "getGraphCtx",
+  "assertGraphBoundToActiveWorkflow",
+  "graphCommandBindingBar",
+  "collectMissingAssets",
+  "activeWorkflowRef",
+  "GET_ERRORS_STEP_CAP_MS",
+  "filterServerConfirmedInputSubfolderMedia",
+  "inputAssetServerUsesWindowsPaths",
+  "scanComboAvailability",
+  "fetchSingleNodeDef",
+  "probeInputAssetPresence",
+  "graphReadBindingChanged",
+  "collectAllGraphs",
+  "adjudicateRecordedMissingNodeTypes",
+  "isRegisteredNodeType",
+  "LiteGraph",
+  "findVisibleNodeByScopedId",
+  "findNodeByScopedId",
+  "getPiniaStore",
+  "combineNodeErrorMaps",
+  "coerceMessageText",
+  "lastExecFailure",
+  "applyRuntimeExecFailure",
+  "collectUnexplainedRedOutlines",
+  "summarizeNode",
+  "tr",
+  "describeActiveGraph",
+  "MAX_STATE_NODES",
+  "fixedCapNote",
+  "missingAssetScanMayBeStale",
+  "missingAssetScopeNote",
+  "comboAvailabilityNote",
+  "uncheckedNodesNote",
+  "stalePlaceholderNote",
+  "boundExecFailurePayload",
+  "collectMissingNodeTypeReasons",
+];
+
+const makeGraphGetErrors = new Function(
+  ...GRAPH_GET_ERRORS_DEPS,
+  `return ({ ${GRAPH_GET_ERRORS_SOURCE} }).graph_get_errors;`,
+);
+
+function makeScopedErrorGraph() {
+  const inner = { id: 125, type: "SamplerCustomAdvanced" };
+  const innerGraph = {
+    _nodes: [inner],
+    getNodeById: (id) => (String(id) === "125" ? inner : null),
+  };
+  const host = { id: 140, type: "Subgraph", subgraph: innerGraph };
+  const rootGraph = {
+    _nodes: [host],
+    getNodeById: (id) => (String(id) === "140" ? host : null),
+  };
+  return { inner, innerGraph, host, rootGraph };
+}
+
+async function runProductionGraphGetErrors({ graph, rootGraph, lastExecFailure }) {
+  const deps = {
+    monotonicNow: () => 0,
+    getErrorsStepBudgetMs: () => 0,
+    hasRawMissingAssetCandidates: () => false,
+    GET_ERRORS_REFRESH_CAP_MS: 18000,
+    refreshMissingAssetTrust: async () => false,
+    refreshComfyNodeDefs: () => {},
+    withRefreshTimeout: () => {},
+    getRefreshInFlight: () => null,
+    nodeDefRefreshInFlight: null,
+    getGraphCtx: () => ({ app: { lastNodeErrors: null }, graph, rootGraph }),
+    assertGraphBoundToActiveWorkflow: () => {},
+    graphCommandBindingBar: () => ({}),
+    collectMissingAssets: () => ({ models: [], media: [], nodeTypes: [], nodeCount: 0 }),
+    activeWorkflowRef: () => null,
+    GET_ERRORS_STEP_CAP_MS: 4000,
+    filterServerConfirmedInputSubfolderMedia: async (media) => media,
+    inputAssetServerUsesWindowsPaths: async () => false,
+    scanComboAvailability: async () => null,
+    fetchSingleNodeDef: () => {},
+    probeInputAssetPresence: () => {},
+    graphReadBindingChanged: () => false,
+    collectAllGraphs: (value) => [value],
+    adjudicateRecordedMissingNodeTypes: (types) => ({ stillMissing: types, stalePlaceholders: [] }),
+    isRegisteredNodeType: () => false,
+    LiteGraph: {},
+    findVisibleNodeByScopedId,
+    findNodeByScopedId,
+    getPiniaStore: () => null,
+    combineNodeErrorMaps: () => null,
+    coerceMessageText: (value) => String(value ?? ""),
+    lastExecFailure,
+    applyRuntimeExecFailure,
+    collectUnexplainedRedOutlines: () => [],
+    summarizeNode: (node) => ({ id: node.id, type: node.type }),
+    tr: (_key, fallback) => fallback,
+    describeActiveGraph: () => ({ scope: "root" }),
+    MAX_STATE_NODES: 50,
+    fixedCapNote: () => "cap",
+    missingAssetScanMayBeStale: () => false,
+    missingAssetScopeNote: () => "stale",
+    comboAvailabilityNote: () => "combo",
+    uncheckedNodesNote: () => "unchecked",
+    stalePlaceholderNote: () => "placeholder",
+    boundExecFailurePayload,
+    collectMissingNodeTypeReasons: () => [],
+  };
+  const executor = makeGraphGetErrors(...GRAPH_GET_ERRORS_DEPS.map((name) => deps[name]));
+  return executor();
+}
+
+test("#1685 production graph_get_errors preserves a scoped runtime error and blames its root host", async () => {
+  const { rootGraph, host } = makeScopedErrorGraph();
+  const result = await runProductionGraphGetErrors({
+    graph: rootGraph,
+    rootGraph,
+    lastExecFailure: {
+      node_id: "140:125",
+      node_type: "SamplerCustomAdvanced",
+      exception_type: "NotImplementedError",
+      exception_message: "aten::_int_mm",
+    },
+  });
+
+  assert.equal(result.errored_count, 1);
+  assert.equal(result.nodes[0].id, host.id);
+  assert.deepEqual(result.nodes[0].reasons, [
+    {
+      kind: "execution",
+      exception_type: "NotImplementedError",
+      message: "aten::_int_mm",
+    },
+  ]);
+  assert.equal(result.last_execution_error.node_id, "140:125");
+  assert.equal(result.note, undefined, "a scoped execution failure must not be reported clean");
+});
+
+test("#1685 production graph_get_errors blames the inner node when that subgraph is visible", async () => {
+  const { inner, innerGraph, rootGraph } = makeScopedErrorGraph();
+  const result = await runProductionGraphGetErrors({
+    graph: innerGraph,
+    rootGraph,
+    lastExecFailure: {
+      node_id: "140:125",
+      node_type: "SamplerCustomAdvanced",
+      exception_message: "inner failure",
+    },
+  });
+
+  assert.equal(result.errored_count, 1);
+  assert.equal(result.nodes[0].id, inner.id);
+  assert.equal(result.nodes[0].reasons[0].message, "inner failure");
+});
+
+test("#1685 production graph_get_errors still rejects a type-mismatched scoped failure", async () => {
+  const { rootGraph } = makeScopedErrorGraph();
+  const result = await runProductionGraphGetErrors({
+    graph: rootGraph,
+    rootGraph,
+    lastExecFailure: {
+      node_id: "140:125",
+      node_type: "DifferentNodeType",
+      exception_message: "foreign failure",
+    },
+  });
+
+  assert.equal(result.errored_count, 0);
+  assert.equal(result.last_execution_error, null);
+  assert.equal(result.note, "no errors recorded since the last execution start");
 });

--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -436,12 +436,20 @@ function makeScopedErrorGraph() {
     _nodes: [inner],
     getNodeById: (id) => (String(id) === "125" ? inner : null),
   };
-  const host = { id: 140, type: "Subgraph", subgraph: innerGraph };
-  const rootGraph = {
-    _nodes: [host],
-    getNodeById: (id) => (String(id) === "140" ? host : null),
+  const siblingInner = { id: 225, type: "SamplerCustomAdvanced" };
+  const siblingGraph = {
+    _nodes: [siblingInner],
+    getNodeById: (id) => (String(id) === "225" ? siblingInner : null),
   };
-  return { inner, innerGraph, host, rootGraph };
+  const host = { id: 140, type: "Subgraph", subgraph: innerGraph };
+  const siblingHost = { id: 141, type: "Subgraph", subgraph: siblingGraph };
+  const rootNode = { id: 900, type: "SamplerCustomAdvanced" };
+  const rootGraph = {
+    _nodes: [host, siblingHost, rootNode],
+    getNodeById: (id) =>
+      ({ 140: host, 141: siblingHost, 900: rootNode })[String(id)] ?? null,
+  };
+  return { inner, innerGraph, host, siblingInner, siblingGraph, siblingHost, rootNode, rootGraph };
 }
 
 async function runProductionGraphGetErrors({ graph, rootGraph, lastExecFailure }) {
@@ -537,6 +545,26 @@ test("#1685 production graph_get_errors blames the inner node when that subgraph
   assert.equal(result.errored_count, 1);
   assert.equal(result.nodes[0].id, inner.id);
   assert.equal(result.nodes[0].reasons[0].message, "inner failure");
+});
+
+test("#1685 production graph_get_errors omits same-type errors outside the visible subgraph", async () => {
+  const { innerGraph, rootGraph } = makeScopedErrorGraph();
+  for (const node_id of ["141:225", "900"]) {
+    const result = await runProductionGraphGetErrors({
+      graph: innerGraph,
+      rootGraph,
+      lastExecFailure: {
+        node_id,
+        node_type: "SamplerCustomAdvanced",
+        exception_message: "foreign failure",
+      },
+    });
+
+    assert.equal(result.errored_count, 0, `foreign ${node_id} must not create an errored node`);
+    assert.deepEqual(result.nodes, [], `foreign ${node_id} must not receive a reason`);
+    assert.equal(result.last_execution_error, null, `foreign ${node_id} must be omitted`);
+    assert.equal(result.note, "no errors recorded since the last execution start");
+  }
 });
 
 test("#1685 production graph_get_errors still rejects a type-mismatched scoped failure", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17768,13 +17768,23 @@ const GRAPH_TOOL_EXECUTORS = {
           );
         }
       }
+      let visibleFailureNode = null;
+      if (e?.node_id != null) {
+        visibleFailureNode =
+          findVisibleNodeByScopedId(rootGraph, nodes, e.node_id) ??
+          // A plain id may already be local to the graph currently shown.
+          byId.get(String(e.node_id)) ??
+          // On the root canvas, a qualified inner id is represented by its host.
+          (graph === rootGraph ? byId.get(String(e.node_id).split(":")[0]) : null);
+        // A valid node in another subgraph/workflow must not dirty this view. Keep
+        // the root-host exception above, but otherwise discard it before the three
+        // correlated output surfaces are assigned.
+        if (!visibleFailureNode) applied = { detail: null, failure: null, reason: null };
+      }
       execFailureDetail = applied.detail;
       execFailure = applied.failure;
-      if (applied.reason && e?.node_id != null) {
-        const visibleFailureNode =
-          findVisibleNodeByScopedId(rootGraph, nodes, e.node_id) ??
-          (graph === rootGraph ? byId.get(String(e.node_id).split(":")[0]) : null);
-        addReason(visibleFailureNode?.id ?? e.node_id, applied.reason);
+      if (applied.reason && visibleFailureNode) {
+        addReason(visibleFailureNode.id, applied.reason);
       }
     } catch {
       /* optional */

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17754,11 +17754,27 @@ const GRAPH_TOOL_EXECUTORS = {
         const store = getPiniaStore("executi" + "on" + "Error");
         e = store?.["lastExecuti" + "on" + "Error"] ?? null;
       }
-      const applied = applyRuntimeExecFailure(e, byId);
+      let applied = applyRuntimeExecFailure(e, byId);
+      // #1685 — execution_error uses a scoped locator for nodes inside a native
+      // subgraph (for example `140:125`), while `byId` only indexes the graph
+      // currently visible on the canvas. Resolve that locator against the active
+      // root graph and run the same type-safe correlation before retaining it.
+      if (!applied.detail && e?.node_id != null) {
+        const scopedNode = findNodeByScopedId(rootGraph, e.node_id);
+        if (scopedNode) {
+          applied = applyRuntimeExecFailure(
+            e,
+            new Map([[String(e.node_id), scopedNode]]),
+          );
+        }
+      }
       execFailureDetail = applied.detail;
       execFailure = applied.failure;
       if (applied.reason && e?.node_id != null) {
-        addReason(e.node_id, applied.reason);
+        const visibleFailureNode =
+          findVisibleNodeByScopedId(rootGraph, nodes, e.node_id) ??
+          (graph === rootGraph ? byId.get(String(e.node_id).split(":")[0]) : null);
+        addReason(visibleFailureNode?.id ?? e.node_id, applied.reason);
       }
     } catch {
       /* optional */

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17772,8 +17772,6 @@ const GRAPH_TOOL_EXECUTORS = {
       if (e?.node_id != null) {
         visibleFailureNode =
           findVisibleNodeByScopedId(rootGraph, nodes, e.node_id) ??
-          // A plain id may already be local to the graph currently shown.
-          byId.get(String(e.node_id)) ??
           // On the root canvas, a qualified inner id is represented by its host.
           (graph === rootGraph ? byId.get(String(e.node_id).split(":")[0]) : null);
         // A valid node in another subgraph/workflow must not dirty this view. Keep


### PR DESCRIPTION
Fixes #1685

### What changed
- Resolve subgraph-qualified `execution_error.node_id` values against the active root graph before applying the existing type-safe runtime correlation.
- Retain errors only when the resolved node is visible, or map a qualified inner error to its host when the root graph is visible.
- Inner views no longer accept ambiguous plain IDs from the root graph, preventing same-ID/same-type root-to-inner collisions from producing false errors.
- Add production `graph_get_errors` coverage for root-visible, inner-visible, same-type sibling/root, same-ID/same-type collision, and type-mismatched scoped failures.

### Evidence
- The reported collision fixture (visible inner `125`, foreign root `125`, same type) now returns `errored_count: 0`, `nodes: []`, `last_execution_error: null`, and the clean note.
- `npm.cmd run test:unit`: 6628 passed, 1 todo.
- Focused production-path tests (`exec-error-bounds` + `asset-staleness`): 138 passed.
- `npm.cmd run check:scope`: passed.
- `npm.cmd run typecheck`: passed.
- `node --check web/js/comfyui-mcp-panel.js`: passed.
- `git diff --check`: passed.