### PR TITLE
fix(panel): reuse verified node schema after object_info timeout

### DIFF
--- a/browser_tests/unit/_graph-get-errors-harness.mjs
+++ b/browser_tests/unit/_graph-get-errors-harness.mjs
@@ -1,0 +1,164 @@
+// Production-path harness for graph_get_errors. Kept outside a *.test.mjs module so other
+// production-path regressions can drive the shipped executor without importing and running
+// this file's unrelated test cases.
+import { PANEL_SRC } from "./_panel-constants.mjs";
+import { findNodeByScopedId, findVisibleNodeByScopedId } from "../../web/js/lib/asset-staleness.js";
+import { applyRuntimeExecFailure, boundExecFailurePayload } from "../../web/js/lib/exec-error-bounds.js";
+import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
+import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
+
+function extractExecutorMethod(source, signature) {
+  const start = source.indexOf(signature);
+  if (start === -1) throw new Error(`${signature} not found in panel source`);
+  const open = source.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "/" && source[i + 1] === "/") {
+      i = source.indexOf("\n", i + 2);
+      continue;
+    }
+    if (ch === "/" && source[i + 1] === "*") {
+      i = source.indexOf("*/", i + 2) + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < source.length; i += 1) {
+        if (source[i] === "\\") i += 1;
+        else if (source[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`unterminated ${signature}`);
+}
+
+const GRAPH_GET_ERRORS_SOURCE = extractExecutorMethod(PANEL_SRC, "  async graph_get_errors() {");
+const GRAPH_GET_ERRORS_DEPS = [
+  "monotonicNow",
+  "getErrorsStepBudgetMs",
+  "hasRawMissingAssetCandidates",
+  "GET_ERRORS_REFRESH_CAP_MS",
+  "refreshMissingAssetTrust",
+  "refreshComfyNodeDefs",
+  "withRefreshTimeout",
+  "getRefreshInFlight",
+  "nodeDefRefreshInFlight",
+  "getGraphCtx",
+  "objectInfoCache",
+  "objectInfoSnapshot",
+  "verifiedNodeDefCache",
+  "assertGraphBoundToActiveWorkflow",
+  "graphCommandBindingBar",
+  "collectMissingAssets",
+  "activeWorkflowRef",
+  "GET_ERRORS_STEP_CAP_MS",
+  "filterServerConfirmedInputSubfolderMedia",
+  "inputAssetServerUsesWindowsPaths",
+  "scanComboAvailability",
+  "fetchSingleNodeInfo",
+  "probeInputAssetPresence",
+  "graphReadBindingChanged",
+  "collectAllGraphs",
+  "adjudicateRecordedMissingNodeTypes",
+  "isRegisteredNodeType",
+  "LiteGraph",
+  "findVisibleNodeByScopedId",
+  "findNodeByScopedId",
+  "getPiniaStore",
+  "combineNodeErrorMaps",
+  "coerceMessageText",
+  "lastExecFailure",
+  "applyRuntimeExecFailure",
+  "collectUnexplainedRedOutlines",
+  "summarizeNode",
+  "tr",
+  "describeActiveGraph",
+  "MAX_STATE_NODES",
+  "fixedCapNote",
+  "missingAssetScanMayBeStale",
+  "missingAssetScopeNote",
+  "comboAvailabilityNote",
+  "uncheckedNodesNote",
+  "stalePlaceholderNote",
+  "boundExecFailurePayload",
+  "collectMissingNodeTypeReasons",
+];
+
+const makeGraphGetErrors = new Function(
+  ...GRAPH_GET_ERRORS_DEPS,
+  `return ({ ${GRAPH_GET_ERRORS_SOURCE} }).graph_get_errors;`,
+);
+
+export async function runProductionGraphGetErrors({
+  graph,
+  rootGraph,
+  lastExecFailure,
+  scan = async () => null,
+  fetchSingleNodeInfo = () => {},
+  // The extracted executor's default scan is a no-op test double. Give it a
+  // usable budget so callers that are not exercising live-scan exhaustion retain
+  // their clean-note assertions.
+  stepBudget = () => 1000,
+  monotonicNow = () => 0,
+  objectInfoCache = createObjectInfoCache(),
+  objectInfoSnapshot = createObjectInfoSnapshot(),
+  verifiedNodeDefCache = createVerifiedNodeDefCache(),
+}) {
+  const deps = {
+    monotonicNow,
+    getErrorsStepBudgetMs: stepBudget,
+    hasRawMissingAssetCandidates: () => false,
+    GET_ERRORS_REFRESH_CAP_MS: 18000,
+    refreshMissingAssetTrust: async () => false,
+    refreshComfyNodeDefs: () => {},
+    withRefreshTimeout: () => {},
+    getRefreshInFlight: () => null,
+    nodeDefRefreshInFlight: null,
+    getGraphCtx: () => ({ app: { lastNodeErrors: null }, graph, rootGraph }),
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache,
+    assertGraphBoundToActiveWorkflow: () => {},
+    graphCommandBindingBar: () => ({}),
+    collectMissingAssets: () => ({ models: [], media: [], nodeTypes: [], nodeCount: 0 }),
+    activeWorkflowRef: () => null,
+    GET_ERRORS_STEP_CAP_MS: 4000,
+    filterServerConfirmedInputSubfolderMedia: async (media) => media,
+    inputAssetServerUsesWindowsPaths: async () => false,
+    scanComboAvailability: scan,
+    fetchSingleNodeInfo,
+    probeInputAssetPresence: () => {},
+    graphReadBindingChanged: () => false,
+    collectAllGraphs: (value) => [value],
+    adjudicateRecordedMissingNodeTypes: (types) => ({ stillMissing: types, stalePlaceholders: [] }),
+    isRegisteredNodeType: () => false,
+    LiteGraph: {},
+    findVisibleNodeByScopedId,
+    findNodeByScopedId,
+    getPiniaStore: () => null,
+    combineNodeErrorMaps: () => null,
+    coerceMessageText: (value) => String(value ?? ""),
+    lastExecFailure,
+    applyRuntimeExecFailure,
+    collectUnexplainedRedOutlines: () => [],
+    summarizeNode: (node) => ({ id: node.id, type: node.type }),
+    tr: (_key, fallback) => fallback,
+    describeActiveGraph: () => ({ scope: "root" }),
+    MAX_STATE_NODES: 50,
+    fixedCapNote: () => "cap",
+    missingAssetScanMayBeStale: () => false,
+    missingAssetScopeNote: () => "stale",
+    comboAvailabilityNote: () => "combo",
+    uncheckedNodesNote: () => "unchecked",
+    stalePlaceholderNote: () => "placeholder",
+    boundExecFailurePayload,
+    collectMissingNodeTypeReasons: () => [],
+  };
+  const executor = makeGraphGetErrors(...GRAPH_GET_ERRORS_DEPS.map((name) => deps[name]));
+  return executor();
+}

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -21,6 +21,8 @@ import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { OBJECT_INFO_DEADLINE_MS } from "../../web/js/lib/object-info-oracle.js";
 import { COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
+import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
 
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -219,6 +221,9 @@ export function addNodeCommandBudgetDeps() {
     ADD_NODE_POST_REFRESH_RESERVE_MS: CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS,
     OBJECT_INFO_SEED_WAIT_MS,
     REFRESH_JOIN_ABANDONED,
+    fetchSingleNodeInfo,
+    // #1709 — each extracted graph_add_node harness gets its own verified-schema session.
+    verifiedNodeDefCache: createVerifiedNodeDefCache(),
     widenSocketProofBudget,
     // A STUB, and labelled as one. These three harnesses are about #821/#1223/#620, none of
     // which reaches this branch. The shipped wording is pinned in single-node-def.test.mjs
@@ -256,5 +261,7 @@ export function setWidgetCommandBudgetDeps() {
     OBJECT_INFO_DEADLINE_MS,
     REFRESH_JOIN_ABANDONED,
     COMBO_REFRESH_NEVER_RAN,
+    // #1709 — a live whole-schema widget read retires this shared add-node proof.
+    verifiedNodeDefCache: createVerifiedNodeDefCache(),
   };
 }

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -21,6 +21,7 @@ import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { OBJECT_INFO_DEADLINE_MS } from "../../web/js/lib/object-info-oracle.js";
 import { COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
+import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
 
@@ -223,6 +224,7 @@ export function addNodeCommandBudgetDeps() {
     REFRESH_JOIN_ABANDONED,
     fetchSingleNodeInfo,
     // #1709 — each extracted graph_add_node harness gets its own verified-schema session.
+    objectInfoCache: createObjectInfoCache(),
     verifiedNodeDefCache: createVerifiedNodeDefCache(),
     widenSocketProofBudget,
     // A STUB, and labelled as one. These three harnesses are about #821/#1223/#620, none of

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -37,7 +37,11 @@ import {
   isRegisteredNodeType,
 } from "../../web/js/lib/node-resolve.js";
 import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
-import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
+import {
+  fetchWholeObjectInfo,
+  objectInfoOracleFailureNote,
+  TRANSPORT_OUTCOME,
+} from "../../web/js/lib/object-info-oracle.js";
 import {
   describeUnmaterializedRequiredWidgets,
   snapshotBackendDef,
@@ -304,6 +308,8 @@ function realGraphAddNode({
     inFlightStarted,
     verifiedNodeDefCache: deps.verifiedNodeDefCache,
     verifiedSchemaContext: context,
+    objectInfoCache: deps.objectInfoCache,
+    objectInfoSnapshot: deps.objectInfoSnapshot,
   };
 }
 
@@ -698,6 +704,49 @@ test("#1709: a direct schema response crossing refresh cannot authorize a later 
     ["/object_info/ExistingNode", "/object_info/ExistingNode", "/object_info"],
     "the stale direct response was discarded and the add reached the timeout fallback",
   );
+});
+
+test("#1709: graph_add_node replaces the old whole cache and snapshot on a changed response", async () => {
+  const comfy = makeComfy();
+  const oldDefs = { OldNode: { input: { required: {} } } };
+  const changedDefs = { NewNode: { input: { required: {} } } };
+  const objectInfoCache = createObjectInfoCache();
+  const objectInfoSnapshot = createObjectInfoSnapshot();
+  await objectInfoCache.read(async () => oldDefs);
+  assert.equal(
+    objectInfoSnapshot.record(oldDefs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
+    true,
+    "the production precondition starts with an older whole authority",
+  );
+
+  const built = realGraphAddNode({
+    comfy,
+    getNodeDefs: async () => changedDefs,
+    overrides: {
+      objectInfoCache,
+      objectInfoSnapshot,
+    },
+  });
+  const result = await built.graph_add_node({ class_type: "NewNode" });
+  assert.equal(result.added.type, "NewNode", "the changed whole response still permits its current class");
+  assert.deepEqual(
+    await objectInfoCache.read(async () => ({ Unexpected: {} })),
+    changedDefs,
+    "the later burst reader cannot see the old whole map",
+  );
+  const fallback = objectInfoSnapshot.authorize({
+    epoch: 0,
+    outcomes: [{ kind: TRANSPORT_OUTCOME.NO_ANSWER }],
+  });
+  assert.ok(fallback.defs, "the changed response remains available as current snapshot authority");
+  assert.equal(Object.prototype.hasOwnProperty.call(fallback.defs, "OldNode"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(fallback.defs, "NewNode"), true);
 });
 
 test("#1709: a same-epoch refresh fences graph_add_node's late whole-schema snapshot write", async () => {

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -239,6 +239,7 @@ function realGraphAddNode({
     recordObjectInfoTypes: (defs) => defs,
     objectInfoHistory: { wasTypeEverDefined: () => false },
     objectInfoSnapshot: { record: () => true, clear: () => {} },
+    objectInfoCache: createObjectInfoCache(),
     verifiedNodeDefCache: createVerifiedNodeDefCache(),
     backendReconnectEpoch: 0,
     readPackImportFailures: async () => [],

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -36,7 +36,8 @@ import {
   assertAddNodeResolvableRefreshing,
   isRegisteredNodeType,
 } from "../../web/js/lib/node-resolve.js";
-import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
+import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
+import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
 import {
   describeUnmaterializedRequiredWidgets,
   snapshotBackendDef,
@@ -50,6 +51,9 @@ import {
 } from "./_panel-constants.mjs";
 import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
 import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
+import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
+import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -58,6 +62,11 @@ const addNodeMatch = panelSrc.match(
   /\n {2}async graph_add_node\(\{ class_type, pos, title \}\) \{[\s\S]*?\n {2}\},/,
 );
 assert.ok(addNodeMatch, "could not locate graph_add_node in panel source");
+
+const graphGetMatch = panelSrc.match(
+  /\n  async graph_get_object_info\(\{ if_none_match \} = \{\}\) \{[\s\S]*?\n  \},/,
+);
+assert.ok(graphGetMatch, "could not locate graph_get_object_info in panel source");
 
 const awaitWidgetsMatch = panelSrc.match(
   /\nasync function awaitRequiredCustomWidgetRegistration\([\s\S]*?\n\}/,
@@ -173,6 +182,9 @@ function realGraphAddNode({
   // is the older reconnect that did NOT see NewNode, so this add's own run is what
   // registers it.
   inFlightDefs = undefined,
+  // Hook the refresh boundary used by the production coalescer. Tests use it to model the
+  // same-epoch refresh invalidation that happens before the payload is registered.
+  onRunRegister = null,
   budgetMs = 400,
   reserveMs = 120,
   registrationMs = 200,
@@ -208,6 +220,7 @@ function realGraphAddNode({
       // #1351 — this add's own registration, after any join. Distinct from holdInFlight:
       // that is someone else's run, this is ours.
       if (defs != null && ownRunMs > 0) await sleep(ownRunMs);
+      onRunRegister?.(defs);
       app.registerNodesFromDefs(defs ?? inFlightDefs ?? (await api.getNodeDefs()));
       return true;
     },
@@ -226,6 +239,7 @@ function realGraphAddNode({
     recordObjectInfoTypes: (defs) => defs,
     objectInfoHistory: { wasTypeEverDefined: () => false },
     objectInfoSnapshot: { record: () => true, clear: () => {} },
+    verifiedNodeDefCache: createVerifiedNodeDefCache(),
     backendReconnectEpoch: 0,
     readPackImportFailures: async () => [],
     api,
@@ -240,7 +254,7 @@ function realGraphAddNode({
     unavailableRequiredWidgetMessage,
     snapshotBackendDef,
     isRegisteredNodeType,
-    fetchSingleNodeDef,
+    fetchSingleNodeInfo,
     describeUnmaterializedRequiredWidgets,
     NODE_DEFS_NO_ANSWER,
     WIDEN_SOCKET_PROOF_TIMEOUT_MS,
@@ -287,8 +301,460 @@ function realGraphAddNode({
     comfy: c,
     runs,
     inFlightStarted,
+    verifiedNodeDefCache: deps.verifiedNodeDefCache,
+    verifiedSchemaContext: context,
   };
 }
+
+function realGraphGetObjectInfo({
+  api,
+  verifiedNodeDefCache,
+  objectInfoCache = createObjectInfoCache(),
+  objectInfoSnapshot = { record: () => true, clear: () => {} },
+}) {
+  const names = [
+    "api",
+    "backendReconnectEpoch",
+    "fetchWholeObjectInfo",
+    "objectInfoCache",
+    "verifiedNodeDefCache",
+    "objectInfoSnapshot",
+    "pageComfyOrigin",
+    "objectInfoOracleFailureNote",
+    "objectInfoFingerprint",
+    "objectInfoUnchanged",
+  ];
+  const factory = new Function(
+    ...names,
+    `const executors = {${graphGetMatch[0]}};
+     return executors.graph_get_object_info;`,
+  );
+  return factory(
+    api,
+    0,
+    fetchWholeObjectInfo,
+    objectInfoCache,
+    verifiedNodeDefCache,
+    objectInfoSnapshot,
+    () => "http://127.0.0.1:8188",
+    objectInfoOracleFailureNote,
+    () => "fp",
+    () => false,
+  );
+}
+
+test("#1709: cached reuse still probes authority and refuses after backend removal", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  // The class is already registered, matching the reported repeated-add path and keeping
+  // the first verification on the single-class route.
+  comfy.app.registerNodesFromDefs(defs);
+  const calls = [];
+  let unavailable = false;
+  let removed = false;
+  const api = {
+    async fetchApi(route) {
+      calls.push(route);
+      if (unavailable) return { status: 503, json: async () => ({}) };
+      if (removed) return { status: 503, json: async () => ({}) };
+      const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+      return {
+        status: 200,
+        json: async () =>
+          Object.prototype.hasOwnProperty.call(defs, classType) ? { [classType]: defs[classType] } : {},
+      };
+    },
+    async getNodeDefs() {
+      calls.push("/object_info");
+      if (removed) return {};
+      return NODE_DEFS_NO_ANSWER;
+    },
+  };
+  const built = realGraphAddNode({
+    comfy,
+    overrides: { api, objectInfoHistory: { wasTypeEverDefined: () => true } },
+  });
+
+  const first = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(first.added.type, "ExistingNode");
+  unavailable = true;
+
+  const second = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(second.added.type, "ExistingNode");
+  assert.equal(comfy.graph._nodes.length, 2);
+  assert.deepEqual(
+    calls,
+    ["/object_info/ExistingNode", "/object_info/ExistingNode", "/object_info"],
+    "the second add used the verified proof only after both live routes timed out",
+  );
+
+  unavailable = false;
+  removed = true;
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "ExistingNode" }),
+    /ABSENT from the current \/object_info|since-removed/i,
+    "an authoritative whole-schema absence cannot be bypassed by the cached proof",
+  );
+  assert.equal(comfy.graph._nodes.length, 2, "the removed backend type was not added again");
+
+  removed = false;
+  const restored = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(restored.added.type, "ExistingNode", "a fresh authoritative re-add still works");
+  assert.equal(comfy.graph._nodes.length, 3);
+});
+
+test("#1709: an overlapping authoritative absence fences a late cached-proof write", async () => {
+  const comfy = makeComfy();
+  const defs = {
+    ...backendObjectInfo(),
+    ExistingNode: {
+      name: "ExistingNode",
+      input: { required: { mode: ["RACE_WIDGET", { default: "ready" }] } },
+      output: ["IMAGE"],
+    },
+  };
+  const customWidget = (node, name, spec) => {
+    const widget = {
+      name,
+      type: "custom",
+      value: spec?.[1]?.default ?? "ready",
+      options: { serialize: true },
+    };
+    node.widgets.push(widget);
+    return { widget };
+  };
+  comfy.widgets.RACE_WIDGET = customWidget;
+  comfy.app.registerNodesFromDefs(defs);
+
+  const calls = [];
+  let unavailable = false;
+  let removed = false;
+  const api = {
+    async fetchApi(route) {
+      calls.push(route);
+      if (unavailable || removed) return { status: 503, json: async () => ({}) };
+      const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+      return {
+        status: 200,
+        json: async () =>
+          Object.prototype.hasOwnProperty.call(defs, classType) ? { [classType]: defs[classType] } : {},
+      };
+    },
+    async getNodeDefs() {
+      calls.push("/object_info");
+      return removed ? {} : NODE_DEFS_NO_ANSWER;
+    },
+  };
+  const built = realGraphAddNode({
+    comfy,
+    overrides: { api, objectInfoHistory: { wasTypeEverDefined: () => true } },
+  });
+
+  const initial = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(initial.added.type, "ExistingNode");
+  delete comfy.widgets.RACE_WIDGET;
+
+  // The real shipped awaitRequiredCustomWidgetRegistration supplies the async pause after
+  // the cached proof has been accepted. Its production widget registry is proxied only to
+  // observe that the first add reached that wait; the actual constructor is restored below.
+  const customWidgetWait = deferred();
+  let waitObserved = false;
+  const widgetRegistry = comfy.app.widgets;
+  comfy.app.widgets = new Proxy(widgetRegistry, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (property === "RACE_WIDGET" && typeof value !== "function" && !waitObserved) {
+        waitObserved = true;
+        customWidgetWait.resolve();
+      }
+      return value;
+    },
+  });
+
+  unavailable = true;
+  const overlappingAdd = built.graph_add_node({ class_type: "ExistingNode" });
+  await customWidgetWait.promise;
+
+  removed = true;
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "ExistingNode" }),
+    /ABSENT from the current \/object_info|since-removed/i,
+    "the overlapping command observes authoritative removal and invalidates proof",
+  );
+  const invalidatedGeneration = built.verifiedNodeDefCache.generation();
+  assert.equal(
+    built.verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: invalidatedGeneration,
+    }),
+    undefined,
+    "authoritative absence removed the pre-existing proof before the first add resumed",
+  );
+
+  comfy.widgets.RACE_WIDGET = customWidget;
+  const resumed = await overlappingAdd;
+  assert.equal(resumed.added.type, "ExistingNode");
+  assert.equal(comfy.graph._nodes.length, 2, "the paused add completed once");
+  assert.equal(
+    built.verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: invalidatedGeneration,
+    }),
+    undefined,
+    "the paused add could not resurrect proof with its pre-invalidation generation",
+  );
+
+  unavailable = true;
+  removed = false;
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "ExistingNode" }),
+    /cannot verify node type|object_info is unavailable|Refusing to add/i,
+    "a later silent add fails closed instead of reusing the stale proof",
+  );
+  assert.equal(comfy.graph._nodes.length, 2, "the later silent add did not mutate the graph");
+  assert.deepEqual(
+    calls,
+    [
+      "/object_info/ExistingNode",
+      "/object_info/ExistingNode",
+      "/object_info",
+      "/object_info",
+      "/object_info/ExistingNode",
+      "/object_info",
+      "/object_info/ExistingNode",
+      "/object_info",
+    ],
+    "the later add still probes both live routes after the fenced write",
+  );
+});
+
+test("#1709: an authoritative empty whole read retires cached proof before timeout fallback", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  comfy.app.registerNodesFromDefs(defs);
+  const calls = [];
+  let removed = false;
+  let unavailable = false;
+  const api = {
+    async getNodeDefs() {
+      calls.push("/object_info");
+      if (unavailable) return NODE_DEFS_NO_ANSWER;
+      if (removed) return {};
+      return defs;
+    },
+    async fetchApi(route) {
+      calls.push(route);
+      if (unavailable || removed) return { status: 503, json: async () => ({}) };
+      const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+      return { status: 200, json: async () => ({ [classType]: defs[classType] }) };
+    },
+  };
+  const built = realGraphAddNode({
+    comfy,
+    overrides: { api, objectInfoHistory: { wasTypeEverDefined: () => true } },
+  });
+  const first = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(first.added.type, "ExistingNode");
+  const beforeGeneration = built.verifiedNodeDefCache.generation();
+  assert.ok(
+    built.verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: beforeGeneration,
+    }),
+    "the first production add established reusable proof",
+  );
+
+  removed = true;
+  const getObjectInfo = realGraphGetObjectInfo({
+    api,
+    verifiedNodeDefCache: built.verifiedNodeDefCache,
+    objectInfoCache: createObjectInfoCache(),
+  });
+  const denied = await getObjectInfo({});
+  assert.equal(denied.ok, false, "the authoritative empty whole schema still refuses");
+  const afterGeneration = built.verifiedNodeDefCache.generation();
+  assert.ok(afterGeneration > beforeGeneration, "the live deny-all answer advanced the cache fence");
+  assert.equal(
+    built.verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: afterGeneration,
+    }),
+    undefined,
+    "the authoritative empty whole read retired the cached proof",
+  );
+
+  removed = false;
+  unavailable = true;
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "ExistingNode" }),
+    /cannot verify node type|object_info is unavailable|Refusing to add/i,
+    "a later timeout cannot fall back to proof retired by the empty answer",
+  );
+  assert.equal(comfy.graph._nodes.length, 1, "the refused timeout fallback did not add a node");
+  assert.deepEqual(
+    calls,
+    ["/object_info/ExistingNode", "/object_info", "/object_info/ExistingNode", "/object_info"],
+    "the later add reached both live probes rather than bypassing them",
+  );
+});
+
+test("#1709: a direct schema response crossing refresh cannot authorize a later timeout fallback", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  comfy.app.registerNodesFromDefs(defs);
+  const snapshot = createObjectInfoSnapshot();
+  assert.equal(
+    snapshot.record(defs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
+    true,
+    "the pre-refresh production state has an old whole-schema snapshot",
+  );
+
+  const directStarted = deferred();
+  const oldDirectResponse = deferred();
+  let holdDirect = false;
+  const calls = [];
+  const api = {
+    async fetchApi(route) {
+      calls.push(route);
+      if (route === "/object_info/ExistingNode" && holdDirect) {
+        directStarted.resolve();
+        await oldDirectResponse.promise;
+      }
+      const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+      return {
+        status: 200,
+        json: async () =>
+          Object.prototype.hasOwnProperty.call(defs, classType) ? { [classType]: defs[classType] } : {},
+      };
+    },
+    async getNodeDefs() {
+      calls.push("/object_info");
+      return NODE_DEFS_NO_ANSWER;
+    },
+  };
+  const built = realGraphAddNode({
+    comfy,
+    overrides: {
+      api,
+      objectInfoSnapshot: snapshot,
+      objectInfoHistory: { wasTypeEverDefined: () => true },
+    },
+  });
+
+  const initial = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(initial.added.type, "ExistingNode");
+  const beforeRefreshGeneration = built.verifiedNodeDefCache.generation();
+  assert.ok(
+    built.verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: beforeRefreshGeneration,
+    }),
+    "the initial add established the reusable proof",
+  );
+
+  holdDirect = true;
+  const pendingAdd = built.graph_add_node({ class_type: "ExistingNode" });
+  await directStarted.promise;
+
+  // This is the same state transition registerComfyNodeDefs performs at refresh start:
+  // old whole-schema membership and verified per-class proof are both retired before the
+  // refresh fetch is allowed to establish new authority.
+  snapshot.clear();
+  built.verifiedNodeDefCache.clear();
+  const afterRefreshGeneration = built.verifiedNodeDefCache.generation();
+  assert.ok(afterRefreshGeneration > beforeRefreshGeneration);
+
+  oldDirectResponse.resolve();
+  await assert.rejects(
+    () => pendingAdd,
+    /cannot verify node type|object_info is unavailable|Refusing to add/i,
+    "the old direct response cannot authorize after refresh; the timeout fallback refuses",
+  );
+  assert.equal(comfy.graph._nodes.length, 1, "the stale response did not mutate the graph");
+  assert.equal(snapshot.peek().held, false, "the old whole-schema snapshot stayed retired");
+  assert.equal(
+    built.verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: afterRefreshGeneration,
+    }),
+    undefined,
+    "the old direct response did not repopulate verified proof",
+  );
+  assert.deepEqual(
+    calls,
+    ["/object_info/ExistingNode", "/object_info/ExistingNode", "/object_info"],
+    "the stale direct response was discarded and the add reached the timeout fallback",
+  );
+});
+
+test("#1709: a same-epoch refresh fences graph_add_node's late whole-schema snapshot write", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  assert.equal(
+    snapshot.record(defs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
+    true,
+    "the pre-refresh state starts with a whole-schema snapshot",
+  );
+  let unavailable = false;
+  const api = {
+    async getNodeDefs() {
+      return unavailable ? NODE_DEFS_NO_ANSWER : defs;
+    },
+    async fetchApi(route) {
+      if (unavailable) return { status: 503, json: async () => ({}) };
+      const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+      return { status: 200, json: async () => ({ [classType]: defs[classType] }) };
+    },
+  };
+  const built = realGraphAddNode({
+    comfy,
+    onRunRegister: (refreshDefs) => {
+      if (refreshDefs != null) {
+        // registerComfyNodeDefs performs this transition before registration. Keep the
+        // backend epoch unchanged: this is precisely the same-epoch race under review.
+        snapshot.clear();
+        verifiedNodeDefCache.clear();
+      }
+    },
+    overrides: {
+      api,
+      objectInfoSnapshot: snapshot,
+      verifiedNodeDefCache,
+    },
+  });
+
+  const first = await built.graph_add_node({ class_type: "NewNode" });
+  assert.equal(first.added.type, "NewNode", "the refresh still registers and adds the requested class");
+  assert.equal(snapshot.peek().held, false, "the pre-refresh whole result was not filed after refresh cleared it");
+
+  unavailable = true;
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    /cannot verify node type|object_info is unavailable|Refusing to add/i,
+    "a later silent add refuses because the fenced snapshot supplied no stale fallback",
+  );
+  assert.equal(comfy.graph._nodes.length, 1, "the later timeout did not add through old snapshot authority");
+});
 
 // ---------------------------------------------------------------------------
 // 1. The reported composition: the join alone would exhaust the command.

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -37,11 +37,14 @@ import {
   isRegisteredNodeType,
 } from "../../web/js/lib/node-resolve.js";
 import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
