### PR TITLE
fix: roll back Fast Bypasser linked modes (#2146)

### DIFF
--- a/browser_tests/unit/fast-bypasser-widget-write.test.mjs
+++ b/browser_tests/unit/fast-bypasser-widget-write.test.mjs
@@ -1,7 +1,6 @@
 /**
- * #2146 — Fast Groups Bypasser rows are actions whose callbacks can mutate node modes.
- * The generic widget writer must keep the valid write, but a failed verification must restore
- * the group repeater and every linked input mode without snapshotting unrelated graph state.
+ * #2146 — Fast Groups Bypasser rows are valid actions whose real row action can propagate a
+ * mode through an rgthree repeater. Failed widget verification must restore every mode touched.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -11,16 +10,42 @@ import { applyWidgetWrite, WidgetWriteError } from "../../web/js/lib/widget-writ
 const BYPASSER = "Fast Groups Bypasser (rgthree)";
 const ROW = "RGTHREE_TOGGLE_AND_NAV";
 const REPEATER = "Mute / Bypass Repeater (rgthree)";
+const RELAY = "Mute / Bypass Relay (rgthree)";
 
-function makeFixture(callback) {
-  const loadAudio1 = { id: 11, type: "LoadAudio", mode: 0 };
-  const loadAudio2 = { id: 12, type: "LoadAudio", mode: 2 };
+function defineMode(node, initial, onChange) {
+  let current = initial;
+  Object.defineProperty(node, "mode", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return current;
+    },
+    set(value) {
+      current = value;
+      onChange?.(value);
+    },
+  });
+}
+
+function makeFixture({ forceVerificationFailure = false } = {}) {
+  const loadAudio1 = { id: 11, type: "LoadAudio" };
+  const loadAudio2 = { id: 12, type: "LoadAudio" };
   const repeater = {
     id: 13,
     type: REPEATER,
-    mode: 2,
     inputs: [{ link: 101 }, { link: 102 }],
   };
+
+  defineMode(loadAudio1, 0);
+  defineMode(loadAudio2, 2);
+  defineMode(repeater, 2, (value) => {
+    // This is the repeater's actual mode side effect: changing its mode propagates to each
+    // connected input. The group order intentionally puts a linked node before the repeater,
+    // which exposes restoration strategies that rely on incidental Set iteration order.
+    loadAudio1.mode = value;
+    loadAudio2.mode = value;
+  });
+
   const nodes = new Map([
     [loadAudio1.id, loadAudio1],
     [loadAudio2.id, loadAudio2],
@@ -35,18 +60,29 @@ function makeFixture(callback) {
       return nodes.get(id) ?? null;
     },
   };
-  for (const n of nodes.values()) n.graph = graph;
+  for (const node of nodes.values()) node.graph = graph;
 
   const group = {
     graph,
-    _children: new Set([repeater]),
+    _children: new Set([loadAudio1, repeater, loadAudio2]),
     recomputeInsideNodes() {},
   };
   const row = {
     name: ROW,
     value: { toggled: false },
     group,
-    callback,
+    // This models the real Fast Groups row action: the writer has already assigned the
+    // requested composite value, then the row action applies its group mode change.
+    doModeChange(force) {
+      const newMode = force ? 4 : 2;
+      for (const groupNode of group._children) groupNode.mode = newMode;
+      group.rgthree_hasAnyActiveNode = !!force;
+      this.value = { toggled: !!force };
+    },
+    callback(value) {
+      this.doModeChange(value.toggled);
+      if (forceVerificationFailure) this.value = { toggled: false };
+    },
   };
   const unrelated = { id: 99, type: "KSampler", mode: 0 };
   const bypasser = {
@@ -59,33 +95,27 @@ function makeFixture(callback) {
   return { bypasser, row, repeater, loadAudio1, loadAudio2, unrelated };
 }
 
-test("#2146: a failed Fast Bypasser verification restores the repeater and every linked mode", () => {
-  const fixture = makeFixture(function (value) {
-    // The action callback has already changed all of its reachable modes, but the widget value
-    // itself did not retain the request, forcing the generic verification/refusal path.
-    this.value = { toggled: false };
-    fixture.repeater.mode = value.toggled ? 4 : 0;
-    fixture.loadAudio1.mode = value.toggled ? 4 : 0;
-    fixture.loadAudio2.mode = value.toggled ? 4 : 0;
-  });
+test("#2146: failed real row action restores propagation regardless of group order", () => {
+  const fixture = makeFixture({ forceVerificationFailure: true });
+  let failure;
 
   assert.throws(
-    () => applyWidgetWrite(fixture.bypasser, ROW, { toggled: true }),
-    (error) => error instanceof WidgetWriteError && /did not retain the requested value/.test(error.message),
+    () => applyWidgetWrite(fixture.bypasser, "rgthree_toggle_and_nav.toggled", true),
+    (error) => {
+      failure = error;
+      return error instanceof WidgetWriteError && /did not retain the requested value/.test(error.message);
+    },
   );
+  assert.equal(failure.partialWrite, false);
   assert.equal(fixture.row.value.toggled, false);
-  assert.equal(fixture.repeater.mode, 2, "the group repeater mode is restored");
-  assert.equal(fixture.loadAudio1.mode, 0, "the first linked LoadAudio mode is restored");
-  assert.equal(fixture.loadAudio2.mode, 2, "the second linked LoadAudio mode is restored");
+  assert.equal(fixture.repeater.mode, 2, "the repeater mode is restored");
+  assert.equal(fixture.loadAudio1.mode, 0, "the first linked mode is restored after repeater propagation");
+  assert.equal(fixture.loadAudio2.mode, 2, "the second linked mode is restored after repeater propagation");
   assert.equal(fixture.unrelated.mode, 0, "unrelated graph state is not part of the journal");
 });
 
-test("#2146: a valid Fast Bypasser toggle keeps the action and its linked mode changes", () => {
-  const fixture = makeFixture(function (value) {
-    fixture.repeater.mode = value.toggled ? 4 : 0;
-    fixture.loadAudio1.mode = value.toggled ? 4 : 0;
-    fixture.loadAudio2.mode = value.toggled ? 4 : 0;
-  });
+test("#2146: a valid Fast Bypasser row action keeps the toggle and propagated modes", () => {
+  const fixture = makeFixture();
 
   const result = applyWidgetWrite(fixture.bypasser, ROW, { toggled: true });
 
@@ -94,4 +124,66 @@ test("#2146: a valid Fast Bypasser toggle keeps the action and its linked mode c
   assert.equal(fixture.repeater.mode, 4);
   assert.equal(fixture.loadAudio1.mode, 4);
   assert.equal(fixture.loadAudio2.mode, 4);
+});
+
+test("#2146: a multi-input relay is not treated as an input-less dispatcher", () => {
+  const relayTarget = { id: 21, type: "LoadAudio" };
+  let targetModeReads = 0;
+  defineMode(relayTarget, 0);
+  const relay = {
+    id: 22,
+    type: RELAY,
+    mode: 2,
+    inputs: [{ link: null }, { link: null }],
+    outputs: [{ links: [201] }],
+    isInputConnected(index) {
+      return this.inputs[index]?.link != null;
+    },
+    isAnyOutputConnected() {
+      return true;
+    },
+  };
+  const originalTargetMode = Object.getOwnPropertyDescriptor(relayTarget, "mode");
+  Object.defineProperty(relayTarget, "mode", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      targetModeReads++;
+      return originalTargetMode.get();
+    },
+    set(value) {
+      originalTargetMode.set(value);
+    },
+  });
+  const nodes = new Map([
+    [relay.id, relay],
+    [relayTarget.id, relayTarget],
+  ]);
+  const graph = {
+    links: { 201: { target_id: relayTarget.id } },
+    getNodeById(id) {
+      return nodes.get(id) ?? null;
+    },
+  };
+  relay.graph = graph;
+  relayTarget.graph = graph;
+  const group = { graph, _children: new Set([relay]), recomputeInsideNodes() {} };
+  const row = {
+    name: ROW,
+    value: { toggled: false },
+    group,
+    callback() {
+      this.value = { toggled: false };
+      relay.mode = 4;
+    },
+  };
+  const bypasser = { id: 20, type: BYPASSER, graph, widgets: [row] };
+
+  assert.throws(
+    () => applyWidgetWrite(bypasser, ROW, { toggled: true }),
+    (error) => error instanceof WidgetWriteError && /did not retain the requested value/.test(error.message),
+  );
+  assert.equal(targetModeReads, 0, "a multi-input relay's output is outside the mode journal");
+  assert.equal(relayTarget.mode, 0);
+  assert.equal(relay.mode, 2);
 });

--- a/browser_tests/unit/fast-bypasser-widget-write.test.mjs
+++ b/browser_tests/unit/fast-bypasser-widget-write.test.mjs
@@ -1,6 +1,6 @@
 /**
- * #2146 — Fast Groups Bypasser rows are valid actions whose real row action can propagate a
- * mode through an rgthree repeater. Failed widget verification must restore every mode touched.
+ * #2146 — Fast Groups Bypasser rows are valid actions whose production-shaped widget exposes
+ * toggle()/doModeChange(), not widget.callback. Failed MCP writes must restore every mode touched.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -27,7 +27,13 @@ function defineMode(node, initial, onChange) {
   });
 }
 
-function makeFixture({ forceVerificationFailure = false } = {}) {
+function makeFixture({
+  initialToggled = false,
+  initialModes = [4, 4],
+  repeaterMode = 4,
+  disableModeChange = false,
+  rowName = ROW,
+} = {}) {
   const loadAudio1 = { id: 11, type: "LoadAudio" };
   const loadAudio2 = { id: 12, type: "LoadAudio" };
   const repeater = {
@@ -36,12 +42,11 @@ function makeFixture({ forceVerificationFailure = false } = {}) {
     inputs: [{ link: 101 }, { link: 102 }],
   };
 
-  defineMode(loadAudio1, 0);
-  defineMode(loadAudio2, 2);
-  defineMode(repeater, 2, (value) => {
+  defineMode(loadAudio1, initialModes[0]);
+  defineMode(loadAudio2, initialModes[1]);
+  defineMode(repeater, repeaterMode, (value) => {
     // This is the repeater's actual mode side effect: changing its mode propagates to each
-    // connected input. The group order intentionally puts a linked node before the repeater,
-    // which exposes restoration strategies that rely on incidental Set iteration order.
+    // connected input. The group order intentionally puts a linked node before the repeater.
     loadAudio1.mode = value;
     loadAudio2.mode = value;
   });
@@ -62,65 +67,121 @@ function makeFixture({ forceVerificationFailure = false } = {}) {
   };
   for (const node of nodes.values()) node.graph = graph;
 
+  const bypasser = {
+    id: 10,
+    type: BYPASSER,
+    graph,
+    modeOn: 0,
+    modeOff: 4,
+    properties: {},
+    widgets: [],
+  };
   const group = {
     graph,
     _children: new Set([loadAudio1, repeater, loadAudio2]),
     recomputeInsideNodes() {},
   };
   const row = {
-    name: ROW,
-    value: { toggled: false },
+    name: rowName,
+    value: { toggled: initialToggled },
     group,
-    // This models the real Fast Groups row action: the writer has already assigned the
-    // requested composite value, then the row action applies its group mode change.
-    doModeChange(force) {
-      const newMode = force ? 4 : 2;
-      for (const groupNode of group._children) groupNode.mode = newMode;
-      group.rgthree_hasAnyActiveNode = !!force;
-      this.value = { toggled: !!force };
+    node: bypasser,
+    // These are the production row action methods: mouse handling calls toggle(), which
+    // updates the row value and then invokes doModeChange(). There is intentionally no callback.
+    doModeChange() {
+      if (disableModeChange) return;
+      group.recomputeInsideNodes();
+      const hasAnyActiveNodes = [...group._children].some((node) => node.mode === 0);
+      const newValue = !hasAnyActiveNodes;
+      for (const groupNode of group._children) {
+        groupNode.mode = newValue ? this.node.modeOn : this.node.modeOff;
+      }
+      group.rgthree_hasAnyActiveNode = newValue;
+      this.value = { toggled: newValue };
     },
-    callback(value) {
-      this.doModeChange(value.toggled);
-      if (forceVerificationFailure) this.value = { toggled: false };
+    toggle(value) {
+      value = value == null ? !this.value.toggled : value;
+      if (value !== this.value.toggled) {
+        this.value = { toggled: value };
+        this.doModeChange();
+      }
     },
   };
-  const unrelated = { id: 99, type: "KSampler", mode: 0 };
-  const bypasser = {
-    id: 10,
-    type: BYPASSER,
-    graph,
-    widgets: [row],
-  };
+  bypasser.widgets.push(row);
 
+  const unrelated = { id: 99, type: "KSampler", mode: 0 };
   return { bypasser, row, repeater, loadAudio1, loadAudio2, unrelated };
 }
 
-test("#2146: failed real row action restores propagation regardless of group order", () => {
-  const fixture = makeFixture({ forceVerificationFailure: true });
+test("#2146: a no-callback row action rolls back propagation regardless of group order", () => {
+  const fixture = makeFixture({ initialToggled: true, initialModes: [0, 2], repeaterMode: 0 });
   let failure;
 
+  assert.equal(fixture.row.callback, undefined);
   assert.throws(
-    () => applyWidgetWrite(fixture.bypasser, "rgthree_toggle_and_nav.toggled", true),
+    () =>
+      applyWidgetWrite(fixture.bypasser, "rgthree_toggle_and_nav.toggled", false, {
+        // Force the normal post-action verification failure after the real row action ran.
+        afterChange() {
+          fixture.row.value = { toggled: true };
+        },
+      }),
     (error) => {
       failure = error;
       return error instanceof WidgetWriteError && /did not retain the requested value/.test(error.message);
     },
   );
   assert.equal(failure.partialWrite, false);
-  assert.equal(fixture.row.value.toggled, false);
-  assert.equal(fixture.repeater.mode, 2, "the repeater mode is restored");
-  assert.equal(fixture.loadAudio1.mode, 0, "the first linked mode is restored after repeater propagation");
-  assert.equal(fixture.loadAudio2.mode, 2, "the second linked mode is restored after repeater propagation");
+  assert.deepEqual(fixture.row.value, { toggled: true });
+  assert.equal(fixture.repeater.mode, 0, "the repeater mode is restored");
+  assert.equal(fixture.loadAudio1.mode, 0, "the first linked mode is restored after propagation");
+  assert.equal(fixture.loadAudio2.mode, 2, "the second linked mode is restored after propagation");
   assert.equal(fixture.unrelated.mode, 0, "unrelated graph state is not part of the journal");
 });
 
-test("#2146: a valid Fast Bypasser row action keeps the toggle and propagated modes", () => {
+test("#2146: a no-callback row action performs a valid toggle and propagates its mode", () => {
   const fixture = makeFixture();
 
   const result = applyWidgetWrite(fixture.bypasser, ROW, { toggled: true });
 
+  assert.equal(fixture.row.callback, undefined);
   assert.deepEqual(result.value, { toggled: true });
   assert.deepEqual(fixture.row.value, { toggled: true });
+  assert.equal(fixture.repeater.mode, 0);
+  assert.equal(fixture.loadAudio1.mode, 0);
+  assert.equal(fixture.loadAudio2.mode, 0);
+});
+
+test("#2146: a case-insensitive row lookup still journals the canonical action", () => {
+  const fixture = makeFixture({ initialToggled: true, initialModes: [0, 2], repeaterMode: 0, rowName: ROW.toLowerCase() });
+
+  assert.throws(
+    () =>
+      applyWidgetWrite(fixture.bypasser, ROW.toUpperCase() + ".toggled", false, {
+        afterChange() {
+          fixture.row.value = { toggled: true };
+        },
+      }),
+    (error) => error instanceof WidgetWriteError && /did not retain the requested value/.test(error.message),
+  );
+  assert.equal(fixture.repeater.mode, 0);
+  assert.equal(fixture.loadAudio1.mode, 0);
+  assert.equal(fixture.loadAudio2.mode, 2);
+});
+
+test("#2146: a no-op canonical action cannot report a toggle without a mode change", () => {
+  const fixture = makeFixture({ disableModeChange: true });
+  let failure;
+
+  assert.throws(
+    () => applyWidgetWrite(fixture.bypasser, ROW, { toggled: true }),
+    (error) => {
+      failure = error;
+      return error instanceof WidgetWriteError && /did not change any linked node modes/.test(error.message);
+    },
+  );
+  assert.equal(failure.partialWrite, false);
+  assert.deepEqual(fixture.row.value, { toggled: false });
   assert.equal(fixture.repeater.mode, 4);
   assert.equal(fixture.loadAudio1.mode, 4);
   assert.equal(fixture.loadAudio2.mode, 4);
@@ -168,19 +229,33 @@ test("#2146: a multi-input relay is not treated as an input-less dispatcher", ()
   relay.graph = graph;
   relayTarget.graph = graph;
   const group = { graph, _children: new Set([relay]), recomputeInsideNodes() {} };
+  const bypasser = {
+    id: 20,
+    type: BYPASSER,
+    graph,
+    widgets: [],
+  };
   const row = {
     name: ROW,
     value: { toggled: false },
     group,
-    callback() {
-      this.value = { toggled: false };
+    doModeChange() {
       relay.mode = 4;
     },
+    toggle(value) {
+      this.value = { toggled: value };
+      this.doModeChange();
+    },
   };
-  const bypasser = { id: 20, type: BYPASSER, graph, widgets: [row] };
+  bypasser.widgets.push(row);
 
   assert.throws(
-    () => applyWidgetWrite(bypasser, ROW, { toggled: true }),
+    () =>
+      applyWidgetWrite(bypasser, ROW, { toggled: true }, {
+        afterChange() {
+          row.value = { toggled: false };
+        },
+      }),
     (error) => error instanceof WidgetWriteError && /did not retain the requested value/.test(error.message),
   );
   assert.equal(targetModeReads, 0, "a multi-input relay's output is outside the mode journal");

--- a/browser_tests/unit/fast-bypasser-widget-write.test.mjs
+++ b/browser_tests/unit/fast-bypasser-widget-write.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * #2146 — Fast Groups Bypasser rows are actions whose callbacks can mutate node modes.
+ * The generic widget writer must keep the valid write, but a failed verification must restore
+ * the group repeater and every linked input mode without snapshotting unrelated graph state.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyWidgetWrite, WidgetWriteError } from "../../web/js/lib/widget-write.js";
+
+const BYPASSER = "Fast Groups Bypasser (rgthree)";
+const ROW = "RGTHREE_TOGGLE_AND_NAV";
+const REPEATER = "Mute / Bypass Repeater (rgthree)";
+
+function makeFixture(callback) {
+  const loadAudio1 = { id: 11, type: "LoadAudio", mode: 0 };
+  const loadAudio2 = { id: 12, type: "LoadAudio", mode: 2 };
+  const repeater = {
+    id: 13,
+    type: REPEATER,
+    mode: 2,
+    inputs: [{ link: 101 }, { link: 102 }],
+  };
+  const nodes = new Map([
+    [loadAudio1.id, loadAudio1],
+    [loadAudio2.id, loadAudio2],
+    [repeater.id, repeater],
+  ]);
+  const graph = {
+    links: {
+      101: { origin_id: loadAudio1.id },
+      102: { origin_id: loadAudio2.id },
+    },
+    getNodeById(id) {
+      return nodes.get(id) ?? null;
+    },
+  };
+  for (const n of nodes.values()) n.graph = graph;
+
+  const group = {
+    graph,
+    _children: new Set([repeater]),
+    recomputeInsideNodes() {},
+  };
+  const row = {
+    name: ROW,
+    value: { toggled: false },
+    group,
+    callback,
+  };
+  const unrelated = { id: 99, type: "KSampler", mode: 0 };
+  const bypasser = {
+    id: 10,
+    type: BYPASSER,
+    graph,
+    widgets: [row],
+  };
+
+  return { bypasser, row, repeater, loadAudio1, loadAudio2, unrelated };
+}
+
+test("#2146: a failed Fast Bypasser verification restores the repeater and every linked mode", () => {
+  const fixture = makeFixture(function (value) {
+    // The action callback has already changed all of its reachable modes, but the widget value
+    // itself did not retain the request, forcing the generic verification/refusal path.
+    this.value = { toggled: false };
+    fixture.repeater.mode = value.toggled ? 4 : 0;
+    fixture.loadAudio1.mode = value.toggled ? 4 : 0;
+    fixture.loadAudio2.mode = value.toggled ? 4 : 0;
+  });
+
+  assert.throws(
+    () => applyWidgetWrite(fixture.bypasser, ROW, { toggled: true }),
+    (error) => error instanceof WidgetWriteError && /did not retain the requested value/.test(error.message),
+  );
+  assert.equal(fixture.row.value.toggled, false);
+  assert.equal(fixture.repeater.mode, 2, "the group repeater mode is restored");
+  assert.equal(fixture.loadAudio1.mode, 0, "the first linked LoadAudio mode is restored");
+  assert.equal(fixture.loadAudio2.mode, 2, "the second linked LoadAudio mode is restored");
+  assert.equal(fixture.unrelated.mode, 0, "unrelated graph state is not part of the journal");
+});
+
+test("#2146: a valid Fast Bypasser toggle keeps the action and its linked mode changes", () => {
+  const fixture = makeFixture(function (value) {
+    fixture.repeater.mode = value.toggled ? 4 : 0;
+    fixture.loadAudio1.mode = value.toggled ? 4 : 0;
+    fixture.loadAudio2.mode = value.toggled ? 4 : 0;
+  });
+
+  const result = applyWidgetWrite(fixture.bypasser, ROW, { toggled: true });
+
+  assert.deepEqual(result.value, { toggled: true });
+  assert.deepEqual(fixture.row.value, { toggled: true });
+  assert.equal(fixture.repeater.mode, 4);
+  assert.equal(fixture.loadAudio1.mode, 4);
+  assert.equal(fixture.loadAudio2.mode, 4);
+});

--- a/browser_tests/unit/fast-bypasser-widget-write.test.mjs
+++ b/browser_tests/unit/fast-bypasser-widget-write.test.mjs
@@ -97,12 +97,12 @@ function makeFixture({
         groupNode.mode = newValue ? this.node.modeOn : this.node.modeOff;
       }
       group.rgthree_hasAnyActiveNode = newValue;
-      this.value = { toggled: newValue };
+      this.value.toggled = newValue;
     },
     toggle(value) {
       value = value == null ? !this.value.toggled : value;
       if (value !== this.value.toggled) {
-        this.value = { toggled: value };
+        this.value.toggled = value;
         this.doModeChange();
       }
     },
@@ -115,6 +115,8 @@ function makeFixture({
 
 test("#2146: a no-callback row action rolls back propagation regardless of group order", () => {
   const fixture = makeFixture({ initialToggled: true, initialModes: [0, 2], repeaterMode: 0 });
+  fixture.row.value.label = "production-row";
+  let afterChangeCalls = 0;
   let failure;
 
   assert.equal(fixture.row.callback, undefined);
@@ -123,7 +125,7 @@ test("#2146: a no-callback row action rolls back propagation regardless of group
       applyWidgetWrite(fixture.bypasser, "rgthree_toggle_and_nav.toggled", false, {
         // Force the normal post-action verification failure after the real row action ran.
         afterChange() {
-          fixture.row.value = { toggled: true };
+          if (afterChangeCalls++ === 0) fixture.row.value = { toggled: true };
         },
       }),
     (error) => {
@@ -132,7 +134,7 @@ test("#2146: a no-callback row action rolls back propagation regardless of group
     },
   );
   assert.equal(failure.partialWrite, false);
-  assert.deepEqual(fixture.row.value, { toggled: true });
+  assert.deepEqual(fixture.row.value, { toggled: true, label: "production-row" });
   assert.equal(fixture.repeater.mode, 0, "the repeater mode is restored");
   assert.equal(fixture.loadAudio1.mode, 0, "the first linked mode is restored after propagation");
   assert.equal(fixture.loadAudio2.mode, 2, "the second linked mode is restored after propagation");

--- a/browser_tests/unit/rgthree-fast-groups.test.mjs
+++ b/browser_tests/unit/rgthree-fast-groups.test.mjs
@@ -1,5 +1,5 @@
 /**
- * #983 — a write to rgthree's Fast Groups toggle row is refused, because it cannot land.
+ * #983 — a write to rgthree's Fast Groups Muter toggle row is refused, because it cannot land.
  *
  * Established from the pack's own source (rgthree-comfy `src_web/comfyui/`), not from the
  * report: `BaseFastGroupsModeChanger` declares `serialize_widgets = false` (so the value never
@@ -19,20 +19,24 @@ import {
 const BYPASSER = "Fast Groups Bypasser (rgthree)";
 const MUTER = "Fast Groups Muter (rgthree)";
 
-test("#983: the reported write is classified derived", () => {
+test("#983: the Fast Groups Muter write is classified derived", () => {
   // The exact address from the report, including the composite sub-field.
   assert.equal(
-    classifyRgthreeFastGroupsWrite({ type: BYPASSER }, "RGTHREE_TOGGLE_AND_NAV.toggled"),
+    classifyRgthreeFastGroupsWrite({ type: MUTER }, "RGTHREE_TOGGLE_AND_NAV.toggled"),
     "derived",
   );
   // And the bare widget name, which addresses the same widget.
-  assert.equal(classifyRgthreeFastGroupsWrite({ type: BYPASSER }, RGTHREE_TOGGLE_WIDGET), "derived");
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: MUTER }, RGTHREE_TOGGLE_WIDGET), "derived");
 });
 
-test("#983: the Muter is covered too — it is the same base class", () => {
-  // FastGroupsBypasser extends BaseFastGroupsModeChanger, which is where serialize_widgets =
-  // false and the refresh-overwrite live, so both node types have the identical problem.
-  assert.equal(classifyRgthreeFastGroupsWrite({ type: MUTER }, "RGTHREE_TOGGLE_AND_NAV.toggled"), "derived");
+test("#2146: a Fast Groups Bypasser row remains a writable action control", () => {
+  // Bypasser callbacks change linked node modes. They are transactional at the widget-write
+  // boundary, so this existing refusal must not broaden to them.
+  assert.equal(
+    classifyRgthreeFastGroupsWrite({ type: BYPASSER }, "RGTHREE_TOGGLE_AND_NAV.toggled"),
+    null,
+  );
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: BYPASSER }, RGTHREE_TOGGLE_WIDGET), null);
 });
 
 test("#983: ANOTHER widget on the same node is NOT refused", () => {

--- a/browser_tests/unit/rgthree-fast-groups.test.mjs
+++ b/browser_tests/unit/rgthree-fast-groups.test.mjs
@@ -29,6 +29,17 @@ test("#983: the Fast Groups Muter write is classified derived", () => {
   assert.equal(classifyRgthreeFastGroupsWrite({ type: MUTER }, RGTHREE_TOGGLE_WIDGET), "derived");
 });
 
+test("#983: the Muter refusal survives case-insensitive widget resolution", () => {
+  assert.equal(
+    classifyRgthreeFastGroupsWrite({ type: MUTER }, "rgthree_toggle_and_nav.toggled"),
+    "derived",
+  );
+  assert.equal(
+    classifyRgthreeFastGroupsWrite({ type: BYPASSER }, "rgthree_toggle_and_nav.toggled"),
+    null,
+  );
+});
+
 test("#2146: a Fast Groups Bypasser row remains a writable action control", () => {
   // Bypasser callbacks change linked node modes. They are transactional at the widget-write
   // boundary, so this existing refusal must not broaden to them.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15145,13 +15145,11 @@ const GRAPH_TOOL_EXECUTORS = {
         setDirty: () => graph.setDirtyCanvas(true, true),
       });
     }
-    // #983: rgthree's Fast Groups Muter/Bypasser toggle rows are DERIVED READOUTS of whether
-    // the matched group has an active node — the node re-reads each one from the group on
-    // every refresh and declares `serialize_widgets = false`, so a write is reverted and
-    // never reaches the workflow. The reported shape was a clean success followed immediately
-    // by the old value. Refused loudly, keyed to BOTH the node type and the widget name so
-    // nothing else on those nodes is affected. See the lib for the three source facts and for
-    // why this refuses rather than driving the node's own toggle().
+    // #983: rgthree's Fast Groups Muter toggle rows are DERIVED READOUTS of whether the matched
+    // group has an active node — the node re-reads each one from the group on every refresh and
+    // declares `serialize_widgets = false`, so a write is reverted and never reaches the
+    // workflow. Fast Groups Bypasser rows are action controls; their callback-driven mode
+    // mutation is kept on the normal transactional widget-write path (#2146).
     if (classifyRgthreeFastGroupsWrite(node, widget) === "derived") {
       throw new Error(rgthreeFastGroupsRefusal(widget, node.id, node.type));
     }

--- a/web/js/lib/rgthree-fast-groups.js
+++ b/web/js/lib/rgthree-fast-groups.js
@@ -54,10 +54,11 @@
 
 /** The rgthree node types whose toggle rows are derived readouts. `addRgthree()` in the pack's
  *  constants.ts appends " (rgthree)" to every name, which is what reaches `node.type`. */
-const FAST_GROUPS_TYPES = new Set(["Fast Groups Muter (rgthree)"]);
+const FAST_GROUPS_TYPES = new Set(["Fast Groups Muter (rgthree)".toLowerCase()]);
 
 /** The widget name the pack gives every toggle row. */
 export const RGTHREE_TOGGLE_WIDGET = "RGTHREE_TOGGLE_AND_NAV";
+const NORMALIZED_RGTHREE_TOGGLE_WIDGET = RGTHREE_TOGGLE_WIDGET.toLowerCase();
 
 /** The base widget name a request addresses, with any composite sub-field removed:
  *  `"RGTHREE_TOGGLE_AND_NAV.toggled"` and `"RGTHREE_TOGGLE_AND_NAV"` both name the same widget. */
@@ -81,8 +82,8 @@ function baseWidgetName(widgetName) {
  */
 export function classifyRgthreeFastGroupsWrite(node, widgetName) {
   const type = node && typeof node === "object" ? node.type : undefined;
-  if (typeof type !== "string" || !FAST_GROUPS_TYPES.has(type)) return null;
-  return baseWidgetName(widgetName) === RGTHREE_TOGGLE_WIDGET ? "derived" : null;
+  if (typeof type !== "string" || !FAST_GROUPS_TYPES.has(type.toLowerCase())) return null;
+  return baseWidgetName(widgetName).toLowerCase() === NORMALIZED_RGTHREE_TOGGLE_WIDGET ? "derived" : null;
 }
 
 /**

--- a/web/js/lib/rgthree-fast-groups.js
+++ b/web/js/lib/rgthree-fast-groups.js
@@ -1,16 +1,18 @@
-// #983 — rgthree's Fast Groups Muter/Bypasser toggle is DERIVED, and a widget write to it
-// cannot take effect. Refused loudly rather than reported as a success that silently reverts.
+// #983 — rgthree's Fast Groups Muter toggle is DERIVED, and a widget write to it cannot take
+// effect. Refused loudly rather than reported as a success that silently reverts.
 //
-// The reported shape: `panel_set_widget` on `RGTHREE_TOGGLE_AND_NAV.toggled = false` returned
-// a clean success showing `{"toggled": false}`, and the very next `panel_query_graph` showed
-// `{"toggled": true}` again, with the target node still active.
+// The original reported shape: `panel_set_widget` on `RGTHREE_TOGGLE_AND_NAV.toggled = false`
+// returned a clean success showing `{"toggled": false}`, and the very next `panel_query_graph`
+// showed `{"toggled": true}` again, with the target node still active.
 //
 // THREE FACTS FROM THE PACK'S OWN SOURCE (rgthree-comfy `src_web/comfyui/`), any one of which
-// is enough on its own — this is not inferred from the report:
+// is enough on its own — this is not inferred from the report. They apply to the Fast Groups
+// Muter. Fast Groups Bypasser rows are action controls and stay on the normal transactional
+// write path; widget-write.js owns rollback for the mode changes their callbacks can cause.
 //
 //  1. `BaseFastGroupsModeChanger` sets `override serialize_widgets = false`
-//     (fast_groups_muter.ts). Both Muter and Bypasser extend it, so these nodes NEVER
-//     serialize widget values into the workflow. A write cannot persist even in principle.
+//     (fast_groups_muter.ts). The Fast Groups Muter never serializes widget values into the
+//     workflow. A write cannot persist even in principle.
 //
 //  2. The node's own refresh loop OVERWRITES the value from the live graph:
 //
@@ -52,7 +54,7 @@
 
 /** The rgthree node types whose toggle rows are derived readouts. `addRgthree()` in the pack's
  *  constants.ts appends " (rgthree)" to every name, which is what reaches `node.type`. */
-const FAST_GROUPS_TYPES = new Set(["Fast Groups Muter (rgthree)", "Fast Groups Bypasser (rgthree)"]);
+const FAST_GROUPS_TYPES = new Set(["Fast Groups Muter (rgthree)"]);
 
 /** The widget name the pack gives every toggle row. */
 export const RGTHREE_TOGGLE_WIDGET = "RGTHREE_TOGGLE_AND_NAV";

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1948,6 +1948,11 @@ export function applyWidgetWrite(
   const objectWrite = coerced !== null && typeof coerced === "object";
   const expected = objectWrite ? JSON.parse(JSON.stringify(coerced)) : coerced;
 
+  // #2146 — the live Fast Bypasser row's supported action mutates `value.toggled` in place.
+  // Resolve it before taking the prior-value snapshot so rollback can isolate the complete
+  // row object from that mutation without changing generic widget-write identity semantics.
+  const fastBypasserAction = resolveFastBypasserAction(targetNode, w, coerced, w.value);
+
   const matchesExpected = (actual) =>
     objectWrite
       ? actual !== null &&
@@ -1966,13 +1971,17 @@ export function applyWidgetWrite(
   // outer rail, not the (potentially divergent) inner widget's prior value (#583).
   // Keep the latter separately for diagnostics; it is not the API-level
   // `previous` for a promoted request.
-  const previous = w.value;
   const previousParent = parentWidget ? parentWidget.value : undefined;
   const deepClone = (v) => (v !== null && typeof v === "object" ? JSON.parse(JSON.stringify(v)) : v);
   const structurallyEqual = (a, b) =>
     (a !== null && typeof a === "object") || (b !== null && typeof b === "object")
       ? JSON.stringify(a) === JSON.stringify(b)
       : Object.is(a, b);
+  // #2146 — toggle(value) mutates the live row's value object in place. Keep a complete
+  // structural snapshot for this action path so `w.value = previous` cannot reattach the
+  // already-mutated object and leave a false partial-write result. Generic widgets retain
+  // their historical prior-reference behavior; only this known action shape needs isolation.
+  const previous = fastBypasserAction ? deepClone(w.value) : w.value;
   const previousClone = deepClone(previous);
   const previousParentClone = parentWidget ? deepClone(previousParent) : undefined;
   // #477: prior values (+ deep clones) of the secondary display proxies, so rollback
@@ -2066,10 +2075,8 @@ export function applyWidgetWrite(
   // allowing it to mutate linked modes that this writer cannot restore.
   const fastBypasserModes = captureFastBypasserModeTransaction(targetNode, w);
   // #2146 — Fast Bypasser rows do not expose a widget.callback. Their supported UI action is
-  // the row's own toggle(value), which assigns the row value and invokes doModeChange().
+  // the row's own toggle(value), which mutates the row value and invokes doModeChange().
   // Bridge that canonical action instead of assigning the value and falsely reporting success.
-  const fastBypasserAction = resolveFastBypasserAction(targetNode, w, coerced, previous);
-
   // The undo hooks are BOOKKEEPING (litegraph history). Invoke them exception-SAFE
   // so a throwing hook can never bypass our verification/rollback and leave a silent
   // partial write; a stateful hook that mutates values is still caught because ALL

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -379,6 +379,228 @@ function resolveWidgetByName(node, widgetName) {
   return matches[0] ?? null;
 }
 
+// #2146 — Fast Groups Bypasser rows are action controls. Their callback can set the mode of
+// every node in the selected group, and rgthree's Mute / Bypass Repeater can continue that
+// change through linked inputs. The ordinary widget rollback knows only about widget/property
+// projections, so keep a deliberately small mode journal for this one runtime shape.
+const FAST_GROUPS_BYPASSER_TYPE = "Fast Groups Bypasser (rgthree)";
+const FAST_GROUPS_TOGGLE_WIDGET = "RGTHREE_TOGGLE_AND_NAV";
+const NODE_MODE_REPEATER_TYPE = "Mute / Bypass Repeater (rgthree)";
+const NODE_MODE_RELAY_TYPE = "Mute / Bypass Relay (rgthree)";
+
+function runtimeNodeType(node) {
+  try {
+    if (typeof node?.type === "string") return node.type;
+    if (typeof node?.constructor?.type === "string") return node.constructor.type;
+  } catch {
+    // An unreadable third-party node is handled by the fail-closed transaction capture below.
+  }
+  return "";
+}
+
+function widgetBaseName(widgetName) {
+  if (typeof widgetName !== "string") return "";
+  const dot = widgetName.indexOf(".");
+  return dot === -1 ? widgetName : widgetName.slice(0, dot);
+}
+
+function isModePassThrough(node) {
+  const type = runtimeNodeType(node);
+  return type.includes("Reroute") || type.includes("Node Combiner") || type.includes("Node Collector");
+}
+
+function modeTransactionFailure(node, detail) {
+  return new WidgetWriteError(
+    `Cannot set widget on node ${node?.id} (${node?.type}): cannot establish the Fast Groups ` +
+      `Bypasser mode rollback boundary (${detail}); refusing before the callback can mutate ` +
+      `linked node modes (#2146).`,
+  );
+}
+
+/**
+ * Capture only the mode targets a Fast Groups Bypasser row can reach:
+ *   - members of each Fast Bypasser group row on this node;
+ *   - descendants of those members in a subgraph;
+ *   - non-pass-through inputs of rgthree repeaters; and
+ *   - non-pass-through outputs of input-less rgthree relays.
+ *
+ * This intentionally does not walk or snapshot the graph generally. The returned journal is
+ * used only after a write has already failed verification/refused after dispatch.
+ */
+function captureFastBypasserModeTransaction(node, widgetName, writtenWidget) {
+  if (
+    runtimeNodeType(node) !== FAST_GROUPS_BYPASSER_TYPE ||
+    widgetBaseName(widgetName) !== FAST_GROUPS_TOGGLE_WIDGET
+  ) {
+    return null;
+  }
+
+  const rows = [
+    writtenWidget,
+    ...(Array.isArray(node?.widgets) ? node.widgets : []),
+  ].filter((candidate, index, all) => {
+    if (!candidate || widgetBaseName(candidate.name) !== FAST_GROUPS_TOGGLE_WIDGET) return false;
+    return all.indexOf(candidate) === index;
+  });
+  const groups = [];
+  for (const row of rows) {
+    let group;
+    try {
+      group = row.group;
+    } catch {
+      throw modeTransactionFailure(node, "a toggle row's group is unreadable");
+    }
+    if (!group || (typeof group !== "object" && typeof group !== "function")) {
+      throw modeTransactionFailure(node, "a toggle row has no live group");
+    }
+    if (!groups.includes(group)) groups.push(group);
+  }
+  if (!groups.length) throw modeTransactionFailure(node, "no live toggle-row group was found");
+
+  const entries = [];
+  const seenNodes = new Set();
+  const propagationQueue = [];
+
+  const addNodeTree = (candidate) => {
+    if (!candidate || typeof candidate !== "object" || seenNodes.has(candidate)) return;
+    const type = runtimeNodeType(candidate);
+    let mode;
+    try {
+      mode = candidate.mode;
+    } catch {
+      throw modeTransactionFailure(node, `node ${candidate.id ?? "?"}'s mode is unreadable`);
+    }
+    seenNodes.add(candidate);
+    entries.push({ node: candidate, previous: mode });
+    if (type === NODE_MODE_REPEATER_TYPE || type === NODE_MODE_RELAY_TYPE) {
+      propagationQueue.push(candidate);
+    }
+
+    let subgraph = null;
+    try {
+      const isSubgraph =
+        typeof candidate.isSubgraphNode === "function"
+          ? candidate.isSubgraphNode()
+          : !!candidate.subgraph;
+      subgraph = isSubgraph ? candidate.subgraph : null;
+    } catch {
+      throw modeTransactionFailure(node, `node ${candidate.id ?? "?"}'s subgraph is unreadable`);
+    }
+    if (subgraph != null) {
+      if (!Array.isArray(subgraph.nodes)) {
+        throw modeTransactionFailure(node, `node ${candidate.id ?? "?"}'s subgraph nodes are unreadable`);
+      }
+      for (const child of subgraph.nodes) addNodeTree(child);
+    }
+  };
+
+  const graphFor = (candidate, group) => candidate?.graph ?? group?.graph ?? node?.graph;
+  const connectedRoots = (start, direction, group, skipRelays) => {
+    const queue = [start];
+    const walked = new Set();
+    while (queue.length) {
+      const current = queue.shift();
+      if (!current || walked.has(current)) continue;
+      walked.add(current);
+      const graph = graphFor(current, group);
+      const slots = direction === "input" ? current.inputs : current.outputs;
+      if (!graph || !Array.isArray(slots)) continue;
+      for (const slot of slots) {
+        let linkId;
+        try {
+          linkId = direction === "input" ? slot?.link : null;
+          if (direction === "output") {
+            for (const outputLinkId of Array.isArray(slot?.links) ? slot.links : []) {
+              const link = graph.links?.[outputLinkId];
+              const connected = graph.getNodeById?.(link?.target_id);
+              if (!connected) continue;
+              if (isModePassThrough(connected)) queue.push(connected);
+              else addNodeTree(connected);
+            }
+            continue;
+          }
+        } catch {
+          throw modeTransactionFailure(node, "a linked mode path is unreadable");
+        }
+        if (linkId == null) continue;
+        let link;
+        let connected;
+        try {
+          link = graph.links?.[linkId];
+          connected = graph.getNodeById?.(link?.origin_id);
+        } catch {
+          throw modeTransactionFailure(node, "a linked mode path is unreadable");
+        }
+        if (!connected) continue;
+        if (skipRelays && runtimeNodeType(connected) === NODE_MODE_RELAY_TYPE) continue;
+        if (isModePassThrough(connected)) queue.push(connected);
+        else addNodeTree(connected);
+      }
+    }
+  };
+
+  for (const group of groups) {
+    let members;
+    try {
+      group.recomputeInsideNodes?.();
+      members = group._children;
+    } catch {
+      throw modeTransactionFailure(node, "a toggle-row group is unreadable");
+    }
+    if (members == null) throw modeTransactionFailure(node, "a toggle-row group has no members");
+    let groupNodes;
+    try {
+      groupNodes = Array.from(members);
+    } catch {
+      throw modeTransactionFailure(node, "a toggle-row group member list is unreadable");
+    }
+    for (const groupNode of groupNodes) addNodeTree(groupNode);
+  }
+
+  while (propagationQueue.length) {
+    const current = propagationQueue.shift();
+    const type = runtimeNodeType(current);
+    if (type === NODE_MODE_REPEATER_TYPE) {
+      const group = groups.find((candidate) => candidate?.graph === current?.graph) ?? groups[0];
+      connectedRoots(current, "input", group, true);
+    } else if (type === NODE_MODE_RELAY_TYPE) {
+      let hasInput = false;
+      try {
+        hasInput = Array.isArray(current.inputs) && current.inputs.some((input) => input?.link != null);
+      } catch {
+        throw modeTransactionFailure(node, `relay ${current.id ?? "?"}'s inputs are unreadable`);
+      }
+      if (!hasInput) {
+        const group = groups.find((candidate) => candidate?.graph === current?.graph) ?? groups[0];
+        connectedRoots(current, "output", group, false);
+      }
+    }
+  }
+
+  return {
+    restore() {
+      for (const entry of entries) {
+        try {
+          if (!Object.is(entry.node.mode, entry.previous)) entry.node.mode = entry.previous;
+        } catch {
+          // Read-back below turns this into an honest partial-state error.
+        }
+      }
+    },
+    unrestored() {
+      const failed = [];
+      for (const entry of entries) {
+        try {
+          if (!Object.is(entry.node.mode, entry.previous)) failed.push(entry);
+        } catch {
+          failed.push(entry);
+        }
+      }
+      return failed;
+    },
+  };
+}
+
 // DECLARED field schema for known composite widgets. Types are enforced from THIS
 // schema, never inferred from the current value — a field whose current value is `null`
 // still enforces the correct type, so a scalar of the wrong type (e.g. a number into a
@@ -1717,6 +1939,11 @@ export function applyWidgetWrite(
   // to the other mid-write, which would otherwise slip past the identity compare.
   const prevOuterWidgetsIdentityStable = prevOuterWidgetsRef ? widgetsListHasStableIdentity(node) : false;
 
+  // #2146 — capture the narrow Fast Bypasser mode boundary before the undo envelope opens.
+  // If the live row shape cannot be bounded, refuse before assigning the widget value rather
+  // than allowing a callback to mutate linked modes that this writer cannot restore.
+  const fastBypasserModes = captureFastBypasserModeTransaction(node, widgetName, w);
+
   // The undo hooks are BOOKKEEPING (litegraph history). Invoke them exception-SAFE
   // so a throwing hook can never bypass our verification/rollback and leave a silent
   // partial write; a stateful hook that mutates values is still caught because ALL
@@ -2263,6 +2490,10 @@ export function applyWidgetWrite(
           /* restore best-effort; read-back below is authoritative */
         }
       }
+      // #2146 — restore the Fast Bypasser's group/repeater mode journal inside the same
+      // rollback envelope. Repeater setters may themselves propagate to linked nodes, so the
+      // journal restores the roots first and then verifies every captured primitive mode below.
+      fastBypasserModes?.restore();
     } finally {
       safeAfter();
     }
@@ -2297,6 +2528,11 @@ export function applyWidgetWrite(
         const label = `display "${displayWidgets[i].name}"`;
         rollbackFailed = rollbackFailed ? `${rollbackFailed} and ${label}` : label;
       }
+    }
+    const unrestoredFastModes = fastBypasserModes?.unrestored() ?? [];
+    if (unrestoredFastModes.length) {
+      const label = `Fast Bypasser linked node modes (${unrestoredFastModes.length} node(s))`;
+      rollbackFailed = rollbackFailed ? `${rollbackFailed} and ${label}` : label;
     }
     // The serialization binding must be back to its original store key, else queue
     // compilation still reads whatever entry a callback re-pointed it to.

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -423,21 +423,18 @@ function modeTransactionFailure(node, detail) {
 
 function relayDispatchesMode(node, owner) {
   try {
-    const inputs = Array.isArray(node.inputs) ? node.inputs : [];
+    const inputs = node.inputs;
+    if (!Array.isArray(inputs)) {
+      throw modeTransactionFailure(owner, `relay ${node?.id ?? "?"}'s inputs are unreadable`);
+    }
     // rgthree's NodeModeRelay dispatches only when it has at most one input slot,
     // input 0 is unconnected, and an output is connected. A multi-input relay with
     // empty slots is not an input-less dispatcher.
     if (inputs.length > 1) return false;
-    const inputConnected =
-      typeof node.isInputConnected === "function"
-        ? node.isInputConnected(0)
-        : inputs[0]?.link != null;
-    const outputConnected =
-      typeof node.isAnyOutputConnected === "function"
-        ? node.isAnyOutputConnected()
-        : Array.isArray(node.outputs) &&
-          node.outputs.some((output) => Array.isArray(output?.links) && output.links.length > 0);
-    return !inputConnected && outputConnected;
+    if (typeof node.isInputConnected !== "function" || typeof node.isAnyOutputConnected !== "function") {
+      throw modeTransactionFailure(owner, `relay ${node?.id ?? "?"}'s runtime connection contract is unreadable`);
+    }
+    return !node.isInputConnected(0) && node.isAnyOutputConnected();
   } catch {
     throw modeTransactionFailure(owner, `relay ${node?.id ?? "?"}'s connection state is unreadable`);
   }
@@ -451,7 +448,7 @@ function relayDispatchesMode(node, owner) {
  *   - non-pass-through outputs of input-less rgthree relays.
  *
  * This intentionally does not walk or snapshot the graph generally. The returned journal is
- * used only after a write has already failed verification/refused after dispatch.
+ * used to verify the canonical action changed a reachable mode and to roll it back on failure.
  */
 function captureFastBypasserModeTransaction(node, writtenWidget) {
   if (
@@ -465,7 +462,9 @@ function captureFastBypasserModeTransaction(node, writtenWidget) {
     writtenWidget,
     ...(Array.isArray(node?.widgets) ? node.widgets : []),
   ].filter((candidate, index, all) => {
-    if (!candidate || widgetBaseName(candidate.name) !== FAST_GROUPS_TOGGLE_WIDGET) return false;
+    if (!candidate || normalizedWidgetBaseName(candidate.name) !== FAST_GROUPS_TOGGLE_WIDGET.toLowerCase()) {
+      return false;
+    }
     return all.indexOf(candidate) === index;
   });
   const groups = [];
@@ -649,6 +648,17 @@ function captureFastBypasserModeTransaction(node, writtenWidget) {
   };
 
   return {
+    changed() {
+      let unreadable = false;
+      for (const entry of entries) {
+        try {
+          if (!Object.is(entry.node.mode, entry.previous)) return true;
+        } catch {
+          unreadable = true;
+        }
+      }
+      return unreadable ? null : false;
+    },
     restore() {
       const restoreEntry = (entry) => {
         try {
@@ -677,6 +687,39 @@ function captureFastBypasserModeTransaction(node, writtenWidget) {
       }
       return failed;
     },
+  };
+}
+
+function resolveFastBypasserAction(node, widget, coerced, previous) {
+  if (
+    runtimeNodeType(node) !== FAST_GROUPS_BYPASSER_TYPE ||
+    normalizedWidgetBaseName(widget?.name) !== FAST_GROUPS_TOGGLE_WIDGET.toLowerCase()
+  ) {
+    return null;
+  }
+  if (
+    coerced === null ||
+    typeof coerced !== "object" ||
+    Array.isArray(coerced) ||
+    typeof coerced.toggled !== "boolean"
+  ) {
+    throw modeTransactionFailure(node, "the toggle action value is unreadable");
+  }
+  let toggle;
+  let doModeChange;
+  try {
+    toggle = widget.toggle;
+    doModeChange = widget.doModeChange;
+  } catch {
+    throw modeTransactionFailure(node, "the toggle action is unreadable");
+  }
+  if (typeof toggle !== "function" || typeof doModeChange !== "function") {
+    throw modeTransactionFailure(node, "the live row has no canonical toggle action");
+  }
+  return {
+    toggle,
+    requested: coerced.toggled,
+    requiresModeChange: previous?.toggled !== coerced.toggled,
   };
 }
 
@@ -2019,9 +2062,13 @@ export function applyWidgetWrite(
   const prevOuterWidgetsIdentityStable = prevOuterWidgetsRef ? widgetsListHasStableIdentity(node) : false;
 
   // #2146 — capture the narrow Fast Bypasser mode boundary before the undo envelope opens.
-  // If the live row shape cannot be bounded, refuse before assigning the widget value rather
-  // than allowing a callback to mutate linked modes that this writer cannot restore.
+  // If the live row shape cannot be bounded, refuse before invoking the action rather than
+  // allowing it to mutate linked modes that this writer cannot restore.
   const fastBypasserModes = captureFastBypasserModeTransaction(targetNode, w);
+  // #2146 — Fast Bypasser rows do not expose a widget.callback. Their supported UI action is
+  // the row's own toggle(value), which assigns the row value and invokes doModeChange().
+  // Bridge that canonical action instead of assigning the value and falsely reporting success.
+  const fastBypasserAction = resolveFastBypasserAction(targetNode, w, coerced, previous);
 
   // The undo hooks are BOOKKEEPING (litegraph history). Invoke them exception-SAFE
   // so a throwing hook can never bypass our verification/rollback and leave a silent
@@ -2082,7 +2129,13 @@ export function applyWidgetWrite(
     // the rail's — otherwise a forwarding view would double-invoke the side effect.
     // The rail's value serializes directly from `parentWidget.value`, which we set
     // here, so it needs no callback of its own.
-    if (!instanceScoped) w.value = coerced;
+    if (!instanceScoped) {
+      if (fastBypasserAction) {
+        Reflect.apply(fastBypasserAction.toggle, valueWidget, [fastBypasserAction.requested]);
+      } else {
+        w.value = coerced;
+      }
+    }
     if (parentWidget) parentWidget.value = coerced;
     // #477: sync the parent-facing DISPLAY proxies too. They are VIEWS of the same
     // promoted value (no semantic callback of their own — the inner target's fires
@@ -2144,12 +2197,14 @@ export function applyWidgetWrite(
     // non-callable callback still throws a TypeError exactly as before, and it takes
     // the argument list without spreading — no `Symbol.iterator` to poison either.
     // `reflectApply` is captured at module load for the same reason.
-    widgetCallback = valueWidget.callback;
-    if (widgetCallback !== null && widgetCallback !== undefined) {
-      const callbackArgs = [coerced, canvas, valueNode, valueNode.pos, undefined];
-      threwFromCallback = true;
-      reflectApply(widgetCallback, valueWidget, callbackArgs);
-      threwFromCallback = false; // reached only when it RETURNED — a throw leaves it set
+    if (!fastBypasserAction) {
+      widgetCallback = valueWidget.callback;
+      if (widgetCallback !== null && widgetCallback !== undefined) {
+        const callbackArgs = [coerced, canvas, valueNode, valueNode.pos, undefined];
+        threwFromCallback = true;
+        reflectApply(widgetCallback, valueWidget, callbackArgs);
+        threwFromCallback = false; // reached only when it RETURNED — a throw leaves it set
+      }
     }
     // #1533 — AFTER the callback, still inside this envelope so afterChange
     // captures the restored number. A VHSINT missing-step snap stores NaN (and a
@@ -2359,6 +2414,21 @@ export function applyWidgetWrite(
           recheckThrew ? "; re-resolving the promotion threw" : ""
         }), so the rail that was synced is no longer the value that serializes at queue time. Rolled ` +
         `back to avoid a silently-stale render (#366).`;
+    }
+  }
+
+  // #2146 — a canonical Fast Bypasser action is not a successful widget write unless the
+  // action actually changed a reachable linked mode when the requested toggle changed. This
+  // catches the old false success path where only the composite row value was assigned.
+  if (!failure && fastBypasserAction?.requiresModeChange) {
+    const modeChanged = fastBypasserModes?.changed();
+    if (modeChanged !== true) {
+      failure =
+        modeChanged === null
+          ? `Fast Bypasser row action changed the toggle, but its linked node modes could not be ` +
+            `verified.`
+          : `Fast Bypasser row action did not change any linked node modes; refusing to report ` +
+            `the toggle as applied.`;
     }
   }
 

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -404,6 +404,10 @@ function widgetBaseName(widgetName) {
   return dot === -1 ? widgetName : widgetName.slice(0, dot);
 }
 
+function normalizedWidgetBaseName(widgetName) {
+  return widgetBaseName(widgetName).toLowerCase();
+}
+
 function isModePassThrough(node) {
   const type = runtimeNodeType(node);
   return type.includes("Reroute") || type.includes("Node Combiner") || type.includes("Node Collector");
@@ -417,6 +421,28 @@ function modeTransactionFailure(node, detail) {
   );
 }
 
+function relayDispatchesMode(node, owner) {
+  try {
+    const inputs = Array.isArray(node.inputs) ? node.inputs : [];
+    // rgthree's NodeModeRelay dispatches only when it has at most one input slot,
+    // input 0 is unconnected, and an output is connected. A multi-input relay with
+    // empty slots is not an input-less dispatcher.
+    if (inputs.length > 1) return false;
+    const inputConnected =
+      typeof node.isInputConnected === "function"
+        ? node.isInputConnected(0)
+        : inputs[0]?.link != null;
+    const outputConnected =
+      typeof node.isAnyOutputConnected === "function"
+        ? node.isAnyOutputConnected()
+        : Array.isArray(node.outputs) &&
+          node.outputs.some((output) => Array.isArray(output?.links) && output.links.length > 0);
+    return !inputConnected && outputConnected;
+  } catch {
+    throw modeTransactionFailure(owner, `relay ${node?.id ?? "?"}'s connection state is unreadable`);
+  }
+}
+
 /**
  * Capture only the mode targets a Fast Groups Bypasser row can reach:
  *   - members of each Fast Bypasser group row on this node;
@@ -427,10 +453,10 @@ function modeTransactionFailure(node, detail) {
  * This intentionally does not walk or snapshot the graph generally. The returned journal is
  * used only after a write has already failed verification/refused after dispatch.
  */
-function captureFastBypasserModeTransaction(node, widgetName, writtenWidget) {
+function captureFastBypasserModeTransaction(node, writtenWidget) {
   if (
     runtimeNodeType(node) !== FAST_GROUPS_BYPASSER_TYPE ||
-    widgetBaseName(widgetName) !== FAST_GROUPS_TOGGLE_WIDGET
+    normalizedWidgetBaseName(writtenWidget?.name) !== FAST_GROUPS_TOGGLE_WIDGET.toLowerCase()
   ) {
     return null;
   }
@@ -459,7 +485,9 @@ function captureFastBypasserModeTransaction(node, widgetName, writtenWidget) {
 
   const entries = [];
   const seenNodes = new Set();
+  const entriesByNode = new Map();
   const propagationQueue = [];
+  const propagationEdges = new Map();
 
   const addNodeTree = (candidate) => {
     if (!candidate || typeof candidate !== "object" || seenNodes.has(candidate)) return;
@@ -471,8 +499,13 @@ function captureFastBypasserModeTransaction(node, widgetName, writtenWidget) {
       throw modeTransactionFailure(node, `node ${candidate.id ?? "?"}'s mode is unreadable`);
     }
     seenNodes.add(candidate);
-    entries.push({ node: candidate, previous: mode });
-    if (type === NODE_MODE_REPEATER_TYPE || type === NODE_MODE_RELAY_TYPE) {
+    const propagates =
+      type === NODE_MODE_REPEATER_TYPE ||
+      (type === NODE_MODE_RELAY_TYPE && relayDispatchesMode(candidate, node));
+    const entry = { node: candidate, previous: mode, propagates };
+    entries.push(entry);
+    entriesByNode.set(candidate, entry);
+    if (propagates) {
       propagationQueue.push(candidate);
     }
 
@@ -494,12 +527,24 @@ function captureFastBypasserModeTransaction(node, widgetName, writtenWidget) {
     }
   };
 
+  const recordPropagationEdge = (source, target) => {
+    const sourceEntry = entriesByNode.get(source);
+    const targetEntry = entriesByNode.get(target);
+    if (!sourceEntry?.propagates || !targetEntry?.propagates || source === target) return;
+    let targets = propagationEdges.get(source);
+    if (!targets) {
+      targets = new Set();
+      propagationEdges.set(source, targets);
+    }
+    targets.add(target);
+  };
+
   const graphFor = (candidate, group) => candidate?.graph ?? group?.graph ?? node?.graph;
   const connectedRoots = (start, direction, group, skipRelays) => {
-    const queue = [start];
+    const queue = [{ node: start, source: start }];
     const walked = new Set();
     while (queue.length) {
-      const current = queue.shift();
+      const { node: current, source } = queue.shift();
       if (!current || walked.has(current)) continue;
       walked.add(current);
       const graph = graphFor(current, group);
@@ -514,8 +559,11 @@ function captureFastBypasserModeTransaction(node, widgetName, writtenWidget) {
               const link = graph.links?.[outputLinkId];
               const connected = graph.getNodeById?.(link?.target_id);
               if (!connected) continue;
-              if (isModePassThrough(connected)) queue.push(connected);
-              else addNodeTree(connected);
+              if (isModePassThrough(connected)) queue.push({ node: connected, source });
+              else {
+                addNodeTree(connected);
+                recordPropagationEdge(source, connected);
+              }
             }
             continue;
           }
@@ -533,8 +581,11 @@ function captureFastBypasserModeTransaction(node, widgetName, writtenWidget) {
         }
         if (!connected) continue;
         if (skipRelays && runtimeNodeType(connected) === NODE_MODE_RELAY_TYPE) continue;
-        if (isModePassThrough(connected)) queue.push(connected);
-        else addNodeTree(connected);
+        if (isModePassThrough(connected)) queue.push({ node: connected, source });
+        else {
+          addNodeTree(connected);
+          recordPropagationEdge(source, connected);
+        }
       }
     }
   };
@@ -564,27 +615,55 @@ function captureFastBypasserModeTransaction(node, widgetName, writtenWidget) {
       const group = groups.find((candidate) => candidate?.graph === current?.graph) ?? groups[0];
       connectedRoots(current, "input", group, true);
     } else if (type === NODE_MODE_RELAY_TYPE) {
-      let hasInput = false;
-      try {
-        hasInput = Array.isArray(current.inputs) && current.inputs.some((input) => input?.link != null);
-      } catch {
-        throw modeTransactionFailure(node, `relay ${current.id ?? "?"}'s inputs are unreadable`);
-      }
-      if (!hasInput) {
+      if (entriesByNode.get(current)?.propagates) {
         const group = groups.find((candidate) => candidate?.graph === current?.graph) ?? groups[0];
         connectedRoots(current, "output", group, false);
       }
     }
   }
 
+  const propagationRestoreOrder = () => {
+    const propagating = entries.filter((entry) => entry.propagates);
+    const indegree = new Map(propagating.map((entry) => [entry.node, 0]));
+    for (const [source, targets] of propagationEdges) {
+      if (!indegree.has(source)) continue;
+      for (const target of targets) {
+        if (indegree.has(target)) indegree.set(target, indegree.get(target) + 1);
+      }
+    }
+    const ready = propagating.filter((entry) => indegree.get(entry.node) === 0);
+    const ordered = [];
+    while (ready.length) {
+      const entry = ready.shift();
+      ordered.push(entry);
+      for (const target of propagationEdges.get(entry.node) ?? []) {
+        if (!indegree.has(target)) continue;
+        const next = indegree.get(target) - 1;
+        indegree.set(target, next);
+        if (next === 0) ready.push(entriesByNode.get(target));
+      }
+    }
+    // A cyclic mode graph cannot be topologically ordered; keep the captured order and
+    // let the authoritative read-back report any irreconcilable mode conflict honestly.
+    return ordered.length === propagating.length ? ordered : propagating;
+  };
+
   return {
     restore() {
-      for (const entry of entries) {
+      const restoreEntry = (entry) => {
         try {
           if (!Object.is(entry.node.mode, entry.previous)) entry.node.mode = entry.previous;
         } catch {
           // Read-back below turns this into an honest partial-state error.
         }
+      };
+      // Restore mode-propagating roots in upstream-to-downstream order, then restore every
+      // ordinary node after the last propagation. This handles a group whose iteration order
+      // places a linked node before its repeater: the repeater may overwrite it during restore,
+      // so linked nodes must be the final writes.
+      for (const entry of propagationRestoreOrder()) restoreEntry(entry);
+      for (const entry of entries) {
+        if (!entry.propagates) restoreEntry(entry);
       }
     },
     unrestored() {
@@ -1942,7 +2021,7 @@ export function applyWidgetWrite(
   // #2146 — capture the narrow Fast Bypasser mode boundary before the undo envelope opens.
   // If the live row shape cannot be bounded, refuse before assigning the widget value rather
   // than allowing a callback to mutate linked modes that this writer cannot restore.
-  const fastBypasserModes = captureFastBypasserModeTransaction(node, widgetName, w);
+  const fastBypasserModes = captureFastBypasserModeTransaction(targetNode, w);
 
   // The undo hooks are BOOKKEEPING (litegraph history). Invoke them exception-SAFE
   // so a throwing hook can never bypass our verification/rollback and leave a silent


### PR DESCRIPTION
## Summary
- keep the existing Fast Groups refusal scoped to Muter rows
- preserve valid Fast Groups Bypasser actions while journaling only reachable group, repeater, relay, and subgraph node modes
- restore the narrow mode journal on callback, verification, or rollback failure
- add forced-failure and successful-toggle regressions

Refs artokun/comfyui-mcp#2146

## Verification
- npm.cmd run test:unit
- npm.cmd run typecheck
- node --check on changed JavaScript modules
- git diff --cached --check
