### PR TITLE
feat: add authenticated fetch_image bridge command

### DIFF
--- a/browser_tests/unit/fetch-image.test.mjs
+++ b/browser_tests/unit/fetch-image.test.mjs
@@ -1,0 +1,216 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fetchImageForMcp, validateFetchImageRef } from "../../web/js/lib/fetch-image.js";
+import { commandIsCanvasIndependent, commandIsCanvasTargetless } from "../../web/js/lib/workflow-chat-identity.js";
+
+function response({ status = 200, mime = "image/png", bytes = [], contentLength, body = true } = {}) {
+  const data = Uint8Array.from(bytes);
+  let consumed = false;
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get(name) {
+        const key = name.toLowerCase();
+        if (key === "content-type") return mime;
+        if (key === "content-length") return contentLength == null ? null : String(contentLength);
+        return null;
+      },
+    },
+    body: body
+      ? {
+          getReader() {
+            return {
+              async read() {
+                if (consumed) return { done: true, value: undefined };
+                consumed = true;
+                return { done: false, value: data };
+              },
+              cancel() {},
+              releaseLock() {},
+            };
+          },
+        }
+      : null,
+  };
+}
+
+async function rejection(promise, code) {
+  await assert.rejects(promise, (error) => {
+    assert.equal(error.code, code, error.message);
+    return true;
+  });
+}
+
+test("#2149: valid refs use the API/base-path URL and return bounded media bytes", async () => {
+  const calls = [];
+  const result = await fetchImageForMcp(
+    { filename: "cat.png", subfolder: "renders", type: "output" },
+    {
+      api: { apiURL: (path) => `/comfy${path}` },
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return response({ bytes: [0, 1, 2, 255] });
+      },
+    },
+  );
+
+  assert.deepEqual(result, { ok: true, base64: "AAEC/w==", mimeType: "image/png", bytes: 4 });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "/comfy/view?filename=cat.png&subfolder=renders&type=output");
+  assert.equal(calls[0].init.credentials, "include");
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(calls[0].init.cache, "no-store");
+  assert.ok(calls[0].init.signal instanceof AbortSignal);
+});
+
+test("#2149: the normal panel API helper receives the same relative route and credentials", async () => {
+  const calls = [];
+  const result = await fetchImageForMcp(
+    { filename: "cat.png" },
+    {
+      api: {
+        apiURL: (path) => `/base${path}`,
+        fetchApi: async (path, init) => {
+          calls.push({ path, init });
+          return response({ bytes: [137, 80, 78, 71] });
+        },
+      },
+    },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(calls[0].path, "/view?filename=cat.png&subfolder=&type=output");
+  assert.equal(calls[0].init.credentials, "include");
+});
+
+test("#2149: file refs reject separators, traversal, invalid subfolders, types, URLs, and extra fields", async () => {
+  const invalidRefs = [
+    { filename: 7 },
+    { filename: "   " },
+    { filename: "nested/cat.png" },
+    { filename: "nested\\cat.png" },
+    { filename: ".." },
+    { filename: "cat.png", subfolder: 7 },
+    { filename: "cat.png", subfolder: "../outside" },
+    { filename: "cat.png", subfolder: "nested\\child" },
+    { filename: "cat.png", subfolder: "/absolute" },
+    { filename: "cat.png", subfolder: "http://evil.test" },
+    { filename: "cat.png", type: "models" },
+    { filename: "https://evil.test/cat.png" },
+    { filename: "cat.png", url: "https://evil.test" },
+    { filename: "cat.png", origin: "https://evil.test" },
+    { filename: "cat.png", target: "other-tab" },
+  ];
+
+  for (const ref of invalidRefs) {
+    assert.throws(() => validateFetchImageRef(ref), { code: "invalid_input" }, JSON.stringify(ref));
+    await rejection(
+      fetchImageForMcp(ref, {
+        api: { apiURL: (path) => path },
+        fetchImpl: async () => { throw new Error("must not fetch"); },
+      }),
+      "invalid_input",
+    );
+  }
+});
+
+test("#2149: an absolute API URL must remain same-origin", async () => {
+  await rejection(
+    fetchImageForMcp(
+      { filename: "cat.png" },
+      {
+        api: { apiURL: () => "https://evil.test/view?filename=cat.png" },
+        expectedOrigin: "https://panel.test",
+        fetchImpl: async () => { throw new Error("must not fetch"); },
+      },
+    ),
+    "invalid_origin",
+  );
+});
+
+test("#2149: HTTP failures preserve status classification", async () => {
+  let error;
+  try {
+    await fetchImageForMcp(
+      { filename: "missing.png" },
+      {
+        api: { apiURL: (path) => path },
+        fetchImpl: async () => response({ status: 404, mime: "text/html", body: false }),
+      },
+    );
+  } catch (caught) {
+    error = caught;
+  }
+  assert.equal(error?.code, "http_error");
+  assert.equal(error?.status, 404);
+  assert.match(error?.message ?? "", /HTTP 404/);
+});
+
+test("#2149: non-media MIME types are refused", async () => {
+  await rejection(
+    fetchImageForMcp(
+      { filename: "not-an-image.txt" },
+      {
+        api: { apiURL: (path) => path },
+        fetchImpl: async () => response({ mime: "text/plain", bytes: [1] }),
+      },
+    ),
+    "invalid_mime",
+  );
+});
+
+test("#2149: Content-Length and streamed bytes cannot exceed the configured cap", async () => {
+  await rejection(
+    fetchImageForMcp(
+      { filename: "large.png" },
+      {
+        api: { apiURL: (path) => path },
+        maxBytes: 4,
+        fetchImpl: async () => response({ contentLength: 5, bytes: [1, 2, 3, 4, 5] }),
+      },
+    ),
+    "too_large",
+  );
+
+  await rejection(
+    fetchImageForMcp(
+      { filename: "chunked.png" },
+      {
+        api: { apiURL: (path) => path },
+        maxBytes: 4,
+        fetchImpl: async () => response({ bytes: [1, 2, 3, 4, 5] }),
+      },
+    ),
+    "too_large",
+  );
+});
+
+test("#2149: the fetch and body read have an abort timeout", async () => {
+  let signal;
+  await rejection(
+    fetchImageForMcp(
+      { filename: "hung.png" },
+      {
+        api: { apiURL: (path) => path },
+        timeoutMs: 10,
+        fetchImpl: async (_url, init) => {
+          signal = init.signal;
+          return new Promise(() => {});
+        },
+      },
+    ),
+    "timeout",
+  );
+  assert.equal(signal?.aborted, true);
+});
+
+test("#2149: fetch_image is wired as a canvas-independent dispatcher command", () => {
+  const source = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(source, /fetch_image\(args = \{\}\)/);
+  assert.match(source, /return fetchImageForMcp\(args, \{ api \}\)/);
+  assert.match(source, /"ui_render", "ui_update", "fetch_image"/);
+  assert.equal(commandIsCanvasIndependent("fetch_image"), true);
+  assert.equal(commandIsCanvasTargetless("fetch_image"), true);
+});

--- a/browser_tests/unit/fetch-image.test.mjs
+++ b/browser_tests/unit/fetch-image.test.mjs
@@ -4,12 +4,24 @@ import { readFileSync } from "node:fs";
 import { fetchImageForMcp, validateFetchImageRef } from "../../web/js/lib/fetch-image.js";
 import { commandIsCanvasIndependent, commandIsCanvasTargetless } from "../../web/js/lib/workflow-chat-identity.js";
 
-function response({ status = 200, mime = "image/png", bytes = [], contentLength, body = true } = {}) {
+function response({
+  status = 200,
+  mime = "image/png",
+  bytes = [],
+  contentLength,
+  body = true,
+  url,
+  type,
+  redirected = false,
+} = {}) {
   const data = Uint8Array.from(bytes);
   let consumed = false;
   return {
     status,
     ok: status >= 200 && status < 300,
+    ...(url === undefined ? {} : { url }),
+    ...(type === undefined ? {} : { type }),
+    redirected,
     headers: {
       get(name) {
         const key = name.toLowerCase();
@@ -62,6 +74,7 @@ test("#2149: valid refs use the API/base-path URL and return bounded media bytes
   assert.equal(calls[0].init.credentials, "include");
   assert.equal(calls[0].init.method, "GET");
   assert.equal(calls[0].init.cache, "no-store");
+  assert.equal(calls[0].init.redirect, "manual");
   assert.ok(calls[0].init.signal instanceof AbortSignal);
 });
 
@@ -83,6 +96,7 @@ test("#2149: the normal panel API helper receives the same relative route and cr
   assert.equal(result.ok, true);
   assert.equal(calls[0].path, "/view?filename=cat.png&subfolder=&type=output");
   assert.equal(calls[0].init.credentials, "include");
+  assert.equal(calls[0].init.redirect, "manual");
 });
 
 test("#2149: file refs reject separators, traversal, invalid subfolders, types, URLs, and extra fields", async () => {
@@ -146,6 +160,50 @@ test("#2149: HTTP failures preserve status classification", async () => {
   assert.equal(error?.code, "http_error");
   assert.equal(error?.status, 404);
   assert.match(error?.message ?? "", /HTTP 404/);
+});
+
+test("#2149: redirects and cross-origin final response URLs are typed refusals", async () => {
+  const options = {
+    api: { apiURL: (path) => path },
+    expectedOrigin: "https://panel.test",
+  };
+
+  await rejection(
+    fetchImageForMcp(
+      { filename: "redirect.png" },
+      { ...options, fetchImpl: async () => response({ status: 302, url: "https://panel.test/login", body: false }) },
+    ),
+    "redirect_error",
+  );
+  await rejection(
+    fetchImageForMcp(
+      { filename: "opaque-redirect.png" },
+      { ...options, fetchImpl: async () => response({ status: 0, type: "opaqueredirect", body: false }) },
+    ),
+    "redirect_error",
+  );
+  await rejection(
+    fetchImageForMcp(
+      { filename: "cross-origin.png" },
+      { ...options, fetchImpl: async () => response({ url: "https://evil.test/image.png", bytes: [1] }) },
+    ),
+    "invalid_origin",
+  );
+});
+
+test("#2149: a same-origin final response URL remains valid", async () => {
+  const result = await fetchImageForMcp(
+    { filename: "same-origin.png" },
+    {
+      api: { apiURL: (path) => `https://panel.test/base${path}` },
+      expectedOrigin: "https://panel.test",
+      fetchImpl: async (url, init) => {
+        assert.equal(init.redirect, "manual");
+        return response({ url, bytes: [1, 2, 3] });
+      },
+    },
+  );
+  assert.equal(result.bytes, 3);
 });
 
 test("#2149: non-media MIME types are refused", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -288,6 +288,7 @@ import { recordSkillFromGraph, persistRecordedSkill } from "./lib/record-skill.j
 // was individually correct and their sum was not, and a sum cannot be asserted against the
 // 1.7MB panel IIFE.
 import { makeCommandBudget } from "./lib/command-budget.js";
+import { fetchImageForMcp } from "./lib/fetch-image.js";
 // #1184 — the ORDER a backend switch commits in. A module because the defect is an
 // ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
 import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
@@ -11968,6 +11969,11 @@ function lateWorkflowSaveReceipts() {
 }
 
 const GRAPH_TOOL_EXECUTORS = {
+  // Read-only MCP get_image relay. It accepts only a ComfyUI file reference,
+  // fetches same-origin /view bytes, and never paints into the panel chat.
+  fetch_image(args = {}) {
+    return fetchImageForMcp(args, { api });
+  },
   // #608: force a fresh /object_info re-register + combo refresh so an asset that
   // appeared server-side AFTER page-load — an upload_image action:"stage" input, a freshly
   // downloaded model/LoRA/VAE, a newly installed node pack — becomes selectable in
@@ -25172,7 +25178,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // commands get the normal activity card.
         const SILENT_CMDS = new Set([
           "ask_user", "request_secret", "set_todo", "show_media", "open_civitai",
-          "ui_render", "ui_update",
+          "ui_render", "ui_update", "fetch_image",
           "civitai_results", "civitai_highlight", "civitai_clear_highlight",
           "civitai_switch_tab", "civitai_search", "civitai_open_lightbox",
           "open_training", "training_get_state", "training_set_field",

--- a/web/js/lib/fetch-image.js
+++ b/web/js/lib/fetch-image.js
@@ -1,0 +1,332 @@
+// Read-only ComfyUI /view relay for the MCP get_image tool.
+//
+// This module deliberately accepts only a file reference. It never accepts a
+// URL or an origin, and it never paints anything in the panel UI.
+
+export const FETCH_IMAGE_TIMEOUT_MS = 8000;
+export const MAX_FETCH_IMAGE_BYTES = 32 * 1024 * 1024;
+
+const SUPPORTED_TYPES = new Set(["input", "output", "temp"]);
+const REF_FIELDS = new Set(["filename", "subfolder", "type"]);
+// These are bridge transport/routing fields, not fetch_image arguments. The
+// dispatcher may stamp them onto every command frame before it reaches us.
+const COMMAND_FRAME_FIELDS = new Set([
+  "cmd",
+  "rid",
+  "retry_of",
+  "timeout_ms",
+  "epoch",
+  "workflow_uuid",
+  "workflow_path",
+]);
+
+function fetchImageError(code, message, extra = {}) {
+  const error = new Error(message);
+  error.code = code;
+  Object.assign(error, extra);
+  return error;
+}
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function invalidRef(message) {
+  return fetchImageError("invalid_input", `fetch_image rejected the file reference: ${message}`);
+}
+
+function hasControlCharacter(value) {
+  return /[\u0000-\u001f\u007f]/.test(value);
+}
+
+function hasEncodedPathSyntax(value) {
+  return /%(?:2f|2e|5c)/i.test(value);
+}
+
+function validateFilename(filename) {
+  if (typeof filename !== "string" || filename.trim() === "") {
+    throw invalidRef("filename must be a non-empty string");
+  }
+  if (hasControlCharacter(filename) || hasEncodedPathSyntax(filename)) {
+    throw invalidRef("filename contains control or encoded path syntax");
+  }
+  if (/[\\/]/.test(filename) || filename === "." || filename === "..") {
+    throw invalidRef("filename must be a single file name without path separators or traversal");
+  }
+  if (/[?#:]/.test(filename)) {
+    throw invalidRef("filename contains URL or platform path syntax");
+  }
+}
+
+function validateSubfolder(subfolder) {
+  if (subfolder === undefined) return "";
+  if (typeof subfolder !== "string") throw invalidRef("subfolder must be a string when provided");
+  if (subfolder === "") return "";
+  if (
+    hasControlCharacter(subfolder) ||
+    hasEncodedPathSyntax(subfolder) ||
+    subfolder.startsWith("/") ||
+    subfolder.endsWith("/") ||
+    subfolder.includes("\\") ||
+    subfolder.includes("//") ||
+    /[?#:]/.test(subfolder)
+  ) {
+    throw invalidRef("subfolder is not a safe relative folder path");
+  }
+  const segments = subfolder.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    throw invalidRef("subfolder contains empty or traversal segments");
+  }
+  return subfolder;
+}
+
+function validateType(type) {
+  const resolved = type === undefined ? "output" : type;
+  if (typeof resolved !== "string" || !SUPPORTED_TYPES.has(resolved)) {
+    throw invalidRef(`type must be one of ${Array.from(SUPPORTED_TYPES).join(", ")}`);
+  }
+  return resolved;
+}
+
+function validateRefFields(ref, { allowCommandFields = false } = {}) {
+  if (!ref || typeof ref !== "object" || Array.isArray(ref)) {
+    throw invalidRef("expected an object");
+  }
+  for (const key of Object.keys(ref)) {
+    if (!REF_FIELDS.has(key) && !(allowCommandFields && COMMAND_FRAME_FIELDS.has(key))) {
+      throw invalidRef(`unexpected field "${key}"`);
+    }
+  }
+  if (!hasOwn(ref, "filename")) throw invalidRef("filename is required");
+  validateFilename(ref.filename);
+  const subfolder = validateSubfolder(hasOwn(ref, "subfolder") ? ref.subfolder : undefined);
+  const type = validateType(hasOwn(ref, "type") ? ref.type : undefined);
+  return { filename: ref.filename, subfolder, type };
+}
+
+/** Validate and normalize the public `{filename, subfolder?, type?}` shape. */
+export function validateFetchImageRef(ref) {
+  return validateRefFields(ref);
+}
+
+function viewPath(ref) {
+  const query = new URLSearchParams({
+    filename: ref.filename,
+    subfolder: ref.subfolder,
+    type: ref.type,
+  });
+  return `/view?${query.toString()}`;
+}
+
+function pageOrigin() {
+  const origin = globalThis.location?.origin;
+  return typeof origin === "string" && origin && origin !== "null" ? origin : null;
+}
+
+function resolveSameOriginUrl(api, path, expectedOrigin = pageOrigin()) {
+  if (typeof api?.apiURL !== "function") {
+    throw fetchImageError("api_unavailable", "fetch_image requires the panel API URL helper");
+  }
+  let rawUrl;
+  try {
+    rawUrl = api.apiURL(path);
+  } catch (error) {
+    throw fetchImageError("api_unavailable", `fetch_image could not resolve the /view URL: ${error?.message ?? error}`);
+  }
+  if (typeof rawUrl !== "string" || rawUrl === "") {
+    throw fetchImageError("api_unavailable", "fetch_image could not resolve the /view URL");
+  }
+  try {
+    const parsed = new URL(rawUrl, expectedOrigin || "http://comfyui-panel.invalid");
+    if (expectedOrigin && parsed.origin !== expectedOrigin) {
+      throw fetchImageError("invalid_origin", "fetch_image resolved a non-same-origin /view URL");
+    }
+    if (!expectedOrigin && parsed.origin !== "http://comfyui-panel.invalid") {
+      throw fetchImageError("invalid_origin", "fetch_image cannot verify an absolute /view URL origin");
+    }
+  } catch (error) {
+    if (error?.code) throw error;
+    throw fetchImageError("invalid_origin", "fetch_image resolved an invalid /view URL");
+  }
+  return rawUrl;
+}
+
+function responseHeader(response, name) {
+  try {
+    return typeof response?.headers?.get === "function" ? response.headers.get(name) : null;
+  } catch {
+    return null;
+  }
+}
+
+function mediaMimeType(response) {
+  const raw = responseHeader(response, "content-type") || "";
+  const mimeType = raw.split(";", 1)[0].trim().toLowerCase();
+  if (!/^(?:image|video|audio)\/[a-z0-9][a-z0-9.+-]*$/.test(mimeType)) {
+    throw fetchImageError(
+      "invalid_mime",
+      `fetch_image received a non-media MIME type "${mimeType || "unset"}"`,
+    );
+  }
+  return mimeType;
+}
+
+function declaredLength(response) {
+  const raw = responseHeader(response, "content-length");
+  if (!raw || !/^\d+$/.test(raw.trim())) return null;
+  const length = Number(raw);
+  return Number.isSafeInteger(length) ? length : null;
+}
+
+function timeoutState(timeoutMs) {
+  const controller = new AbortController();
+  const timeoutError = fetchImageError("timeout", `fetch_image timed out after ${timeoutMs}ms`);
+  let rejectTimeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    rejectTimeout = reject;
+  });
+  const timer = setTimeout(() => {
+    controller.abort();
+    rejectTimeout(timeoutError);
+  }, timeoutMs);
+  return {
+    controller,
+    timeoutPromise,
+    timeoutError,
+    dispose: () => clearTimeout(timer),
+  };
+}
+
+async function readResponseBytes(response, maxBytes, timeoutPromise) {
+  const length = declaredLength(response);
+  if (length !== null && length > maxBytes) {
+    throw fetchImageError("too_large", `fetch_image response exceeds the ${maxBytes}-byte limit`, { bytes: length });
+  }
+
+  if (typeof response?.body?.getReader === "function") {
+    const reader = response.body.getReader();
+    const chunks = [];
+    let total = 0;
+    try {
+      while (true) {
+        const part = await Promise.race([reader.read(), timeoutPromise]);
+        if (part.done) break;
+        const chunk = part.value instanceof Uint8Array ? part.value : new Uint8Array(part.value);
+        total += chunk.byteLength;
+        if (total > maxBytes) {
+          try { void reader.cancel(); } catch { /* best effort */ }
+          throw fetchImageError("too_large", `fetch_image response exceeds the ${maxBytes}-byte limit`, { bytes: total });
+        }
+        chunks.push(chunk);
+      }
+    } finally {
+      try { reader.releaseLock?.(); } catch { /* best effort */ }
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return bytes;
+  }
+
+  if (typeof response?.arrayBuffer !== "function") {
+    throw fetchImageError("read_error", "fetch_image response has no readable body");
+  }
+  // A non-streaming host cannot be allowed to allocate an unbounded body just
+  // to discover its size after the fact. Real browser Responses take the
+  // streaming branch; this fallback is only safe with a trusted small length.
+  if (length === null) {
+    throw fetchImageError("read_error", "fetch_image response has no bounded body length");
+  }
+  const buffer = await Promise.race([response.arrayBuffer(), timeoutPromise]);
+  const bytes = new Uint8Array(buffer);
+  if (bytes.byteLength > maxBytes) {
+    throw fetchImageError("too_large", `fetch_image response exceeds the ${maxBytes}-byte limit`, { bytes: bytes.byteLength });
+  }
+  return bytes;
+}
+
+function bytesToBase64(bytes) {
+  if (typeof globalThis.btoa === "function") {
+    const parts = [];
+    // 0x6000 is divisible by three, so concatenating chunk encodings is safe.
+    for (let offset = 0; offset < bytes.length; offset += 0x6000) {
+      const chunk = bytes.subarray(offset, Math.min(offset + 0x6000, bytes.length));
+      parts.push(globalThis.btoa(String.fromCharCode(...chunk)));
+    }
+    return parts.join("");
+  }
+  if (globalThis.Buffer) return globalThis.Buffer.from(bytes).toString("base64");
+  throw fetchImageError("encode_error", "fetch_image cannot base64-encode the response");
+}
+
+/**
+ * Fetch a ComfyUI file reference for MCP get_image.
+ *
+ * `args` may be the bridge command frame (transport fields are ignored after
+ * validation) or a direct file reference in unit tests. The panel API helper
+ * remains the preferred transport so its normal base-path and credentials
+ * behavior is preserved; the raw fetch fallback is only for minimal hosts.
+ */
+export async function fetchImageForMcp(
+  args,
+  {
+    api,
+    fetchImpl = globalThis.fetch,
+    timeoutMs = FETCH_IMAGE_TIMEOUT_MS,
+    maxBytes = MAX_FETCH_IMAGE_BYTES,
+    expectedOrigin,
+  } = {},
+) {
+  if (!(timeoutMs > 0) || !Number.isFinite(timeoutMs)) {
+    throw fetchImageError("invalid_config", "fetch_image timeout must be positive");
+  }
+  if (!(maxBytes > 0) || !Number.isFinite(maxBytes)) {
+    throw fetchImageError("invalid_config", "fetch_image byte limit must be positive");
+  }
+  const ref = validateRefFields(args, { allowCommandFields: true });
+  const path = viewPath(ref);
+  const url = resolveSameOriginUrl(api, path, expectedOrigin ?? pageOrigin());
+  const timeout = timeoutState(timeoutMs);
+  const request = {
+    method: "GET",
+    cache: "no-store",
+    credentials: "include",
+    signal: timeout.controller.signal,
+  };
+  try {
+    let response;
+    try {
+      if (typeof api?.fetchApi === "function") {
+        response = await Promise.race([api.fetchApi(path, request), timeout.timeoutPromise]);
+      } else {
+        if (typeof fetchImpl !== "function") throw fetchImageError("api_unavailable", "fetch_image has no fetch transport");
+        response = await Promise.race([fetchImpl(url, request), timeout.timeoutPromise]);
+      }
+    } catch (error) {
+      if (error === timeout.timeoutError || timeout.controller.signal.aborted) throw timeout.timeoutError;
+      if (error?.code) throw error;
+      throw fetchImageError("network_error", `fetch_image could not reach /view: ${error?.message ?? error}`);
+    }
+
+    const status = Number(response?.status);
+    const ok = response?.ok === true || (Number.isFinite(status) && status >= 200 && status < 300);
+    if (!ok) {
+      throw fetchImageError(
+        "http_error",
+        `fetch_image /view returned HTTP ${Number.isFinite(status) ? status : "unknown"}`,
+        { status: Number.isFinite(status) ? status : null },
+      );
+    }
+    const mimeType = mediaMimeType(response);
+    const bytes = await readResponseBytes(response, maxBytes, timeout.timeoutPromise);
+    return { ok: true, base64: bytesToBase64(bytes), mimeType, bytes: bytes.byteLength };
+  } catch (error) {
+    if (error === timeout.timeoutError || timeout.controller.signal.aborted) throw timeout.timeoutError;
+    throw error?.code ? error : fetchImageError("read_error", `fetch_image failed: ${error?.message ?? error}`);
+  } finally {
+    timeout.dispose();
+  }
+}

--- a/web/js/lib/fetch-image.js
+++ b/web/js/lib/fetch-image.js
@@ -159,6 +159,41 @@ function responseHeader(response, name) {
   }
 }
 
+function validateResponseOrigin(response, expectedOrigin) {
+  const rawUrl = response?.url;
+  if (rawUrl == null || rawUrl === "") return;
+  if (typeof rawUrl !== "string") {
+    throw fetchImageError("invalid_origin", "fetch_image received a response with an invalid URL");
+  }
+  try {
+    const parsed = new URL(rawUrl, expectedOrigin || "http://comfyui-panel.invalid");
+    if (
+      (!expectedOrigin && parsed.origin !== "http://comfyui-panel.invalid") ||
+      (expectedOrigin && parsed.origin !== expectedOrigin)
+    ) {
+      throw fetchImageError("invalid_origin", "fetch_image received a non-same-origin response URL");
+    }
+  } catch (error) {
+    if (error?.code) throw error;
+    throw fetchImageError("invalid_origin", "fetch_image received an invalid response URL");
+  }
+}
+
+function rejectRedirectResponse(response) {
+  const status = Number(response?.status);
+  if (
+    response?.type === "opaqueredirect" ||
+    response?.redirected === true ||
+    (Number.isFinite(status) && status >= 300 && status < 400)
+  ) {
+    throw fetchImageError(
+      "redirect_error",
+      `fetch_image rejected a redirect response${Number.isFinite(status) ? ` (HTTP ${status})` : ""}`,
+      { status: Number.isFinite(status) ? status : null },
+    );
+  }
+}
+
 function mediaMimeType(response) {
   const raw = responseHeader(response, "content-type") || "";
   const mimeType = raw.split(";", 1)[0].trim().toLowerCase();
@@ -288,12 +323,14 @@ export async function fetchImageForMcp(
   }
   const ref = validateRefFields(args, { allowCommandFields: true });
   const path = viewPath(ref);
-  const url = resolveSameOriginUrl(api, path, expectedOrigin ?? pageOrigin());
+  const origin = expectedOrigin ?? pageOrigin();
+  const url = resolveSameOriginUrl(api, path, origin);
   const timeout = timeoutState(timeoutMs);
   const request = {
     method: "GET",
     cache: "no-store",
     credentials: "include",
+    redirect: "manual",
     signal: timeout.controller.signal,
   };
   try {
@@ -311,6 +348,8 @@ export async function fetchImageForMcp(
       throw fetchImageError("network_error", `fetch_image could not reach /view: ${error?.message ?? error}`);
     }
 
+    validateResponseOrigin(response, origin);
+    rejectRedirectResponse(response);
     const status = Number(response?.status);
     const ok = response?.ok === true || (Number.isFinite(status) && status >= 200 && status < 300);
     if (!ok) {

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -396,6 +396,7 @@ const CANVAS_INDEPENDENT_COMMANDS = new Set([
   'nodes_queue_status',
   'graph_update_node',
   'graph_get_virtual_types',
+  'fetch_image',
   'comfy_reboot',
   'free_vram',
 ]);


### PR DESCRIPTION
Paired with artokun/comfyui-mcp#2149.\n\nAdd the canvas-independent fetch_image bridge command used by the MCP orchestrator's authenticated loopback relay. Fetches same-origin /view content with credentials, manual redirect/final-origin checks, image MIME validation, timeout, bounded streaming, and a 32 MiB cap.\n\nValidation: focused fetch-image tests, identity tests, typecheck, full unit corpus, and independent SHIP review passed.\n