### PR TITLE
fix(panel): disclose rgthree lora row creation route

### DIFF
--- a/browser_tests/unit/pressable-widget.test.mjs
+++ b/browser_tests/unit/pressable-widget.test.mjs
@@ -114,6 +114,17 @@ test("#757 the hint does not PROMISE that clicking creates the slot", () => {
   assert.doesNotMatch(hint, /will create|creates the widget you asked for/i);
 });
 
+test("#1694 the hint discloses the narrow programmatic rgthree route", () => {
+  const hint = pressableWidgetHint(freshPowerLoraLoader(), "lora_1");
+  assert.match(hint, /do not need the click/i);
+  assert.match(hint, /lora-slot OBJECT rather than a bare filename/i);
+  assert.match(hint, /\{"on": true, "lora": "<file>\.safetensors", "strength": 1\}/);
+
+  const wrongType = pressableWidgetHint({ ...freshPowerLoraLoader(), type: "Other Node" }, "lora_1");
+  assert.doesNotMatch(wrongType, /do not need the click|bare filename/i);
+  assert.doesNotMatch(pressableWidgetHint(freshPowerLoraLoader(), "lora1"), /do not need the click|bare filename/i);
+});
+
 test("#757 it says the missing capability out loud", () => {
   // Otherwise the next reasonable move is to hunt for a press tool that does not
   // exist, which is its own dead end.

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -595,7 +595,12 @@ function powerLoraNode({ separate = false, drawnRows = [] } = {}) {
     id: 153,
     type: POWER_LORA_LOADER_TYPE,
     properties: { "Show Strengths": separate ? "Separate Model & Clip" : "Single Strength" },
-    widgets: [{ name: "divider" }, { name: "PowerLoraLoaderHeaderWidget" }, { name: "divider" }, { name: "➕ Add Lora" }],
+    widgets: [
+      { name: "divider" },
+      { name: "PowerLoraLoaderHeaderWidget" },
+      { name: "divider" },
+      { name: "➕ Add Lora", type: "custom", onMouseClick() {}, mouseClickCallback() {} },
+    ],
     loraWidgetsCounter: 0,
     size: [200, 60],
     computeSize: () => [200, 60 + 20 * node.widgets.filter((w) => /^lora_\d+$/.test(w?.name ?? "")).length],
@@ -624,7 +629,7 @@ const loraOracle = { getFreshObjectInfo: async () => ({ [POWER_LORA_LOADER_TYPE]
  * ChangeTracker captures by serializing the graph, which is what runs each widget's
  * `serializeValue` — so a probe that does not serialize cannot see this class of defect at all.
  */
-async function loraWriteThrough(node, { create }) {
+async function loraWriteThrough(node, { create, value = SLOT_JSON } = {}) {
   let depth = 0;
   const serializeAll = () => {
     for (const w of node.widgets) {
@@ -648,6 +653,7 @@ async function loraWriteThrough(node, { create }) {
     ...(create
       ? {
           prepareWriteTarget: () => {
+            if (!isRgthreeLoraRowCreation(node, "lora_1", value)) return null;
             const made = createRgthreeLoraRow(node, "lora_1", {});
             return { undo: () => made.remove().incomplete };
           },
@@ -655,7 +661,7 @@ async function loraWriteThrough(node, { create }) {
       : {}),
   };
   try {
-    return { ok: true, result: await runSetWidget(node, "lora_1", SLOT_JSON, opts) };
+    return { ok: true, result: await runSetWidget(node, "lora_1", value, opts) };
   } catch (err) {
     return { ok: false, message: err.message };
   }
@@ -689,6 +695,29 @@ test("#757 a Single Strength creation still SUCCEEDS — the originally reported
   const row = node.widgets.find((w) => w.name === "lora_1");
   assert.equal(row.value.lora, "x.safetensors", "and the requested value is on the row");
   assert.equal(row.value.strengthTwo, null, "untouched, because this mode does not use it");
+});
+
+test("#1694 the production write boundary explains the object route without accepting a bare filename", async () => {
+  const node = powerLoraNode({ separate: false });
+  const before = node.widgets.map((w) => w.name);
+
+  const bare = await loraWriteThrough(node, { create: true, value: "some_lora.safetensors" });
+  assert.equal(bare.ok, false, "a bare filename is not a lora-slot value");
+  assert.match(bare.message, /lora-slot OBJECT rather than a bare filename/i);
+  assert.deepEqual(node.widgets.map((w) => w.name), before, "the refused bare filename creates no row");
+  assert.equal(node.loraWidgetsCounter, 0, "the refused bare filename does not spend a row name");
+
+  const created = await loraWriteThrough(node, { create: true, value: SLOT_JSON });
+  assert.equal(created.ok, true, created.message);
+  assert.equal(node.widgets.find((w) => w.name === "lora_1").value.lora, "x.safetensors");
+
+  const existing = await loraWriteThrough(node, {
+    create: true,
+    value: JSON.stringify({ on: true, lora: "replacement.safetensors", strength: 0.75 }),
+  });
+  assert.equal(existing.ok, true, existing.message);
+  assert.equal(node.widgets.find((w) => w.name === "lora_1").value.lora, "replacement.safetensors");
+  assert.equal(node.loraWidgetsCounter, 1, "the existing-row write does not mint another row");
 });
 
 test("#757 the created row is settled to the SAME mode an existing row has", async () => {

--- a/web/js/lib/pressable-widget.js
+++ b/web/js/lib/pressable-widget.js
@@ -59,6 +59,24 @@ export function pressableWidgets(node) {
 }
 
 /**
+ * The extra sentence for the one dynamic row this panel can mint without pressing a control.
+ *
+ * Keep this keyed to the same type/name boundary as the production creation route. The
+ * caller's value is deliberately not inspected here: `slotValue()` remains the single source
+ * of truth for what the route accepts, and a bare filename must continue to refuse.
+ */
+function rgthreeLoraRowCreationHint(node, widgetName) {
+  const type = node?.type ?? node?.comfyClass;
+  if (type !== "Power Lora Loader (rgthree)") return "";
+  if (typeof widgetName !== "string" || !/^lora_\d+$/.test(widgetName)) return "";
+  return (
+    ` For THIS node you do not need the click: pass a lora-slot OBJECT rather than a bare ` +
+    `filename and the row is minted for you — e.g. ` +
+    `{"on": true, "lora": "<file>.safetensors", "strength": 1}.`
+  );
+}
+
+/**
  * The sentence to append to a missing-widget refusal, or "" when there is
  * nothing to add.
  *
@@ -83,6 +101,7 @@ export function pressableWidgetHint(node, widgetName) {
     `${plural ? "one is" : "it is"} clicked (rgthree's Power Lora Loader builds its ` +
     `\`lora_1\`, \`lora_2\`, … rows this way). If "${widgetName}" is a slot of that kind, ask the ` +
     `user to click ${plural ? "the relevant button" : names} in the ComfyUI tab and then set it — ` +
-    `writing an existing slot works normally. There is no tool to press a widget yet.`
+    `writing an existing slot works normally. There is no tool to press a widget yet.` +
+    rgthreeLoraRowCreationHint(node, widgetName)
   );
 }


### PR DESCRIPTION
Fixes #1694. Disclose the existing programmatic rgthree lora_N creation route only for Power Lora Loader (rgthree) lora_N requests, direct callers to the accepted lora-slot object shape without widening bare filename acceptance, and add hint plus real runSetWidget production-boundary regression coverage. Validation: focused 91 passed; full unit 6646 passed, 1 todo, 0 failed; typecheck, scope, syntax, i18n, vocabulary, and diff checks passed.