### PR TITLE
fix(panel): complete bounded live error audit

### DIFF
--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -26,6 +26,8 @@ import {
   applyRuntimeExecFailure,
 } from "../../web/js/lib/exec-error-bounds.js";
 import { findNodeByScopedId, findVisibleNodeByScopedId } from "../../web/js/lib/asset-staleness.js";
+import { scanComboAvailability } from "../../web/js/lib/live-combo-availability.js";
+import { SINGLE_NODE_INFO_OUTCOME } from "../../web/js/lib/single-node-def.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PANEL_SOURCE = readFileSync(
@@ -396,7 +398,7 @@ const GRAPH_GET_ERRORS_DEPS = [
   "filterServerConfirmedInputSubfolderMedia",
   "inputAssetServerUsesWindowsPaths",
   "scanComboAvailability",
-  "fetchSingleNodeDef",
+  "fetchSingleNodeInfo",
   "probeInputAssetPresence",
   "graphReadBindingChanged",
   "collectAllGraphs",
@@ -463,10 +465,17 @@ function makeScopedErrorGraph() {
   };
 }
 
-async function runProductionGraphGetErrors({ graph, rootGraph, lastExecFailure }) {
+async function runProductionGraphGetErrors({
+  graph,
+  rootGraph,
+  lastExecFailure,
+  scan = async () => null,
+  fetchSingleNodeInfo = () => {},
+  stepBudget = () => 0,
+}) {
   const deps = {
     monotonicNow: () => 0,
-    getErrorsStepBudgetMs: () => 0,
+    getErrorsStepBudgetMs: stepBudget,
     hasRawMissingAssetCandidates: () => false,
     GET_ERRORS_REFRESH_CAP_MS: 18000,
     refreshMissingAssetTrust: async () => false,
@@ -482,8 +491,8 @@ async function runProductionGraphGetErrors({ graph, rootGraph, lastExecFailure }
     GET_ERRORS_STEP_CAP_MS: 4000,
     filterServerConfirmedInputSubfolderMedia: async (media) => media,
     inputAssetServerUsesWindowsPaths: async () => false,
-    scanComboAvailability: async () => null,
-    fetchSingleNodeDef: () => {},
+    scanComboAvailability: scan,
+    fetchSingleNodeInfo,
     probeInputAssetPresence: () => {},
     graphReadBindingChanged: () => false,
     collectAllGraphs: (value) => [value],
@@ -514,6 +523,49 @@ async function runProductionGraphGetErrors({ graph, rootGraph, lastExecFailure }
   const executor = makeGraphGetErrors(...GRAPH_GET_ERRORS_DEPS.map((name) => deps[name]));
   return executor();
 }
+
+test("#1691 production graph_get_errors batches live class reads and keeps uncertain types unchecked", async () => {
+  const working = {
+    id: 1,
+    type: "WorkingPack",
+    widgets: [{ name: "pick", value: "bad" }],
+    has_errors: true,
+  };
+  const uncertain = {
+    id: 2,
+    type: "InstalledButUnreachablePack",
+    widgets: [{ name: "pick", value: "ok" }],
+    constructor: { nodeData: { output_node: true } },
+  };
+  const graph = {
+    _nodes: [working, uncertain],
+    getNodeById: (id) => ([working, uncertain].find((node) => String(node.id) === String(id)) ?? null),
+  };
+  const fetchInfo = async (className) => {
+    if (className === "WorkingPack") {
+      return {
+        [SINGLE_NODE_INFO_OUTCOME]: true,
+        kind: "present",
+        body: { WorkingPack: { input: { required: { pick: [["ok"], {}] } } } },
+      };
+    }
+    return { [SINGLE_NODE_INFO_OUTCOME]: true, kind: "unknown" };
+  };
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    scan: scanComboAvailability,
+    fetchSingleNodeInfo: fetchInfo,
+    stepBudget: () => 1000,
+  });
+
+  assert.equal(result.unavailable_widget_values.length, 1);
+  assert.equal(result.unavailable_widget_values[0].type, "WorkingPack");
+  assert.equal(result.unchecked_nodes.length, 1);
+  assert.equal(result.unchecked_nodes[0].type, "InstalledButUnreachablePack");
+  assert.match(result.unchecked_nodes[0].reason, /could not be looked up/);
+});
 
 test("#1685 production graph_get_errors preserves a scoped runtime error and blames its root host", async () => {
   const { rootGraph, host } = makeScopedErrorGraph();

--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -471,10 +471,14 @@ async function runProductionGraphGetErrors({
   lastExecFailure,
   scan = async () => null,
   fetchSingleNodeInfo = () => {},
-  stepBudget = () => 0,
+  // The extracted executor's default scan is a no-op test double. Give it a
+  // usable budget so legacy tests that are not exercising live-scan exhaustion
+  // retain their clean-note assertions.
+  stepBudget = () => 1000,
+  monotonicNow = () => 0,
 }) {
   const deps = {
-    monotonicNow: () => 0,
+    monotonicNow,
     getErrorsStepBudgetMs: stepBudget,
     hasRawMissingAssetCandidates: () => false,
     GET_ERRORS_REFRESH_CAP_MS: 18000,
@@ -565,6 +569,44 @@ test("#1691 production graph_get_errors batches live class reads and keeps uncer
   assert.equal(result.unchecked_nodes.length, 1);
   assert.equal(result.unchecked_nodes[0].type, "InstalledButUnreachablePack");
   assert.match(result.unchecked_nodes[0].reason, /could not be looked up/);
+  assert.equal(result.note, undefined, "an unchecked live scan must not emit a clean note");
+});
+
+test("#1691 production graph_get_errors keeps budget-cutoff scans non-clean and uses its monotonic clock", async () => {
+  const graph = { _nodes: [], getNodeById: () => null };
+  const monotonicNow = () => 123;
+  let scanOptions;
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    scan: async (_nodes, _fetch, options) => {
+      scanOptions = options;
+      return { unavailable: [], unknown: [], unchecked_budget_exhausted: true };
+    },
+    stepBudget: () => 1000,
+    monotonicNow,
+  });
+
+  assert.equal(scanOptions.now, monotonicNow);
+  assert.equal(result.unchecked_budget_exhausted, true);
+  assert.equal(result.note, undefined, "a budget-cutoff live scan must not emit a clean note");
+});
+
+test("#1691 production graph_get_errors discloses a scan skipped after the shared budget is spent", async () => {
+  const graph = { _nodes: [], getNodeById: () => null };
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    scan: async () => {
+      throw new Error("the scan must not start without a budget");
+    },
+    stepBudget: () => 0,
+  });
+
+  assert.equal(result.unchecked_budget_exhausted, true);
+  assert.equal(result.note, undefined, "a skipped live scan must not emit a clean note");
 });
 
 test("#1685 production graph_get_errors preserves a scoped runtime error and blames its root host", async () => {

--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -191,6 +191,22 @@ test("#1691 a hung class batch returns an explicit budget cutoff", async () => {
   assert.match(r.unknown[0].reason, /budget/);
 });
 
+test("#1691 a timed-out class batch aborts its in-flight lookups", async () => {
+  const signals = [];
+  const r = await scanComboAvailability(
+    Array.from({ length: 8 }, (_, i) => node(i, `Hung${i}`, [{ name: "pick", value: "ok" }])),
+    (_className, signal) => new Promise((_resolve, reject) => {
+      signals.push(signal);
+      signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    }),
+    { budgetMs: 25 },
+  );
+  assert.equal(signals.length, 8, "the production batch should start all eight bounded reads");
+  assert.ok(signals.every((signal) => signal?.aborted), "every timed-out read must be aborted");
+  assert.equal(r.unchecked_budget_exhausted, true);
+  assert.equal(r.unavailable.length, 0);
+});
+
 test("#745 empty / malformed input is answered with empty, never a throw", async () => {
   assert.deepEqual(await scanComboAvailability(null, async () => LORA), { unavailable: [], unknown: [] });
   assert.deepEqual(await scanComboAvailability([], null), { unavailable: [], unknown: [] });

--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -27,6 +27,7 @@ import {
   comboAvailabilityNote,
   linkDrivenWidgetNames,
 } from "../../web/js/lib/live-combo-availability.js";
+import { SINGLE_NODE_INFO_OUTCOME } from "../../web/js/lib/single-node-def.js";
 
 /** An /object_info/<class> body in the verified shape. */
 const classBody = (name, required) => ({ [name]: { input: { required } } });
@@ -142,6 +143,52 @@ test("#745 one fetch per distinct CLASS, not per node", async () => {
     node(i, "LoraLoaderModelOnly", [{ name: "lora_name", value: "a.safetensors" }]));
   await scanComboAvailability(nodes, async (cls) => { seen.push(cls); return LORA; });
   assert.equal(seen.length, 1);
+});
+
+test("#1691 class lookups are bounded batches, with red/output classes first", async () => {
+  const seen = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const nodes = Array.from({ length: 16 }, (_, i) =>
+    node(i, `Class${i}`, [{ name: "pick", value: "ok" }]));
+  nodes[15].has_errors = true;
+  nodes[14].constructor = { nodeData: { output_node: true } };
+  const r = await scanComboAvailability(nodes, async (cls) => {
+    seen.push(cls);
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    inFlight -= 1;
+    return classBody(cls, { pick: [["ok"], {}] });
+  });
+  assert.equal(r.unknown.length, 0);
+  assert.equal(seen.length, 16);
+  assert.ok(maxInFlight <= 8, `batch concurrency ${maxInFlight} exceeded the bound`);
+  assert.deepEqual(seen.slice(0, 2), ["Class15", "Class14"]);
+});
+
+test("#1691 an uncertain per-class route is unchecked, never a missing type", async () => {
+  const r = await scanComboAvailability(
+    [node(7, "WorkingPack", [{ name: "pick", value: "ok" }])],
+    async () => ({ [SINGLE_NODE_INFO_OUTCOME]: true, kind: "unknown" }),
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.equal(r.unknown.length, 1);
+  assert.match(r.unknown[0].reason, /could not be looked up/);
+  assert.doesNotMatch(r.unknown[0].reason, /not found/);
+});
+
+test("#1691 a hung class batch returns an explicit budget cutoff", async () => {
+  const started = Date.now();
+  const r = await scanComboAvailability(
+    [node(8, "HungPack", [{ name: "pick", value: "ok" }])],
+    () => new Promise(() => {}),
+    { budgetMs: 25 },
+  );
+  assert.ok(Date.now() - started < 1000, "the live scan must not await a hung class route");
+  assert.equal(r.unchecked_budget_exhausted, true);
+  assert.equal(r.unavailable.length, 0);
+  assert.match(r.unknown[0].reason, /budget/);
 });
 
 test("#745 empty / malformed input is answered with empty, never a throw", async () => {

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -89,6 +89,18 @@ test("#1691 the scan-facing route distinguishes absent from transport uncertaint
   }
 });
 
+test("#1691 the scan-facing route forwards its abort signal", async () => {
+  const controller = new AbortController();
+  let seenOptions;
+  const fetchApi = async (_route, options) => {
+    seenOptions = options;
+    return { status: 200, json: async () => ({ WorkingPack: { input: {} } }) };
+  };
+  const result = await fetchSingleNodeInfo("WorkingPack", fetchApi, controller.signal);
+  assert.equal(result.kind, "present");
+  assert.equal(seenOptions.signal, controller.signal);
+});
+
 test("#767 every kind of DOUBT returns null, never a conclusion", async () => {
   // An older ComfyUI without the route.
   assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ status: 404, body: {} })), null);

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -22,7 +22,12 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { fetchSingleNodeDef, singleDefConfirms } from "../../web/js/lib/single-node-def.js";
+import {
+  fetchSingleNodeDef,
+  fetchSingleNodeInfo,
+  singleDefConfirms,
+  SINGLE_NODE_INFO_OUTCOME,
+} from "../../web/js/lib/single-node-def.js";
 import { OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -66,6 +71,22 @@ test("#767 ABSENCE is {} with HTTP 200 on this route, and is NOT a verdict", asy
   // an observation collapsed into a definite negative.
   const got = await fetchSingleNodeDef("LTXVImgToVideoConditionOnly", fakeApi({ body: {} }));
   assert.equal(got, null);
+});
+
+test("#1691 the scan-facing route distinguishes absent from transport uncertainty", async () => {
+  const absent = await fetchSingleNodeInfo("MissingPack", fakeApi({ body: {} }));
+  assert.equal(absent[SINGLE_NODE_INFO_OUTCOME], true);
+  assert.equal(absent.kind, "absent");
+
+  for (const options of [
+    { status: 404, body: {} },
+    { throws: true },
+    { body: { SomeOtherPack: {} } },
+  ]) {
+    const unknown = await fetchSingleNodeInfo("WorkingPack", fakeApi(options));
+    assert.equal(unknown[SINGLE_NODE_INFO_OUTCOME], true);
+    assert.equal(unknown.kind, "unknown");
+  }
 });
 
 test("#767 every kind of DOUBT returns null, never a conclusion", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17611,17 +17611,28 @@ const GRAPH_TOOL_EXECUTORS = {
       if (scanBudgetMs > 0) {
         liveScan = await scanComboAvailability(
           nodes,
-          (cls) => fetchSingleNodeInfo(cls, (route) => api?.fetchApi?.(route)),
+          (cls, signal) =>
+            fetchSingleNodeInfo(
+              cls,
+              (route, options) => api?.fetchApi?.(route, options),
+              signal,
+            ),
           {
             budgetMs: scanBudgetMs,
+            now: monotonicNow,
             backslashIsSeparator,
             confirmServerAsset: (_value, ref) =>
               probeInputAssetPresence(ref, errorsStepBudget(GET_ERRORS_STEP_CAP_MS)),
           },
         );
+      } else {
+        liveScan = { unavailable: [], unknown: [], unchecked_budget_exhausted: true };
       }
     } catch {
-      liveScan = null; // never let the scan take down the error report
+      liveScan = {
+        unavailable: [],
+        unknown: [{ reason: "the live error scan could not complete" }],
+      }; // never let the scan take down the error report
     }
 
     let postProbeRootGraph = null;
@@ -17844,6 +17855,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // emitted `unavailable_widget_values: [...]` and "no errors recorded" in ONE
     // payload. Every entry in that list is a value the server does not offer, so the
     // node fails on it at queue time whichever kind it is.
+    const liveScanIncomplete = Boolean(
+      liveScan?.unknown?.length || liveScan?.unchecked_budget_exhausted,
+    );
     const clean =
       !nodeErrors &&
       !execFailure &&
@@ -17853,7 +17867,8 @@ const GRAPH_TOOL_EXECUTORS = {
       !missingNodeTypes.length &&
       !missingNodeCount &&
       !stalePlaceholders.length &&
-      !liveScan?.unavailable?.length;
+      !liveScan?.unavailable?.length &&
+      !liveScanIncomplete;
     return {
       viewing: describeActiveGraph(graph),
       node_count: nodes.length,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -198,7 +198,7 @@ import {
   resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
-import { fetchSingleNodeDef } from "./lib/single-node-def.js";
+import { fetchSingleNodeDef, fetchSingleNodeInfo } from "./lib/single-node-def.js";
 import { withWorkflowUuid } from "./lib/graph-view-identity.js";
 import { saveReplyIdentity, shouldEstablishIdentityAfterSave } from "./lib/save-reply-identity.js";
 import { describeOpenActiveBinding } from "./lib/open-active-binding.js";
@@ -17611,7 +17611,7 @@ const GRAPH_TOOL_EXECUTORS = {
       if (scanBudgetMs > 0) {
         liveScan = await scanComboAvailability(
           nodes,
-          (cls) => fetchSingleNodeDef(cls, (route) => api?.fetchApi?.(route)),
+          (cls) => fetchSingleNodeInfo(cls, (route) => api?.fetchApi?.(route)),
           {
             budgetMs: scanBudgetMs,
             backslashIsSeparator,

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -57,6 +57,19 @@ const FILE_LIKE = /\.[A-Za-z0-9_]{2,12}$/;
 /** Existing production type-scoped object-info reads use this same concurrency. */
 const LIVE_SCAN_BATCH_SIZE = 8;
 
+/** The direct helper is also used by focused callers outside the panel IIFE. */
+function defaultMonotonicNow() {
+  try {
+    if (typeof performance !== "undefined" && typeof performance.now === "function") {
+      const value = performance.now();
+      if (Number.isFinite(value)) return value;
+    }
+  } catch {
+    // Fall through to the legacy runtime clock.
+  }
+  return Date.now();
+}
+
 /** True when the options look like files on disk. An empty list cannot be judged
  *  this way, so the caller supplies the fallback (see `optionsNameFiles`). */
 export function optionsLookLikeFiles(options) {
@@ -272,6 +285,11 @@ function serverConsidersEqual(option, value, backslashIsSeparator = false) {
   return typeof a === "number" && typeof b === "number" && a === b;
 }
 
+/**
+ * `fetchClassInfo` receives `(className, signal)`. Production forwards that signal
+ * to the panel API, so a shared-budget timeout can cancel the underlying fetch;
+ * callers that do not accept the second argument still get the bounded fallback.
+ */
 export async function scanComboAvailability(
   nodes,
   fetchClassInfo,
@@ -279,7 +297,7 @@ export async function scanComboAvailability(
     maxClasses = 80,
     maxAssetProbes = 48,
     budgetMs = 0,
-    now = () => Date.now(),
+    now = defaultMonotonicNow,
     confirmServerAsset = null,
     backslashIsSeparator = false,
   } = {},
@@ -309,6 +327,9 @@ export async function scanComboAvailability(
   const cache = new Map();
   const classLimit = new Set();
   const budgetLimit = new Set();
+  // Every shipped browser has AbortController. If a legacy runtime does not, keep
+  // the fallback serial so one unabortable request cannot leave a whole batch live.
+  const batchSize = typeof AbortController === "function" ? LIVE_SCAN_BATCH_SIZE : 1;
   const entryFromResponse = (className, response) => {
     let branded = false;
     let kind;
@@ -361,14 +382,22 @@ export async function scanComboAvailability(
       return;
     }
     const run = (className) => {
+      const controller = typeof AbortController === "function" ? new AbortController() : null;
       const request = Promise.resolve()
-        .then(() => fetchClassInfo(className))
+        .then(() => fetchClassInfo(className, controller?.signal))
         .then(
           (value) => ({ value, settledAt: now() }),
           () => ({ error: true, settledAt: now() }),
         );
       return Number.isFinite(remaining)
-        ? withTimeout(request, remaining, () => null)
+        ? withTimeout(request, remaining, () => {
+            try {
+              controller?.abort();
+            } catch {
+              // A broken AbortController cannot turn a bounded step into a hang.
+            }
+            return null;
+          })
         : request;
     };
     const results = await Promise.all(batch.map((className) => run(className)));
@@ -385,8 +414,8 @@ export async function scanComboAvailability(
     }
   };
 
-  for (let offset = 0; offset < allowedClasses.length; offset += LIVE_SCAN_BATCH_SIZE) {
-    const batch = allowedClasses.slice(offset, offset + LIVE_SCAN_BATCH_SIZE);
+  for (let offset = 0; offset < allowedClasses.length; offset += batchSize) {
+    const batch = allowedClasses.slice(offset, offset + batchSize);
     if (outOfBudget || !(now() < deadline)) {
       outOfBudget = true;
       for (const className of allowedClasses.slice(offset)) budgetLimit.add(className);

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -43,6 +43,8 @@ import {
   uploadConfigOf,
   uploadInputAccepts,
 } from "./input-asset.js";
+import { withTimeout } from "./bounded-step.js";
+import { SINGLE_NODE_INFO_OUTCOME } from "./single-node-def.js";
 
 /** Inputs whose combo lists name files on disk, rather than modes like
  *  `sampler_name: [euler, …]`. A value outside ANY combo's options is a genuine
@@ -51,6 +53,9 @@ import {
  *  themselves — a filename carries an extension — never from the input name, so a
  *  pack using its own naming is judged on what it actually offers. */
 const FILE_LIKE = /\.[A-Za-z0-9_]{2,12}$/;
+
+/** Existing production type-scoped object-info reads use this same concurrency. */
+const LIVE_SCAN_BATCH_SIZE = 8;
 
 /** True when the options look like files on disk. An empty list cannot be judged
  *  this way, so the caller supplies the fallback (see `optionsNameFiles`). */
@@ -291,40 +296,117 @@ export async function scanComboAvailability(
   // agent with NO error surface at all (#589). That is strictly worse than the
   // omission this scan exists to close, so the scan fails CLOSED: when the budget
   // is gone the remaining classes are UNCHECKED and say so.
-  const deadline = budgetMs > 0 ? now() + budgetMs : Infinity;
+  const startedAt = now();
+  const clockUsable = Number.isFinite(startedAt);
+  const deadline = budgetMs > 0 && clockUsable ? startedAt + budgetMs : Infinity;
+  if (budgetMs > 0 && !clockUsable) outOfBudget = true;
 
   // One fetch per distinct CLASS, not per node — a canvas with thirty
-  // KSamplers must not become thirty requests.
+  // KSamplers must not become thirty requests. The production type-scoped
+  // object-info path already proves that eight concurrent class routes are a
+  // supported shape; use the same bound here, while charging the whole batch
+  // to this scan's one deadline.
   const cache = new Map();
-  const comboMapFor = async (className) => {
+  const classLimit = new Set();
+  const budgetLimit = new Set();
+  const entryFromResponse = (className, response) => {
+    let branded = false;
+    let kind;
+    let body = response;
+    try {
+      branded = response?.[SINGLE_NODE_INFO_OUTCOME] === true;
+      kind = response?.kind;
+      if (branded) body = response.body;
+    } catch {
+      return { reason: "node type could not be looked up (/object_info response was unreadable)" };
+    }
+    if (branded && kind === "unknown") {
+      return { reason: "node type could not be looked up (/object_info call failed)" };
+    }
+    if (branded && kind === "absent") return { reason: "node type not found in /object_info" };
+    const combos = comboInputsOf(body, className);
+    if (combos === null) {
+      return {
+        reason: branded
+          ? "node type could not be looked up (/object_info response was malformed)"
+          : "node type not found in /object_info",
+      };
+    }
+    return { combos, configs: comboConfigsOf(body, className) ?? new Map() };
+  };
+
+  const classNames = new Map();
+  for (let index = 0; index < nodes.length; index += 1) {
+    const node = nodes[index];
+    const className = typeof node?.type === "string" ? node.type : null;
+    if (!className || !Array.isArray(node.widgets)) continue;
+    if (isFrontendVirtualNode(node) || className === "CustomCombo") continue;
+    const priority = (node?.has_errors === true ? 2 : 0) +
+      (node?.constructor?.nodeData?.output_node === true ? 1 : 0);
+    const previous = classNames.get(className);
+    if (!previous || priority > previous.priority) classNames.set(className, { priority, index });
+  }
+  const orderedClasses = [...classNames.entries()]
+    .sort((a, b) => b[1].priority - a[1].priority || a[1].index - b[1].index)
+    .map(([className]) => className);
+  const allowedClasses = orderedClasses.slice(0, Math.max(0, maxClasses));
+  for (const className of orderedClasses.slice(allowedClasses.length)) classLimit.add(className);
+
+  const budgetReason = "not checked: get_errors ran out of its shared server-call budget";
+  const fetchBatch = async (batch) => {
+    const remaining = deadline - now();
+    if (!(remaining > 0)) {
+      outOfBudget = true;
+      for (const className of batch) budgetLimit.add(className);
+      return;
+    }
+    const run = (className) => {
+      const request = Promise.resolve()
+        .then(() => fetchClassInfo(className))
+        .then(
+          (value) => ({ value, settledAt: now() }),
+          () => ({ error: true, settledAt: now() }),
+        );
+      return Number.isFinite(remaining)
+        ? withTimeout(request, remaining, () => null)
+        : request;
+    };
+    const results = await Promise.all(batch.map((className) => run(className)));
+    for (let i = 0; i < batch.length; i += 1) {
+      const result = results[i];
+      if (!result || result.error || !Number.isFinite(result.settledAt) || result.settledAt > deadline) {
+        const overBudget = !result || !Number.isFinite(result?.settledAt) || result.settledAt > deadline;
+        outOfBudget = outOfBudget || overBudget;
+        if (overBudget) budgetLimit.add(batch[i]);
+        else cache.set(batch[i], { reason: "node type could not be looked up (/object_info call failed)" });
+        continue;
+      }
+      cache.set(batch[i], entryFromResponse(batch[i], result.value));
+    }
+  };
+
+  for (let offset = 0; offset < allowedClasses.length; offset += LIVE_SCAN_BATCH_SIZE) {
+    const batch = allowedClasses.slice(offset, offset + LIVE_SCAN_BATCH_SIZE);
+    if (outOfBudget || !(now() < deadline)) {
+      outOfBudget = true;
+      for (const className of allowedClasses.slice(offset)) budgetLimit.add(className);
+      break;
+    }
+    await fetchBatch(batch);
+  }
+
+  const comboMapFor = (className) => {
     if (cache.has(className)) return cache.get(className);
-    // A bound on DISTINCT classes, not nodes. get_errors answers inside the
-    // orchestrator's reply deadline, and an unbounded scan on a pathological
-    // canvas would spend it on lookups. Past the cap every further class is
-    // UNCHECKED and says so — silently skipping them would make a truncated
-    // scan read exactly like a clean one.
-    if (cache.size >= maxClasses) {
+    if (classLimit.has(className)) {
       truncated += 1;
       return { reason: `not checked: this call's ${maxClasses}-node-type lookup cap was reached` };
     }
-    if (now() >= deadline) {
-      outOfBudget = true;
+    if (budgetLimit.has(className) || outOfBudget) {
       truncated += 1;
-      return { reason: "not checked: get_errors ran out of its shared server-call budget" };
+      return { reason: budgetReason };
     }
-    let entry;
-    try {
-      const body = await fetchClassInfo(className);
-      const combos = comboInputsOf(body, className);
-      entry = combos === null
-        ? { reason: "node type not found in /object_info" }
-        : { combos, configs: comboConfigsOf(body, className) ?? new Map() };
-    } catch {
-      // A failed lookup is UNKNOWN, never "no combos".
-      entry = { reason: "node type could not be looked up (/object_info call failed)" };
-    }
-    cache.set(className, entry);
-    return entry;
+    truncated += 1;
+    return { reason: "not checked: get_errors could not schedule this node type lookup" };
   };
 
   // #1357 — an UPLOAD combo is the one option list the server cannot fully

--- a/web/js/lib/single-node-def.js
+++ b/web/js/lib/single-node-def.js
@@ -69,12 +69,13 @@ export function singleDefConfirms(body, classType) {
  */
 export const SINGLE_NODE_INFO_OUTCOME = Symbol.for("comfyui-mcp.singleNodeInfoOutcome");
 
-export async function fetchSingleNodeInfo(classType, fetchApi) {
+export async function fetchSingleNodeInfo(classType, fetchApi, signal) {
   const unknown = () => ({ [SINGLE_NODE_INFO_OUTCOME]: true, kind: "unknown" });
   if (typeof classType !== "string" || classType === "") return unknown();
   if (typeof fetchApi !== "function") return unknown();
   try {
-    const response = await fetchApi(`/object_info/${encodeURIComponent(classType)}`);
+    const route = `/object_info/${encodeURIComponent(classType)}`;
+    const response = signal ? await fetchApi(route, { signal }) : await fetchApi(route);
     if (!response || (typeof response.status === "number" && (response.status < 200 || response.status >= 300))) {
       return unknown();
     }
@@ -104,11 +105,12 @@ export async function fetchSingleNodeInfo(classType, fetchApi) {
  * Ask the backend about ONE node type.
  *
  * @param {string} classType
- * @param {(route: string) => Promise<{ status?: number, json?: () => Promise<unknown> }>} fetchApi
+ * @param {(route: string, options?: { signal?: AbortSignal }) => Promise<{ status?: number, json?: () => Promise<unknown> }>} fetchApi
+ * @param {AbortSignal} [signal]
  * @returns {Promise<object|null>} the defs object when it CONFIRMS the type,
  *   null in every other case — including every kind of doubt.
  */
-export async function fetchSingleNodeDef(classType, fetchApi) {
-  const outcome = await fetchSingleNodeInfo(classType, fetchApi);
+export async function fetchSingleNodeDef(classType, fetchApi, signal) {
+  const outcome = await fetchSingleNodeInfo(classType, fetchApi, signal);
   return outcome.kind === "present" ? outcome.body : null;
 }

--- a/web/js/lib/single-node-def.js
+++ b/web/js/lib/single-node-def.js
@@ -62,6 +62,45 @@ export function singleDefConfirms(body, classType) {
 }
 
 /**
+ * The live error scan needs to distinguish a class the server answered as absent
+ * from a per-class route that did not answer. The add-node fast path deliberately
+ * collapses both to null so it can fall through to its whole-schema authority; the
+ * read path cannot do that because null currently reads as "node type not found".
+ */
+export const SINGLE_NODE_INFO_OUTCOME = Symbol.for("comfyui-mcp.singleNodeInfoOutcome");
+
+export async function fetchSingleNodeInfo(classType, fetchApi) {
+  const unknown = () => ({ [SINGLE_NODE_INFO_OUTCOME]: true, kind: "unknown" });
+  if (typeof classType !== "string" || classType === "") return unknown();
+  if (typeof fetchApi !== "function") return unknown();
+  try {
+    const response = await fetchApi(`/object_info/${encodeURIComponent(classType)}`);
+    if (!response || (typeof response.status === "number" && (response.status < 200 || response.status >= 300))) {
+      return unknown();
+    }
+    const body = typeof response.json === "function" ? await response.json() : null;
+    if (!body || typeof body !== "object" || Array.isArray(body)) return unknown();
+    if (singleDefConfirms(body, classType)) {
+      return { [SINGLE_NODE_INFO_OUTCOME]: true, kind: "present", body };
+    }
+    // ComfyUI's per-class route answers a missing class as an empty 200 object.
+    // A non-empty body naming some other class is a malformed/proxy response, not
+    // evidence about the requested class.
+    let empty = false;
+    try {
+      empty = Object.keys(body).length === 0;
+    } catch {
+      return unknown();
+    }
+    return empty
+      ? { [SINGLE_NODE_INFO_OUTCOME]: true, kind: "absent" }
+      : unknown();
+  } catch {
+    return unknown();
+  }
+}
+
+/**
  * Ask the backend about ONE node type.
  *
  * @param {string} classType
@@ -70,22 +109,6 @@ export function singleDefConfirms(body, classType) {
  *   null in every other case — including every kind of doubt.
  */
 export async function fetchSingleNodeDef(classType, fetchApi) {
-  if (typeof classType !== "string" || classType === "") return null;
-  if (typeof fetchApi !== "function") return null;
-  let body;
-  try {
-    const res = await fetchApi(`/object_info/${encodeURIComponent(classType)}`);
-    // A non-2xx is not evidence of anything about the type — an older build
-    // without this route answers 404, and a proxy sign-in page answers 200 with
-    // HTML. Both must reach the full fetch, not a conclusion.
-    if (!res || (typeof res.status === "number" && (res.status < 200 || res.status >= 300))) {
-      return null;
-    }
-    body = typeof res.json === "function" ? await res.json() : null;
-  } catch {
-    // Network failure, abort, unparseable body. All of them mean "I did not find
-    // out", and this returns the value that says exactly that.
-    return null;
-  }
-  return singleDefConfirms(body, classType) ? body : null;
+  const outcome = await fetchSingleNodeInfo(classType, fetchApi);
+  return outcome.kind === "present" ? outcome.body : null;
 }


### PR DESCRIPTION
Fixes #1691

Summary:
- Batch live /object_info class reads in groups of eight within the existing shared graph_get_errors step budget.
- Prioritize runtime-error and output nodes, and disclose timeouts or uncertain routes as unchecked instead of false missing-type success.
- Fail closed when live scans are incomplete: clean is false and the no-errors note is suppressed.
- Propagate AbortSignal cancellation to timed-out class reads, with a serial legacy fallback when AbortController is unavailable.
- Preserve the existing fetchSingleNodeDef add-node behavior and add production-path regression coverage.

Validation:
- npm.cmd run test:unit (6645 passed, 0 failed, 1 todo)
- Focused regressions (94 passed, 0 failed)
- npm.cmd run typecheck
- npm.cmd run check:scope
- npm.cmd run i18n:check
- i18n render and tool vocabulary checks
- node --check production files
- git diff --check

No merge or release performed.