### PR TITLE
fix(1696): identify remote combo refusal provenance

### DIFF
--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -42,7 +42,10 @@ import { runSetWidget } from "../../web/js/lib/set-widget.js";
 // The PRODUCTION combo refresh + the authoritative "server says this combo is empty"
 // oracle that gates #507's last-resort acceptance.
 import { refreshComboOptionsFromDefs } from "../../web/js/lib/asset-staleness.js";
-import { serverDeclaresEmptyComboOptions } from "../../web/js/lib/input-asset.js";
+import {
+  serverDeclaresEmptyComboOptions,
+  serverDeclaresRemoteComboOptions,
+} from "../../web/js/lib/input-asset.js";
 // #1223 — the REAL snapshot, so the #1126 fallback is driven against the DETACHED name-only
 // map production actually hands back, never a hand-rolled full schema.
 import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
@@ -1726,6 +1729,23 @@ function starObjectInfo(serverOptions = []) {
   info["StarOllamaPromptHelper"] = { input: { required: { model: [serverOptions, {}] } } };
   return info;
 }
+function remoteComboFixture(liveOptions = []) {
+  const reg = loadedRegistry(["LTXVAudioVAELoader"]);
+  const widget = { name: "ckpt_name", type: "combo", options: { values: liveOptions }, value: "" };
+  const node = { id: 1696, type: "LTXVAudioVAELoader", widgets: [widget], constructor: reg["LTXVAudioVAELoader"] };
+  return { reg, node, widget };
+}
+function remoteComboObjectInfo() {
+  const info = objectInfo();
+  info["LTXVAudioVAELoader"] = {
+    input: {
+      required: {
+        ckpt_name: ["COMBO", { remote: { route: "/internal/files/checkpoints" } }],
+      },
+    },
+  };
+  return info;
+}
 // The PRODUCTION combo refresh (the same function the panel injects as refreshCombos),
 // so these tests inherit its real semantics — notably that it deliberately NEVER clobbers
 // a dynamic (function) option source. A hand-rolled stand-in that overwrote functions
@@ -1850,6 +1870,43 @@ test("#507 SEVERE: a DYNAMIC (function) source returning [] while the SERVER pub
   ).then(() => {
     assert.equal(widget.value, "", "must not have mutated — the server list is real");
   });
+});
+
+test("#1696 e2e: a remote combo refusal names unavailable provenance, not an empty list", async () => {
+  const { reg, node, widget } = remoteComboFixture([]);
+  const remote = remoteComboObjectInfo();
+  assert.equal(
+    serverDeclaresRemoteComboOptions(remote, "LTXVAudioVAELoader", "ckpt_name"),
+    true,
+    "the fixture must identify the separate remote option source",
+  );
+  assert.equal(
+    serverDeclaresEmptyComboOptions(remote, "LTXVAudioVAELoader", "ckpt_name"),
+    false,
+    "a remote source is not a server-declared empty list",
+  );
+
+  await assert.rejects(
+    runSetWidget(node, "ckpt_name", "ltx-video.safetensors", {
+      registry: reg,
+      getRegistry: () => reg,
+      getFreshObjectInfo: async () => remote,
+      wasTypeEverDefined: () => true,
+      refreshCombos: refreshFromServer,
+      ...HOOKS,
+    }),
+    (err) => {
+      assert.match(err.message, /combo_source=remote/);
+      assert.match(err.message, /option_list=unavailable/);
+      assert.match(err.message, /verdict=unknown/);
+      assert.match(err.message, /requested value was not validated/);
+      assert.match(err.message, /NOTHING WAS WRITTEN/);
+      assert.doesNotMatch(err.message, /EMPTY option list/i);
+      assert.doesNotMatch(err.message, /may simply be stale|refreshing it before deciding/i);
+      return true;
+    },
+  );
+  assert.equal(widget.value, "", "the remote/unreadable path remains fail-closed");
 });
 
 test("#507: a dynamic source returning [] AND a server-declared empty list DOES write", () => {

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -274,6 +274,25 @@ export function serverDeclaresEmptyComboOptions(defsByType, type, widgetName) {
 }
 
 /**
+ * TRUE when /object_info identifies a V2 COMBO whose options arrive from a separate remote
+ * source. That source is not an empty option list: the panel cannot know its valid values until
+ * the remote fetch lands, so this must never authorize #507's blind write.
+ */
+export function serverDeclaresRemoteComboOptions(defsByType, type, widgetName) {
+  try {
+    if (!defsByType || !type || !widgetName) return false;
+    const input = defsByType[type]?.input;
+    if (!input) return false;
+    const spec =
+      (input.required && input.required[widgetName]) ??
+      (input.optional && input.optional[widgetName]);
+    return Array.isArray(spec) && spec[0] === "COMBO" && !!spec[1]?.remote;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True when `value`'s file extension is a plausibly-LOADABLE asset for the upload
  * `config`'s kind (image/video/audio/model). This is the strictness gate on top of a
  * mere server-existence probe (#240): `/view?type=input` confirms the file is on disk

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -46,6 +46,7 @@ import {
   uploadInputAccepts,
   addComboOption,
   serverDeclaresEmptyComboOptions,
+  serverDeclaresRemoteComboOptions,
 } from "./input-asset.js";
 
 /**
@@ -1494,6 +1495,29 @@ export async function runSetWidget(
             `read, or set a value the server's list contains.`,
         );
       }
+    }
+
+    // #1696 — a live remote combo can expose no local values while /object_info correctly says
+    // that its source is a separate fetch. The generic `latest.message` below was written for
+    // a stale local empty list and therefore tells the caller to refresh the same thing again,
+    // while also claiming a fact the remote schema never established. Preserve the refusal, but
+    // report the source and uncertainty that actually blocked validation.
+    if (
+      latest?.emptyOptions &&
+      serverDeclaresRemoteComboOptions(
+        freshDefs ?? undefined,
+        authTarget?.type,
+        concreteWidgetName ?? writeTargetWidgetName ?? widgetName,
+      )
+    ) {
+      throw new Error(
+        `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type})` +
+          `${typeof refreshCombos === "function" ? " after refreshing combo options" : ""}: ` +
+          `[combo_source=remote; option_list=unavailable; verdict=unknown] The server schema ` +
+          `exposes a REMOTE option source for this input, so the valid option set is not ` +
+          `currently enumerable by the panel. The requested value was not validated. ` +
+          `NOTHING WAS WRITTEN. Make the remote model list available and retry.`,
+      );
     }
 
     // No recovery succeeded — refuse honestly with the freshest rejection. The rejection's


### PR DESCRIPTION
Closes #1696.

## Summary
- classify a V2 remote combo source separately from a server-declared empty option list
- keep the remote/unavailable combo write fail-closed, but report combo_source=remote and erdict=unknown after the refresh ladder
- add a production-path regression through unSetWidget for LTXVAudioVAELoader.ckpt_name

## Validation
- 
ode --test --test-name-pattern "#1696" browser_tests/unit/node-resolve.test.mjs
- relevant combo/set-widget tests: 566 passed, 0 failed
- 
pm.cmd run test:unit: 6,659 passed, 0 failed, 1 existing todo
- 
pm.cmd run check:scope
- 
pm.cmd run typecheck

No MCP coordination is needed: this is confined to the Panel refusal/provenance path. No merge or release performed.