### PR TITLE
fix(panel): refuse id-less panel_run acknowledgements

### DIFF
--- a/browser_tests/unit/describe-command-i18n.test.mjs
+++ b/browser_tests/unit/describe-command-i18n.test.mjs
@@ -75,6 +75,19 @@ test("a number that is not a count never selects a plural form", () => {
   assert.equal(say("graph_screenshot", { width: 1024, height: 768 }), "Captured workflow image (1024×768)");
 });
 
+test("#1690: queued_unknown activity is uncertain, not blocked or duplicate-retry messaging", () => {
+  __setCatalogForTest("en", {});
+  const card = describeCommand("graph_run", {}, { ok: true, result: {
+    queued_unknown: true,
+    error: "The queue acknowledgement was incomplete",
+    retry_guidance: "A blind retry can duplicate the render",
+  } });
+  assert.equal(card.text, "Run outcome uncertain");
+  assert.equal(card.detail, "The queue acknowledgement was incomplete");
+  assert.doesNotMatch(card.text, /blocked/i);
+  assert.doesNotMatch(String(card.detail), /retry|duplicate/i);
+});
+
 test("Korean gets its single form for every number", () => {
   // The exact case `n === 1 ? "" : "s"` cannot express: Korean has ONE plural category, so
   // a catalog that supplies only `_other` must serve 1 and 4 alike.

--- a/browser_tests/unit/queue-rejection.test.mjs
+++ b/browser_tests/unit/queue-rejection.test.mjs
@@ -143,9 +143,17 @@ test("run-to-node carries ran_to_node alongside the prompt_id", () => {
   assert.equal(r.ran_to_node, 42);
 });
 
-test("no captured prompt_id (older frontend) still returns a valid accept", () => {
+test("no captured prompt_id is outcome-unknown, never a queued success", () => {
   const r = buildQueueAcceptResult({ batchCount: 1, promptIds: [] });
-  assert.deepEqual(r, { queued: true, batch_count: 1 });
+  assert.equal(r.queued_unknown, true);
+  assert.equal(r.queued, undefined);
+  assert.equal(r.prompt_id, undefined);
+  assert.equal(r.indeterminate_count, 1);
+  assert.match(r.error, /prompt_id/);
+
+  const blank = buildQueueAcceptResult({ batchCount: 1, promptIds: ["", "   "] });
+  assert.equal(blank.queued_unknown, true, "blank receipts are not usable queue evidence");
+  assert.equal(blank.prompt_id, undefined);
 });
 
 test("a NUMERIC prompt_id is normalized to a string at ingestion (#370)", () => {

--- a/browser_tests/unit/queue-rejection.test.mjs
+++ b/browser_tests/unit/queue-rejection.test.mjs
@@ -156,6 +156,16 @@ test("no captured prompt_id is outcome-unknown, never a queued success", () => {
   assert.equal(blank.prompt_id, undefined);
 });
 
+test("#1690: a mixed batch keeps known ids but makes the whole acknowledgement uncertain", () => {
+  const r = buildQueueAcceptResult({ batchCount: 2, promptIds: ["   ", "p2"], uncertainCount: 1 });
+  assert.equal(r.queued_unknown, true);
+  assert.equal(r.queued, undefined);
+  assert.equal(r.prompt_id, "p2", "the known receipt remains available for correlation");
+  assert.equal(r.queued_count, 1);
+  assert.equal(r.indeterminate_count, 1);
+  assert.match(r.error, /incomplete|usable prompt_id/i);
+});
+
 test("a NUMERIC prompt_id is normalized to a string at ingestion (#370)", () => {
   const r = buildQueueAcceptResult({ batchCount: 1, promptIds: [7] });
   assert.strictEqual(r.prompt_id, "7"); // string, not number

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -133,6 +133,17 @@ function makeServerWithoutPromptId() {
   return fetchApi;
 }
 
+function makeServerSequence(bodies) {
+  const calls = [];
+  const fetchApi = async (route, options) => {
+    calls.push({ route, options, at: Date.now() });
+    const body = bodies[Math.min(calls.length - 1, bodies.length - 1)];
+    return jsonResponse(200, body);
+  };
+  fetchApi.calls = calls;
+  return fetchApi;
+}
+
 /**
  * @param {object} o
  * @param {number} o.drainMs how long the busy processor takes to get to our item
@@ -890,7 +901,7 @@ function makeUnscopedFrontend({ apiTarget, mode, drainMs = 5 }) {
     queueItems: [],
     graph: { _nodes: [] },
     graphToPrompt: async () => ({ output: OUR_OUTPUT, workflow: {} }),
-    queuePrompt: async () => {
+    queuePrompt: async (_number, batch = 1) => {
       const post = () =>
         apiTarget.fetchApi("/prompt", {
           method: "POST",
@@ -907,7 +918,7 @@ function makeUnscopedFrontend({ apiTarget, mode, drainMs = 5 }) {
         if (typeof t.unref === "function") t.unref();
         return new Promise(() => {});
       }
-      await post();
+      for (let i = 0; i < Math.max(1, Math.floor(Number(batch)) || 1); i++) await post();
       return true;
     },
   };
@@ -1030,6 +1041,46 @@ test("#1690 production path: a full run without a prompt_id is outcome-unknown, 
   }
 });
 
+test("#1690 production path: a blank plus valid batch receipt is outcome-unknown, never queued:true", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = {
+      fetchApi: makeServerSequence([{ prompt_id: "   " }, { prompt_id: "p2" }]),
+    };
+    const app = makeUnscopedFrontend({ apiTarget, mode: "late" });
+    const built = realGraphRun({ app, apiTarget, budgetMs: 15000, serializeMs: 8000 });
+    const res = await built.graph_run({ batch_count: 2 });
+    assert.equal(apiTarget.fetchApi.calls.length, 2, "the production batch path made both /prompt requests");
+    assert.equal(res.queued_unknown, true);
+    assert.notEqual(res.queued, true, "one unusable receipt taints the whole batch acknowledgement");
+    assert.equal(res.prompt_id, "p2", "the valid receipt remains available for correlation");
+    assert.equal(res.queued_count, 1);
+    assert.equal(res.indeterminate_count, 1);
+  } finally {
+    stop();
+  }
+});
+
+test("#1690 production path: a missing receipt with node errors stays queued_unknown", async () => {
+  const stop = keepAlive();
+  try {
+    const nodeErrors = { "9": { errors: [{ message: "stale validation metadata" }] } };
+    const apiTarget = { fetchApi: makeServerSequence([{ node_errors: nodeErrors }]) };
+    const app = makeUnscopedFrontend({ apiTarget, mode: "late" });
+    // This is the frontend fallback channel under review: it is populated even
+    // though the current 200 response did not provide a usable receipt.
+    app.lastNodeErrors = nodeErrors;
+    const built = realGraphRun({ app, apiTarget, budgetMs: 15000, serializeMs: 8000 });
+    const res = await built.graph_run({});
+    assert.equal(res.queued_unknown, true);
+    assert.equal(res.queued, undefined, "missing receipt must not become queued:false from stale node errors");
+    assert.notEqual(res.queued, false);
+    assert.match(String(res.error), /prompt_id|acknowledgement/i);
+  } finally {
+    stop();
+  }
+});
+
 test("#1565 P1: the run interceptor COUNTS what left the panel, so the reply states it rather than assuming it", async () => {
   const stop = keepAlive();
   try {
@@ -1040,15 +1091,15 @@ test("#1565 P1: the run interceptor COUNTS what left the panel, so the reply sta
       return { status: 200, clone: () => ({ json: async () => ({ prompt_id: "p1" }) }), text: async () => "{}" };
     };
     const interceptor = createRunFetchInterceptor({ origFetchApi: inner });
-    assert.deepEqual(interceptor.state, { posted: 0, inFlight: 0 });
+    assert.deepEqual(interceptor.state, { posted: 0, inFlight: 0, missingPromptIds: 0 });
     const post = interceptor("/prompt", { method: "POST", body: JSON.stringify({ prompt: {} }) });
-    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 1 }, "counted BEFORE the request leaves");
+    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 1, missingPromptIds: 0 }, "counted BEFORE the request leaves");
     release();
     await post;
-    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 0 }, "and settled when it answers");
+    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 0, missingPromptIds: 0 }, "and settled when it answers");
     // A non-prompt request is never counted as this run's work.
     await interceptor("/queue", { method: "GET" });
-    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 0 });
+    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 0, missingPromptIds: 0 });
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -137,8 +137,9 @@ function makeServerSequence(bodies) {
   const calls = [];
   const fetchApi = async (route, options) => {
     calls.push({ route, options, at: Date.now() });
-    const body = bodies[Math.min(calls.length - 1, bodies.length - 1)];
-    return jsonResponse(200, body);
+    const entry = bodies[Math.min(calls.length - 1, bodies.length - 1)];
+    const described = entry && typeof entry === "object" && Object.hasOwn(entry, "status");
+    return jsonResponse(described ? entry.status : 200, described ? entry.body : entry);
   };
   fetchApi.calls = calls;
   return fetchApi;
@@ -1076,6 +1077,30 @@ test("#1690 production path: a missing receipt with node errors stays queued_unk
     assert.equal(res.queued, undefined, "missing receipt must not become queued:false from stale node errors");
     assert.notEqual(res.queued, false);
     assert.match(String(res.error), /prompt_id|acknowledgement/i);
+  } finally {
+    stop();
+  }
+});
+
+test("#1690 production path: a definitive refusal beats another batch item's missing receipt", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = {
+      fetchApi: makeServerSequence([
+        {},
+        {
+          status: 400,
+          body: { error: { type: "prompt_outputs_failed_validation", message: "definitive refusal" } },
+        },
+      ]),
+    };
+    const app = makeUnscopedFrontend({ apiTarget, mode: "late" });
+    const built = realGraphRun({ app, apiTarget, budgetMs: 15000, serializeMs: 8000 });
+    const res = await built.graph_run({ batch_count: 2 });
+    assert.equal(apiTarget.fetchApi.calls.length, 2, "the production batch path observed both /prompt responses");
+    assert.equal(res.queued, false, "a definitive refusal remains a refusal for the whole acknowledgement");
+    assert.equal(res.queued_unknown, undefined);
+    assert.match(String(res.error), /definitive refusal|prompt_outputs_failed_validation/i);
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -123,6 +123,16 @@ function makeServer() {
   return fetchApi;
 }
 
+function makeServerWithoutPromptId() {
+  const calls = [];
+  const fetchApi = async (route, options) => {
+    calls.push({ route, options, at: Date.now() });
+    return jsonResponse(200, {});
+  };
+  fetchApi.calls = calls;
+  return fetchApi;
+}
+
 /**
  * @param {object} o
  * @param {number} o.drainMs how long the busy processor takes to get to our item
@@ -998,6 +1008,23 @@ test("#1565 P1: a HEALTHY full run is untouched — same accept result, no budge
     const built = realGraphRun({ app, apiTarget, budgetMs: 15000, serializeMs: 8000 });
     const res = await built.graph_run({});
     assert.deepEqual(res, { queued: true, batch_count: 1, prompt_id: "srv-1" });
+  } finally {
+    stop();
+  }
+});
+
+test("#1690 production path: a full run without a prompt_id is outcome-unknown, never queued:true", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServerWithoutPromptId() };
+    const app = makeUnscopedFrontend({ apiTarget, mode: "late" });
+    const built = realGraphRun({ app, apiTarget, budgetMs: 15000, serializeMs: 8000 });
+    const res = await built.graph_run({});
+    assert.equal(apiTarget.fetchApi.calls.length, 1, "the production queue path made one /prompt request");
+    assert.equal(res.queued_unknown, true);
+    assert.notEqual(res.queued, true, "a queue acknowledgement without a receipt must not claim success");
+    assert.equal(res.prompt_id, undefined);
+    assert.match(String(res.error), /prompt_id/);
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -984,6 +984,41 @@ test("#556 r6: an attributed post with a MALFORMED response (200 without prompt_
   }
 });
 
+test("#1690: a scoped batch with a blank receipt and a valid receipt is uncertain, not queued:true", async () => {
+  const stop = keepAlive();
+  try {
+    const responses = [jsonResponse(200, { prompt_id: "   " }), jsonResponse(200, { prompt_id: "p2" })];
+    let responseIndex = 0;
+    const server = makeServer(() => responses[responseIndex++]);
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    app.queuePrompt = async (number, batch) => {
+      for (let i = 0; i < batch; i++) {
+        const body = frontendBody({ number, targets: ["14"] });
+        app.posted.push(body);
+        await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      }
+      return true;
+    };
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app,
+      apiTarget,
+      execIds: ["14"],
+      batch: 2,
+      toNodeId: 14,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(server.calls.length, 2);
+    assert.deepEqual(ids, ["p2"], "the usable receipt remains ledger-eligible");
+    assert.equal(result.verified, 1);
+    assert.equal(result.indeterminate, 1, "the blank receipt consumes an uncertain batch slot");
+    assert.notEqual(result.outcome, "dispatched", "one blank receipt prevents a full-batch claim");
+  } finally {
+    stop();
+  }
+});
+
 test("#556 r6: a GENUINE server rejection still flows through the established #358 rejection channel (not a dispatch failure)", async () => {
   const rejectionBody = { error: { type: "prompt_outputs_failed_validation", message: "bad input" } };
   const spy = makeServer(async () => jsonResponse(400, rejectionBody));
@@ -1630,7 +1665,7 @@ test("#630 gate r8 P1: an INDETERMINATE dispatch omits `queued` — neither true
   // Bound the slice to THIS branch's return, or it runs on into the
   // nothing-dispatched `queued: false` below and the assertion means nothing.
   const indetBlock = block.slice(indetStart, block.indexOf("}; }", indetStart) + 4);
-  assert.ok(indetBlock.length > 100 && indetBlock.length < 900, "the branch was isolated, not the whole tail");
+  assert.ok(indetBlock.length > 100 && indetBlock.length < 1400, "the branch was isolated, not the whole tail");
   assert.doesNotMatch(indetBlock, /queued: false/,
     "a definite negative about a request whose fate we say we cannot determine");
   assert.match(indetBlock, /queued_unknown: true/);
@@ -1841,7 +1876,7 @@ test("#630 gate r5 P1: graph_run discloses a PARTIAL batch's queued work instead
   const start = source.indexOf("if (runScopeResult && runScopeResult.outcome !== \"dispatched\")");
   assert.ok(start > 0);
   const block = source.slice(start, start + 4600).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
-  assert.match(block, /if \(runScopeResult\.verified > 0\)/, "the partial case is distinguished from a total failure");
+  assert.match(block, /if \(runScopeResult\.verified > 0 && unresolved === 0\)/, "only a fully verified partial is reported queued");
   assert.match(block, /partially_queued: true/);
   assert.match(block, /queued_prompt_ids: queuedPromptIds\.slice\(\)/, "the caller can TRACK what is already running");
   assert.match(block, /Re-run only the remaining/, "and is told not to re-run the whole batch");
@@ -1946,18 +1981,22 @@ test("#630 gate r6: graph_run never states a remainder it cannot count, and neve
   const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
   const start = source.indexOf('if (runScopeResult && runScopeResult.outcome !== "dispatched")');
   assert.ok(start > 0);
-  const block = source.slice(start, start + 4200).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
+  const block = source.slice(start, start + 5600).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
   // A partial no longer asserts "not queued" for prompts that are executing.
   assert.match(block, /queued: true, complete: false, partially_queued: true/,
     "a partial batch is queued-but-incomplete, never a flat failure");
   assert.match(block, /incomplete_reason: runScopeResult\.error/,
     "and its reason does not masquerade as an error about work that did happen");
   // The remainder is only named when it is actually knowable.
-  assert.match(block, /const unknown = runScopeResult\.indeterminate > 0;/);
-  // …and that flag must actually SELECT the guidance. Asserting only that both
-  // strings exist would pass a version that always names a remainder.
-  assert.match(block, /retry_guidance: unknown \?/,
-    "the indeterminate flag gates which guidance is given, it is not merely computed");
+  assert.match(block, /const unresolved = \(runScopeResult\.indeterminate \?\? 0\) \+ \(runScopeResult\.inFlight \?\? 0\);/);
+  // …and that count must actually SELECT the uncertain result. Asserting only
+  // that both strings exist would pass a version that still reports queued:true.
+  assert.match(block, /if \(runScopeResult\.verified > 0 && unresolved === 0\)/,
+    "unresolved receipts veto the partial queued:true result");
+  assert.match(block, /if \(unresolved > 0\)/,
+    "the unresolved count selects the queued_unknown result");
+  assert.match(block, /queued_count: runScopeResult\.verified/,
+    "known prompt ids remain disclosed as partial evidence");
   assert.match(block, /the remaining count cannot be stated from here without risking a duplicate render/);
   assert.match(block, /Check the ComfyUI queue before re-running anything/);
   // Zero verified + an indeterminate dispatch is still not "nothing ran".

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -782,6 +782,7 @@
       "roll_back_resend": "Roll back & resend",
       "run_blocked": "Run blocked",
       "run_blocked_by_node_errors": "Run blocked by node errors",
+      "run_outcome_uncertain": "Run outcome uncertain",
       "run_the_workflow_and_tell_me_if": "Run the workflow and tell me if it errors",
       "running": "Running",
       "running_lowercase": "running",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16774,7 +16774,9 @@ const GRAPH_TOOL_EXECUTORS = {
     const capturePromptId = (pid) => {
       // EVERY accepted prompt_id, string-normalized at capture (0 and "0"
       // are the same run) so #370 reconcile stays string-vs-string.
-      if (!queuedPromptIds.includes(pid)) queuedPromptIds.push(pid);
+      const id = String(pid).trim();
+      if (!id) return;
+      if (!queuedPromptIds.includes(id)) queuedPromptIds.push(id);
     };
     // #1504 — node_errors that arrived on an ACCEPTED (200) reply: the outputs
     // ComfyUI dropped from a prompt it queued anyway ("Output will be ignored").

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17195,19 +17195,19 @@ const GRAPH_TOOL_EXECUTORS = {
     // batch response was missing its receipt.
     const missingPromptIds = Number(runInterceptor?.state?.missingPromptIds) || 0;
     // Verdict from BOTH channels: the captured top-level rejection (#358) and the
-    // per-node errors the frontend stashed. null ⇒ genuinely accepted.
-    if (missingPromptIds === 0) {
-      const rejection = summarizePromptRejection({
-        rejection: promptRejection,
-        lastNodeErrors: missingPromptIds === 0 ? app.lastNodeErrors : null,
-        runToNode: runToNodeInfo,
-        // #1504 — the prompt_id(s) ComfyUI MINTED for this run. A minted id is a
-        // receipt of acceptance, so per-node errors that arrive beside one are
-        // dropped outputs, not a refusal of the whole prompt.
-        acceptedPromptIds: queuedPromptIds,
-      });
-      if (rejection) return rejection;
-    }
+    // per-node errors the frontend stashed. null ⇒ genuinely accepted. Missing
+    // receipts suppress only the stale frontend fallback; an explicit refusal
+    // captured from /prompt still wins over the unknown acknowledgement.
+    const rejection = summarizePromptRejection({
+      rejection: promptRejection,
+      lastNodeErrors: missingPromptIds === 0 ? app.lastNodeErrors : null,
+      runToNode: runToNodeInfo,
+      // #1504 — the prompt_id(s) ComfyUI MINTED for this run. A minted id is a
+      // receipt of acceptance, so per-node errors that arrive beside one are
+      // dropped outputs, not a refusal of the whole prompt.
+      acceptedPromptIds: queuedPromptIds,
+    });
+    if (rejection) return rejection;
     // Surface the queued prompt_id(s) so the agent can correlate/track the run —
     // #370 reconciliation and mcp#531 (panel_run must return the prompt_id even
     // when a render is already running) both depend on this being reported.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17046,8 +17046,8 @@ const GRAPH_TOOL_EXECUTORS = {
       // recoverable gap. So a partial reports queued:true with complete:false,
       // and the reason moves out of `error` (which reads as "this did not
       // happen") into `incomplete_reason`.
-      if (runScopeResult.verified > 0) {
-        const unknown = runScopeResult.indeterminate > 0;
+      const unresolved = (runScopeResult.indeterminate ?? 0) + (runScopeResult.inFlight ?? 0);
+      if (runScopeResult.verified > 0 && unresolved === 0) {
         return {
           queued: true,
           complete: false,
@@ -17061,16 +17061,11 @@ const GRAPH_TOOL_EXECUTORS = {
           // threw, or its response was unparseable — ComfyUI may or may not
           // have queued it. Naming a precise remainder there would send the
           // caller to re-run something that could already be rendering.
-          retry_guidance: unknown
-            ? `${runScopeResult.verified} of ${batch} prompt(s) ARE queued and scoped to ` +
-              `node ${to_node_id} (prompt_ids above). ${runScopeResult.indeterminate} more ` +
-              `left the panel but their outcome could NOT be determined — ComfyUI may or ` +
-              `may not have queued them. Check the ComfyUI queue before re-running anything: ` +
-              `the remaining count cannot be stated from here without risking a duplicate render.`
-            : `${runScopeResult.verified} of ${batch} prompt(s) ARE queued and scoped to ` +
-              `node ${to_node_id}; they are running and are tracked by the prompt_ids above. ` +
-              `Re-run only the remaining ${Math.max(0, batch - runScopeResult.verified)} — ` +
-              `re-running the full batch would queue the already-running prompt(s) again.`,
+          retry_guidance:
+            `${runScopeResult.verified} of ${batch} prompt(s) ARE queued and scoped to ` +
+            `node ${to_node_id}; they are running and are tracked by the prompt_ids above. ` +
+            `Re-run only the remaining ${Math.max(0, batch - runScopeResult.verified)} — ` +
+            `re-running the full batch would queue the already-running prompt(s) again.`,
         };
       }
       // Nothing verified. But "nothing verified" is still not always "nothing
@@ -17088,18 +17083,25 @@ const GRAPH_TOOL_EXECUTORS = {
       // `inFlight` counts requests that HAD LEFT the panel and were still
       // awaiting a response when the wait expired (gate r9) — same epistemic
       // status as an indeterminate one: it may be accepted a moment from now.
-      const unresolved = (runScopeResult.indeterminate ?? 0) + (runScopeResult.inFlight ?? 0);
       if (unresolved > 0) {
         return {
           queued_unknown: true,
+          ...(runScopeResult.verified > 0
+            ? {
+                queued_count: runScopeResult.verified,
+                prompt_id: queuedPromptIds[0],
+                ...(queuedPromptIds.length > 1 ? { prompt_ids: queuedPromptIds.slice() } : {}),
+              }
+            : {}),
           error: runScopeResult.error,
           indeterminate_count: unresolved,
           retry_guidance:
-            `No prompt was CONFIRMED queued, but ${unresolved} request(s) ` +
-            `DID leave the panel and their outcome could not be determined — ComfyUI may have ` +
+            `${runScopeResult.verified > 0 ? `${runScopeResult.verified} prompt(s) WERE confirmed queued, but ` : "No prompt was CONFIRMED queued, but "}` +
+            `${unresolved} request(s) DID leave the panel and their outcome could not be determined — ComfyUI may have ` +
             `queued them, and they carried the run-to-node scope. Check the ComfyUI queue ` +
-            `before retrying rather than assuming nothing ran; a blind retry can render the ` +
-            `branch twice. This result deliberately omits "queued" because neither true nor ` +
+            `before re-running anything rather than assuming nothing ran; a blind retry can render the ` +
+            `branch twice; the remaining count cannot be stated from here without risking a ` +
+            `duplicate render. This result deliberately omits "queued" because neither true nor ` +
             `false is an honest answer here.`,
         };
       }
@@ -17185,24 +17187,34 @@ const GRAPH_TOOL_EXECUTORS = {
           `"queued" because neither true nor false is honest here.`,
       };
     }
+    // A 200 response without a usable receipt is not a node-error refusal. The
+    // frontend may have left stale lastNodeErrors from an earlier attempt (or
+    // recorded node metadata before the receipt was lost), so receipt
+    // uncertainty takes precedence over that fallback channel. A raw top-level
+    // rejection captured from /prompt remains definitive, even if another
+    // batch response was missing its receipt.
+    const missingPromptIds = Number(runInterceptor?.state?.missingPromptIds) || 0;
     // Verdict from BOTH channels: the captured top-level rejection (#358) and the
     // per-node errors the frontend stashed. null ⇒ genuinely accepted.
-    const rejection = summarizePromptRejection({
-      rejection: promptRejection,
-      lastNodeErrors: app.lastNodeErrors,
-      runToNode: runToNodeInfo,
-      // #1504 — the prompt_id(s) ComfyUI MINTED for this run. A minted id is a
-      // receipt of acceptance, so per-node errors that arrive beside one are
-      // dropped outputs, not a refusal of the whole prompt.
-      acceptedPromptIds: queuedPromptIds,
-    });
-    if (rejection) return rejection;
+    if (missingPromptIds === 0) {
+      const rejection = summarizePromptRejection({
+        rejection: promptRejection,
+        lastNodeErrors: missingPromptIds === 0 ? app.lastNodeErrors : null,
+        runToNode: runToNodeInfo,
+        // #1504 — the prompt_id(s) ComfyUI MINTED for this run. A minted id is a
+        // receipt of acceptance, so per-node errors that arrive beside one are
+        // dropped outputs, not a refusal of the whole prompt.
+        acceptedPromptIds: queuedPromptIds,
+      });
+      if (rejection) return rejection;
+    }
     // Surface the queued prompt_id(s) so the agent can correlate/track the run —
     // #370 reconciliation and mcp#531 (panel_run must return the prompt_id even
     // when a render is already running) both depend on this being reported.
     const accept = buildQueueAcceptResult({
       batchCount: batch,
       promptIds: queuedPromptIds,
+      uncertainCount: missingPromptIds,
       ranToNode: partialTargets ? Number(to_node_id) : null,
       // #1504 — outputs ComfyUI dropped from the prompt it queued.
       droppedOutputs: acceptedNodeErrors,
@@ -27280,6 +27292,15 @@ function describeCommand(cmd, msg, reply) {
         text: tr("panel.canvas_action", "Canvas: {action}", { action: r.canvas?.action?.replace(/_/g, " ") }),
       };
     case "graph_run":
+      if (r.queued_unknown) {
+        return {
+          icon: "pi-question-circle",
+          text: tr("panel.run_outcome_uncertain", "Run outcome uncertain"),
+          // Do not render retry_guidance here: the activity card must not turn
+          // an ambiguous acknowledgement into duplicate-retry messaging.
+          detail: r.error ?? "The panel could not confirm the queue acknowledgement.",
+        };
+      }
       return r.queued
         ? {
             // #985 — an accepted prompt carrying outputs from muted/bypassed

--- a/web/js/lib/queue-rejection.js
+++ b/web/js/lib/queue-rejection.js
@@ -196,12 +196,14 @@ function normalizeNodeErrors(ne) {
  * @param {object} args
  * @param {number} args.batchCount
  * @param {(string|null)[]} [args.promptIds]  Accepted prompt_ids, in queue order.
+ * @param {number} [args.uncertainCount] Accepted responses without a usable prompt_id.
  * @param {number|null} [args.ranToNode]      Present for a run-to-node partial run.
  * @param {object|null} [args.droppedOutputs] `node_errors` from the ACCEPTED 200 reply.
  */
 export function buildQueueAcceptResult({
   batchCount,
   promptIds = [],
+  uncertainCount = 0,
   ranToNode = null,
   droppedOutputs = null,
 } = {}) {
@@ -212,16 +214,23 @@ export function buildQueueAcceptResult({
   // reports one id.
   const ids = normalizeAcceptedIds(promptIds);
   const dropped = normalizeNodeErrors(droppedOutputs);
-  if (!ids.length) {
+  const unknown = Math.max(0, Math.floor(Number(uncertainCount)) || 0);
+  if (!ids.length || unknown > 0) {
     const count = Math.max(1, Math.floor(Number(batchCount)) || 1);
     return {
       queued_unknown: true,
       batch_count: batchCount,
-      indeterminate_count: count,
+      ...(ids.length ? { queued_count: ids.length, prompt_id: ids[0] } : {}),
+      ...(ids.length > 1 ? { prompt_ids: [...ids] } : {}),
+      indeterminate_count: unknown || count,
       error:
-        "The queue acknowledgement did not include a usable prompt_id, so the panel cannot confirm or correlate this run.",
+        unknown > 0
+          ? "The queue acknowledgement was incomplete: at least one accepted prompt did not include a usable prompt_id, so the panel cannot confirm or correlate the full run."
+          : "The queue acknowledgement did not include a usable prompt_id, so the panel cannot confirm or correlate this run.",
       retry_guidance:
-        "The run may have been accepted. Check the ComfyUI queue or history before retrying; a blind retry can duplicate the render.",
+        unknown > 0
+          ? "Some prompts may have been accepted. Check the ComfyUI queue or history before retrying; a blind retry can duplicate the render."
+          : "The run may have been accepted. Check the ComfyUI queue or history before retrying; a blind retry can duplicate the render.",
       ...(ranToNode != null ? { ran_to_node: ranToNode } : {}),
     };
   }

--- a/web/js/lib/queue-rejection.js
+++ b/web/js/lib/queue-rejection.js
@@ -181,7 +181,9 @@ function normalizeNodeErrors(ne) {
  * the agent can correlate/track the run — #370 reconciliation and mcp#531
  * (panel_run must return the prompt_id, even when a render is already running)
  * both depend on this. `prompt_id` is the first accepted id; `prompt_ids` is only
- * added for a batch that queued more than one.
+ * added for a batch that queued more than one. A missing id is not represented as
+ * `queued:true`: the request may have reached ComfyUI, but the panel has no receipt
+ * with which to prove or correlate that outcome.
  *
  * #1504 — an accepted run may have DROPPED some outputs. ComfyUI reports those on the
  * 200 body's `node_errors`, and they are reported here verbatim, on an otherwise normal
@@ -203,16 +205,26 @@ export function buildQueueAcceptResult({
   ranToNode = null,
   droppedOutputs = null,
 } = {}) {
-  // NORMALIZE to strings at this ingestion boundary (drop null/undefined) so the
-  // reported prompt_id(s), and everything that later reconciles against them, are
-  // string-vs-string — a numeric /prompt id can't slip through as a number (#370).
-  // Dedupe AFTER normalization (via Set) so a mixed 0 / "0" batch reports one id.
-  const ids = [
-    ...new Set(
-      (Array.isArray(promptIds) ? promptIds : []).filter((x) => x != null).map((x) => String(x)),
-    ),
-  ];
+  // NORMALIZE to trimmed strings at this ingestion boundary (drop null/undefined
+  // and blank values) so the reported prompt_id(s), and everything that later
+  // reconciles against them, are string-vs-string — a numeric /prompt id can't slip
+  // through as a number (#370). Dedupe AFTER normalization so a mixed 0 / "0" batch
+  // reports one id.
+  const ids = normalizeAcceptedIds(promptIds);
   const dropped = normalizeNodeErrors(droppedOutputs);
+  if (!ids.length) {
+    const count = Math.max(1, Math.floor(Number(batchCount)) || 1);
+    return {
+      queued_unknown: true,
+      batch_count: batchCount,
+      indeterminate_count: count,
+      error:
+        "The queue acknowledgement did not include a usable prompt_id, so the panel cannot confirm or correlate this run.",
+      retry_guidance:
+        "The run may have been accepted. Check the ComfyUI queue or history before retrying; a blind retry can duplicate the render.",
+      ...(ranToNode != null ? { ran_to_node: ranToNode } : {}),
+    };
+  }
   return {
     queued: true,
     batch_count: batchCount,

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -1200,19 +1200,39 @@ export function scopeDispatchError({ toNodeId, detail, verified, batch }) {
  * prompt id was minted AND which outputs were dropped, in one structured receipt.
  * `lastNodeErrors` cannot distinguish those two cases at all.
  */
-async function captureRunResponse(res, { onRejection, onPromptId, onAcceptedNodeErrors }) {
+function normalizePromptId(value) {
+  if (value == null) return null;
+  const id = String(value).trim();
+  return id || null;
+}
+
+async function captureRunResponse(res, { onRejection, onPromptId, onAcceptedNodeErrors, onMissingPromptId }) {
   try {
     const body = await res.clone().json();
     if (res.status !== 200) {
       if (body && (body.error || body.node_errors)) {
         onRejection?.({ error: body.error ?? null, node_errors: body.node_errors ?? null });
+      } else {
+        onMissingPromptId?.();
       }
-    } else if (body && body.prompt_id != null) {
-      onPromptId?.(String(body.prompt_id));
-      reportAcceptedNodeErrors(body, onAcceptedNodeErrors);
+    } else {
+      const promptId = normalizePromptId(body?.prompt_id);
+      if (promptId != null) {
+        onPromptId?.(promptId);
+        reportAcceptedNodeErrors(body, onAcceptedNodeErrors);
+      } else {
+        // A 200 proves the request reached the server, but without a usable
+        // receipt it cannot prove which batch item was accepted or correlate
+        // its completion. Do not let stale app.lastNodeErrors turn this into
+        // a definitive refusal.
+        onMissingPromptId?.();
+      }
     }
   } catch {
-    // non-JSON body / clone unsupported — the caller falls back to lastNodeErrors.
+    // An unreadable body cannot establish either a definitive refusal or a
+    // usable acceptance receipt, regardless of status. Keep the acknowledgement
+    // uncertain so a mixed batch cannot be reported as fully queued.
+    onMissingPromptId?.();
   }
 }
 
@@ -1235,8 +1255,9 @@ async function classifyRunResponse(res, { onRejection, onPromptId, onAcceptedNod
   try {
     const body = await res.clone().json();
     if (res.status === 200) {
-      if (body && body.prompt_id != null) {
-        onPromptId?.(String(body.prompt_id));
+      const promptId = normalizePromptId(body?.prompt_id);
+      if (promptId != null) {
+        onPromptId?.(promptId);
         reportAcceptedNodeErrors(body, onAcceptedNodeErrors); // #1504
         return "accepted";
       }
@@ -1263,6 +1284,8 @@ async function classifyRunResponse(res, { onRejection, onPromptId, onAcceptedNod
  * #1565 — IT ALSO COUNTS WHAT LEFT. `interceptor.state` is live:
  *   - `posted`   /prompt requests this run handed to the network, ever;
  *   - `inFlight` those whose response has not come back yet.
+ *   - `missingPromptIds` responses that did come back but carried no usable
+ *     prompt_id receipt (including an unreadable/empty acknowledgement).
  * A full run whose `app.queuePrompt` is abandoned at the command budget has to say
  * whether anything actually left the panel, and "nothing was queued" and "a request
  * is in flight" are different answers with different retry advice — only one of them
@@ -1275,7 +1298,7 @@ export function createRunFetchInterceptor({
   onPromptId = null,
   onAcceptedNodeErrors = null,
 } = {}) {
-  const state = { posted: 0, inFlight: 0 };
+  const state = { posted: 0, inFlight: 0, missingPromptIds: 0 };
   const interceptor = async function runFetchInterceptor(route, options) {
     // Classified BEFORE the request leaves, because that is the only moment at which
     // "this one is ours to count" can still be decided. Guarded: reading `options`
@@ -1294,8 +1317,17 @@ export function createRunFetchInterceptor({
     }
     try {
       const res = await origFetchApi(route, options);
-      if (isPost && res) {
-        await captureRunResponse(res, { onRejection, onPromptId, onAcceptedNodeErrors });
+      if (isPost) {
+        if (res) {
+          await captureRunResponse(res, {
+            onRejection,
+            onPromptId,
+            onAcceptedNodeErrors,
+            onMissingPromptId: () => state.missingPromptIds++,
+          });
+        } else {
+          state.missingPromptIds++;
+        }
       }
       return res;
     } finally {


### PR DESCRIPTION
Fixes #1690

Follow-up to the independent review:
- Normalize every /prompt receipt before capture; blank/whitespace or unreadable receipts taint the acknowledgement, so mixed accepted batches return queued_unknown while retaining usable prompt IDs for correlation.
- Preserve definitive raw /prompt refusal precedence: a batch containing a missing receipt and a genuine top-level refusal returns queued:false. Missing receipts suppress only stale frontend lastNodeErrors.
- Render queued_unknown activity as “Run outcome uncertain” without blocked or duplicate-retry messaging.
- Add production-path regressions for mixed blank+valid batches, missing receipts with node errors, mixed missing-receipt plus definitive-refusal batches, scoped acknowledgement handling, and the shipped activity renderer.
- Preserve nonblank IDs and numeric 0 normalization.

Checks:
- npm.cmd run test:unit — 6635 passed, 1 todo, 0 failed
- Focused run/queue/scope/activity suites — 208 passed, 0 failed
- npm.cmd run typecheck
- npm.cmd run check:scope
- npm.cmd run i18n:check and i18n render checks
- JavaScript syntax checks and git diff --check

Commits: ea6d843e, 80391102