+import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
 import {
   fetchWholeObjectInfo,
   objectInfoOracleFailureNote,
   TRANSPORT_OUTCOME,
 } from "../../web/js/lib/object-info-oracle.js";
+import { describeNodeDefRefresh, NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
+import { comboRebuildCovered } from "../../web/js/lib/asset-staleness.js";
 import {
   describeUnmaterializedRequiredWidgets,
   snapshotBackendDef,
@@ -49,6 +52,10 @@ import {
 import {
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
+  NODE_DEFS_FETCH_SHARE,
+  NODE_DEFS_RUN_BUDGET_MS,
+  COMBO_OK,
+  COMBO_NO_ANSWER,
   WIDEN_SOCKET_PROOF_TIMEOUT_MS,
   monotonicNow,
   widenSocketProofBudget,
@@ -82,6 +89,43 @@ assert.ok(placementMatch, "could not locate placementFor");
 
 const boundedMatch = panelSrc.match(/\nasync function boundedGetNodeDefs\([\s\S]*?\n\}/);
 assert.ok(boundedMatch, "could not locate boundedGetNodeDefs in panel source");
+
+function extractFunction(marker) {
+  const start = panelSrc.indexOf(marker);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = panelSrc.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < panelSrc.length; i += 1) {
+    const ch = panelSrc[i];
+    if (ch === "/" && panelSrc[i + 1] === "/") {
+      i = panelSrc.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && panelSrc[i + 1] === "*") {
+      i = panelSrc.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < panelSrc.length; i += 1) {
+        if (panelSrc[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (panelSrc[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return panelSrc.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function: ${marker}`);
+}
+
+const registerComfyNodeDefsBody = extractFunction("async function registerComfyNodeDefs(");
 
 // The SHIPPED refusal, built from source rather than restated. A hand-copied sentence here
 // would let the real one drift into naming a remedy that cannot work while this file stayed
@@ -163,6 +207,84 @@ function makeComfy() {
   return { app, LG, graph, widgets };
 }
 
+/** Build the SHIPPED refresh body so the graph-add regression crosses the real
+ * `registerComfyNodeDefs(preloadedDefs, runOpts)` invalidation boundary. */
+function realRegisterComfyNodeDefs({ app, api, objectInfoCache, objectInfoSnapshot, verifiedNodeDefCache, epoch = 0 }) {
+  const names = [
+    "app",
+    "api",
+    "recordObjectInfoTypes",
+    "reapplyDefsToLiveNodes",
+    "comboRebuildCovered",
+    "describeNodeDefRefresh",
+    "NODE_DEF_REFRESH_REASONS",
+    "fetchNodeDefsWithRetry",
+    "withTimeout",
+    "NODE_DEFS_NO_ANSWER",
+    "COMBO_OK",
+    "COMBO_NO_ANSWER",
+    "NODE_DEFS_FETCH_TIMEOUT_MS",
+    "NODE_DEFS_RUN_BUDGET_MS",
+    "NODE_DEFS_FETCH_SHARE",
+    "fetchWholeObjectInfo",
+    "nodeDefsBudgetLeft",
+    "monotonicNow",
+    "NODE_DEFS_RETRY_DELAYS_MS",
+    "objectInfoCache",
+    "objectInfoSnapshot",
+    "verifiedNodeDefCache",
+    "initialBackendReconnectEpoch",
+    "comfyBackendSocketDown",
+    "TRANSPORT_OUTCOME",
+  ];
+  const values = {
+    app,
+    api,
+    recordObjectInfoTypes: (defs) => defs,
+    reapplyDefsToLiveNodes: () => {},
+    comboRebuildCovered,
+    describeNodeDefRefresh,
+    NODE_DEF_REFRESH_REASONS,
+    fetchNodeDefsWithRetry: (getDefs, opts) => fetchNodeDefsWithRetry(getDefs, { ...opts, sleep: async () => {} }),
+    withTimeout,
+    NODE_DEFS_NO_ANSWER,
+    COMBO_OK,
+    COMBO_NO_ANSWER,
+    NODE_DEFS_FETCH_TIMEOUT_MS,
+    NODE_DEFS_RUN_BUDGET_MS,
+    NODE_DEFS_FETCH_SHARE,
+    fetchWholeObjectInfo,
+    nodeDefsBudgetLeft: (deadline, share = 1) => Math.max(1, Math.floor((deadline - monotonicNow()) * share)),
+    monotonicNow,
+    NODE_DEFS_RETRY_DELAYS_MS: OBJECT_INFO_RETRY_DELAYS_MS,
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache,
+    initialBackendReconnectEpoch: epoch,
+    comfyBackendSocketDown: false,
+    TRANSPORT_OUTCOME,
+  };
+  const factory = new Function(
+    ...names,
+    `const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
+      if (typeof api?.getNodeDefs !== "function") return null;
+      const settled = await withTimeout(
+        Promise.resolve().then(() => api.getNodeDefs()).then((value) => ({ value }), (err) => ({ err })),
+        ms,
+        () => NODE_DEFS_NO_ANSWER,
+      );
+      if (settled === NODE_DEFS_NO_ANSWER) return NODE_DEFS_NO_ANSWER;
+      if ("err" in settled) throw settled.err;
+      return settled.value;
+    };
+    let backendReconnectEpoch = initialBackendReconnectEpoch;
+    let nodeDefsRefreshConfirmed = false;
+    ${registerComfyNodeDefsBody}
+    return registerComfyNodeDefs;`,
+  );
+  return factory(...names.map((name) => values[name]));
+}
+
 /**
  * Build the SHIPPED `graph_add_node` with the REAL coalescer behind it.
  *
@@ -192,6 +314,7 @@ function realGraphAddNode({
   budgetMs = 400,
   reserveMs = 120,
   registrationMs = 200,
+  productionRegister = null,
   overrides = {},
 } = {}) {
   const c = comfy ?? makeComfy();
@@ -217,8 +340,9 @@ function realGraphAddNode({
     setInFlight: (p) => {
       inFlight = p;
     },
-    runRegister: async (defs) => {
+    runRegister: async (defs, runOpts, runControl) => {
       runs.push(defs);
+      if (productionRegister) return productionRegister(defs, runOpts, runControl);
       // The reconnect run — the one with no payload — is the one a test can hold open.
       if (defs == null && holdInFlight) await holdInFlight;
       // #1351 — this add's own registration, after any join. Distinct from holdInFlight:
@@ -709,9 +833,12 @@ test("#1709: a direct schema response crossing refresh cannot authorize a later 
 test("#1709: graph_add_node replaces the old whole cache and snapshot on a changed response", async () => {
   const comfy = makeComfy();
   const oldDefs = { OldNode: { input: { required: {} } } };
-  const changedDefs = { NewNode: { input: { required: {} } } };
+  const changedDefs = {
+    NewNode: { input: { required: { count: ["INT", { default: 1 }] } } },
+  };
   const objectInfoCache = createObjectInfoCache();
   const objectInfoSnapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
   await objectInfoCache.read(async () => oldDefs);
   assert.equal(
     objectInfoSnapshot.record(oldDefs, {
@@ -724,22 +851,40 @@ test("#1709: graph_add_node replaces the old whole cache and snapshot on a chang
     true,
     "the production precondition starts with an older whole authority",
   );
+  comfy.app.refreshComboInNodes = async () => {};
+  const originalRegister = comfy.app.registerNodesFromDefs;
+  comfy.app.registerNodesFromDefs = (defs) => {
+    defs.NewNode.input.required.count[1].default = 999;
+    originalRegister(defs);
+  };
+  const api = {
+    getNodeDefs: async () => changedDefs,
+    fetchApi: async () => ({ status: 503, json: async () => ({}) }),
+  };
+  const productionRegister = realRegisterComfyNodeDefs({
+    app: comfy.app,
+    api,
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache,
+  });
 
   const built = realGraphAddNode({
     comfy,
     getNodeDefs: async () => changedDefs,
+    productionRegister,
     overrides: {
+      api,
       objectInfoCache,
       objectInfoSnapshot,
+      verifiedNodeDefCache,
     },
   });
   const result = await built.graph_add_node({ class_type: "NewNode" });
   assert.equal(result.added.type, "NewNode", "the changed whole response still permits its current class");
-  assert.deepEqual(
-    await objectInfoCache.read(async () => ({ Unexpected: {} })),
-    changedDefs,
-    "the later burst reader cannot see the old whole map",
-  );
+  const cached = await objectInfoCache.read(async () => ({ Unexpected: {} }));
+  assert.equal(cached.NewNode.input.required.count[1].default, 1, "the cache is isolated from registration-hook mutation");
+  assert.equal(Object.prototype.hasOwnProperty.call(cached, "OldNode"), false, "the old whole map was replaced");
   const fallback = objectInfoSnapshot.authorize({
     epoch: 0,
     outcomes: [{ kind: TRANSPORT_OUTCOME.NO_ANSWER }],
@@ -795,7 +940,7 @@ test("#1709: a same-epoch refresh fences graph_add_node's late whole-schema snap
 
   const first = await built.graph_add_node({ class_type: "NewNode" });
   assert.equal(first.added.type, "NewNode", "the refresh still registers and adds the requested class");
-  assert.equal(snapshot.peek().held, false, "the pre-refresh whole result was not filed after refresh cleared it");
+  assert.equal(snapshot.peek().held, true, "the authoritative whole result was re-filed against the post-refresh generation");
 
   unavailable = true;
   await assert.rejects(

--- a/browser_tests/unit/add-node-loaded-subgraph.test.mjs
+++ b/browser_tests/unit/add-node-loaded-subgraph.test.mjs
@@ -30,7 +30,7 @@ import {
   isRegisteredNodeType,
   subgraphUuidAddRefusal,
 } from "../../web/js/lib/node-resolve.js";
-import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
+import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
 import {
   describeUnmaterializedRequiredWidgets,
   snapshotBackendDef,
@@ -188,7 +188,7 @@ function realGraphAddNode(comfy, overrides = {}) {
     unavailableRequiredWidgetMessage,
     snapshotBackendDef,
     isRegisteredNodeType,
-    fetchSingleNodeDef,
+    fetchSingleNodeInfo,
     describeUnmaterializedRequiredWidgets,
     NODE_DEFS_NO_ANSWER,
     WIDEN_SOCKET_PROOF_TIMEOUT_MS,

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -44,7 +44,7 @@ import {
   assertAddNodeResolvableRefreshing,
   isRegisteredNodeType,
 } from "../../web/js/lib/node-resolve.js";
-import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
+import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
 import {
   describeUnmaterializedRequiredWidgets,
   snapshotBackendDef,
@@ -225,7 +225,7 @@ function realGraphAddNode(comfy, overrides = {}) {
     unavailableRequiredWidgetMessage,
     snapshotBackendDef,
     isRegisteredNodeType,
-    fetchSingleNodeDef,
+    fetchSingleNodeInfo,
     describeUnmaterializedRequiredWidgets,
     NODE_DEFS_NO_ANSWER,
     WIDEN_SOCKET_PROOF_TIMEOUT_MS,

--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -30,7 +30,7 @@
 // THE HARNESS: these tests run the SHIPPED `graph_add_node` body, extracted from the panel
 // source and given injected collaborators — the same technique as
 // add-node-upload-widget.test.mjs. A helper-only test could not have caught this: both
-// `registeredSocketTypes` and `fetchSingleNodeDef` are individually correct. The defect is
+// `registeredSocketTypes` and `fetchSingleNodeInfo` are individually correct. The defect is
 // entirely in which payload the CALL SITE hands to which question.
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -50,7 +50,7 @@ import {
   assertAddNodeResolvableRefreshing,
   isRegisteredNodeType,
 } from "../../web/js/lib/node-resolve.js";
-import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
+import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
 import {
   describeUnmaterializedRequiredWidgets,
   snapshotBackendDef,
@@ -310,7 +310,7 @@ function realGraphAddNode(comfy, overrides = {}) {
     unavailableRequiredWidgetMessage,
     snapshotBackendDef,
     isRegisteredNodeType,
-    fetchSingleNodeDef,
+    fetchSingleNodeInfo,
     describeUnmaterializedRequiredWidgets,
     // #1180 — the panel's bounded `api.getNodeDefs()` and its timeout sentinel. Both are
     // module-scope in the real file; this harness rebuilds `graph_add_node` in a synthetic

--- a/browser_tests/unit/add-node-upload-widget.test.mjs
+++ b/browser_tests/unit/add-node-upload-widget.test.mjs
@@ -61,7 +61,7 @@ import {
 // ReferenceError that the resolver catches and reports as "object_info is
 // unavailable", which is how this harness caught the omission.
 import { isRegisteredNodeType } from "../../web/js/lib/node-resolve.js";
-import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
+import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
 
 // #1180 — READ from the panel, never restated here. Shared, because this block existed
 // verbatim in both widen harnesses, and the whole point of reading a constant instead of
@@ -250,7 +250,7 @@ function realGraphAddNode(comfy, overrides = {}) {
     unavailableRequiredWidgetMessage,
     snapshotBackendDef,
     isRegisteredNodeType,
-    fetchSingleNodeDef,
+    fetchSingleNodeInfo,
     describeUnmaterializedRequiredWidgets,
     // #1180 — the panel's bounded api.getNodeDefs() and its sentinel. Module-scope in the
     // real file; this harness rebuilds the executor in a synthetic scope, so they are

--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -25,10 +25,12 @@ import {
   executionErrorMatchesCurrentGraph,
   applyRuntimeExecFailure,
 } from "../../web/js/lib/exec-error-bounds.js";
-import { findNodeByScopedId, findVisibleNodeByScopedId } from "../../web/js/lib/asset-staleness.js";
 import { scanComboAvailability } from "../../web/js/lib/live-combo-availability.js";
 import { SINGLE_NODE_INFO_OUTCOME } from "../../web/js/lib/single-node-def.js";
+import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
+import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
 import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
+import { runProductionGraphGetErrors } from "./_graph-get-errors-harness.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PANEL_SOURCE = readFileSync(
@@ -348,91 +350,8 @@ test("graph_get_errors correlates runtime failures through applyRuntimeExecFailu
 });
 
 // #1685: the regression is in the shipped graph_get_errors executor, not in the
-// standalone correlation helper. Run that executor against a root graph with a
-// native subgraph so a scoped execution_error must survive the complete scan.
-function extractExecutorMethod(source, signature) {
-  const start = source.indexOf(signature);
-  assert.notEqual(start, -1, `${signature} not found in panel source`);
-  const open = source.indexOf("{", start);
-  let depth = 0;
-  for (let i = open; i < source.length; i += 1) {
-    const ch = source[i];
-    if (ch === "/" && source[i + 1] === "/") {
-      i = source.indexOf("\n", i + 2);
-      continue;
-    }
-    if (ch === "/" && source[i + 1] === "*") {
-      i = source.indexOf("*/", i + 2) + 1;
-      continue;
-    }
-    if (ch === '"' || ch === "'" || ch === "`") {
-      const quote = ch;
-      for (i += 1; i < source.length; i += 1) {
-        if (source[i] === "\\") i += 1;
-        else if (source[i] === quote) break;
-      }
-      continue;
-    }
-    if (ch === "{") depth += 1;
-    if (ch === "}" && --depth === 0) return source.slice(start, i + 1);
-  }
-  throw new Error(`unterminated ${signature}`);
-}
-
-const GRAPH_GET_ERRORS_SOURCE = extractExecutorMethod(PANEL_SOURCE, "  async graph_get_errors() {");
-const GRAPH_GET_ERRORS_DEPS = [
-  "monotonicNow",
-  "getErrorsStepBudgetMs",
-  "hasRawMissingAssetCandidates",
-  "GET_ERRORS_REFRESH_CAP_MS",
-  "refreshMissingAssetTrust",
-  "refreshComfyNodeDefs",
-  "withRefreshTimeout",
-  "getRefreshInFlight",
-  "nodeDefRefreshInFlight",
-  "getGraphCtx",
-  "verifiedNodeDefCache",
-  "assertGraphBoundToActiveWorkflow",
-  "graphCommandBindingBar",
-  "collectMissingAssets",
-  "activeWorkflowRef",
-  "GET_ERRORS_STEP_CAP_MS",
-  "filterServerConfirmedInputSubfolderMedia",
-  "inputAssetServerUsesWindowsPaths",
-  "scanComboAvailability",
-  "fetchSingleNodeInfo",
-  "probeInputAssetPresence",
-  "graphReadBindingChanged",
-  "collectAllGraphs",
-  "adjudicateRecordedMissingNodeTypes",
-  "isRegisteredNodeType",
-  "LiteGraph",
-  "findVisibleNodeByScopedId",
-  "findNodeByScopedId",
-  "getPiniaStore",
-  "combineNodeErrorMaps",
-  "coerceMessageText",
-  "lastExecFailure",
-  "applyRuntimeExecFailure",
-  "collectUnexplainedRedOutlines",
-  "summarizeNode",
-  "tr",
-  "describeActiveGraph",
-  "MAX_STATE_NODES",
-  "fixedCapNote",
-  "missingAssetScanMayBeStale",
-  "missingAssetScopeNote",
-  "comboAvailabilityNote",
-  "uncheckedNodesNote",
-  "stalePlaceholderNote",
-  "boundExecFailurePayload",
-  "collectMissingNodeTypeReasons",
-];
-
-const makeGraphGetErrors = new Function(
-  ...GRAPH_GET_ERRORS_DEPS,
-  `return ({ ${GRAPH_GET_ERRORS_SOURCE} }).graph_get_errors;`,
-);
+// standalone correlation helper. The shared harness drives that executor against a
+// root graph with a native subgraph so a scoped execution_error survives the complete scan.
 
 function makeScopedErrorGraph() {
   const inner = { id: 125, type: "SamplerCustomAdvanced" };
@@ -465,71 +384,6 @@ function makeScopedErrorGraph() {
     collidingRootNode,
     rootGraph,
   };
-}
-
-async function runProductionGraphGetErrors({
-  graph,
-  rootGraph,
-  lastExecFailure,
-  scan = async () => null,
-  fetchSingleNodeInfo = () => {},
-  // The extracted executor's default scan is a no-op test double. Give it a
-  // usable budget so legacy tests that are not exercising live-scan exhaustion
-  // retain their clean-note assertions.
-  stepBudget = () => 1000,
-  monotonicNow = () => 0,
-  verifiedNodeDefCache = createVerifiedNodeDefCache(),
-}) {
-  const deps = {
-    monotonicNow,
-    getErrorsStepBudgetMs: stepBudget,
-    hasRawMissingAssetCandidates: () => false,
-    GET_ERRORS_REFRESH_CAP_MS: 18000,
-    refreshMissingAssetTrust: async () => false,
-    refreshComfyNodeDefs: () => {},
-    withRefreshTimeout: () => {},
-    getRefreshInFlight: () => null,
-    nodeDefRefreshInFlight: null,
-    getGraphCtx: () => ({ app: { lastNodeErrors: null }, graph, rootGraph }),
-    verifiedNodeDefCache,
-    assertGraphBoundToActiveWorkflow: () => {},
-    graphCommandBindingBar: () => ({}),
-    collectMissingAssets: () => ({ models: [], media: [], nodeTypes: [], nodeCount: 0 }),
-    activeWorkflowRef: () => null,
-    GET_ERRORS_STEP_CAP_MS: 4000,
-    filterServerConfirmedInputSubfolderMedia: async (media) => media,
-    inputAssetServerUsesWindowsPaths: async () => false,
-    scanComboAvailability: scan,
-    fetchSingleNodeInfo,
-    probeInputAssetPresence: () => {},
-    graphReadBindingChanged: () => false,
-    collectAllGraphs: (value) => [value],
-    adjudicateRecordedMissingNodeTypes: (types) => ({ stillMissing: types, stalePlaceholders: [] }),
-    isRegisteredNodeType: () => false,
-    LiteGraph: {},
-    findVisibleNodeByScopedId,
-    findNodeByScopedId,
-    getPiniaStore: () => null,
-    combineNodeErrorMaps: () => null,
-    coerceMessageText: (value) => String(value ?? ""),
-    lastExecFailure,
-    applyRuntimeExecFailure,
-    collectUnexplainedRedOutlines: () => [],
-    summarizeNode: (node) => ({ id: node.id, type: node.type }),
-    tr: (_key, fallback) => fallback,
-    describeActiveGraph: () => ({ scope: "root" }),
-    MAX_STATE_NODES: 50,
-    fixedCapNote: () => "cap",
-    missingAssetScanMayBeStale: () => false,
-    missingAssetScopeNote: () => "stale",
-    comboAvailabilityNote: () => "combo",
-    uncheckedNodesNote: () => "unchecked",
-    stalePlaceholderNote: () => "placeholder",
-    boundExecFailurePayload,
-    collectMissingNodeTypeReasons: () => [],
-  };
-  const executor = makeGraphGetErrors(...GRAPH_GET_ERRORS_DEPS.map((name) => deps[name]));
-  return executor();
 }
 
 test("#1691 production graph_get_errors batches live class reads and keeps uncertain types unchecked", async () => {
@@ -585,9 +439,25 @@ test("#1709 production graph_get_errors retires add proof on definitive class pr
   const graph = { _nodes: [node], getNodeById: () => node };
   const def = { input: { required: { mode: [["old"], {}] } } };
   const cache = createVerifiedNodeDefCache();
+  const objectInfoCache = createObjectInfoCache();
+  const objectInfoSnapshot = createObjectInfoSnapshot();
+  const wholeDefs = { RemovedNode: def, OtherNode: { input: { required: {} } } };
   const proofContext = {};
   let generation = cache.generation();
   cache.set("RemovedNode", def, { epoch: 0, context: proofContext, generation });
+  await objectInfoCache.read(async () => wholeDefs);
+  assert.equal(objectInfoCache.peek().cached, true, "the whole payload starts cached");
+  assert.equal(
+    objectInfoSnapshot.record(wholeDefs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: generation,
+      currentGeneration: generation,
+      whole: true,
+    }),
+    true,
+    "the whole membership snapshot starts held",
+  );
   let present = true;
   const fetchInfo = async () =>
     present
@@ -600,25 +470,46 @@ test("#1709 production graph_get_errors retires add proof on definitive class pr
     lastExecFailure: null,
     scan: scanComboAvailability,
     fetchSingleNodeInfo: fetchInfo,
+    objectInfoCache,
+    objectInfoSnapshot,
     verifiedNodeDefCache: cache,
     stepBudget: () => 1000,
   });
   assert.ok(cache.generation() > generation, "a definitive present class read retired old proof");
+  assert.equal(objectInfoCache.peek().cached, false, "definitive class presence retires whole cache authority");
+  assert.equal(objectInfoSnapshot.peek().held, false, "definitive class presence retires whole snapshot authority");
 
   present = false;
   generation = cache.generation();
   cache.set("RemovedNode", def, { epoch: 0, context: proofContext, generation });
+  await objectInfoCache.read(async () => wholeDefs);
+  assert.equal(objectInfoCache.peek().cached, true, "the whole payload is reseeded before absence");
+  assert.equal(
+    objectInfoSnapshot.record(wholeDefs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: generation,
+      currentGeneration: generation,
+      whole: true,
+    }),
+    true,
+    "the whole membership snapshot is reseeded before absence",
+  );
   const result = await runProductionGraphGetErrors({
     graph,
     rootGraph: graph,
     lastExecFailure: null,
     scan: scanComboAvailability,
     fetchSingleNodeInfo: fetchInfo,
+    objectInfoCache,
+    objectInfoSnapshot,
     verifiedNodeDefCache: cache,
     stepBudget: () => 1000,
   });
   assert.equal(result.unchecked_nodes.length, 1, "the explicit absent class remains unchecked, not falsely clean");
   assert.ok(cache.generation() > generation, "a definitive absent class read retired old proof");
+  assert.equal(objectInfoCache.peek().cached, false, "definitive class absence retires whole cache authority");
+  assert.equal(objectInfoSnapshot.peek().held, false, "definitive class absence retires whole snapshot authority");
   assert.equal(
     cache.get("RemovedNode", { epoch: 0, context: proofContext, generation: cache.generation() }),
     undefined,
@@ -632,6 +523,8 @@ test("#1709 production graph_get_errors retires add proof on definitive class pr
     lastExecFailure: null,
     scan: scanComboAvailability,
     fetchSingleNodeInfo: async () => ({ [SINGLE_NODE_INFO_OUTCOME]: true, kind: "unknown" }),
+    objectInfoCache,
+    objectInfoSnapshot,
     verifiedNodeDefCache: cache,
     stepBudget: () => 1000,
   });

--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -28,6 +28,7 @@ import {
 import { findNodeByScopedId, findVisibleNodeByScopedId } from "../../web/js/lib/asset-staleness.js";
 import { scanComboAvailability } from "../../web/js/lib/live-combo-availability.js";
 import { SINGLE_NODE_INFO_OUTCOME } from "../../web/js/lib/single-node-def.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PANEL_SOURCE = readFileSync(
@@ -390,6 +391,7 @@ const GRAPH_GET_ERRORS_DEPS = [
   "getRefreshInFlight",
   "nodeDefRefreshInFlight",
   "getGraphCtx",
+  "verifiedNodeDefCache",
   "assertGraphBoundToActiveWorkflow",
   "graphCommandBindingBar",
   "collectMissingAssets",
@@ -476,6 +478,7 @@ async function runProductionGraphGetErrors({
   // retain their clean-note assertions.
   stepBudget = () => 1000,
   monotonicNow = () => 0,
+  verifiedNodeDefCache = createVerifiedNodeDefCache(),
 }) {
   const deps = {
     monotonicNow,
@@ -488,6 +491,7 @@ async function runProductionGraphGetErrors({
     getRefreshInFlight: () => null,
     nodeDefRefreshInFlight: null,
     getGraphCtx: () => ({ app: { lastNodeErrors: null }, graph, rootGraph }),
+    verifiedNodeDefCache,
     assertGraphBoundToActiveWorkflow: () => {},
     graphCommandBindingBar: () => ({}),
     collectMissingAssets: () => ({ models: [], media: [], nodeTypes: [], nodeCount: 0 }),
@@ -570,6 +574,69 @@ test("#1691 production graph_get_errors batches live class reads and keeps uncer
   assert.equal(result.unchecked_nodes[0].type, "InstalledButUnreachablePack");
   assert.match(result.unchecked_nodes[0].reason, /could not be looked up/);
   assert.equal(result.note, undefined, "an unchecked live scan must not emit a clean note");
+});
+
+test("#1709 production graph_get_errors retires add proof on definitive class presence and absence", async () => {
+  const node = {
+    id: 31,
+    type: "RemovedNode",
+    widgets: [{ name: "mode", type: "combo", value: "old" }],
+  };
+  const graph = { _nodes: [node], getNodeById: () => node };
+  const def = { input: { required: { mode: [["old"], {}] } } };
+  const cache = createVerifiedNodeDefCache();
+  const proofContext = {};
+  let generation = cache.generation();
+  cache.set("RemovedNode", def, { epoch: 0, context: proofContext, generation });
+  let present = true;
+  const fetchInfo = async () =>
+    present
+      ? { [SINGLE_NODE_INFO_OUTCOME]: true, kind: "present", body: { RemovedNode: def } }
+      : { [SINGLE_NODE_INFO_OUTCOME]: true, kind: "absent", body: {} };
+
+  await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    scan: scanComboAvailability,
+    fetchSingleNodeInfo: fetchInfo,
+    verifiedNodeDefCache: cache,
+    stepBudget: () => 1000,
+  });
+  assert.ok(cache.generation() > generation, "a definitive present class read retired old proof");
+
+  present = false;
+  generation = cache.generation();
+  cache.set("RemovedNode", def, { epoch: 0, context: proofContext, generation });
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    scan: scanComboAvailability,
+    fetchSingleNodeInfo: fetchInfo,
+    verifiedNodeDefCache: cache,
+    stepBudget: () => 1000,
+  });
+  assert.equal(result.unchecked_nodes.length, 1, "the explicit absent class remains unchecked, not falsely clean");
+  assert.ok(cache.generation() > generation, "a definitive absent class read retired old proof");
+  assert.equal(
+    cache.get("RemovedNode", { epoch: 0, context: proofContext, generation: cache.generation() }),
+    undefined,
+    "the absent class has no reusable proof after get_errors",
+  );
+
+  const afterAbsence = cache.generation();
+  const timeout = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    scan: scanComboAvailability,
+    fetchSingleNodeInfo: async () => ({ [SINGLE_NODE_INFO_OUTCOME]: true, kind: "unknown" }),
+    verifiedNodeDefCache: cache,
+    stepBudget: () => 1000,
+  });
+  assert.equal(cache.generation(), afterAbsence, "an unknown/timeout class read remains non-authoritative");
+  assert.equal(timeout.unchecked_nodes.length, 1);
 });
 
 test("#1691 production graph_get_errors keeps budget-cutoff scans non-clean and uses its monotonic clock", async () => {

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -70,6 +70,8 @@ import {
 } from "../../web/js/lib/node-def-refresh.js";
 import { comboRebuildCovered } from "../../web/js/lib/asset-staleness.js";
 import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
+import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
+import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -427,6 +429,8 @@ function buildRegisterComfyNodeDefs({
   // #608 — defaults to the REAL oracle. Overridden only to OBSERVE what it is handed.
   fetchWholeObjectInfo: fetchWholeObjectInfoImpl = fetchWholeObjectInfo,
   verifiedNodeDefCache = createVerifiedNodeDefCache(),
+  objectInfoCache = cacheSpy,
+  objectInfoSnapshot = snapshotSpy,
 }) {
   const body = extractFunction("async function registerComfyNodeDefs(");
   const factory = new Function(
@@ -522,10 +526,10 @@ function buildRegisterComfyNodeDefs({
     NODE_DEFS_RETRY_DELAYS_MS,
     // #716 — the shipping function drops the widget-write burst cache after a successful
     // fetch. A spy, so the harness can prove that happens rather than merely tolerate it.
-    cacheSpy,
+    objectInfoCache,
     // #1223 — a spy, so a test can prove the run retires the last-observed schema and
     // re-records only a payload it fetched itself.
-    snapshotSpy,
+    objectInfoSnapshot,
     verifiedNodeDefCache,
     7,
     socketDown,
@@ -559,6 +563,49 @@ test("#635: the shipping register run end-to-end success reports refreshed", asy
   const verdict = await registerComfyNodeDefs(undefined);
   assert.deepEqual(verdict, { refreshed: true, reason: "refreshed" });
   assert.equal(getConfirmed(), true);
+});
+
+test("#1709: a graph_add whole payload survives the real preloaded refresh and hook mutation", async () => {
+  const objectInfoCache = createObjectInfoCache();
+  const objectInfoSnapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  const defs = {
+    NewNode: {
+      input: { required: { count: ["INT", { default: 1 }] } },
+    },
+  };
+  const app = {
+    graph: null,
+    refreshComboInNodes: async () => {},
+    registerNodesFromDefs: async (payload) => {
+      // This is the production hook mutation that must not contaminate the cached backend
+      // response: ComfyUI's registration path can add frontend-only input metadata in place.
+      payload.NewNode.input.required.count[1].default = 999;
+    },
+  };
+  const built = buildRegisterComfyNodeDefs({
+    appValue: app,
+    apiValue: { getNodeDefs: async () => ({ Unexpected: {} }) },
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache,
+  });
+
+  const verdict = await built.registerComfyNodeDefs(defs, { preloadedWholeSchema: true });
+  assert.equal(verdict.refreshed, true, "the real preloaded refresh completes");
+  assert.equal(defs.NewNode.input.required.count[1].default, 999, "the registration hook mutated its input");
+  const cached = await objectInfoCache.read(async () => ({ Unexpected: {} }));
+  assert.equal(
+    cached.NewNode.input.required.count[1].default,
+    1,
+    "the cache keeps a detached pre-hook whole schema",
+  );
+  const fallback = objectInfoSnapshot.authorize({
+    epoch: 7,
+    generation: verifiedNodeDefCache.generation(),
+    outcomes: [{ kind: TRANSPORT_OUTCOME.NO_ANSWER }],
+  });
+  assert.ok(fallback.defs?.NewNode, "the post-refresh snapshot remains timeout-usable");
 });
 
 test("#1695: a run superseded by reconnect cannot report fresh or restore combo trust", async () => {

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -65,6 +65,7 @@ import {
   NODE_DEF_REFRESH_REASONS,
 } from "../../web/js/lib/node-def-refresh.js";
 import { comboRebuildCovered } from "../../web/js/lib/asset-staleness.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -347,7 +348,10 @@ test("#635: the shipping registerComfyNodeDefs returns its verdict through the p
     "the shared global stays a strict boolean, and #1193 admits the panel's OWN completed " +
       "combo rebuild as the second way the live lists became current",
   );
-  assert.match(body, /const runIsCurrent = !comfyBackendSocketDown && runStartedAtEpoch === backendReconnectEpoch;/);
+  assert.match(
+    body,
+    /const runIsCurrent =\s*!comfyBackendSocketDown &&\s*runStartedAtEpoch === backendReconnectEpoch &&\s*runStartedAtGeneration === verifiedNodeDefCache\.generation\(\);/,
+  );
   assert.match(body, /reason: NODE_DEF_REFRESH_REASONS\.REFRESH_SUPERSEDED/);
   // #1193 — the two inputs must stay SEPARATE all the way to the verdict. Merging them
   // into one flag would make an abandoned-but-locally-rebuilt run indistinguishable from
@@ -418,6 +422,7 @@ function buildRegisterComfyNodeDefs({
   socketDown = false,
   // #608 — defaults to the REAL oracle. Overridden only to OBSERVE what it is handed.
   fetchWholeObjectInfo: fetchWholeObjectInfoImpl = fetchWholeObjectInfo,
+  verifiedNodeDefCache = createVerifiedNodeDefCache(),
 }) {
   const body = extractFunction("async function registerComfyNodeDefs(");
   const factory = new Function(
@@ -452,6 +457,7 @@ function buildRegisterComfyNodeDefs({
     // recording is stamped with. Both are module state in the panel, so the extracted
     // body throws ReferenceError without them.
     "objectInfoSnapshot",
+    "verifiedNodeDefCache",
     "initialBackendReconnectEpoch",
     "comfyBackendSocketDown",
     // #1562 — the oracle's per-route OUTCOME vocabulary. The fetch phase reads route 2's
@@ -516,6 +522,7 @@ function buildRegisterComfyNodeDefs({
     // #1223 — a spy, so a test can prove the run retires the last-observed schema and
     // re-records only a payload it fetched itself.
     snapshotSpy,
+    verifiedNodeDefCache,
     7,
     socketDown,
     TRANSPORT_OUTCOME,

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -50,7 +50,11 @@ const makeBoundedGetNodeDefs = (apiValue) => (timeoutMs = NODE_DEFS_FETCH_TIMEOU
 
 /** #716 — records invalidate() calls so a test can assert the refresh drops the cache. */
 let cacheInvalidations = 0;
-const cacheSpy = { invalidate: () => { cacheInvalidations += 1; }, read: async (f) => f() };
+const cacheSpy = {
+  invalidate: () => { cacheInvalidations += 1; },
+  replace: () => true,
+  read: async (f) => f(),
+};
 
 /** #1223 — the last-observed-schema snapshot the refresh run also clears and re-records. */
 let snapshotClears = 0;

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -2492,7 +2492,13 @@ const snapshotOpts = (reg, extra = {}) => ({
 function detachedSnapshotDefs(fullMap) {
   const snap = createObjectInfoSnapshot();
   assert.equal(
-    snap.record(fullMap, { observedAtEpoch: 7, currentEpoch: 7, whole: true }),
+    snap.record(fullMap, {
+      observedAtEpoch: 7,
+      currentEpoch: 7,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
     true,
     "fixture precondition: the snapshot accepted the whole map",
   );

--- a/browser_tests/unit/object-info-cache.test.mjs
+++ b/browser_tests/unit/object-info-cache.test.mjs
@@ -169,22 +169,28 @@ test("#1709: replace retires old cache entries and late in-flight responses", as
     await gate;
     return { OldType: {} };
   });
-  assert.equal(cache.replace({ NewType: {} }), true, "a definitive non-empty map replaces the old authority");
+  const replacement = {
+    NewType: { input: { required: { count: ["INT", { default: 1 }] } } },
+  };
+  assert.equal(cache.replace(replacement), true, "a definitive non-empty map replaces the old authority");
+  replacement.NewType.input.required.count[1].default = 999;
   release();
   await stale;
 
   let refetched = false;
-  assert.deepEqual(
-    await cache.read(async () => {
-      refetched = true;
-      return { Unexpected: {} };
-    }),
-    { NewType: {} },
-    "the late old response cannot overwrite the replacement",
-  );
+  const cachedReplacement = await cache.read(async () => {
+    refetched = true;
+    return { Unexpected: {} };
+  });
+  assert.equal(cachedReplacement.NewType.input.required.count[1].default, 1, "nested hook mutation is detached");
+  assert.equal(Object.isFrozen(cachedReplacement.NewType.input.required.count[1]), true, "nested data is frozen");
+  assert.equal(Object.isFrozen(cachedReplacement.NewType.input.required.count), true, "arrays are frozen");
   assert.equal(refetched, false, "the replacement remains the current burst entry");
   assert.equal(cache.replace({}), false, "an empty response is not an authority replacement");
-  assert.deepEqual(await cache.read(async () => ({ Unexpected: {} })), { NewType: {} });
+  assert.equal(
+    (await cache.read(async () => ({ Unexpected: {} }))).NewType.input.required.count[1].default,
+    1,
+  );
 });
 
 test("#716: every joined caller sees a failing fetch fail", async () => {

--- a/browser_tests/unit/object-info-cache.test.mjs
+++ b/browser_tests/unit/object-info-cache.test.mjs
@@ -157,6 +157,36 @@ test("#716: a read after invalidation does not JOIN the retired request", async 
   assert.deepEqual(await cache.read(async () => ({ ShouldNotBeCalled: {} })), { NewType: {} });
 });
 
+test("#1709: replace retires old cache entries and late in-flight responses", async () => {
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  await cache.read(async () => ({ OldType: {} }));
+  c.advance(OBJECT_INFO_CACHE_TTL_MS + 1);
+
+  let release;
+  const gate = new Promise((resolve) => (release = resolve));
+  const stale = cache.read(async () => {
+    await gate;
+    return { OldType: {} };
+  });
+  assert.equal(cache.replace({ NewType: {} }), true, "a definitive non-empty map replaces the old authority");
+  release();
+  await stale;
+
+  let refetched = false;
+  assert.deepEqual(
+    await cache.read(async () => {
+      refetched = true;
+      return { Unexpected: {} };
+    }),
+    { NewType: {} },
+    "the late old response cannot overwrite the replacement",
+  );
+  assert.equal(refetched, false, "the replacement remains the current burst entry");
+  assert.equal(cache.replace({}), false, "an empty response is not an authority replacement");
+  assert.deepEqual(await cache.read(async () => ({ Unexpected: {} })), { NewType: {} });
+});
+
 test("#716: every joined caller sees a failing fetch fail", async () => {
   // codex noted this was untested. A coalesced failure that resolved for some callers and
   // rejected for others would be a fence that authorizes for one write and refuses another

--- a/browser_tests/unit/object-info-cache.test.mjs
+++ b/browser_tests/unit/object-info-cache.test.mjs
@@ -8,7 +8,7 @@
 // real clock is a slow test that eventually becomes a flaky one.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { OBJECT_INFO_CACHE_TTL_MS, createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
+import { CACHE_OUTCOME, OBJECT_INFO_CACHE_TTL_MS, createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { fetchWholeObjectInfo } from "../../web/js/lib/object-info-oracle.js";
 import { noBackendAnswerEstablished } from "../../web/js/lib/object-info-snapshot.js";
 
@@ -26,7 +26,7 @@ test("#716: a burst of reads costs ONE fetch", async () => {
     fetches += 1;
     return DEFS;
   };
-  for (let i = 0; i < 29; i++) assert.equal(await cache.read(fetchDefs), DEFS);
+  for (let i = 0; i < 29; i++) assert.deepEqual(await cache.read(fetchDefs), DEFS);
   assert.equal(fetches, 1, "29 widget writes, one download — the whole point of the issue");
 });
 
@@ -193,6 +193,58 @@ test("#1709: replace retires old cache entries and late in-flight responses", as
   );
 });
 
+test("#1709: ordinary read deep-detaches nested outcome schemas", async () => {
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  const source = {
+    KSampler: { input: { required: { count: ["INT", { default: 1 }] } } },
+  };
+  const outcome = {
+    [CACHE_OUTCOME]: true,
+    defs: source,
+    failures: ["fallback unavailable"],
+    outcomes: [{ route: "client" }],
+  };
+
+  const returned = await cache.read(async () => outcome);
+  returned.defs.KSampler.input.required.count[1].default = 999;
+  const cached = await cache.read(async () => ({ Unexpected: {} }));
+
+  assert.equal(cached[CACHE_OUTCOME], true, "the cache keeps the outcome wrapper tag");
+  assert.deepEqual(cached.failures, ["fallback unavailable"], "diagnostics survive the detached copy");
+  assert.equal(cached.defs.KSampler.input.required.count[1].default, 1);
+  assert.equal(Object.isFrozen(cached.defs.KSampler.input.required.count[1]), true);
+  assert.equal(Object.isFrozen(cached.defs.KSampler.input.required.count), true);
+});
+
+test("#1709: readFresh deep-detaches nested schemas and does not cache an empty answer", async () => {
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  const source = {
+    KSampler: { input: { required: { count: ["INT", { default: 1 }] } } },
+  };
+  const returned = await cache.readFresh(async () => source);
+  returned.value.KSampler.input.required.count[1].default = 999;
+
+  let ordinaryFetches = 0;
+  const cached = await cache.read(async () => {
+    ordinaryFetches += 1;
+    return { Unexpected: {} };
+  });
+  assert.equal(ordinaryFetches, 0, "the fresh non-empty response remains the cache entry");
+  assert.equal(cached.KSampler.input.required.count[1].default, 1);
+  assert.equal(Object.isFrozen(cached.KSampler.input.required.count[1]), true);
+  assert.equal(Object.isFrozen(cached.KSampler.input.required.count), true);
+
+  cache.invalidate();
+  assert.equal(
+    (await cache.readFresh(async () => null)).value,
+    null,
+    "an unavailable forced read reaches its caller",
+  );
+  assert.equal(cache.peek().cached, false, "an unavailable forced read is not cached");
+});
+
 test("#716: every joined caller sees a failing fetch fail", async () => {
   // codex noted this was untested. A coalesced failure that resolved for some callers and
   // rejected for others would be a fence that authorizes for one write and refuses another
@@ -219,7 +271,8 @@ test("#716: the shared payload cannot have type keys added or removed", async ()
   // direction is adding a key — authorizing a type nobody installed.
   const c = clock();
   const cache = createObjectInfoCache({ now: c.now });
-  const defs = await cache.read(async () => ({ KSampler: {} }));
+  await cache.read(async () => ({ KSampler: {} }));
+  const defs = await cache.read(async () => ({ Unexpected: {} }));
   assert.throws(() => {
     "use strict";
     defs.ForgedType = {};
@@ -556,7 +609,7 @@ test("#1126: readFresh actually re-fetches — the stored entry never satisfies 
   const forced = await cache.readFresh(async () => DEFS, { stamp: () => 1 });
   assert.equal(forced.value, DEFS, "the forced read goes to the server anyway");
   // …and the fresher payload replaces the stored one, so later ordinary readers benefit.
-  assert.equal(await cache.read(async () => ({ MustNotBeFetched: {} })), DEFS);
+  assert.deepEqual(await cache.read(async () => ({ MustNotBeFetched: {} })), DEFS);
 });
 
 test("#1126: an invalidate() retires a forced reread too — it must not be joined afterwards", async () => {

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -70,7 +70,7 @@ test("#982 (codex r2) an EMPTY map from the client is its ANSWER — the fallbac
   // route then would overrule it with a broader schema, which is the one direction this
   // fallback must never move. `{}` therefore fails closed WITHOUT a second attempt.
   let fetched = 0;
-  const { defs, failures } = await fetchWholeObjectInfo({
+  const { defs, authoritativeEmpty, failures } = await fetchWholeObjectInfo({
     getNodeDefs: async () => ({}),
     fetchApi: async () => {
       fetched += 1;
@@ -78,8 +78,19 @@ test("#982 (codex r2) an EMPTY map from the client is its ANSWER — the fallbac
     },
   });
   assert.equal(defs, null, "fail closed on the answer the client gave");
+  assert.equal(authoritativeEmpty, true, "the empty answer is distinguished from a timeout");
   assert.equal(fetched, 0, "the raw route is never asked to overrule it");
   assert.match(failures[0], /EMPTY schema — treated as its answer, not as an absence/);
+});
+
+test("#982 an EMPTY map from the HTTP route is also an authoritative deny-all answer", async () => {
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => okResponse({}),
+  });
+  assert.equal(result.defs, null);
+  assert.equal(result.authoritativeEmpty, true);
+  assert.match(result.failures[1], /EMPTY schema — treated as its answer, not as an absence/);
 });
 
 test("#982 a client that returned NOTHING leaves the question open, and the fallback answers", async () => {
@@ -93,11 +104,12 @@ test("#982 a client that returned NOTHING leaves the question open, and the fall
   }
 });
 test("#982 both routes failing yields NO defs and names both", async () => {
-  const { defs, failures } = await fetchWholeObjectInfo({
+  const { defs, authoritativeEmpty, failures } = await fetchWholeObjectInfo({
     getNodeDefs: async () => null,
     fetchApi: async () => ({ ok: false, status: 503 }),
   });
   assert.equal(defs, null, "fail closed — the fence refuses on a null payload");
+  assert.equal(authoritativeEmpty, undefined, "a timeout/failure is not an authoritative deny-all");
   assert.equal(failures.length, 2);
   assert.match(failures[0], /api\.getNodeDefs\(\) returned no usable schema/);
   assert.match(failures[1], /GET \/object_info was not OK \(status 503\)/);

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -35,6 +35,7 @@ import {
 } from "../../web/js/lib/object-info-oracle.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
 import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 
 const SCHEMA = { KSampler: { input: {} }, H3Keyframes: { input: {} } };
 const silence = [
@@ -42,8 +43,14 @@ const silence = [
   { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
 ];
 /** The v2 record contract: an epoch captured before the fetch, unchanged since, and a claim. */
-const stored = (snap, defs = SCHEMA, epoch = 3) =>
-  snap.record(defs, { observedAtEpoch: epoch, currentEpoch: epoch, whole: true });
+const stored = (snap, defs = SCHEMA, epoch = 3, generation = 0) =>
+  snap.record(defs, {
+    observedAtEpoch: epoch,
+    currentEpoch: epoch,
+    observedAtGeneration: generation,
+    currentGeneration: generation,
+    whole: true,
+  });
 
 // ---------------------------------------------------------------------------
 // Condition 4: the backend never ANSWERED
@@ -404,7 +411,13 @@ test("#1223 a reconnect DURING the fetch is refused at record time", () => {
   // captured before the request goes out and re-checked when the answer lands.
   const snap = createObjectInfoSnapshot();
   assert.equal(
-    snap.record(SCHEMA, { observedAtEpoch: 3, currentEpoch: 4, whole: true }),
+    snap.record(SCHEMA, {
+      observedAtEpoch: 3,
+      currentEpoch: 4,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
     false,
     "the connection was replaced while this payload was in flight",
   );
@@ -417,16 +430,52 @@ test("#1223 a payload nobody vouched for as WHOLE is refused", () => {
   // type read as absent and the ever-seen gate diagnose the whole install as removed packs.
   // `record` cannot judge wholeness from the value, so it requires the claim.
   const snap = createObjectInfoSnapshot();
-  assert.equal(snap.record(SCHEMA, { observedAtEpoch: 1, currentEpoch: 1 }), false);
-  assert.equal(snap.record(SCHEMA, { observedAtEpoch: 1, currentEpoch: 1, whole: false }), false);
-  assert.equal(snap.record(SCHEMA, { observedAtEpoch: 1, currentEpoch: 1, whole: "yes" }), false);
+  assert.equal(
+    snap.record(SCHEMA, {
+      observedAtEpoch: 1,
+      currentEpoch: 1,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+    }),
+    false,
+  );
+  assert.equal(
+    snap.record(SCHEMA, {
+      observedAtEpoch: 1,
+      currentEpoch: 1,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: false,
+    }),
+    false,
+  );
+  assert.equal(
+    snap.record(SCHEMA, {
+      observedAtEpoch: 1,
+      currentEpoch: 1,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: "yes",
+    }),
+    false,
+  );
   assert.equal(snap.peek().held, false);
 });
 
 test("#1223 an unreadable epoch refuses, at record time and at authorize time", () => {
   const snap = createObjectInfoSnapshot();
   for (const bad of [undefined, null, NaN, Infinity, "3"]) {
-    assert.equal(snap.record(SCHEMA, { observedAtEpoch: bad, currentEpoch: bad, whole: true }), false, `record ${String(bad)}`);
+    assert.equal(
+      snap.record(SCHEMA, {
+        observedAtEpoch: bad,
+        currentEpoch: bad,
+        observedAtGeneration: 0,
+        currentGeneration: 0,
+        whole: true,
+      }),
+      false,
+      `record ${String(bad)}`,
+    );
   }
   stored(snap);
   for (const bad of [undefined, null, NaN, Infinity, "3"]) {
@@ -475,7 +524,13 @@ test("#1223 only a payload that could authorize anything is stored", () => {
   // `undefined` silently tested the good schema and the case passed for the wrong reason.
   for (const bad of [null, undefined, {}, [], "schema", 7, [SCHEMA]]) {
     assert.equal(
-      snap.record(bad, { observedAtEpoch: 3, currentEpoch: 3, whole: true }),
+      snap.record(bad, {
+        observedAtEpoch: 3,
+        currentEpoch: 3,
+        observedAtGeneration: 0,
+        currentGeneration: 0,
+        whole: true,
+      }),
       false,
       `${String(bad)} is not a schema`,
     );
@@ -511,6 +566,28 @@ test("#1223 clear() retires it — a suspicion of change outranks a stored schem
   snap.clear();
   assert.equal(snap.authorize({ epoch: 2, socketDown: false, outcomes: silence }).defs, null);
   assert.equal(snap.peek().held, false);
+});
+
+test("#1709 a same-epoch generation retirement rejects a late snapshot writer", () => {
+  const snap = createObjectInfoSnapshot();
+  assert.equal(stored(snap, SCHEMA, 3, 4), true);
+  snap.clear();
+  assert.equal(
+    snap.record(SCHEMA, {
+      observedAtEpoch: 3,
+      currentEpoch: 3,
+      observedAtGeneration: 4,
+      currentGeneration: 5,
+      whole: true,
+    }),
+    false,
+    "same-epoch refresh invalidation still fences the old writer",
+  );
+  assert.equal(
+    snap.authorize({ epoch: 3, generation: 5, socketDown: false, outcomes: silence }).defs,
+    null,
+    "the retired snapshot cannot authorize at the new generation",
+  );
 });
 
 test("#1223 a successful write authorized this way DISCLOSES it", () => {
@@ -575,7 +652,16 @@ function extractSetWidgetOracle() {
  * `epochDuringFetch` lets a test move the connection epoch WHILE the read is in flight —
  * the reconnect-mid-fetch hazard, which cannot be exercised any other way.
  */
-function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epochDuringFetch = null, onFetch = null }) {
+function buildShippedOracle({
+  api,
+  socketDown = false,
+  epoch = 5,
+  snapshot,
+  verifiedNodeDefCache = createVerifiedNodeDefCache(),
+  objectInfoCache = createObjectInfoCache(),
+  epochDuringFetch = null,
+  onFetch = null,
+}) {
   const body = extractSetWidgetOracle();
   const factory = new Function(
     "api",
@@ -583,6 +669,7 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     "realFetchWholeObjectInfo",
     "CACHE_OUTCOME",
     "objectInfoSnapshot",
+    "verifiedNodeDefCache",
     "initialEpoch",
     "epochDuringFetch",
     "comfyBackendSocketDown",
@@ -643,11 +730,12 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
   );
   return factory(
     api,
-    createObjectInfoCache(),
+    objectInfoCache,
     fetchWholeObjectInfo,
-    CACHE_OUTCOME,
-    snapshot,
-    epoch,
+     CACHE_OUTCOME,
+     snapshot,
+     verifiedNodeDefCache,
+     epoch,
     epochDuringFetch,
     socketDown,
     objectInfoOracleFailureNote,
@@ -668,6 +756,41 @@ test("#1223 SHIPPED: a live answer is returned and snapshotted", async () => {
   assert.deepEqual(snapshot.peek(), { held: true, epoch: 5 }, "stamped with the connection it was read on");
   assert.equal(o.readNote(), null, "a live authorization discloses nothing, because there is nothing to disclose");
   assert.deepEqual(o.readHistory(), [SCHEMA], "and it IS a real observation, so the ever-seen history takes it");
+});
+
+test("#1709 SHIPPED: authoritative empty retires cache and snapshot, while timeout stays non-authoritative", async () => {
+  let defs = SCHEMA;
+  const api = {
+    getNodeDefs: async () => defs,
+    fetchApi: async () => ({ status: 503, json: async () => ({}) }),
+  };
+  const snapshot = createObjectInfoSnapshot();
+  const cache = createObjectInfoCache();
+  const o = buildShippedOracle({ api, snapshot, objectInfoCache: cache, epoch: 5 });
+
+  assert.deepEqual(await o.getFreshObjectInfo(), SCHEMA, "the initial whole read establishes both old trust roots");
+  assert.equal(cache.peek().cached, true);
+  assert.equal(snapshot.peek().held, true);
+
+  defs = undefined;
+  const timedOut = await o.refetchObjectInfoLive();
+  assert.equal(timedOut, null, "an unavailable forced read has no schema to promote");
+  assert.equal(cache.peek().cached, true, "timeout did not turn a still-valid old cache into an invalidation");
+  assert.equal(snapshot.peek().held, true, "timeout did not turn a still-valid old snapshot into an invalidation");
+
+  defs = {};
+  const denied = await o.refetchObjectInfoLive();
+  assert.equal(denied, null, "authoritative empty remains fail-closed");
+  assert.equal(cache.peek().cached, false, "authoritative empty retired the old whole payload");
+  assert.equal(snapshot.peek().held, false, "authoritative empty retired old membership proof");
+
+  defs = undefined;
+  assert.equal(
+    await o.getFreshObjectInfo(),
+    null,
+    "the later ordinary timeout cannot resurrect the retired schema through cache or snapshot fallback",
+  );
+  assert.match(o.readIneligibility(), /no snapshot|schema/i, "the timeout path remains a refusal without old authority");
 });
 
 test("#1223 SHIPPED: a reconnect DURING the read means the answer is not snapshotted", async () => {
@@ -946,9 +1069,10 @@ function extractExecutor(name) {
 }
 
 function buildExecutor(name, deps) {
-  const names = Object.keys(deps);
+  const runtimeDeps = { verifiedNodeDefCache: createVerifiedNodeDefCache(), ...deps };
+  const names = Object.keys(runtimeDeps);
   const factory = new Function(...names, `const executors = { ${extractExecutor(name)} };\nreturn executors.${name};`);
-  return factory(...names.map((n) => deps[n]));
+  return factory(...names.map((n) => runtimeDeps[n]));
 }
 
 test("#1223 SHIPPED get_object_info: a successful whole read IS filed", async () => {
@@ -1006,6 +1130,28 @@ test("#1223 SHIPPED get_object_info: a FAILED read files nothing", async () => {
   assert.equal(snapshot.peek().held, false);
 });
 
+test("#1709 SHIPPED get_object_info: a same-epoch refresh crossing the read cannot file its snapshot", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  const get = buildExecutor("graph_get_object_info", {
+    fetchWholeObjectInfo: async () => {
+      verifiedNodeDefCache.clear();
+      return { defs: SCHEMA, failures: [], outcomes: [] };
+    },
+    objectInfoSnapshot: snapshot,
+    verifiedNodeDefCache,
+    backendReconnectEpoch: 9,
+    api: { getNodeDefs: async () => SCHEMA },
+    pageComfyOrigin: () => "http://127.0.0.1:8188",
+    objectInfoOracleFailureNote: () => "",
+    objectInfoFingerprint: () => "fp",
+    objectInfoUnchanged: () => false,
+  });
+  const res = await get({});
+  assert.equal(res.ok, true, "the read itself still returns its live payload");
+  assert.equal(snapshot.peek().held, false, "the old-generation result was not accepted as snapshot authority");
+});
+
 function buildRemoveWidget({ snapshot, epoch = 4, cache, defs = SCHEMA }) {
   const node = { id: 3, type: "KSampler", comfyClass: "KSampler", widgets: [{ name: "seed" }] };
   return buildExecutor("graph_remove_widget", {
@@ -1061,17 +1207,18 @@ test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and 
   // type read as absent and the ever-seen gate diagnose the install as removed packs.
   assert.match(
     PANEL_SRC,
-    /if \(freshDefs && !freshDefsAreSingleClass && addNodeObservedAtEpoch !== null\) \{\s*\n\s*objectInfoSnapshot\.record\(/,
+    /addNodeObservedAtEpoch !== null[\s\S]*addNodeObservedAtGeneration !== null[\s\S]*objectInfoSnapshot\.record\(/,
     "add_node files its payload only when it fetched the WHOLE schema, and only then",
   );
   for (const site of sites) {
-    const call = PANEL_SRC.slice(site.index, site.index + 260);
+    const call = PANEL_SRC.slice(site.index, site.index + 420);
     assert.match(call, /whole: true/, `the record site at index ${site.index} states the wholeness claim`);
     assert.match(call, /observedAtEpoch/, `the record site at index ${site.index} stamps the issuance epoch`);
+    assert.match(call, /observedAtGeneration/, `the record site at index ${site.index} stamps the schema generation`);
   }
   assert.match(
     PANEL_SRC,
-    /if \(!preloadedDefs\) \{\s*\n\s*objectInfoSnapshot\.record\(/,
+    /if \(!preloadedDefs && refreshResponseIsCurrent\) \{\s*\n\s*objectInfoSnapshot\.record\(/,
     "the refresh run records only a payload it fetched itself — a caller-supplied one is not provably whole",
   );
 });
@@ -1083,7 +1230,14 @@ test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and 
  * MATCHES the pattern, so disabling the startup snapshot left the assertion green. Mutation
  * caught that. A test for whether code RUNS has to run it.
  */
-function buildShippedSeed({ api, epoch = 2, snapshot, epochDuringFetch = null }) {
+function buildShippedSeed({
+  api,
+  epoch = 2,
+  snapshot,
+  verifiedNodeDefCache = createVerifiedNodeDefCache(),
+  epochDuringFetch = null,
+  generationDuringFetch = false,
+}) {
   const start = PANEL_SRC.indexOf("function seedObjectInfoHistory()");
   assert.notEqual(start, -1, "seedObjectInfoHistory not found");
   const open = PANEL_SRC.indexOf("{", start);
@@ -1107,6 +1261,7 @@ function buildShippedSeed({ api, epoch = 2, snapshot, epochDuringFetch = null })
   const factory = new Function(
     "api",
     "objectInfoSnapshot",
+    "verifiedNodeDefCache",
     "initialEpoch",
     "epochDuringFetch",
     "objectInfoHistory",
@@ -1124,17 +1279,23 @@ function buildShippedSeed({ api, epoch = 2, snapshot, epochDuringFetch = null })
        setEpoch: (n) => { backendReconnectEpoch = n; },
      };`,
   );
+  let seedFetchCount = 0;
   const built = factory(
     {
       getNodeDefs: async () => {
         // Move the epoch WHILE the request is outstanding — the reconnect-mid-fetch hazard.
-        if (epochDuringFetch !== null) built.setEpoch(epochDuringFetch);
-        return api.defs;
+        if (epochDuringFetch !== null && seedFetchCount++ === 0) {
+          built.setEpoch(epochDuringFetch);
+          return api.defs;
+        }
+        if (generationDuringFetch) verifiedNodeDefCache.clear();
+        return epochDuringFetch !== null ? null : api.defs;
       },
-    },
-    snapshot,
-    epoch,
-    null,
+     },
+     snapshot,
+     verifiedNodeDefCache,
+     epoch,
+    epochDuringFetch,
     { loseBaseline: () => {} },
   );
   return built;
@@ -1164,8 +1325,24 @@ test("#1223 SHIPPED STARTUP: a reconnect during the seed's fetch is not filed", 
   const snapshot = createObjectInfoSnapshot();
   const seed = buildShippedSeed({ api: { defs: SCHEMA }, epoch: 2, snapshot, epochDuringFetch: 3 });
   await seed.run();
-  assert.equal(seed.wasSeeded(), true, "the history is still seeded — that trust root is separate");
+  assert.equal(seed.wasSeeded(), false, "a replaced connection cannot establish the history baseline");
   assert.equal(snapshot.peek().held, false, "but the payload describes the connection that was replaced");
+});
+
+test("#1709 SHIPPED STARTUP: a same-epoch refresh during the seed's fetch is not filed", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  const seed = buildShippedSeed({
+    api: { defs: SCHEMA },
+    epoch: 2,
+    snapshot,
+    verifiedNodeDefCache,
+    generationDuringFetch: true,
+  });
+  await seed.run();
+  assert.equal(seed.wasSeeded(), false, "a generation that changes on every retry keeps the baseline unseeded");
+  assert.deepEqual(seed.readRecorded(), [], "no pre-refresh result was recorded as history");
+  assert.equal(snapshot.peek().held, false, "the pre-refresh whole result was not recorded at the same epoch");
 });
 
 test("#1223 the socket handlers clear the snapshot DIRECTLY, not by way of a refresh", () => {
@@ -1197,6 +1374,18 @@ test("#1223 the disclosure rides on its OWN field, never on `warning`", () => {
     !/warning:[^\n]*snapshotAuthorizationNote/.test(body),
     "the provenance note never competes for the warning slot",
   );
+});
+
+test("#1709 every live whole-schema reader retires cache and snapshot on authoritative empty", () => {
+  for (const name of ["graph_get_object_info", "graph_set_widget", "graph_remove_widget"]) {
+    const start = PANEL_SRC.indexOf(`  async ${name}(`);
+    assert.notEqual(start, -1, `${name} not found`);
+    const next = PANEL_SRC.indexOf("\n  async graph_", start + 1);
+    const handler = PANEL_SRC.slice(start, next === -1 ? PANEL_SRC.length : next);
+    assert.match(handler, /authoritativeEmpty/, `${name} classifies authoritative empty`);
+    assert.match(handler, /objectInfoCache\.invalidate\(\)/, `${name} retires the burst payload`);
+    assert.match(handler, /objectInfoSnapshot\.clear\(\)/, `${name} retires membership proof`);
+  }
 });
 
 test("#1223 no comment cites a symbol that does not exist", () => {

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -1069,7 +1069,11 @@ function extractExecutor(name) {
 }
 
 function buildExecutor(name, deps) {
-  const runtimeDeps = { verifiedNodeDefCache: createVerifiedNodeDefCache(), ...deps };
+  const runtimeDeps = {
+    objectInfoCache: createObjectInfoCache(),
+    verifiedNodeDefCache: createVerifiedNodeDefCache(),
+    ...deps,
+  };
   const names = Object.keys(runtimeDeps);
   const factory = new Function(...names, `const executors = { ${extractExecutor(name)} };\nreturn executors.${name};`);
   return factory(...names.map((n) => runtimeDeps[n]));
@@ -1218,7 +1222,7 @@ test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and 
   }
   assert.match(
     PANEL_SRC,
-    /if \(!preloadedDefs && refreshResponseIsCurrent\) \{\s*\n\s*objectInfoSnapshot\.record\(/,
+    /if \(!preloadedDefs && refreshResponseIsCurrent\) \{[\s\S]{0,420}objectInfoSnapshot\.record\(/,
     "the refresh run records only a payload it fetched itself — a caller-supplied one is not provably whole",
   );
 });
@@ -1234,6 +1238,7 @@ function buildShippedSeed({
   api,
   epoch = 2,
   snapshot,
+  objectInfoCache = createObjectInfoCache(),
   verifiedNodeDefCache = createVerifiedNodeDefCache(),
   epochDuringFetch = null,
   generationDuringFetch = false,
@@ -1261,6 +1266,7 @@ function buildShippedSeed({
   const factory = new Function(
     "api",
     "objectInfoSnapshot",
+    "objectInfoCache",
     "verifiedNodeDefCache",
     "initialEpoch",
     "epochDuringFetch",
@@ -1293,6 +1299,7 @@ function buildShippedSeed({
       },
      },
      snapshot,
+     objectInfoCache,
      verifiedNodeDefCache,
      epoch,
     epochDuringFetch,

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -822,7 +822,7 @@ test("#1223 SHIPPED: a CACHE HIT is never filed as evidence — it can predate a
 
   snapshot.clear(); // what a reconnect does
   o.setEpoch(6); // ...and the epoch it bumps
-  assert.equal(await o.getFreshObjectInfo(), SCHEMA, "the cache still answers its waiter");
+  assert.deepEqual(await o.getFreshObjectInfo(), SCHEMA, "the cache still answers its waiter");
   assert.equal(
     snapshot.peek().held,
     false,

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -1222,8 +1222,8 @@ test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and 
   }
   assert.match(
     PANEL_SRC,
-    /if \(!preloadedDefs && refreshResponseIsCurrent\) \{[\s\S]{0,420}objectInfoSnapshot\.record\(/,
-    "the refresh run records only a payload it fetched itself — a caller-supplied one is not provably whole",
+    /if \(\(!preloadedDefs \|\| preloadedWholeSchema\) && refreshResponseIsCurrent\) \{[\s\S]{0,1200}objectInfoSnapshot\.record\(/,
+    "the refresh run records fetched payloads or the graph_add caller's explicitly verified whole payload",
   );
 });
 

--- a/browser_tests/unit/refresh-graph-guard.test.mjs
+++ b/browser_tests/unit/refresh-graph-guard.test.mjs
@@ -52,6 +52,7 @@ import {
 } from "./_panel-constants.mjs";
 
 import { comboRebuildCovered } from "../../web/js/lib/asset-staleness.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 
 const NODE_DEFS_RETRY_DELAYS_MS = OBJECT_INFO_RETRY_DELAYS_MS;
 
@@ -246,8 +247,9 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     "NODE_DEFS_RETRY_DELAYS_MS",
     "objectInfoCache",
     "objectInfoSnapshot",
-     "backendReconnectEpoch",
-     "comfyBackendSocketDown",
+    "verifiedNodeDefCache",
+    "backendReconnectEpoch",
+    "comfyBackendSocketDown",
     // #1275 — the guard's collaborators, REAL lib functions, so this harness proves
     // the shipped wiring and not a re-implementation of it.
     "liveGraphNodeInventory",
@@ -295,8 +297,9 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     NODE_DEFS_RETRY_DELAYS_MS,
     { invalidate: () => {}, read: async (f) => f() },
     { clear: () => {}, record: () => true },
-     7,
-     false,
+    createVerifiedNodeDefCache(),
+    7,
+    false,
     liveGraphNodeInventory,
     vanishedLiveNodes,
     missingInventoryIds,

--- a/browser_tests/unit/refresh-graph-guard.test.mjs
+++ b/browser_tests/unit/refresh-graph-guard.test.mjs
@@ -295,7 +295,7 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
       nodeDefsBudgetLeft,
     monotonicNow,
     NODE_DEFS_RETRY_DELAYS_MS,
-    { invalidate: () => {}, read: async (f) => f() },
+    { invalidate: () => {}, replace: () => true, read: async (f) => f() },
     { clear: () => {}, record: () => true },
     createVerifiedNodeDefCache(),
     7,

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -19,6 +19,7 @@ import {
   resolveMissingModelDirectory,
 } from "../../web/js/lib/asset-staleness.js";
 import { withoutFrontendVirtualTypes } from "../../web/js/lib/frontend-virtual-nodes.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 
 const SRC = readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
 
@@ -61,7 +62,7 @@ function buildRun({ appValue, apiValue, withTimeoutImpl = withTimeout, runBudget
     "describeNodeDefRefresh", "NODE_DEF_REFRESH_REASONS", "fetchNodeDefsWithRetry", "withTimeout", "NODE_DEFS_NO_ANSWER",
     "COMBO_OK", "COMBO_NO_ANSWER", "NODE_DEFS_FETCH_TIMEOUT_MS", "NODE_DEFS_RUN_BUDGET_MS",
     "NODE_DEFS_FETCH_SHARE", "fetchWholeObjectInfo", "nodeDefsBudgetLeft", "monotonicNow",
-    "NODE_DEFS_RETRY_DELAYS_MS", "objectInfoCache", "objectInfoSnapshot", "backendReconnectEpoch",
+    "NODE_DEFS_RETRY_DELAYS_MS", "objectInfoCache", "objectInfoSnapshot", "verifiedNodeDefCache", "backendReconnectEpoch",
     "comfyBackendSocketDown",
     "TRANSPORT_OUTCOME",
   ];
@@ -83,6 +84,7 @@ function buildRun({ appValue, apiValue, withTimeoutImpl = withTimeout, runBudget
     NODE_DEFS_RETRY_DELAYS_MS: OBJECT_INFO_RETRY_DELAYS_MS,
     objectInfoCache: cacheSpy,
     objectInfoSnapshot: snapshotSpy,
+    verifiedNodeDefCache: createVerifiedNodeDefCache(),
     backendReconnectEpoch: 7,
     comfyBackendSocketDown: false,
     TRANSPORT_OUTCOME,

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -48,7 +48,7 @@ const COMBO_OK = Symbol("combo-refreshed");
 const COMBO_NO_ANSWER = Symbol("combo-timeout");
 const monotonicNow = () => performance.now();
 const nodeDefsBudgetLeft = (deadline, share = 1) => Math.max(1, Math.floor((deadline - monotonicNow()) * share));
-const cacheSpy = { invalidate: () => {}, read: async (f) => f() };
+const cacheSpy = { invalidate: () => {}, replace: () => true, read: async (f) => f() };
 const snapshotSpy = { clear: () => {}, record: () => true };
 const COMMAND_BUDGET = 2500;
 const RELAY = 3000;

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1364,6 +1364,7 @@ const EXECUTOR_DEPS = [
   "OBJECT_INFO_DEADLINE_MS",
   "REFRESH_JOIN_ABANDONED",
   "COMBO_REFRESH_NEVER_RAN",
+  "verifiedNodeDefCache",
   // The coalescer's live slot. This harness's refreshCombos path is never exercised (the
   // runSetWidget double never calls it), so a fixed null is the truth here.
   "nodeDefRefreshInFlight",

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -389,8 +389,8 @@ test("#1223 × #1126 wiring: graph_set_widget THREADS the schema provenance into
   // retain a schema the panel itself had just superseded.
   assert.match(
     body,
-    /if \(readProvenance === "live"\) \{\s*objectInfoSnapshot\.record\(/,
-    "only a live answer may be filed as the last-observed schema",
+    /if \(readProvenance === "live" && generationIsCurrent\) \{[\s\S]{0,300}?objectInfoSnapshot\.record\(/,
+    "only a live answer may retire add proofs and be filed as the last-observed schema",
   );
   // …and the lib must be able to force a genuinely live re-read, or a cache hit could only
   // ever fail closed — refusing writes 2..N of an ordinary burst. Through `readFresh`, NOT a
@@ -402,8 +402,11 @@ test("#1223 × #1126 wiring: graph_set_widget THREADS the schema provenance into
     /refetchObjectInfoLive:[\s\S]{0,240}objectInfoCache\.readFresh\(/,
     "the executor must offer a coalescing, non-retiring forced reread",
   );
+  const forcedRecoveryStart = body.indexOf("refetchObjectInfoLive:");
+  assert.notEqual(forcedRecoveryStart, -1, "the forced recovery entry point must exist");
+  const forcedRecovery = body.slice(forcedRecoveryStart, body.indexOf("// #1560", forcedRecoveryStart));
   assert.doesNotMatch(
-    body,
+    forcedRecovery,
     /objectInfoCache\.invalidate\(\)/,
     "…and must NOT reach for the global invalidation on the recovery path",
   );
@@ -444,7 +447,7 @@ test("#1582 wiring: a reusable snapshot shortens only the ordinary schema probe"
   );
   assert.match(
     body,
-    /reuseSnapshot &&[\s\S]{0,260}objectInfoSnapshot\.isReusable\([\s\S]{0,180}OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS/,
+    /reuseSnapshot &&[\s\S]{0,500}objectInfoSnapshot\.isReusable\([\s\S]{0,260}OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS/,
     "a current-connection snapshot must cap the ordinary serial probe",
   );
   assert.match(

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -186,6 +186,27 @@ test("#1560 A: a PROMOTED nested write asks about ALL THREE types (#716/#821's '
   );
 });
 
+test("#1709: a partial scoped batch reports only definitive classes for proof retirement", async () => {
+  const backend = largeInstall({
+    perClass: async (type) => {
+      if (type === "PresentNode") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ PresentNode: { input: { required: {} } } }),
+        };
+      }
+      if (type === "UnknownNode") throw new Error("timeout");
+      return undefined;
+    },
+  });
+  const result = await fetchTypeScopedObjectInfo(["PresentNode", "UnknownNode"], {
+    fetchApi: backend.fetchApi,
+  });
+  assert.equal(result.defs, null, "an incomplete batch remains unauthorized");
+  assert.deepEqual(result.covered, ["PresentNode"], "only the definitive class is reported for invalidation");
+});
+
 test("#1560 A: the scoped payload is NEVER recorded into the #1223 snapshot", async () => {
   // object-info-snapshot.js requires an explicit `whole: true` claim precisely so a
   // per-class payload cannot make every OTHER type read as a removed pack. This route must
@@ -531,8 +552,8 @@ test("#1560: the panel WIRES the scoped route, gated on the silence licence and 
   // `readObjectInfo` more than once (the #1126 live re-ask).
   assert.match(
     src,
-    /outcomes: outcome\?\.outcomes,\s*\}\);[\s\S]{0,400}?scopedReadLicensed = noBackendAnswerEstablished\(outcome\?\.outcomes\);/,
-    "decided in the same breath as objectInfoSnapshot.authorize, from the same evidence",
+    /outcomes: outcome\?\.outcomes,\s*\}\);[\s\S]{0,500}?scopedReadLicensed = schemaResponseIsCurrent && noBackendAnswerEstablished\(outcome\?\.outcomes\);/,
+    "decided in the same breath as objectInfoSnapshot.authorize, from the same evidence and current-generation fence",
   );
   assert.match(src, /if \(!scopedReadLicensed\) \{/, "a route that ANSWERED is never overruled");
   assert.match(src, /let scopedReadLicensed = false;/, "and it licenses nothing until a read establishes it");

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -27,7 +27,11 @@ import assert from "node:assert/strict";
 import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
 import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
-import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
+import {
+  createObjectInfoCache,
+  CACHE_OUTCOME,
+  OBJECT_INFO_CACHE_TTL_MS,
+} from "../../web/js/lib/object-info-cache.js";
 import {
   fetchWholeObjectInfo,
   objectInfoOracleFailureNote,
@@ -761,6 +765,75 @@ test("#1709: authoritative empty retires whole cache and snapshot before ordinar
     ["/object_info", "/object_info"],
     "the later ordinary read reached both live routes after the cache was retired",
   );
+});
+
+test("#1709: graph_get_object_info replaces changed whole authority before graph_set_widget timeout", async () => {
+  const widget = { name: "text", type: "text", value: "before" };
+  const oldDef = { input: { required: { text: ["STRING", {}] } } };
+  const oldDefs = { RemovedNode: oldDef };
+  const changedDefs = { OtherNode: { input: { required: {} } } };
+  const node = {
+    id: 215,
+    type: "RemovedNode",
+    widgets: [widget],
+    constructor: { nodeData: oldDef, comfyClass: "RemovedNode" },
+  };
+  let now = 0;
+  let liveDefs = oldDefs;
+  const objectInfoCache = createObjectInfoCache({ now: () => now });
+  const objectInfoSnapshot = createObjectInfoSnapshot();
+  const built = realGraphSetWidget({
+    node,
+    objectInfoCache,
+    objectInfoSnapshot,
+    getNodeDefsImpl: async () => liveDefs,
+    fetchApiImpl: async () =>
+      liveDefs
+        ? { status: 200, json: async () => liveDefs }
+        : { status: 504, json: async () => ({}) },
+    oracleDefs: oldDefs,
+    registeredNodeTypes: {
+      LoadImage: {},
+      Note: {},
+      RemovedNode: { nodeData: oldDef, comfyClass: "RemovedNode" },
+    },
+  });
+
+  const first = await built.graph_set_widget({
+    node_id: 215,
+    widget: "text",
+    value: "live-old",
+    workflow_uuid: "u",
+  });
+  assert.equal(first.set.value, "live-old", "the old whole schema establishes the initial authority");
+
+  liveDefs = changedDefs;
+  const get = realGraphGetObjectInfo({
+    api: built.api,
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache: built.verifiedNodeDefCache,
+  });
+  const fresh = await get({});
+  assert.equal(fresh.ok, true, "the changed non-empty whole response is authoritative");
+  assert.deepEqual(
+    await objectInfoCache.read(async () => ({ Unexpected: {} })),
+    changedDefs,
+    "a later burst read sees the changed whole map, not the old cached map",
+  );
+  assert.equal(objectInfoSnapshot.peek().held, true, "the replacement map is also the snapshot authority");
+
+  // Let the replacement expire, then make both live routes silent. The timeout path must
+  // consult the replacement snapshot and refuse RemovedNode; it must not resurrect the
+  // previous whole map that graph_get_object_info superseded.
+  now += OBJECT_INFO_CACHE_TTL_MS + 1;
+  liveDefs = null;
+  await assert.rejects(
+    () => built.graph_set_widget({ node_id: 215, widget: "text", value: "stale", workflow_uuid: "u" }),
+    /Cannot set widget|does not provide|object_info is unavailable|refused/i,
+    "the timeout fallback refuses the removed class",
+  );
+  assert.equal(widget.value, "live-old", "the stale timeout path did not mutate the widget");
 });
 
 test("#1709: a definitive per-class absence retires cached whole proof before graph_set_widget timeout fallback", async () => {

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -28,7 +28,20 @@ import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widg
 import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
-import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
+import {
+  fetchWholeObjectInfo,
+  objectInfoOracleFailureNote,
+  TRANSPORT_OUTCOME,
+} from "../../web/js/lib/object-info-oracle.js";
+import {
+  createObjectInfoSnapshot,
+  noBackendAnswerEstablished,
+} from "../../web/js/lib/object-info-snapshot.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
+import {
+  fetchTypeScopedObjectInfo,
+  SCOPED_OBJECT_INFO_DEADLINE_MS,
+} from "../../web/js/lib/scoped-object-info.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "../../web/js/lib/rgthree-lora-row.js";
 import { inputAssetViewQuery } from "../../web/js/lib/input-asset.js";
 import {
@@ -37,6 +50,11 @@ import {
   SET_WIDGET_COMMAND_BUDGET_MS,
   SET_WIDGET_POST_REFRESH_RESERVE_MS,
 } from "./_panel-constants.mjs";
+
+const graphGetMatch = PANEL_SRC.match(
+  /\n  async graph_get_object_info\(\{ if_none_match \} = \{\}\) \{[\s\S]*?\n  \},/,
+);
+assert.ok(graphGetMatch, "could not locate graph_get_object_info in the panel source");
 
 // ---------------------------------------------------------------------------
 // 1. The lib: an abandoned refresh is a worded, honest, retryable refusal.
@@ -204,6 +222,7 @@ const EXECUTOR_DEPS = [
   "objectInfoSnapshot",
   "recordObjectInfoTypes",
   "objectInfoOracleFailureNote",
+  "noBackendAnswerEstablished",
   "comfyBackendSocketDown",
   "comfyBackendIsDown",
   "objectInfoHistory",
@@ -223,6 +242,9 @@ const EXECUTOR_DEPS = [
   "OBJECT_INFO_DEADLINE_MS",
   "REFRESH_JOIN_ABANDONED",
   "COMBO_REFRESH_NEVER_RAN",
+  "verifiedNodeDefCache",
+  "fetchTypeScopedObjectInfo",
+  "SCOPED_OBJECT_INFO_DEADLINE_MS",
   // The coalescer's live slot. The shipped refreshCombos reads it BEFORE calling the
   // coalescer, so the value captured at build time is exactly what that read must see:
   // the in-flight run a test started before dispatching the command.
@@ -271,6 +293,11 @@ function realGraphSetWidget({
   oracleDefs = null,
   // /view probe behaviour: default answers 404 (the asset is not there).
   fetchApiImpl = null,
+  getNodeDefsImpl = null,
+  objectInfoCache = createObjectInfoCache(),
+  objectInfoSnapshot = { record: () => true, authorize: () => ({ defs: null, reason: "none recorded" }) },
+  verifiedNodeDefCache = createVerifiedNodeDefCache(),
+  registeredNodeTypes = { LoadImage: {}, Note: {} },
 } = {}) {
   const graph = {
     _nodes: [node],
@@ -283,8 +310,9 @@ function realGraphSetWidget({
     graph,
     // "Note" registered with NO nodeData/comfyClass — a genuine frontend-only class, the
     // two positive signals the #475 exemption requires.
-    LG: { registered_node_types: { LoadImage: {}, Note: {} } },
+    LG: { registered_node_types: registeredNodeTypes },
     rootGraph: graph,
+    workflow: { uuid: "wf" },
   };
 
   // The authorization oracle answers with a schema that does NOT contain the (frontend-
@@ -294,6 +322,7 @@ function realGraphSetWidget({
   const api = {
     getNodeDefs: async () => {
       if (oracleDelayMs) await sleep(oracleDelayMs);
+      if (getNodeDefsImpl) return getNodeDefsImpl();
       return oracleDefs ?? { LoadImage: { input: { required: { image: [["old_a.png"], {}] } } } };
     },
     fetchApi: fetchApiImpl ?? (async () => ({ ok: false, status: 404 })),
@@ -339,14 +368,15 @@ function realGraphSetWidget({
     assertActiveWorkflowCommandTarget: () => {},
     WORKFLOW_UUID_FIELD: "workflow_uuid",
     runSetWidget,
-    objectInfoCache: createObjectInfoCache(),
+    objectInfoCache,
     CACHE_OUTCOME,
     fetchWholeObjectInfo,
     api,
     backendReconnectEpoch: 0,
-    objectInfoSnapshot: { record: () => true, authorize: () => ({ defs: null, reason: "none recorded" }) },
+    objectInfoSnapshot,
     recordObjectInfoTypes: (defs) => defs,
     objectInfoOracleFailureNote,
+    noBackendAnswerEstablished,
     comfyBackendSocketDown: false,
     comfyBackendIsDown: () => false,
     // "Note" is frontend-only and never seen on a backend — never-seen is the verdict that
@@ -358,6 +388,9 @@ function realGraphSetWidget({
     clearStaleRedFlag: () => {},
     snapshotAuthorizationNote: () => "",
     ...setWidgetCommandBudgetDeps(),
+    verifiedNodeDefCache,
+    fetchTypeScopedObjectInfo,
+    SCOPED_OBJECT_INFO_DEADLINE_MS,
     SET_WIDGET_COMMAND_BUDGET_MS: budgetMs,
     SET_WIDGET_POST_REFRESH_RESERVE_MS: reserveMs,
     // Captured AFTER the held-open run above has taken the slot — the value the shipped
@@ -374,7 +407,45 @@ function realGraphSetWidget({
     graph_set_widget: factory(...EXECUTOR_DEPS.map((n) => deps[n])),
     runs,
     inFlightStarted,
+    verifiedNodeDefCache: deps.verifiedNodeDefCache,
+    verifiedSchemaContext: context,
+    api,
+    objectInfoCache,
+    objectInfoSnapshot,
   };
+}
+
+/** Build the shipped whole-schema reader with the same cache/snapshot trust roots. */
+function realGraphGetObjectInfo({ api, objectInfoCache, objectInfoSnapshot, verifiedNodeDefCache }) {
+  const names = [
+    "api",
+    "backendReconnectEpoch",
+    "fetchWholeObjectInfo",
+    "objectInfoCache",
+    "verifiedNodeDefCache",
+    "objectInfoSnapshot",
+    "pageComfyOrigin",
+    "objectInfoOracleFailureNote",
+    "objectInfoFingerprint",
+    "objectInfoUnchanged",
+  ];
+  const factory = new Function(
+    ...names,
+    `const executors = {${graphGetMatch[0]}}; return executors.graph_get_object_info;`,
+  );
+  return factory(
+    api,
+    0,
+    fetchWholeObjectInfo,
+    objectInfoCache,
+    verifiedNodeDefCache,
+    objectInfoSnapshot,
+    () => "http://127.0.0.1:8188",
+    objectInfoOracleFailureNote,
+    noBackendAnswerEstablished,
+    () => "fp",
+    () => false,
+  );
 }
 
 // A "Note" node is on the reserved frontend-only allowlist (#475): registered with no
@@ -523,6 +594,166 @@ test("#1418 wiring: a hung /view probe gives up at the budget instead of outlivi
   );
   assert.ok(probed, "the probe did run — it is bounded, not skipped");
   assert.equal(widget.value, "example.png", "nothing was written");
+});
+
+test("#1709: a live graph_set_widget schema read retires cached add-node proof", async () => {
+  const node = { id: 211, type: "RemovedNode", widgets: [{ name: "mode", type: "combo", value: "a" }] };
+  const built = realGraphSetWidget({
+    node,
+    oracleDefs: { OtherNode: { input: { required: {} } } },
+  });
+  const binding = { app: {}, graph: {}, rootGraph: {}, workflow: {} };
+  const cached = { input: { required: {} } };
+  const generation = built.verifiedNodeDefCache.generation();
+  built.verifiedNodeDefCache.set("RemovedNode", cached, { epoch: 0, context: binding, generation });
+  assert.equal(
+    built.verifiedNodeDefCache.get("RemovedNode", { epoch: 0, context: binding, generation }),
+    cached,
+    "the precondition is a live verified add proof",
+  );
+
+  await assert.rejects(
+    () => built.graph_set_widget({ node_id: 211, widget: "mode", value: "b", workflow_uuid: "u" }),
+    /Cannot set widget|refused/i,
+    "the authoritative whole schema refuses the removed backend type",
+  );
+  assert.equal(
+    built.verifiedNodeDefCache.get("RemovedNode", {
+      epoch: 0,
+      context: binding,
+      generation: built.verifiedNodeDefCache.generation(),
+    }),
+    undefined,
+    "the live whole-schema observation retired the stale add proof",
+  );
+});
+
+test("#1709: scoped graph_set_widget reads retire proof on definitive presence and absence", async () => {
+  const def = { input: { required: { mode: ["STRING", {}] } } };
+  const node = {
+    id: 213,
+    type: "RemovedNode",
+    widgets: [{ name: "mode", type: "text", value: "old" }],
+    constructor: { nodeData: def, comfyClass: "RemovedNode" },
+  };
+  const cache = createVerifiedNodeDefCache();
+  const registeredNodeTypes = {
+    LoadImage: {},
+    Note: {},
+    RemovedNode: { nodeData: def, comfyClass: "RemovedNode" },
+  };
+  let present = true;
+  const built = realGraphSetWidget({
+    node,
+    verifiedNodeDefCache: cache,
+    registeredNodeTypes,
+    getNodeDefsImpl: async () => undefined,
+    fetchApiImpl: async (route) => {
+      if (route === "/object_info") return { ok: false, status: 504 };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => (present ? { RemovedNode: def } : {}),
+      };
+    },
+  });
+  const context = built.verifiedSchemaContext;
+  let generation = cache.generation();
+  cache.set("RemovedNode", def, { epoch: 0, context, generation });
+  assert.ok(
+    cache.get("RemovedNode", { epoch: 0, context, generation }),
+    "the scoped reader starts with reusable add proof",
+  );
+
+  const first = await built.graph_set_widget({ node_id: 213, widget: "mode", value: "new", workflow_uuid: "u" });
+  assert.equal(first.set.value, "new", "a definitive scoped presence still authorizes the widget write");
+  assert.ok(cache.generation() > generation, "scoped presence retired the pre-existing proof");
+
+  present = false;
+  generation = cache.generation();
+  cache.set("RemovedNode", def, { epoch: 0, context, generation });
+  await assert.rejects(
+    () => built.graph_set_widget({ node_id: 213, widget: "mode", value: "refused", workflow_uuid: "u" }),
+    /Cannot set widget|does not provide|refused/i,
+    "a definitive scoped absence refuses the removed class",
+  );
+  assert.ok(cache.generation() > generation, "scoped absence retired the pre-existing proof");
+  assert.equal(
+    cache.get("RemovedNode", { epoch: 0, context, generation: cache.generation() }),
+    undefined,
+    "the absent scoped answer leaves no reusable add proof",
+  );
+});
+
+test("#1709: authoritative empty retires whole cache and snapshot before ordinary timeout refusal", async () => {
+  const widget = { name: "text", type: "text", value: "old" };
+  const node = { id: 212, type: "LoadImage", widgets: [widget] };
+  const oldDefs = { LoadImage: { input: { required: { text: ["STRING", {}] } } } };
+  const objectInfoCache = createObjectInfoCache();
+  const objectInfoSnapshot = createObjectInfoSnapshot();
+  const calls = [];
+  let unavailable = false;
+  let authoritativeEmpty = false;
+  const built = realGraphSetWidget({
+    node,
+    objectInfoCache,
+    objectInfoSnapshot,
+    getNodeDefsImpl: async () => {
+      calls.push("/object_info");
+      if (unavailable) return undefined;
+      return authoritativeEmpty ? {} : oldDefs;
+    },
+    fetchApiImpl: async (route) => {
+      calls.push(route);
+      return unavailable ? { status: 503, json: async () => ({}) } : { status: 200, json: async () => oldDefs };
+    },
+  });
+
+  const first = await built.graph_set_widget({ node_id: 212, widget: "text", value: "new", workflow_uuid: "u" });
+  assert.equal(first.set.value, "new", "the initial live schema authorizes the ordinary write");
+  assert.equal(objectInfoCache.peek().cached, true, "the initial whole payload is in the burst cache");
+  assert.equal(objectInfoSnapshot.peek().held, true, "the initial whole payload is in the last-observed snapshot");
+  assert.ok(
+    objectInfoSnapshot.authorize({
+      epoch: 0,
+      outcomes: [{ kind: TRANSPORT_OUTCOME.NO_ANSWER }],
+    }).defs,
+    "the old snapshot really could authorize during silence before the deny-all answer",
+  );
+
+  authoritativeEmpty = true;
+  const get = realGraphGetObjectInfo({
+    api: built.api,
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache: built.verifiedNodeDefCache,
+  });
+  const denied = await get({});
+  assert.equal(denied.ok, false, "the live empty whole schema is a deny-all answer");
+  assert.equal(objectInfoCache.peek().cached, false, "authoritative empty retired the old whole payload");
+  assert.equal(objectInfoSnapshot.peek().held, false, "authoritative empty retired old membership proof");
+  assert.equal(
+    objectInfoSnapshot.authorize({
+      epoch: 0,
+      outcomes: [{ kind: TRANSPORT_OUTCOME.NO_ANSWER }],
+    }).defs,
+    null,
+    "the cleared snapshot cannot authorize the removed type during a later outage",
+  );
+
+  authoritativeEmpty = false;
+  unavailable = true;
+  await assert.rejects(
+    () => built.graph_set_widget({ node_id: 212, widget: "text", value: "refused", workflow_uuid: "u" }),
+    /Cannot set widget|object_info is unavailable|refused/i,
+    "the later ordinary timeout path refuses instead of serving old whole-schema state",
+  );
+  assert.equal(widget.value, "new", "the timeout refusal did not write");
+  assert.deepEqual(
+    calls.slice(-2),
+    ["/object_info", "/object_info"],
+    "the later ordinary read reached both live routes after the cache was retired",
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -27,6 +27,7 @@ import assert from "node:assert/strict";
 import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
 import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
 import {
   createObjectInfoCache,
   CACHE_OUTCOME,
@@ -48,6 +49,8 @@ import {
 } from "../../web/js/lib/scoped-object-info.js";
 import { SINGLE_NODE_INFO_OUTCOME } from "../../web/js/lib/single-node-def.js";
 import { scanComboAvailability } from "../../web/js/lib/live-combo-availability.js";
+import { comboRebuildCovered } from "../../web/js/lib/asset-staleness.js";
+import { describeNodeDefRefresh, NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "../../web/js/lib/rgthree-lora-row.js";
 import { inputAssetViewQuery } from "../../web/js/lib/input-asset.js";
 import {
@@ -55,6 +58,14 @@ import {
   setWidgetCommandBudgetDeps,
   SET_WIDGET_COMMAND_BUDGET_MS,
   SET_WIDGET_POST_REFRESH_RESERVE_MS,
+  COMBO_OK,
+  COMBO_NO_ANSWER,
+  NODE_DEFS_FETCH_TIMEOUT_MS,
+  NODE_DEFS_RUN_BUDGET_MS,
+  NODE_DEFS_FETCH_SHARE,
+  NODE_DEFS_NO_ANSWER,
+  monotonicNow,
+  nodeDefsBudgetLeft,
 } from "./_panel-constants.mjs";
 import { runProductionGraphGetErrors } from "./_graph-get-errors-harness.mjs";
 
@@ -62,6 +73,43 @@ const graphGetMatch = PANEL_SRC.match(
   /\n  async graph_get_object_info\(\{ if_none_match \} = \{\}\) \{[\s\S]*?\n  \},/,
 );
 assert.ok(graphGetMatch, "could not locate graph_get_object_info in the panel source");
+
+function extractFunction(marker) {
+  const start = PANEL_SRC.indexOf(marker);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = PANEL_SRC.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < PANEL_SRC.length; i += 1) {
+    const ch = PANEL_SRC[i];
+    if (ch === "/" && PANEL_SRC[i + 1] === "/") {
+      i = PANEL_SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && PANEL_SRC[i + 1] === "*") {
+      i = PANEL_SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < PANEL_SRC.length; i += 1) {
+        if (PANEL_SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (PANEL_SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return PANEL_SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function: ${marker}`);
+}
+
+const REGISTER_COMFY_NODE_DEFS_SRC = extractFunction("async function registerComfyNodeDefs(");
 
 // ---------------------------------------------------------------------------
 // 1. The lib: an abandoned refresh is a worded, honest, retryable refusal.
@@ -424,6 +472,83 @@ function realGraphSetWidget({
     objectInfoCache,
     objectInfoSnapshot,
   };
+}
+
+/** The real refresh body used by graph_add_node when it supplies a whole preloaded payload. */
+function realPreloadedRefresh({ app, api, objectInfoCache, objectInfoSnapshot, verifiedNodeDefCache }) {
+  const names = [
+    "app",
+    "api",
+    "recordObjectInfoTypes",
+    "reapplyDefsToLiveNodes",
+    "comboRebuildCovered",
+    "describeNodeDefRefresh",
+    "NODE_DEF_REFRESH_REASONS",
+    "fetchNodeDefsWithRetry",
+    "withTimeout",
+    "NODE_DEFS_NO_ANSWER",
+    "COMBO_OK",
+    "COMBO_NO_ANSWER",
+    "NODE_DEFS_FETCH_TIMEOUT_MS",
+    "NODE_DEFS_RUN_BUDGET_MS",
+    "NODE_DEFS_FETCH_SHARE",
+    "fetchWholeObjectInfo",
+    "nodeDefsBudgetLeft",
+    "monotonicNow",
+    "NODE_DEFS_RETRY_DELAYS_MS",
+    "objectInfoCache",
+    "objectInfoSnapshot",
+    "verifiedNodeDefCache",
+    "initialBackendReconnectEpoch",
+    "comfyBackendSocketDown",
+    "TRANSPORT_OUTCOME",
+  ];
+  const values = {
+    app,
+    api,
+    recordObjectInfoTypes: (defs) => defs,
+    reapplyDefsToLiveNodes: () => {},
+    comboRebuildCovered,
+    describeNodeDefRefresh,
+    NODE_DEF_REFRESH_REASONS,
+    fetchNodeDefsWithRetry: (getDefs, opts) => fetchNodeDefsWithRetry(getDefs, { ...opts, sleep: async () => {} }),
+    withTimeout,
+    NODE_DEFS_NO_ANSWER,
+    COMBO_OK,
+    COMBO_NO_ANSWER,
+    NODE_DEFS_FETCH_TIMEOUT_MS,
+    NODE_DEFS_RUN_BUDGET_MS,
+    NODE_DEFS_FETCH_SHARE,
+    fetchWholeObjectInfo,
+    nodeDefsBudgetLeft,
+    monotonicNow,
+    NODE_DEFS_RETRY_DELAYS_MS: OBJECT_INFO_RETRY_DELAYS_MS,
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache,
+    initialBackendReconnectEpoch: 0,
+    comfyBackendSocketDown: false,
+    TRANSPORT_OUTCOME,
+  };
+  const factory = new Function(
+    ...names,
+    `const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
+      if (typeof api?.getNodeDefs !== "function") return null;
+      const settled = await withTimeout(
+        Promise.resolve().then(() => api.getNodeDefs()).then((value) => ({ value }), (err) => ({ err })),
+        ms,
+        () => NODE_DEFS_NO_ANSWER,
+      );
+      if (settled === NODE_DEFS_NO_ANSWER) return NODE_DEFS_NO_ANSWER;
+      if ("err" in settled) throw settled.err;
+      return settled.value;
+    };
+    let backendReconnectEpoch = initialBackendReconnectEpoch;
+    let nodeDefsRefreshConfirmed = false;
+    ${REGISTER_COMFY_NODE_DEFS_SRC}
+    return registerComfyNodeDefs;`,
+  );
+  return factory(...names.map((name) => values[name]));
 }
 
 /** Build the shipped whole-schema reader with the same cache/snapshot trust roots. */
@@ -832,6 +957,77 @@ test("#1709: graph_get_object_info replaces changed whole authority before graph
     () => built.graph_set_widget({ node_id: 215, widget: "text", value: "stale", workflow_uuid: "u" }),
     /Cannot set widget|does not provide|object_info is unavailable|refused/i,
     "the timeout fallback refuses the removed class",
+  );
+  assert.equal(widget.value, "live-old", "the stale timeout path did not mutate the widget");
+});
+
+test("#1709: graph_add preloaded refresh replaces authority before graph_set_widget timeout", async () => {
+  const widget = { name: "text", type: "text", value: "before" };
+  const oldDef = { input: { required: { text: ["STRING", {}] } } };
+  const oldDefs = { RemovedNode: oldDef };
+  const changedDefs = { OtherNode: { input: { required: {} } } };
+  let now = 0;
+  let liveDefs = oldDefs;
+  const objectInfoCache = createObjectInfoCache({ now: () => now });
+  const objectInfoSnapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  const node = {
+    id: 216,
+    type: "RemovedNode",
+    widgets: [widget],
+    constructor: { nodeData: oldDef, comfyClass: "RemovedNode" },
+  };
+  const built = realGraphSetWidget({
+    node,
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache,
+    getNodeDefsImpl: async () => liveDefs,
+    fetchApiImpl: async () =>
+      liveDefs
+        ? { status: 200, json: async () => liveDefs }
+        : { status: 504, json: async () => ({}) },
+    oracleDefs: oldDefs,
+    registeredNodeTypes: {
+      LoadImage: {},
+      Note: {},
+      RemovedNode: { nodeData: oldDef, comfyClass: "RemovedNode" },
+    },
+  });
+  await built.graph_set_widget({ node_id: 216, widget: "text", value: "live-old", workflow_uuid: "u" });
+
+  const refreshApp = {
+    graph: null,
+    refreshComboInNodes: async () => {},
+    registerNodesFromDefs: async (payload) => {
+      payload.OtherNode.input.required.hook_added = ["STRING", {}];
+    },
+  };
+  const refresh = realPreloadedRefresh({
+    app: refreshApp,
+    api: { getNodeDefs: async () => ({ Unexpected: {} }) },
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache,
+  });
+  const verdict = await refresh(changedDefs, { preloadedWholeSchema: true });
+  assert.equal(verdict.refreshed, true, "the actual preloaded refresh completed");
+  assert.equal(Object.prototype.hasOwnProperty.call(changedDefs.OtherNode.input.required, "hook_added"), true);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      (await objectInfoCache.read(async () => ({ Unexpected: {} }))).OtherNode.input.required,
+      "hook_added",
+    ),
+    false,
+    "the cached authority is isolated from registration hooks",
+  );
+
+  now += OBJECT_INFO_CACHE_TTL_MS + 1;
+  liveDefs = null;
+  await assert.rejects(
+    () => built.graph_set_widget({ node_id: 216, widget: "text", value: "stale", workflow_uuid: "u" }),
+    /Cannot set widget|does not provide|object_info is unavailable|refused/i,
+    "the timeout fallback refuses the removed class after graph_add's real preloaded refresh",
   );
   assert.equal(widget.value, "live-old", "the stale timeout path did not mutate the widget");
 });

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -42,6 +42,8 @@ import {
   fetchTypeScopedObjectInfo,
   SCOPED_OBJECT_INFO_DEADLINE_MS,
 } from "../../web/js/lib/scoped-object-info.js";
+import { SINGLE_NODE_INFO_OUTCOME } from "../../web/js/lib/single-node-def.js";
+import { scanComboAvailability } from "../../web/js/lib/live-combo-availability.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "../../web/js/lib/rgthree-lora-row.js";
 import { inputAssetViewQuery } from "../../web/js/lib/input-asset.js";
 import {
@@ -50,6 +52,7 @@ import {
   SET_WIDGET_COMMAND_BUDGET_MS,
   SET_WIDGET_POST_REFRESH_RESERVE_MS,
 } from "./_panel-constants.mjs";
+import { runProductionGraphGetErrors } from "./_graph-get-errors-harness.mjs";
 
 const graphGetMatch = PANEL_SRC.match(
   /\n  async graph_get_object_info\(\{ if_none_match \} = \{\}\) \{[\s\S]*?\n  \},/,
@@ -295,7 +298,11 @@ function realGraphSetWidget({
   fetchApiImpl = null,
   getNodeDefsImpl = null,
   objectInfoCache = createObjectInfoCache(),
-  objectInfoSnapshot = { record: () => true, authorize: () => ({ defs: null, reason: "none recorded" }) },
+  objectInfoSnapshot = {
+    record: () => true,
+    authorize: () => ({ defs: null, reason: "none recorded" }),
+    clear: () => {},
+  },
   verifiedNodeDefCache = createVerifiedNodeDefCache(),
   registeredNodeTypes = { LoadImage: {}, Note: {} },
 } = {}) {
@@ -754,6 +761,117 @@ test("#1709: authoritative empty retires whole cache and snapshot before ordinar
     ["/object_info", "/object_info"],
     "the later ordinary read reached both live routes after the cache was retired",
   );
+});
+
+test("#1709: a definitive per-class absence retires cached whole proof before graph_set_widget timeout fallback", async () => {
+  const widget = { name: "text", type: "text", value: "before" };
+  const def = {
+    input: { required: { mode: [["old"], {}], text: ["STRING", {}] } },
+  };
+  const scanWidget = { name: "mode", type: "combo", options: { values: ["old"] }, value: "old" };
+  const node = {
+    id: 214,
+    type: "RemovedNode",
+    widgets: [widget, scanWidget],
+    constructor: { nodeData: def, comfyClass: "RemovedNode" },
+  };
+  const objectInfoCache = createObjectInfoCache();
+  const objectInfoSnapshot = createObjectInfoSnapshot();
+  let unavailable = false;
+  let holdWholeRead = false;
+  const wholeReadStarted = deferred();
+  const oldWholeResponse = deferred();
+  const wholeDefs = { RemovedNode: def };
+  const built = realGraphSetWidget({
+    node,
+    objectInfoCache,
+    objectInfoSnapshot,
+    oracleDefs: wholeDefs,
+    getNodeDefsImpl: async () => {
+      if (unavailable) return undefined;
+      if (holdWholeRead) {
+        wholeReadStarted.resolve();
+        await oldWholeResponse.promise;
+      }
+      return wholeDefs;
+    },
+    fetchApiImpl: async (route) =>
+      unavailable
+        ? { status: 504, json: async () => ({}) }
+        : { status: 200, json: async () => wholeDefs },
+    registeredNodeTypes: {
+      LoadImage: {},
+      Note: {},
+      RemovedNode: { nodeData: def, comfyClass: "RemovedNode" },
+    },
+  });
+
+  const first = await built.graph_set_widget({
+    node_id: 214,
+    widget: "text",
+    value: "after-first-write",
+    workflow_uuid: "u",
+  });
+  assert.equal(first.set.value, "after-first-write", "the initial live whole schema authorizes the write");
+  assert.equal(objectInfoCache.peek().cached, true, "the whole proof is cached before the class reader runs");
+  assert.equal(objectInfoSnapshot.peek().held, true, "the whole membership proof is held before the class reader runs");
+
+  objectInfoCache.invalidate();
+  objectInfoSnapshot.clear();
+  holdWholeRead = true;
+  const pendingWholeWrite = built.graph_set_widget({
+    node_id: 214,
+    widget: "text",
+    value: "stale-response-write",
+    workflow_uuid: "u",
+  });
+  // Attach the handler before the independent per-class command can retire the response.
+  // Node reports a rejected command as unhandled if the assertion waits until after that
+  // overlapping command has completed.
+  pendingWholeWrite.catch(() => {});
+  await wholeReadStarted.promise;
+
+  const graph = { _nodes: [node], getNodeById: () => node };
+  const absent = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    scan: scanComboAvailability,
+    fetchSingleNodeInfo: async () => ({
+      [SINGLE_NODE_INFO_OUTCOME]: true,
+      kind: "absent",
+      body: {},
+    }),
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache: built.verifiedNodeDefCache,
+    stepBudget: () => 1000,
+  });
+  assert.equal(absent.unchecked_nodes.length, 1, "the definitive per-class absence is reported as unchecked");
+  assert.equal(objectInfoCache.peek().cached, false, "the per-class reader retires the whole burst cache");
+  assert.equal(objectInfoSnapshot.peek().held, false, "the per-class reader retires the whole membership snapshot");
+
+  oldWholeResponse.resolve();
+  await assert.rejects(
+    () => pendingWholeWrite,
+    /REFRESHED|possibly-stale|Refusing|refused/i,
+    "the in-flight whole response issued before per-class absence cannot authorize the write",
+  );
+  assert.equal(widget.value, "after-first-write", "the retired whole response did not mutate the widget");
+
+  unavailable = true;
+  await assert.rejects(
+    () =>
+      built.graph_set_widget({
+        node_id: 214,
+        widget: "mode",
+        value: "refused",
+        workflow_uuid: "u",
+      }),
+    /Cannot set widget|object_info is unavailable|refused/i,
+    "after definitive class absence, a later whole-schema timeout cannot reuse the old proof",
+  );
+  assert.equal(widget.value, "after-first-write", "the timeout fallback refuses before mutating the widget");
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -12,9 +12,9 @@
 // behind each other, and the 30 s reply deadline expired — after which the adds
 // landed anyway, which is where the report's "ghost" nodes came from.
 //
-// The rule this file exists to hold: the fast path may only ever CONFIRM. Every
-// other outcome falls through to the full fetch, so no refusal, removal verdict or
-// history check is ever decided on the smaller payload.
+// The rule this file exists to hold: the fast path may only ever CONFIRM or establish
+// authoritative absence. Unknown outcomes fall through to the full fetch, so no
+// refusal, removal verdict or history check is ever decided on a smaller uncertain payload.
 
 import assert from "node:assert/strict";
 import test from "node:test";
@@ -175,10 +175,10 @@ test("#767 WIRING: the fast path is gated on the type ALREADY being registered",
   // #1180 bounded this call too — it runs FIRST, so an unbounded fast path hung the add
   // before the bounded fallback was ever reached. The gate assertion is about WHERE the
   // single-class fetch sits, which the wrapping does not change.
-  const call = body.indexOf("fetchSingleNodeDef(class_type");
+  const call = body.indexOf("fetchSingleNodeInfo(class_type");
   assert.match(
     body,
-    /withTimeout\(\s*[\r\n]?\s*fetchSingleNodeDef\(class_type/,
+    /withTimeout\(\s*[\r\n]?\s*fetchSingleNodeInfo\(class_type/,
     "the fast path must be bounded: it runs before the fallback and hangs the add on its own",
   );
   // …with the CONSTANT, not a literal. withTimeout treats a non-positive ms as NO bound, so
@@ -189,7 +189,7 @@ test("#767 WIRING: the fast path is gated on the type ALREADY being registered",
   // whole-schema fetch, so the two are additive.
   assert.match(
     body,
-    /fetchSingleNodeDef\(class_type[\s\S]{0,400}?budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)/,
+    /fetchSingleNodeInfo\(class_type[\s\S]{0,400}?budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)/,
     "the fast path must be bounded by the named constant, capped by the command budget",
   );
   assert.ok(guard > 0, "the registered-type gate must be present");
@@ -690,7 +690,7 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
   const wired = [
     [/await awaitObjectInfoHistorySeed\(budget\.bounded\(OBJECT_INFO_SEED_WAIT_MS\)\)/, "the baseline seed wait"],
     [
-      /fetchSingleNodeDef\(class_type[\s\S]{0,400}?budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)/,
+      /fetchSingleNodeInfo\(class_type[\s\S]{0,400}?budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)/,
       "the single-class fast path",
     ],
     [/await boundedGetNodeDefs\(budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)\)/, "the whole-schema fetch"],

--- a/browser_tests/unit/verified-node-def-cache.test.mjs
+++ b/browser_tests/unit/verified-node-def-cache.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
+
+function context() {
+  return {
+    app: {},
+    graph: {},
+    rootGraph: {},
+    workflow: {},
+  };
+}
+
+test("#1709 reuses only a verified class on the same backend and graph binding", () => {
+  const cache = createVerifiedNodeDefCache();
+  const binding = context();
+  const def = { input: { required: { seed: ["INT", {}] } } };
+  const generation = cache.generation();
+
+  assert.equal(cache.set("VRAM_Debug", def, { epoch: 3, context: binding, generation }), true);
+  assert.equal(cache.get("VRAM_Debug", { epoch: 3, context: binding, generation }), def);
+  assert.equal(cache.get("NeverVerified", { epoch: 3, context: binding, generation }), undefined);
+  assert.equal(cache.get("VRAM_Debug", { epoch: 4, context: binding, generation }), undefined);
+  assert.equal(
+    cache.get("VRAM_Debug", { epoch: 3, context: { ...binding, workflow: {} }, generation }),
+    undefined,
+  );
+  assert.equal(
+    cache.get("VRAM_Debug", { epoch: 3, context: { ...binding, graph: {} }, generation }),
+    undefined,
+  );
+});
+
+test("#1709 invalidating a class removes its reuse proof, and invalid inputs never enter", () => {
+  const cache = createVerifiedNodeDefCache();
+  const binding = context();
+  const def = { input: { required: {} } };
+  const generation = cache.generation();
+
+  assert.equal(cache.set("VRAM_Debug", def, { epoch: 0, context: binding, generation }), true);
+  cache.invalidate("VRAM_Debug");
+  assert.ok(cache.generation() > generation, "invalidation advances the write fence");
+  assert.equal(cache.get("VRAM_Debug", { epoch: 0, context: binding, generation }), undefined);
+  assert.equal(
+    cache.set("Never", null, { epoch: 0, context: binding, generation: cache.generation() }),
+    false,
+  );
+  assert.equal(
+    cache.set("Never", {}, { epoch: 0, context: binding, generation }),
+    false,
+    "a late writer from before invalidation cannot repopulate proof",
+  );
+  const currentGeneration = cache.generation();
+  assert.equal(
+    cache.set("Never", {}, { epoch: 0, context: binding, generation: currentGeneration }),
+    true,
+  );
+  cache.clear();
+  assert.equal(
+    cache.get("Never", { epoch: 0, context: binding, generation: currentGeneration }),
+    undefined,
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1322,6 +1322,15 @@ function seedObjectInfoHistory() {
             const currentEpoch = backendReconnectEpoch;
             const currentGeneration = verifiedNodeDefCache.generation();
             if (currentEpoch !== observedAtEpoch || currentGeneration !== observedAtGeneration) continue;
+            // This startup response bypasses the burst cache, so install it as the new
+            // whole-schema authority and retire any request/entry from before it. A later
+            // timeout must not fall back to that older map.
+            if (!objectInfoCache.replace(defs)) objectInfoCache.invalidate();
+            objectInfoSnapshot.clear();
+            // The whole answer also supersedes per-class proofs established before this
+            // startup observation. Advance that fence before filing the replacement.
+            verifiedNodeDefCache.clear();
+            const acceptedGeneration = verifiedNodeDefCache.generation();
             recordObjectInfoTypes(defs);
             // A whole payload, and this is the only reader of it — nothing registers these
             // defs, so no beforeRegisterNodeDef hook can have mutated them yet. `record`
@@ -1329,8 +1338,8 @@ function seedObjectInfoHistory() {
             objectInfoSnapshot.record(defs, {
               observedAtEpoch,
               currentEpoch,
-              observedAtGeneration,
-              currentGeneration,
+              observedAtGeneration: acceptedGeneration,
+              currentGeneration: acceptedGeneration,
               whole: true,
             });
             markObjectInfoHistorySeeded();
@@ -1854,6 +1863,11 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
       runStartedAtEpoch === backendReconnectEpoch &&
       runStartedAtGeneration === verifiedNodeDefCache.generation();
     if (!preloadedDefs && refreshResponseIsCurrent) {
+      // The refresh fetch is a direct whole-schema read, not an objectInfoCache read. Keep
+      // its current answer as the burst authority and retire the snapshot before recording
+      // the replacement, so a timeout cannot use the prior map or membership set.
+      if (!objectInfoCache.replace(defs)) objectInfoCache.invalidate();
+      objectInfoSnapshot.clear();
       objectInfoSnapshot.record(defs, {
         observedAtEpoch: runStartedAtEpoch,
         currentEpoch: runStartedAtEpoch,
@@ -12164,6 +12178,13 @@ const GRAPH_TOOL_EXECUTORS = {
         // a definition this live answer just proved absent.
         objectInfoCache.invalidate();
         objectInfoSnapshot.clear();
+      } else {
+        // This direct whole read bypasses the burst cache. A definitive non-empty answer
+        // therefore has to replace, rather than merely sit beside, the old cached map.
+        // Retiring the old generation also prevents an older in-flight cache read from
+        // restoring that map after this answer has become current.
+        if (!objectInfoCache.replace(defs)) objectInfoCache.invalidate();
+        objectInfoSnapshot.clear();
       }
       if (typeof verifiedNodeDefCache !== "undefined") {
         verifiedNodeDefCache.clear(); // #1709 — this whole live observation may contain changed or absent classes.
@@ -13846,6 +13867,19 @@ const GRAPH_TOOL_EXECUTORS = {
         ) {
           // A live whole-schema answer is authoritative for every class whether it is
           // present, absent, or changed. Retire all old proofs before downstream validation.
+          let hasWholeDefinitions = false;
+          try {
+            hasWholeDefinitions = Object.keys(whole).length > 0;
+          } catch {
+            /* the downstream resolver will fail closed on an unreadable schema */
+          }
+          if (hasWholeDefinitions) {
+            if (!objectInfoCache.replace(whole)) objectInfoCache.invalidate();
+          } else {
+            // `{}` is the direct route's authoritative deny-all answer, not a timeout.
+            objectInfoCache.invalidate();
+          }
+          objectInfoSnapshot.clear();
           verifiedNodeDefCache.clear();
           verifiedSchemaWriteGeneration = verifiedNodeDefCache.generation();
           verifiedSchemaWriteEpoch = issued.epoch;
@@ -15541,6 +15575,11 @@ const GRAPH_TOOL_EXECUTORS = {
             // after the backend has authoritatively said that no classes exist.
             objectInfoCache.invalidate();
             objectInfoSnapshot.clear();
+          } else {
+            // A live cache read has already stored this fresh whole answer. Clear the
+            // detached membership proof before replacing it so a failed record cannot
+            // leave the previous schema eligible for timeout fallback.
+            objectInfoSnapshot.clear();
           }
           if (typeof verifiedNodeDefCache !== "undefined") {
             verifiedNodeDefCache.clear(); // #1709 — a live whole deny-all answer retires per-class proofs too.
@@ -15992,6 +16031,10 @@ const GRAPH_TOOL_EXECUTORS = {
         // this marker is the point at which that old payload and its snapshot stop being
         // admissible evidence.
         objectInfoCache.invalidate();
+        objectInfoSnapshot.clear();
+      } else {
+        // The live cache read installed the definitive non-empty whole answer. Retire the
+        // detached membership proof before recording its replacement as well.
         objectInfoSnapshot.clear();
       }
       if (typeof verifiedNodeDefCache !== "undefined") {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -198,7 +198,8 @@ import {
   resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
-import { fetchSingleNodeDef, fetchSingleNodeInfo } from "./lib/single-node-def.js";
+import { fetchSingleNodeInfo } from "./lib/single-node-def.js";
+import { createVerifiedNodeDefCache } from "./lib/verified-node-def-cache.js";
 import { withWorkflowUuid } from "./lib/graph-view-identity.js";
 import { saveReplyIdentity, shouldEstablishIdentityAfterSave } from "./lib/save-reply-identity.js";
 import { describeOpenActiveBinding } from "./lib/open-active-binding.js";
@@ -1281,6 +1282,10 @@ const recordObjectInfoTypes = (defs) => objectInfoHistory.recordTypes(defs);
 const markObjectInfoHistorySeeded = () => objectInfoHistory.markSeeded();
 // #716 — one /object_info per BURST of widget writes, instead of one per write.
 const objectInfoCache = createObjectInfoCache();
+// #1709 — a successful add proves this class definition for the current backend and graph
+// binding. Reuse only that detached class snapshot; whole /object_info remains the authority
+// for every class not already verified in this exact session/workflow instance.
+const verifiedNodeDefCache = createVerifiedNodeDefCache();
 // #1223 — the last WHOLE /object_info observed on the CURRENT backend connection, so a
 // widget edit is not refused merely because the schema probe went silent while ComfyUI was
 // busy rendering. Consulted only AFTER the oracle has failed, and only under the four
@@ -1311,15 +1316,21 @@ function seedObjectInfoHistory() {
           // — the first widget edit lands while ComfyUI is rendering and both probes time
           // out — found no snapshot and was refused exactly as before the fix.
           const observedAtEpoch = backendReconnectEpoch;
+          const observedAtGeneration = verifiedNodeDefCache.generation();
           const defs = await api.getNodeDefs();
           if (defs && typeof defs === "object" && Object.keys(defs).length > 0) {
+            const currentEpoch = backendReconnectEpoch;
+            const currentGeneration = verifiedNodeDefCache.generation();
+            if (currentEpoch !== observedAtEpoch || currentGeneration !== observedAtGeneration) continue;
             recordObjectInfoTypes(defs);
             // A whole payload, and this is the only reader of it — nothing registers these
             // defs, so no beforeRegisterNodeDef hook can have mutated them yet. `record`
             // still copies out the type names rather than trusting that.
             objectInfoSnapshot.record(defs, {
               observedAtEpoch,
-              currentEpoch: backendReconnectEpoch,
+              currentEpoch,
+              observedAtGeneration,
+              currentGeneration,
               whole: true,
             });
             markObjectInfoHistorySeeded();
@@ -1442,10 +1453,12 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // not to. Re-recorded below if this run's fetch succeeds, so the cost of being wrong here
   // is one refused write during an outage, not a stale authorization.
   objectInfoSnapshot.clear();
+  if (typeof verifiedNodeDefCache !== "undefined") verifiedNodeDefCache.clear();
   // #1223 — the epoch this run STARTED on, captured before any fetch. The recording below
   // is refused if a reconnect lands while the fetch is in flight, so a pre-restart schema
   // can never be filed under post-restart provenance.
   const runStartedAtEpoch = backendReconnectEpoch;
+  const runStartedAtGeneration = verifiedNodeDefCache.generation();
   // A refresh is not authoritative while any of its frontend mutation work is still
   // outstanding. Consumers such as collectMissingAssets must fail closed during that
   // window, even if an earlier run had established trust.
@@ -1837,10 +1850,15 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     // await and can pass its SINGLE-CLASS defs to refresh(), and a one-type map recorded
     // here would make every other type read as absent — the ever-seen gate would then
     // report the entire install as removed packs.
-    if (!preloadedDefs) {
+    const refreshResponseIsCurrent =
+      runStartedAtEpoch === backendReconnectEpoch &&
+      runStartedAtGeneration === verifiedNodeDefCache.generation();
+    if (!preloadedDefs && refreshResponseIsCurrent) {
       objectInfoSnapshot.record(defs, {
         observedAtEpoch: runStartedAtEpoch,
-        currentEpoch: backendReconnectEpoch,
+        currentEpoch: runStartedAtEpoch,
+        observedAtGeneration: runStartedAtGeneration,
+        currentGeneration: runStartedAtGeneration,
         whole: true,
       });
     }
@@ -2018,7 +2036,10 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
               console.warn("[comfyui-mcp-panel] late combo refresh did not complete:", thrown);
             }
             comboCompletionPending = false;
-            const currentRun = !comfyBackendSocketDown && runStartedAtEpoch === backendReconnectEpoch;
+            const currentRun =
+              !comfyBackendSocketDown &&
+              runStartedAtEpoch === backendReconnectEpoch &&
+              runStartedAtGeneration === verifiedNodeDefCache.generation();
             nodeDefsRefreshConfirmed =
               currentRun && !didThrow && !!defs && (comboRan || comboAbandonedAfterRebuild);
             const lateVerdict = buildRefreshVerdict?.();
@@ -2140,7 +2161,10 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     // own phases completed. It may have fetched the pre-restart registry, and its promise can
     // still be the one a bounded acknowledgement is joining. Do not let that old run re-open
     // combo trust while the post-reconnect successor is pending.
-    const runIsCurrent = !comfyBackendSocketDown && runStartedAtEpoch === backendReconnectEpoch;
+    const runIsCurrent =
+      !comfyBackendSocketDown &&
+      runStartedAtEpoch === backendReconnectEpoch &&
+      runStartedAtGeneration === verifiedNodeDefCache.generation();
     nodeDefsRefreshConfirmed =
       runIsCurrent && !comboCompletionPending && !didThrow && !!defs && (comboRan || comboAbandonedAfterRebuild);
   }
@@ -2151,7 +2175,10 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // `force:true` refresh resolves to the freshness verdict of the fetch IT triggered
   // (codex round-6 P0).
   buildRefreshVerdict = () => {
-    const runIsCurrent = !comfyBackendSocketDown && runStartedAtEpoch === backendReconnectEpoch;
+    const runIsCurrent =
+      !comfyBackendSocketDown &&
+      runStartedAtEpoch === backendReconnectEpoch &&
+      runStartedAtGeneration === verifiedNodeDefCache.generation();
     return runIsCurrent
     ? describeNodeDefRefresh({
         appAvailable,
@@ -2397,6 +2424,7 @@ function setupListeners() {
       comfyBackendSocketDown = true;
       comfyBackendOutage.noteDown(landedHelloCount); // #654 — open the outage clock on the FIRST down signal.
       objectInfoSnapshot.clear(); // #1223 — see condition 3 in lib/object-info-snapshot.js.
+      verifiedNodeDefCache.clear(); // #1709 — the old backend cannot vouch for a cached class.
     });
     api.addEventListener("status", (ev) => {
       // A null status payload is ComfyUI's "backend connection lost" signal.
@@ -2421,6 +2449,7 @@ function setupListeners() {
         // too or the restart measures as no outage at all.
         comfyBackendOutage.noteDown(landedHelloCount);
         objectInfoSnapshot.clear(); // #1223 — same reasoning as `reconnecting`.
+        verifiedNodeDefCache.clear(); // #1709 — the old backend cannot vouch for a cached class.
       }
     });
     // ComfyUI's own socket to its backend re-establishing is the reliable
@@ -2436,6 +2465,7 @@ function setupListeners() {
       // new window (codex P1); only an open/new AFTER this reconnect will.
       backendReconnectEpoch += 1;
       backendReconnectedAt = monotonicNow();
+      verifiedNodeDefCache.clear(); // #1709 — require a post-reconnect verification.
       // #605: this reconnect can be a backend RESTART that swapped the Manager
       // generation (3.x ↔ pip v4) under the live tab — the cached dialect then
       // describes a server that is gone. Drop it so the next Manager call
@@ -12114,7 +12144,8 @@ const GRAPH_TOOL_EXECUTORS = {
     // through the burst cache, so every success here is a first-hand observation of the
     // connection it was issued on, and there is no cache hit to exclude.
     const observedAtEpoch = backendReconnectEpoch;
-    const { defs, failures } = await fetchWholeObjectInfo({
+    const observedAtGeneration = verifiedNodeDefCache.generation();
+    const { defs, authoritativeEmpty, failures } = await fetchWholeObjectInfo({
       getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
       fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
     });
@@ -12122,10 +12153,29 @@ const GRAPH_TOOL_EXECUTORS = {
     // floor leaves the next render-time widget edit refused for want of the very map this
     // command just read. Recorded BEFORE the fingerprint/if_none_match early-returns below,
     // so a caller polling with `if_none_match` still keeps the snapshot fed.
-    if (defs) {
+    const epochIsCurrent = backendReconnectEpoch === observedAtEpoch;
+    const generationIsCurrent = verifiedNodeDefCache.generation() === observedAtGeneration;
+    const responseIsCurrent = epochIsCurrent && generationIsCurrent;
+    if ((defs || authoritativeEmpty) && responseIsCurrent) {
+      if (authoritativeEmpty) {
+        // An empty whole response is an authoritative deny-all answer. The burst cache and
+        // last-observed snapshot are separate trust roots from the per-class proof cache, so
+        // retire them too; otherwise a later ordinary read or silent fallback can resurrect
+        // a definition this live answer just proved absent.
+        objectInfoCache.invalidate();
+        objectInfoSnapshot.clear();
+      }
+      if (typeof verifiedNodeDefCache !== "undefined") {
+        verifiedNodeDefCache.clear(); // #1709 — this whole live observation may contain changed or absent classes.
+      }
+    }
+    if (defs && responseIsCurrent) {
+      const currentGeneration = verifiedNodeDefCache.generation();
       objectInfoSnapshot.record(defs, {
         observedAtEpoch,
         currentEpoch: backendReconnectEpoch,
+        observedAtGeneration: currentGeneration,
+        currentGeneration,
         whole: true,
       });
     }
@@ -13598,9 +13648,21 @@ const GRAPH_TOOL_EXECUTORS = {
     // below say WHICH step ran out — the property the whole issue is about, since the
     // alternative was a bare "tab did not reply" that names nothing.
     const budget = makeCommandBudget(ADD_NODE_COMMAND_BUDGET_MS, monotonicNow);
+    // #1709 — the cache is scoped to the exact binding captured before this command's
+    // preflight. A generation fence also makes a proof captured here ineligible for a
+    // late cache write if another overlapping command invalidates the schema meanwhile.
+    const verifiedSchemaContext = capturedContext;
+    const verifiedSchemaStartGeneration = verifiedNodeDefCache.generation();
+    const verifiedSchemaStartEpoch = backendReconnectEpoch;
+    let verifiedSchemaWriteGeneration = null;
+    let verifiedSchemaWriteEpoch = null;
+    const schemaProbeIsCurrent = (issued) =>
+      issued.generation === verifiedNodeDefCache.generation() &&
+      issued.epoch === backendReconnectEpoch;
     // Resolve BEFORE creating so an unresolved type can never be added as a
     // fabricated placeholder (#458). The go/no-go is decided against the CURRENT
-    // backend /object_info (fetched fresh) — NOT the LiteGraph registry, which
+    // backend /object_info, or a class definition already verified for this exact binding
+    // (#1709) — NOT the LiteGraph registry, which
     // keeps STALE POSITIVES for uninstalled packs (#458/P1-C) and MISSES freshly-
     // installed ones (#289). When the backend defines the type but the stale
     // page-load registry lacks it, the defs are refreshed + re-registered so
@@ -13649,6 +13711,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // and the snapshot (already cleared by the reconnect) would stay empty, refusing the very
     // next render-time widget edit. The epoch has to be read where the request goes out.
     let addNodeObservedAtEpoch = null;
+    let addNodeObservedAtGeneration = null;
     // #1192 — set when this add stopped WAITING for a node-def refresh someone else had
     // already started, because waiting longer would have spent the command's whole budget.
     // A FLAG, not a parsed message: `assertAddNodeResolvableRefreshing` swallows a refresh
@@ -13675,15 +13738,15 @@ const GRAPH_TOOL_EXECUTORS = {
         // that branch is unreachable, so the hazard is removed by construction
         // rather than by remembering not to trip it.
         //
-        // The fast path only ever CONFIRMS. Any doubt — an empty {}, a non-200, an
-        // older build without the route, an unparseable body — returns null and
-        // falls through to the identical full fetch below, so no refusal, removal
-        // verdict or history check is decided on anything new.
+        // The fast path only ever CONFIRMS or establishes explicit absence. Any doubt — a
+        // non-200, an older build without the route, an unparseable body, or a timeout —
+        // falls through to the identical full fetch below, so no refusal or removal verdict
+        // is decided on an uncertain smaller payload.
         if (isRegisteredNodeType(LG?.registered_node_types ?? {}, class_type)) {
           // #1180 — THE FAST PATH IS BOUNDED TOO, and it has to be: it runs FIRST, so a
           // half-open connection hangs here before the bounded fallback below is ever
           // reached. Bounding only the fallback left `graph_add_node` hanging on exactly
-          // the connection this issue is about. `fetchSingleNodeDef` awaits both the
+          // the connection this issue is about. `fetchSingleNodeInfo` awaits both the
           // response and its body, so the whole call is wrapped rather than the request
           // alone. A timeout resolves null, which is the same answer it already gives for
           // every other doubt and which sends the add to the full fetch — no new branch.
@@ -13691,13 +13754,32 @@ const GRAPH_TOOL_EXECUTORS = {
           // bound on this path. On a timeout it falls through to the whole-schema fetch,
           // so the two are additive: 10s + 10s of a 30s window on the branch that has not
           // even reached the refresh yet.
+          const issued = {
+            generation: verifiedNodeDefCache.generation(),
+            epoch: backendReconnectEpoch,
+          };
           const one = await withTimeout(
-            fetchSingleNodeDef(class_type, (route) => api?.fetchApi?.(route)),
+            fetchSingleNodeInfo(class_type, (route) => api?.fetchApi?.(route)),
             budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS),
             () => null,
           );
-          if (one) {
-            freshDefs = recordObjectInfoTypes(one);
+          if (schemaProbeIsCurrent(issued) && one?.kind === "absent") {
+            // A 200 `{}` is authoritative absence from the class-scoped route. Do not
+            // let a later whole-schema timeout turn that answer into permission to use
+            // an older verified proof.
+            verifiedNodeDefCache.invalidate(class_type);
+            freshDefs = recordObjectInfoTypes({});
+            freshDefsAreSingleClass = true;
+            currentDef = undefined;
+            return freshDefs;
+          }
+          if (schemaProbeIsCurrent(issued) && one?.kind === "present") {
+            // A live present answer can describe a changed schema. Retire the previous
+            // proof before any later add failure can leave it available as a fallback.
+            verifiedNodeDefCache.invalidate(class_type);
+            verifiedSchemaWriteGeneration = verifiedNodeDefCache.generation();
+            verifiedSchemaWriteEpoch = issued.epoch;
+            freshDefs = recordObjectInfoTypes(one.body);
             freshDefsAreSingleClass = true;
             currentDef = snapshotBackendDef(freshDefs, class_type);
             return freshDefs;
@@ -13710,7 +13792,11 @@ const GRAPH_TOOL_EXECUTORS = {
         // add then fails closed on the same path an empty payload already takes, rather
         // than parking.
         // #1223 — read the epoch HERE, immediately before the whole request is issued.
-        addNodeObservedAtEpoch = backendReconnectEpoch;
+        const issued = {
+          generation: verifiedNodeDefCache.generation(),
+          epoch: backendReconnectEpoch,
+        };
+        addNodeObservedAtEpoch = issued.epoch;
         // #1192 — allowed 10,000 ms here, capped by the caller's remaining budget.
         // #1418 — what this comment used to claim about the OTHER path was never true: it
         // said `graph_set_widget`'s oracle "allows 10,000 ms" and that both were capped, but
@@ -13720,8 +13806,49 @@ const GRAPH_TOOL_EXECUTORS = {
         // deleted because it did real harm twice: a reassurance-shaped claim concealed the
         // very next occurrence of the defect it described (#1413's note, then this one).
         const whole = await boundedGetNodeDefs(budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS));
+        if (!schemaProbeIsCurrent(issued)) {
+          // A response issued on the previous cache generation or backend connection is no
+          // answer for this command. In particular, do not let it become a whole-schema
+          // snapshot or a new verified proof after refresh/reconnect invalidated it.
+          freshDefs = null;
+          freshDefsAreSingleClass = false;
+          currentDef = undefined;
+          return freshDefs;
+        }
+        if (whole === NODE_DEFS_NO_ANSWER) {
+          // #1709 — the verified proof is a last-resort answer only when both live routes
+          // were silent. An explicit whole-schema answer, including an absent class, must
+          // reach node-resolve and invalidate the old proof below.
+          const cachedDef = verifiedNodeDefCache.get(class_type, {
+            epoch: verifiedSchemaStartEpoch,
+            context: verifiedSchemaContext,
+            generation: verifiedSchemaStartGeneration,
+          });
+          if (cachedDef) {
+            verifiedSchemaWriteGeneration = verifiedSchemaStartGeneration;
+            verifiedSchemaWriteEpoch = verifiedSchemaStartEpoch;
+            freshDefs = { [class_type]: cachedDef };
+            freshDefsAreSingleClass = true;
+            currentDef = cachedDef;
+            return freshDefs;
+          }
+        }
         freshDefs = recordObjectInfoTypes(whole === NODE_DEFS_NO_ANSWER ? null : whole);
         freshDefsAreSingleClass = false;
+        if (
+          whole &&
+          typeof whole === "object" &&
+          !Array.isArray(whole)
+        ) {
+          // A live whole-schema answer is authoritative for every class whether it is
+          // present, absent, or changed. Retire all old proofs before downstream validation.
+          verifiedNodeDefCache.clear();
+          verifiedSchemaWriteGeneration = verifiedNodeDefCache.generation();
+          verifiedSchemaWriteEpoch = issued.epoch;
+          // The clear above is this accepted whole answer's own proof retirement. Record the
+          // post-clear generation, so a later refresh can still fence this add's snapshot.
+          addNodeObservedAtGeneration = verifiedNodeDefCache.generation();
+        }
         currentDef = snapshotBackendDef(freshDefs, class_type);
         return freshDefs;
       },
@@ -13810,10 +13937,18 @@ const GRAPH_TOOL_EXECUTORS = {
     // is the honest wholeness claim; the single-class fast path is only taken for an
     // already-registered type, and it sets that flag. Mutation by a beforeRegisterNodeDef
     // hook (#700) is irrelevant here because `record` copies out only the type NAMES.
-    if (freshDefs && !freshDefsAreSingleClass && addNodeObservedAtEpoch !== null) {
+    if (
+      freshDefs &&
+      !freshDefsAreSingleClass &&
+      addNodeObservedAtEpoch !== null &&
+      addNodeObservedAtGeneration !== null
+    ) {
+      const currentGeneration = verifiedNodeDefCache.generation();
       objectInfoSnapshot.record(freshDefs, {
         observedAtEpoch: addNodeObservedAtEpoch,
         currentEpoch: backendReconnectEpoch,
+        observedAtGeneration: addNodeObservedAtGeneration,
+        currentGeneration,
         whole: true,
       });
     }
@@ -13935,7 +14070,7 @@ const GRAPH_TOOL_EXECUTORS = {
           // then name types that payload had already proven — the class's OWN outputs —
           // and say no installed node produces them. That is the false-cause message #695
           // and #700 were about. Any doubt returns null and leaves the proof we have,
-          // which is the same answer-shape fetchSingleNodeDef gives for the same reason.
+          // which is the same answer-shape fetchSingleNodeInfo gives for the same reason.
           if (!whole || typeof whole !== "object" || Array.isArray(whole)) return null;
           if (Object.keys(whole).length === 0) return null;
           return registeredSocketTypes(recordObjectInfoTypes(whole));
@@ -14025,7 +14160,8 @@ const GRAPH_TOOL_EXECUTORS = {
     // No await follows this validation. Re-read the graph/workflow now so a
     // tab or subgraph switch during the async preflight cannot commit to the
     // graph captured at command start.
-    const { graph } = revalidateGraphMutationContext(capturedContext);
+    const validatedContext = revalidateGraphMutationContext(capturedContext);
+    const { graph } = validatedContext;
     graph.beforeChange();
     try {
       node.pos = placementFor(graph, pos);
@@ -14033,6 +14169,20 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.add(node);
     } finally {
       graph.afterChange();
+    }
+    // #1709 — only a node that reached the live graph earns reuse. The definition is already
+    // detached by snapshotBackendDef, and the epoch/context fence prevents it crossing a
+    // reconnect or workflow/graph switch.
+    if (
+      verifiedSchemaWriteGeneration !== null &&
+      verifiedSchemaWriteEpoch === backendReconnectEpoch &&
+      verifiedSchemaWriteGeneration === verifiedNodeDefCache.generation()
+    ) {
+      verifiedNodeDefCache.set(class_type, currentDef, {
+        epoch: verifiedSchemaWriteEpoch,
+        context: validatedContext,
+        generation: verifiedSchemaWriteGeneration,
+      });
     }
     // #1411 — sanitize the freshly created node's aux_id install-hint, mirroring
     // the load-path sanitizer in graph_load. The frontend/Manager
@@ -15270,8 +15420,10 @@ const GRAPH_TOOL_EXECUTORS = {
         // answer for the blind-write recovery.
         const snapshotFence = {
           epoch: backendReconnectEpoch,
+          generation: verifiedNodeDefCache.generation(),
           socketDown: comfyBackendIsDown(),
         };
+        let liveSchemaGeneration = null;
         if (
           reuseSnapshot &&
           typeof objectInfoSnapshot.shouldSkipProbe === "function" &&
@@ -15279,6 +15431,7 @@ const GRAPH_TOOL_EXECUTORS = {
         ) {
           const held = objectInfoSnapshot.authorize({
             epoch: snapshotFence.epoch,
+            generation: snapshotFence.generation,
             socketDown: snapshotFence.socketDown,
             requireSilence: false,
           });
@@ -15319,6 +15472,11 @@ const GRAPH_TOOL_EXECUTORS = {
           provenanceNow,
         } = await readThroughCache(
           async () => {
+            // Capture the schema generation at the actual live request issuance point. The
+            // command may have spent time in the burst cache before its loader starts; a
+            // same-epoch refresh in that gap must not make a pre-refresh fence reject a
+            // post-refresh response, nor let a post-refresh response be filed as pre-refresh.
+            liveSchemaGeneration = verifiedNodeDefCache.generation();
             // #982 — TWO TRANSPORTS for the same question. The reporter's fence refused
             // for "object_info is unavailable" while `/object_info/VAELoader` answered on
             // the same machine, so the frontend client can fail where the HTTP route does
@@ -15346,6 +15504,7 @@ const GRAPH_TOOL_EXECUTORS = {
                   typeof objectInfoSnapshot.isReusable === "function" &&
                   objectInfoSnapshot.isReusable({
                     epoch: backendReconnectEpoch,
+                    generation: verifiedNodeDefCache.generation(),
                     socketDown: comfyBackendIsDown(),
                   })
                   ? OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS
@@ -15355,14 +15514,46 @@ const GRAPH_TOOL_EXECUTORS = {
           },
           { stamp: () => backendReconnectEpoch },
         );
-        const defs = outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
+        const authoritativeEmpty =
+          outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true
+            ? outcome.authoritativeEmpty === true
+            : false;
+        const observedDefs =
+          outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
+        const generationAtIssuance = liveSchemaGeneration ?? snapshotFence.generation;
+        const generationIsCurrent = verifiedNodeDefCache.generation() === generationAtIssuance;
+        // object-info-cache deliberately returns a retired/reconnected payload to its waiter
+        // so the caller can explain the refusal. It is not current authority, however: do
+        // not hand that old map to runSetWidget's type guard after a same-epoch refresh or a
+        // reconnect crossed the request. The cache verdict and this generation fence are both
+        // acceptance gates; the response may still be disclosed, never authorized.
+        const schemaResponseIsCurrent =
+          generationIsCurrent && readProvenance !== "retired" && readProvenance !== "reconnected";
+        const defs = observedDefs;
         oracleFailures = defs ? [] : (outcome?.failures ?? []);
+        if ((defs || authoritativeEmpty) && readProvenance === "live" && generationIsCurrent) {
+          if (authoritativeEmpty) {
+            // Do not let a prior whole payload or last-observed membership snapshot answer
+            // after the backend has authoritatively said that no classes exist.
+            objectInfoCache.invalidate();
+            objectInfoSnapshot.clear();
+          }
+          if (typeof verifiedNodeDefCache !== "undefined") {
+            verifiedNodeDefCache.clear(); // #1709 — a live whole deny-all answer retires per-class proofs too.
+          }
+        }
         if (defs) {
           // #1126 — ONE fact, from the one component that can establish it. The cache says
           // whether the answer it just handed back is the server speaking NOW ("live") or a
           // payload that was served, joined, reconnected out from under, or retired by an
           // `invalidate()` mid-flight. This file no longer re-derives any of that.
           setWidgetSchemaProvenance = provenanceNow;
+          if (!schemaResponseIsCurrent) {
+            // Preserve the payload for the refusal diagnostic, but do not promote it into
+            // backend history or snapshot authority. runSetWidget re-reads this provenance
+            // before type authorization and turns retired/reconnected evidence into a refusal.
+            return defs;
+          }
           // A WHOLE map (this route never asks the per-class one — see the #716/#821 note
           // above), so it is one #1223's fallback may hold — but ONLY if it is live.
           //
@@ -15372,10 +15563,13 @@ const GRAPH_TOOL_EXECUTORS = {
           // epoch — so the snapshot could retain a schema the panel itself had just superseded.
           // Reading the cache's verdict closes that without weakening `record`, whose own
           // checks stay as defence in depth for callers that do not have a verdict to offer.
-          if (readProvenance === "live") {
+          if (readProvenance === "live" && generationIsCurrent) {
+            const currentGeneration = verifiedNodeDefCache.generation();
             objectInfoSnapshot.record(defs, {
               observedAtEpoch: backendReconnectEpoch,
               currentEpoch: backendReconnectEpoch,
+              observedAtGeneration: currentGeneration,
+              currentGeneration,
               whole: true,
             });
           }
@@ -15390,11 +15584,12 @@ const GRAPH_TOOL_EXECUTORS = {
         // looking in the wrong place (#982).
         const fallback = objectInfoSnapshot.authorize({
           epoch: backendReconnectEpoch,
+          generation: verifiedNodeDefCache.generation(),
           socketDown: comfyBackendIsDown(),
           outcomes: outcome?.outcomes,
         });
         // #1560 — the SAME evidence, read ONCE, in the same statement as the snapshot's.
-        scopedReadLicensed = noBackendAnswerEstablished(outcome?.outcomes);
+        scopedReadLicensed = schemaResponseIsCurrent && noBackendAnswerEstablished(outcome?.outcomes);
         if (fallback.defs) {
           // Held for the reply. The write is about to be reported as SUCCEEDED and VERIFIED,
           // and it was verified against a schema nobody could re-fetch — an agent that is
@@ -15480,6 +15675,13 @@ const GRAPH_TOOL_EXECUTORS = {
           fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
           deadlineMs: budget.bounded(SCOPED_OBJECT_INFO_DEADLINE_MS),
         });
+        if (Array.isArray(scoped.covered)) {
+          for (const classType of scoped.covered) {
+            if (typeof classType === "string" && classType) {
+              verifiedNodeDefCache.invalidate(classType);
+            }
+          }
+        }
         // Stamped for the #1126 blind-write ladder, which must NOT treat this as the server's
         // whole word: it is the server answering now about a handful of types.
         //
@@ -15740,6 +15942,8 @@ const GRAPH_TOOL_EXECUTORS = {
     const { graph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
     let oracleFailures = [];
+    const observedAtGeneration = verifiedNodeDefCache.generation();
+    let liveSchemaGeneration = null;
     // #1126 — the cache's own verdict, exactly as graph_set_widget takes it. This route files
     // into the same snapshot, so it needs the same test: "did this call issue the request" is
     // NOT the question, because an `invalidate()` from a refresh/install/download retires a
@@ -15747,21 +15951,52 @@ const GRAPH_TOOL_EXECUTORS = {
     // would then file a schema the panel itself had just superseded.
     const { value: outcome, provenance: readProvenance } = await objectInfoCache.readWithProvenance(
       async () =>
-        fetchWholeObjectInfo({
-          getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
-          fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
-        }),
+        (() => {
+          liveSchemaGeneration = verifiedNodeDefCache.generation();
+          return fetchWholeObjectInfo({
+            getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
+            fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+          });
+        })(),
       { stamp: () => backendReconnectEpoch },
     );
-    const defs = outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
-    oracleFailures = defs ? [] : (outcome?.failures ?? []);
+    const authoritativeEmpty =
+      outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true
+        ? outcome.authoritativeEmpty === true
+        : false;
+    const observedDefs =
+      outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
     // #1223 — this command already paid for a WHOLE /object_info; dropping it leaves the
     // next render-time widget edit refused for want of the map just read. Same argument the
     // history note below already makes for its own trust root.
-    if (defs && readProvenance === "live") {
+    const generationAtIssuance = liveSchemaGeneration ?? observedAtGeneration;
+    const generationIsCurrent = verifiedNodeDefCache.generation() === generationAtIssuance;
+    // A retired/reconnected payload is returned for diagnostics by the burst cache, not for
+    // authorization. A remove-widget call must not use the old declared-input set after the
+    // same refresh/reconnect fence that retired its request.
+    const schemaResponseIsCurrent =
+      generationIsCurrent && readProvenance !== "retired" && readProvenance !== "reconnected";
+    const defs = schemaResponseIsCurrent ? observedDefs : null;
+    oracleFailures = defs ? [] : (outcome?.failures ?? []);
+    if ((defs || authoritativeEmpty) && readProvenance === "live" && generationIsCurrent) {
+      if (authoritativeEmpty) {
+        // The cache deliberately keeps the prior usable payload when a fresh read is empty;
+        // this marker is the point at which that old payload and its snapshot stop being
+        // admissible evidence.
+        objectInfoCache.invalidate();
+        objectInfoSnapshot.clear();
+      }
+      if (typeof verifiedNodeDefCache !== "undefined") {
+        verifiedNodeDefCache.clear(); // #1709 — this whole live answer, including deny-all, supersedes per-class proofs.
+      }
+    }
+    if (defs && readProvenance === "live" && generationIsCurrent) {
+      const currentGeneration = verifiedNodeDefCache.generation();
       objectInfoSnapshot.record(defs, {
         observedAtEpoch: backendReconnectEpoch,
         currentEpoch: backendReconnectEpoch,
+        observedAtGeneration: currentGeneration,
+        currentGeneration,
         whole: true,
       });
     }
@@ -17692,12 +17927,21 @@ const GRAPH_TOOL_EXECUTORS = {
       if (scanBudgetMs > 0) {
         liveScan = await scanComboAvailability(
           nodes,
-          (cls, signal) =>
-            fetchSingleNodeInfo(
+          async (cls, signal) => {
+            const outcome = await fetchSingleNodeInfo(
               cls,
               (route, options) => api?.fetchApi?.(route, options),
               signal,
-            ),
+            );
+            // #1709 — get_errors' per-class reader is a live authority too. A definitive
+            // present answer may describe a changed schema, and `{}` is explicit absence;
+            // retire only that class's reusable add proof. Unknown/timeout outcomes remain
+            // non-authoritative and preserve the later silent-add fallback semantics.
+            if (outcome?.kind === "present" || outcome?.kind === "absent") {
+              verifiedNodeDefCache.invalidate(cls);
+            }
+            return outcome;
+          },
           {
             budgetMs: scanBudgetMs,
             now: monotonicNow,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1405,6 +1405,10 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // actually failed instead of being bucketed as a generic failure.
   let appAvailable = false;
   let defs = preloadedDefs ?? null;
+  // A graph_add_node whole-schema response is authoritative even though it arrives as
+  // preloaded input. The explicit marker is narrowly supplied by that caller; arbitrary
+  // preloaded refresh payloads remain ineligible for whole-schema cache/snapshot authority.
+  const preloadedWholeSchema = runOpts?.preloadedWholeSchema === true;
   let defsRegistered = false;
   let comboApiPresent = false;
   let comboRan = false;
@@ -1862,10 +1866,12 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     const refreshResponseIsCurrent =
       runStartedAtEpoch === backendReconnectEpoch &&
       runStartedAtGeneration === verifiedNodeDefCache.generation();
-    if (!preloadedDefs && refreshResponseIsCurrent) {
-      // The refresh fetch is a direct whole-schema read, not an objectInfoCache read. Keep
-      // its current answer as the burst authority and retire the snapshot before recording
-      // the replacement, so a timeout cannot use the prior map or membership set.
+    if ((!preloadedDefs || preloadedWholeSchema) && refreshResponseIsCurrent) {
+      // A direct refresh fetch, or graph_add_node's explicitly verified whole payload, is
+      // not an objectInfoCache read. Keep its current answer as the burst authority and
+      // retire the snapshot before recording the replacement, so a timeout cannot use the
+      // prior map or membership set. The refresh invalidation above happens first, so this
+      // is the post-refresh generation rather than the add's pre-refresh fence.
       if (!objectInfoCache.replace(defs)) objectInfoCache.invalidate();
       objectInfoSnapshot.clear();
       objectInfoSnapshot.record(defs, {
@@ -13918,8 +13924,25 @@ const GRAPH_TOOL_EXECUTORS = {
       refresh: (defs) =>
         refreshComfyNodeDefs(defs, {
           joinMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS,
+          preloadedWholeSchema: !freshDefsAreSingleClass,
         }).then((outcome) => {
           if (outcome === REFRESH_JOIN_ABANDONED) refreshJoinAbandoned = true;
+          // The refresh intentionally advances the verified generation before registering
+          // this preloaded response. Once its current verdict settles, the response is now
+          // stamped against the post-refresh generation; retaining the old issuance stamp
+          // would make the later snapshot record fail closed even though this refresh just
+          // registered the same authoritative whole map.
+          const refreshIsCurrent =
+            outcome === true || (outcome && typeof outcome === "object" && outcome.refreshed === true);
+          if (
+            refreshIsCurrent &&
+            outcome !== REFRESH_JOIN_ABANDONED &&
+            !freshDefsAreSingleClass &&
+            addNodeObservedAtEpoch !== null &&
+            addNodeObservedAtEpoch === backendReconnectEpoch
+          ) {
+            addNodeObservedAtGeneration = verifiedNodeDefCache.generation();
+          }
           return outcome;
         }),
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13767,6 +13767,8 @@ const GRAPH_TOOL_EXECUTORS = {
             // A 200 `{}` is authoritative absence from the class-scoped route. Do not
             // let a later whole-schema timeout turn that answer into permission to use
             // an older verified proof.
+            objectInfoCache.invalidate();
+            objectInfoSnapshot.clear();
             verifiedNodeDefCache.invalidate(class_type);
             freshDefs = recordObjectInfoTypes({});
             freshDefsAreSingleClass = true;
@@ -13776,6 +13778,8 @@ const GRAPH_TOOL_EXECUTORS = {
           if (schemaProbeIsCurrent(issued) && one?.kind === "present") {
             // A live present answer can describe a changed schema. Retire the previous
             // proof before any later add failure can leave it available as a fallback.
+            objectInfoCache.invalidate();
+            objectInfoSnapshot.clear();
             verifiedNodeDefCache.invalidate(class_type);
             verifiedSchemaWriteGeneration = verifiedNodeDefCache.generation();
             verifiedSchemaWriteEpoch = issued.epoch;
@@ -15552,6 +15556,8 @@ const GRAPH_TOOL_EXECUTORS = {
             // Preserve the payload for the refusal diagnostic, but do not promote it into
             // backend history or snapshot authority. runSetWidget re-reads this provenance
             // before type authorization and turns retired/reconnected evidence into a refusal.
+            setWidgetSchemaProvenance = () =>
+              readProvenance === "reconnected" ? "reconnected" : "retired";
             return defs;
           }
           // A WHOLE map (this route never asks the per-class one — see the #716/#821 note
@@ -15678,6 +15684,8 @@ const GRAPH_TOOL_EXECUTORS = {
         if (Array.isArray(scoped.covered)) {
           for (const classType of scoped.covered) {
             if (typeof classType === "string" && classType) {
+              objectInfoCache.invalidate();
+              objectInfoSnapshot.clear();
               verifiedNodeDefCache.invalidate(classType);
             }
           }
@@ -17935,9 +17943,13 @@ const GRAPH_TOOL_EXECUTORS = {
             );
             // #1709 — get_errors' per-class reader is a live authority too. A definitive
             // present answer may describe a changed schema, and `{}` is explicit absence;
-            // retire only that class's reusable add proof. Unknown/timeout outcomes remain
-            // non-authoritative and preserve the later silent-add fallback semantics.
+            // retire every reusable schema authority: a per-class answer can establish that
+            // the old whole map is stale even though it cannot replace that map. Unknown/
+            // timeout outcomes remain non-authoritative and preserve the later silent-add
+            // fallback semantics.
             if (outcome?.kind === "present" || outcome?.kind === "absent") {
+              objectInfoCache.invalidate();
+              objectInfoSnapshot.clear();
               verifiedNodeDefCache.invalidate(cls);
             }
             return outcome;

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -415,6 +415,49 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
     },
 
     /**
+     * Replace the stored whole schema with a known-current payload.
+     *
+     * Direct whole-schema readers do not come through `readWithProvenance`, but their
+     * definitive answer must still retire the burst entry and any request issued before
+     * that answer. This is an atomic replacement: the generation moves before the value is
+     * exposed, so a late old response cannot overwrite the new authority.
+     *
+     * Empty/unusable values are deliberately ignored. An unavailable or timed-out read is
+     * not authoritative and must not turn into an invalidation merely because a caller
+     * tried to publish it.
+     */
+    replace(next) {
+      if (!next || typeof next !== "object" || Array.isArray(next)) return false;
+      let keys;
+      try {
+        keys = Object.keys(next);
+      } catch {
+        return false;
+      }
+      if (keys.length === 0) return false;
+      let frozen;
+      try {
+        // Keep the caller's response mutable for downstream registration hooks. The
+        // ordinary loader may cache an outcome wrapper, while direct whole readers hand
+        // their map to graph registration after publishing it here; freezing that shared
+        // response would make this cache alter the registration contract.
+        frozen = Object.freeze({ ...next });
+      } catch {
+        return false;
+      }
+      generation += 1;
+      // Retire requests issued against the replaced map. They remain awaitable by their
+      // original callers, but cannot join or repopulate this cache after this point.
+      inflight = null;
+      inflightGeneration = -1;
+      inflightId = 0;
+      freshInflight = null;
+      value = frozen;
+      at = now();
+      return true;
+    },
+
+    /**
      * Drop the entry AND retire anything in flight — for anything that knows, or merely
      * suspects, that the schema may have changed.
      */

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -87,11 +87,18 @@ function cloneAndFreeze(value, seen = new WeakMap()) {
   seen.set(value, clone);
   let keys;
   try {
-    keys = Object.keys(value);
+    keys = Reflect.ownKeys(value);
   } catch {
     throw new TypeError("object_info schema is unreadable");
   }
   for (const key of keys) {
+    let descriptor;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(value, key);
+    } catch {
+      throw new TypeError("object_info schema is unreadable");
+    }
+    if (!descriptor?.enumerable) continue;
     Object.defineProperty(clone, key, {
       value: cloneAndFreeze(value[key], seen),
       enumerable: true,
@@ -100,6 +107,16 @@ function cloneAndFreeze(value, seen = new WeakMap()) {
     });
   }
   return Object.freeze(clone);
+}
+
+function cloneForCache(value) {
+  try {
+    return { ok: true, value: cloneAndFreeze(value) };
+  } catch {
+    // Preserve the loader's result for its current caller, but do not retain an unreadable
+    // graph as a cache authority. This keeps ordinary/readFresh failure semantics unchanged.
+    return { ok: false, value: null };
+  }
 }
 
 /**
@@ -223,16 +240,14 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
           typeof payload === "object" &&
           Object.keys(payload).length > 0
         ) {
-          // SHARED IDENTITY IS NEW (codex): every write used to get its own object, and
-          // now they share one. A consumer that mutated the map would contaminate every
-          // later authorization instead of only its own call. Freezing the TOP LEVEL —
-          // the level the fence's `hasOwnProperty(defs, type)` reads — makes adding or
-          // removing a type key throw here and now, in a test or a dev console, rather
-          // than silently authorizing a type nobody installed. Shallow on purpose: a
-          // deep freeze of a 5MB schema on every fetch would cost more than the fetch
-          // this exists to avoid, and per-class contents are not what the fence rules on.
-          value = Object.freeze(defs);
-          at = now();
+          // Store a private frozen graph, including the outcome wrapper and its enumerable
+          // symbol tag. The loader's mutable result still goes to this caller unchanged,
+          // while later cache readers cannot mutate nested schema authority through it.
+          const cached = cloneForCache(defs);
+          if (cached.ok) {
+            value = cached.value;
+            at = now();
+          }
         }
         return defs;
       } finally {
@@ -406,8 +421,11 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
               typeof payload === "object" &&
               Object.keys(payload).length > 0
             ) {
-              value = Object.freeze(defs);
-              at = now();
+              const cached = cloneForCache(defs);
+              if (cached.ok) {
+                value = cached.value;
+                at = now();
+              }
             }
             return defs;
           } finally {

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -75,6 +75,34 @@ export const CACHE_OUTCOME = Symbol.for("comfyui-mcp.objectInfoOutcome");
 export const OBJECT_INFO_CACHE_TTL_MS = 1500;
 
 /**
+ * Clone the JSON-shaped schema into a private graph and freeze every level. The panel hands
+ * direct whole responses to frontend registration hooks, which are allowed to mutate their
+ * input; the cache must never retain those mutations as backend authority.
+ */
+function cloneAndFreeze(value, seen = new WeakMap()) {
+  if (value === null || typeof value !== "object") return value;
+  const prior = seen.get(value);
+  if (prior) return prior;
+  const clone = Array.isArray(value) ? [] : {};
+  seen.set(value, clone);
+  let keys;
+  try {
+    keys = Object.keys(value);
+  } catch {
+    throw new TypeError("object_info schema is unreadable");
+  }
+  for (const key of keys) {
+    Object.defineProperty(clone, key, {
+      value: cloneAndFreeze(value[key], seen),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return Object.freeze(clone);
+}
+
+/**
  * @param {{ttlMs?: number, now?: () => number}} [opts] `now` is injectable so tests do not
  *   depend on wall-clock timing, which is how a cache test becomes a flaky test.
  */
@@ -439,9 +467,10 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
       try {
         // Keep the caller's response mutable for downstream registration hooks. The
         // ordinary loader may cache an outcome wrapper, while direct whole readers hand
-        // their map to graph registration after publishing it here; freezing that shared
-        // response would make this cache alter the registration contract.
-        frozen = Object.freeze({ ...next });
+        // their map to graph registration after publishing it here; cloning the complete
+        // graph prevents this cache from altering the registration contract or retaining
+        // nested hook mutations.
+        frozen = cloneAndFreeze(next);
       } catch {
         return false;
       }

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -125,6 +125,13 @@ function usableDefs(value) {
   }
 }
 
+function authoritativeEmptyDefs(value) {
+  // Keep the existing answer classification: a non-array object response is an answer even
+  // when its keys cannot be inspected. The oracle already fails closed on that response; the
+  // marker only lets callers retire other verified proofs instead of treating it as silence.
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
 /** How much of a thrown value's own words may ride into a refusal message. */
 const MAX_DETAIL_CHARS = 200;
 
@@ -352,8 +359,9 @@ const GATEWAY_STATUSES = Object.freeze([504]);
  *
  * Returns `{ defs, failures, outcomes }` — `defs` is null unless one route returned a
  * usable payload, `failures` names every route that did not, in order, and `outcomes`
- * carries the same list as TRANSPORT_OUTCOME tags (#1223). An empty `failures` with a null
- * `defs` cannot happen: a route that answers nothing is itself a failure.
+ * carries the same list as TRANSPORT_OUTCOME tags (#1223). An empty authoritative response
+ * also carries `authoritativeEmpty: true`, so callers can distinguish deny-all from a timeout
+ * while preserving the fail-closed `defs: null` shape.
  */
 export async function fetchWholeObjectInfo({
   getNodeDefs,
@@ -599,13 +607,13 @@ export async function fetchWholeObjectInfo({
       // overrule it with a broader schema — the one direction this fallback must never
       // move. Only a client that returned NOTHING (null/undefined/non-object) or threw
       // leaves the question unanswered, and only that may be asked again elsewhere.
-      if (defs && typeof defs === "object" && !Array.isArray(defs)) {
+      if (authoritativeEmptyDefs(defs)) {
         record(
           "client",
           TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
           "api.getNodeDefs() returned an EMPTY schema — treated as its answer, not as an absence",
         );
-        return { [CACHE_OUTCOME]: true, defs: null, failures, outcomes };
+        return { [CACHE_OUTCOME]: true, defs: null, authoritativeEmpty: true, failures, outcomes };
       }
       record(
         "client",
@@ -733,6 +741,14 @@ export async function fetchWholeObjectInfo({
         } else {
           const defs = body.value;
           if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures, outcomes };
+          if (authoritativeEmptyDefs(defs)) {
+            record(
+              "http",
+              TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+              "GET /object_info returned an EMPTY schema — treated as its answer, not as an absence",
+            );
+            return { [CACHE_OUTCOME]: true, defs: null, authoritativeEmpty: true, failures, outcomes };
+          }
           record(
             "http",
             TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,

--- a/web/js/lib/object-info-snapshot.js
+++ b/web/js/lib/object-info-snapshot.js
@@ -53,7 +53,13 @@
  *      refresh path to do it. Provenance, not freshness — a snapshot from a replaced
  *      process is refused outright rather than aged out, so there is no time bound to get
  *      wrong.
- *   4. THE BACKEND NEVER ANSWERED, not merely "the fetch failed". Only outcomes that leave
+ *   4. NO SAME-CONNECTION INVALIDATION SINCE — `verifiedNodeDefCache` advances its
+ *      generation when a refresh/install/download retires schema proof without a reconnect.
+ *      A whole response issued before that event must not be filed under the unchanged epoch,
+ *      or the snapshot fallback would resurrect the pre-refresh type set during the next
+ *      timeout. `record` therefore takes the generation captured before the request and the
+ *      generation at delivery, just as it takes the two epoch values.
+ *   5. THE BACKEND NEVER ANSWERED, not merely "the fetch failed". Only outcomes that leave
  *      the question unanswered license the snapshot: a timeout, a client that returned
  *      NOTHING, a proxy's gateway error (which is the proxy reporting the same silence over
  *      HTTP). Anything that ANSWERED — threw, a non-gateway status, an empty schema, a body
@@ -134,6 +140,7 @@ export function noBackendAnswerEstablished(outcomes) {
 export function createObjectInfoSnapshot() {
   let defs = null;
   let epoch = null;
+  let generation = null;
   // #1582 — have the live whole-map routes already gone silent on THIS connection,
   // after a snapshot was held? The first silent call still has to probe: that is how
   // an answered error keeps refusing, and how a healthy backend still wins. Once
@@ -145,10 +152,10 @@ export function createObjectInfoSnapshot() {
 
   return {
     /**
-     * Store the type membership of a whole map that was OBSERVED at `observedAtEpoch`, if
-     * that is still the epoch we are on.
+     * Store the type membership of a whole map that was OBSERVED at `observedAtEpoch` and
+     * `observedAtGeneration`, if those are still the epoch and schema generation we are on.
      *
-     * THREE THINGS THIS REFUSES, each from a defect found in review:
+     * FOUR THINGS THIS REFUSES, each from a defect found in review:
      *
      * 1. AN EPOCH READ AFTER THE FETCH. `observedAtEpoch` must be captured BEFORE the
      *    request is issued, and is only stored if `currentEpoch` still matches. The first
@@ -166,7 +173,10 @@ export function createObjectInfoSnapshot() {
      *    that payload CAN reach the refresh path (`assertAddNodeResolvableRefreshing`
      *    re-reads the registry across an await and may hand its single-class defs to
      *    `refresh`). The flag makes each call site state the claim rather than imply it.
-     * 3. ANYTHING THAT COULD NOT AUTHORIZE A WRITE ANYWAY — null, empty, an array, a
+     * 3. A RESPONSE THAT SPANNED A SAME-EPOCH INVALIDATION. The verified node-definition
+     *    cache generation is the panel's schema invalidation fence; epoch equality alone is
+     *    insufficient when refresh_nodes clears proof on the same backend connection.
+     * 4. ANYTHING THAT COULD NOT AUTHORIZE A WRITE ANYWAY — null, empty, an array, a
      *    non-object, or an unreadable shape.
      *
      * WHAT IS STORED IS A DETACHED MAP OF TYPE NAMES, never the payload. `registerNodesFromDefs`
@@ -178,10 +188,21 @@ export function createObjectInfoSnapshot() {
      * ~5.4MB schema from being pinned in memory for the life of a connection, and it means
      * the values cannot supply stale combo option lists to anything downstream.
      */
-    record(candidate, { observedAtEpoch, currentEpoch, whole = false } = {}) {
+    record(
+      candidate,
+      {
+        observedAtEpoch,
+        currentEpoch,
+        observedAtGeneration,
+        currentGeneration,
+        whole = false,
+      } = {},
+    ) {
       if (whole !== true) return false;
       if (!Number.isFinite(observedAtEpoch) || !Number.isFinite(currentEpoch)) return false;
       if (observedAtEpoch !== currentEpoch) return false;
+      if (!Number.isFinite(observedAtGeneration) || !Number.isFinite(currentGeneration)) return false;
+      if (observedAtGeneration !== currentGeneration) return false;
       if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
       let keys;
       try {
@@ -208,6 +229,7 @@ export function createObjectInfoSnapshot() {
       // not a hole in the suite, and it is recorded here so the next run does not re-chase
       // it. `currentEpoch` is written because it is the one `authorize` compares against.
       epoch = currentEpoch;
+      generation = currentGeneration;
       // A live observation means the whole-map routes answered. The next widget write
       // must be allowed to prefer that live path rather than inheriting a prior silence.
       probesSilent = false;
@@ -226,7 +248,19 @@ export function createObjectInfoSnapshot() {
      * `shouldSkipProbe` has already recorded that silence on this connection (#1582), so
      * a later write can reuse the held map without minting fake outcomes.
      */
-    authorize({ epoch: currentEpoch, socketDown, outcomes, requireSilence = true } = {}) {
+    authorize(options = {}) {
+      const {
+        epoch: currentEpoch,
+        socketDown,
+        outcomes,
+        requireSilence = true,
+      } = options;
+      // The default keeps standalone snapshot callers source-compatible; every shipped
+      // panel caller passes the live generation explicitly. A caller with no generation
+      // authority must not be able to choose a different generation by omission.
+      const currentGeneration = Object.prototype.hasOwnProperty.call(options, "generation")
+        ? options.generation
+        : generation;
       if (requireSilence !== false && !noBackendAnswerEstablished(outcomes)) {
         return {
           defs: null,
@@ -257,6 +291,14 @@ export function createObjectInfoSnapshot() {
             "ComfyUI process that has been replaced",
         };
       }
+      if (!Number.isFinite(currentGeneration) || currentGeneration !== generation) {
+        return {
+          defs: null,
+          reason:
+            "the node-definition schema was refreshed since that whole map was observed, " +
+            "so the last-observed snapshot is no longer authority",
+        };
+      }
       return { defs, reason: "" };
     },
 
@@ -270,12 +312,18 @@ export function createObjectInfoSnapshot() {
      * The same socket/epoch fence is used so a reconnect cannot inherit the shorter budget
      * or the skip.
      */
-    isReusable({ epoch: currentEpoch, socketDown } = {}) {
+    isReusable(options = {}) {
+      const { epoch: currentEpoch, socketDown } = options;
+      const currentGeneration = Object.prototype.hasOwnProperty.call(options, "generation")
+        ? options.generation
+        : generation;
       return (
         defs !== null &&
         !socketDown &&
         Number.isFinite(currentEpoch) &&
-        currentEpoch === epoch
+        currentEpoch === epoch &&
+        Number.isFinite(currentGeneration) &&
+        currentGeneration === generation
       );
     },
 
@@ -295,14 +343,20 @@ export function createObjectInfoSnapshot() {
      * call still probes so an answered error can refuse; a reconnect, a down socket, or a
      * later live `record` all return false.
      */
-    shouldSkipProbe({ epoch: currentEpoch, socketDown } = {}) {
-      return probesSilent === true && this.isReusable({ epoch: currentEpoch, socketDown });
+    shouldSkipProbe(options = {}) {
+      const { epoch: currentEpoch, socketDown } = options;
+      const reusableOptions = { epoch: currentEpoch, socketDown };
+      if (Object.prototype.hasOwnProperty.call(options, "generation")) {
+        reusableOptions.generation = options.generation;
+      }
+      return probesSilent === true && this.isReusable(reusableOptions);
     },
 
     /** Drop it — for anything that knows, or merely suspects, the schema moved. */
     clear() {
       defs = null;
       epoch = null;
+      generation = null;
       probesSilent = false;
     },
 

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -284,7 +284,13 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     const startedAt = joinMs === null ? 0 : Date.now();
     // #1562 — the caller's RUN allowance, forwarded to every `startRun` below. Built here,
     // once, so no branch can start a run under a different budget than its siblings.
-    const runOpts = opts && Number.isFinite(opts.runBudgetMs) ? { runBudgetMs: opts.runBudgetMs } : undefined;
+    const runOpts =
+      opts && (Number.isFinite(opts.runBudgetMs) || opts.preloadedWholeSchema === true)
+        ? {
+            ...(Number.isFinite(opts.runBudgetMs) ? { runBudgetMs: opts.runBudgetMs } : {}),
+            ...(opts.preloadedWholeSchema === true ? { preloadedWholeSchema: true } : {}),
+          }
+        : undefined;
     const abandonBeforeLocalWork = !!(opts && opts.abandonBeforeLocalWork);
     const remaining = () => (joinMs === null ? null : joinMs - (Date.now() - startedAt));
     const current = getInFlight();

--- a/web/js/lib/scoped-object-info.js
+++ b/web/js/lib/scoped-object-info.js
@@ -426,17 +426,27 @@ export async function fetchTypeScopedObjectInfo(
   }
   const results = settled.value;
   const present = [];
+  const covered = [];
   for (let i = 0; i < wanted.length; i += 1) {
     const r = results[i];
     if (!r?.definitive) {
       // ALL OR NOTHING. One type this write needs is unestablished, so the map cannot
       // authorize the write — and a map that answers some of the question is precisely what
       // #716/#821 were.
-      return { defs: null, covered: [], reason: r?.why || `GET /object_info/${wanted[i]} established nothing` };
+      return {
+        defs: null,
+        // The incomplete batch still established authority for every definitive class. The
+        // production caller uses this only to retire stale per-class add proofs; it never
+        // authorizes from a partial map. Unknown/timeout batches return before this loop and
+        // therefore keep covered empty.
+        covered,
+        reason: r?.why || `GET /object_info/${wanted[i]} established nothing`,
+      };
     }
+    covered.push(wanted[i]);
     if (r.present) present.push([wanted[i], r.def]);
   }
-  return { defs: scopedView(present, new Set(wanted)), covered: wanted, reason: "" };
+  return { defs: scopedView(present, new Set(wanted)), covered, reason: "" };
 }
 
 /**

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -387,6 +387,32 @@ export async function runSetWidget(
   } catch {
     freshDefs = null;
   }
+  // The whole-schema reader may return a retired/reconnected payload to explain why the
+  // request was superseded. That payload is not current authority: refuse it before any
+  // type guard can mistake its old membership for a live backend answer. The explicit
+  // wording keeps the provenance diagnosis actionable, while the panel's scoped fallback
+  // remains unavailable because the superseded whole response did not establish current
+  // silence.
+  if (freshDefs && typeof schemaProvenance === "function") {
+    const provenance = readSchemaProvenance();
+    if (provenance === "reconnected") {
+      throw new Error(
+        `panel_set_widget refused "${widgetName}" on node ${node?.id}: the backend RECONNECTED ` +
+          `while that /object_info request was in flight, so the answer describes a process ` +
+          `that has since been replaced and did not come from the server answering now. ` +
+          `Refusing to write rather than trust a possibly-stale node schema (#1126).`,
+      );
+    }
+    if (provenance === "retired") {
+      throw new Error(
+        `panel_set_widget refused "${widgetName}" on node ${node?.id}: the panel REFRESHED ` +
+          `the node definitions while that /object_info request was in flight, so the answer ` +
+          `was superseded before it arrived and the refresh may be what filled this list. ` +
+          `It did not come from the server answering now; refusing to write rather than trust ` +
+          `a possibly-stale node schema (#1126).`,
+      );
+    }
+  }
 
   // Resolve the promoted inner target ONCE (PURE — no coercion/mutation). Threaded
   // into applyWidgetWrite so the write never re-resolves to a different node.

--- a/web/js/lib/single-node-def.js
+++ b/web/js/lib/single-node-def.js
@@ -63,9 +63,10 @@ export function singleDefConfirms(body, classType) {
 
 /**
  * The live error scan needs to distinguish a class the server answered as absent
- * from a per-class route that did not answer. The add-node fast path deliberately
- * collapses both to null so it can fall through to its whole-schema authority; the
- * read path cannot do that because null currently reads as "node type not found".
+ * from a per-class route that did not answer. The add-node fast path treats only
+ * `unknown` as no answer; an explicit `absent` result retires stale proof before
+ * node resolution. The read path cannot collapse absence to null because null
+ * currently reads as "node type not found".
  */
 export const SINGLE_NODE_INFO_OUTCOME = Symbol.for("comfyui-mcp.singleNodeInfoOutcome");
 

--- a/web/js/lib/verified-node-def-cache.js
+++ b/web/js/lib/verified-node-def-cache.js
@@ -1,0 +1,96 @@
+// #1709 — retain a node definition that graph_add_node already verified and used.
+//
+// This is deliberately narrower than the whole /object_info cache: it stores one detached
+// class definition, and only for the exact backend epoch and graph/workflow binding that
+// performed the verified add. A reconnect, schema refresh, tab switch, or graph switch can
+// therefore never authorize an add from an old entry. Callers still clear it when a schema
+// refresh or backend outage is observed; the identity checks are the last line of defense.
+
+function usableContext(context) {
+  return !!(
+    context &&
+    context.app &&
+    context.graph &&
+    context.rootGraph &&
+    context.workflow
+  );
+}
+
+function sameContext(a, b) {
+  return (
+    a.app === b.app &&
+    a.graph === b.graph &&
+    a.rootGraph === b.rootGraph &&
+    a.workflow === b.workflow
+  );
+}
+
+function usableEpoch(epoch) {
+  return Number.isFinite(epoch);
+}
+
+export function createVerifiedNodeDefCache() {
+  const entries = new Map();
+  let generation = 0;
+
+  return {
+    generation() {
+      return generation;
+    },
+
+    get(classType, { epoch, context, generation: expectedGeneration } = {}) {
+      if (
+        typeof classType !== "string" ||
+        !usableEpoch(epoch) ||
+        !usableContext(context) ||
+        expectedGeneration !== generation
+      ) {
+        return undefined;
+      }
+      const entry = entries.get(classType);
+      if (!entry || entry.epoch !== epoch || !sameContext(entry.context, context)) return undefined;
+      return entry.def;
+    },
+
+    set(classType, def, { epoch, context, generation: expectedGeneration } = {}) {
+      if (
+        typeof classType !== "string" ||
+        !classType ||
+        !def ||
+        typeof def !== "object" ||
+        Array.isArray(def) ||
+        !usableEpoch(epoch) ||
+        !usableContext(context) ||
+        expectedGeneration !== generation
+      ) {
+        return false;
+      }
+      entries.set(classType, {
+        def,
+        epoch,
+        context: {
+          app: context.app,
+          graph: context.graph,
+          rootGraph: context.rootGraph,
+          workflow: context.workflow,
+        },
+      });
+      return true;
+    },
+
+    // An authoritative absence or any schema/backend invalidation drops the type. The
+    // class key is global because an observed backend absence is not workflow-specific.
+    // Advance the generation even when the requested entry is already absent: an in-flight
+    // writer must not repopulate proof after this invalidation.
+    invalidate(classType) {
+      generation += 1;
+      if (typeof classType === "string" && classType) entries.delete(classType);
+      else entries.clear();
+    },
+
+    clear() {
+      generation += 1;
+      entries.clear();
+    },
+  };
+}


### PR DESCRIPTION
Fixes #1709. Reuse verified node schemas only as a generation/epoch-fenced last-resort fallback after live object_info probes time out. Definitive whole/per-class responses retire stale verified, whole-cache, and snapshot authority; refresh/reconnect races cannot resurrect old proofs; cached schemas are recursively detached/frozen. Full unit: 6685 passed, 0 failed, 1 todo. Independent review: SHIP.