### PR TITLE
fix: isolate storyboard posters per render

### DIFF
--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -139,7 +139,23 @@ test("an oversized local video yields a preview AND says it is a sample, not the
   // The source size, in the note, in human units.
   assert.match(reply.note, /72\.1 MB/);
   // A next step that actually shows the agent the sheet.
-  assert.match(reply.note, /call get_image with filename "storyboard_reference_clip\.png", type "temp"/);
+  assert.match(reply.note, /call get_image with filename "storyboard_reference_clip_[^"]+\.png", type "temp"/);
+});
+
+test("#1718: repeated panel_show_media renders use fresh source and storyboard identities", async () => {
+  const first = harness();
+  const second = harness();
+  await composeShowMediaReply([VIDEO_REF], first.deps);
+  await composeShowMediaReply([VIDEO_REF], second.deps);
+
+  assert.match(first.calls.storyboardsFor[0], /[?&]cmcp_storyboard=/);
+  assert.match(second.calls.storyboardsFor[0], /[?&]cmcp_storyboard=/);
+  assert.notEqual(first.calls.storyboardsFor[0], second.calls.storyboardsFor[0]);
+  assert.equal(first.calls.paintedVideos[0].url, first.calls.storyboardsFor[0], "the player and sampler use the fresh source URL");
+  assert.equal(second.calls.paintedVideos[0].url, second.calls.storyboardsFor[0], "the player and sampler use the fresh source URL");
+  assert.match(first.calls.uploads[0].name, /^storyboard_reference_clip_.+\.png$/);
+  assert.match(second.calls.uploads[0].name, /^storyboard_reference_clip_.+\.png$/);
+  assert.notEqual(first.calls.uploads[0].name, second.calls.uploads[0].name);
 });
 
 test("the batch headline states the agent was not sent the files at all", async () => {
@@ -890,7 +906,7 @@ test("a sheet painter that THROWS is disclosed and still leaves the agent its co
   const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
   assert.equal(reply.previews.length, 1);
   assert.match(reply.note, /could not be shown\s+in the chat/);
-  assert.match(reply.note, /call get_image with filename "storyboard_reference_clip\.png"/);
+  assert.match(reply.note, /call get_image with filename "storyboard_reference_clip_[^"]+\.png"/);
 });
 
 test("a sheet that IS painted carries no visibility caveat", async () => {

--- a/browser_tests/unit/run-completion-stills-metadata.test.mjs
+++ b/browser_tests/unit/run-completion-stills-metadata.test.mjs
@@ -166,7 +166,7 @@ test("#1610: video storyboard starts while a stills HEAD is still in flight", as
     "the still rides the mixed frame",
   );
   assert.ok(
-    frame.images.some((m) => m.filename === "storyboard_clip.png"),
+    frame.images.some((m) => /^storyboard_clip_.+\.png$/.test(m.filename)),
     "the sheet rides the mixed frame once the HEAD is released",
   );
 });

--- a/browser_tests/unit/run-completion-video-segment.test.mjs
+++ b/browser_tests/unit/run-completion-video-segment.test.mjs
@@ -270,7 +270,7 @@ test("#1485: the poster still reaches the card when its upload resolves", async 
   resolvePoster();
   await new Promise((r) => setTimeout(r, 0));
   assert.equal(calls.posters.length, 1, "and the card is back-filled by video URL");
-  assert.equal(calls.posters[0].videoUrl, "/view?filename=clip_00001_.mp4");
+  assert.match(calls.posters[0].videoUrl, /^\/view\?filename=clip_00001_\.mp4&cmcp_storyboard=.+$/);
   assert.match(calls.posters[0].posterUrl, /^\/view\?filename=poster_clip_00001__.+\.png$/);
 });
 

--- a/browser_tests/unit/run-completion-video-segment.test.mjs
+++ b/browser_tests/unit/run-completion-video-segment.test.mjs
@@ -269,9 +269,29 @@ test("#1485: the poster still reaches the card when its upload resolves", async 
   assert.equal(calls.posters.length, 0, "the frame did not wait for it");
   resolvePoster();
   await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual(calls.posters, [
-    { videoUrl: "/view?filename=clip_00001_.mp4", posterUrl: "/view?filename=poster_clip_00001_.png" },
-  ], "and the card is back-filled by video URL exactly as before");
+  assert.equal(calls.posters.length, 1, "and the card is back-filled by video URL");
+  assert.equal(calls.posters[0].videoUrl, "/view?filename=clip_00001_.mp4");
+  assert.match(calls.posters[0].posterUrl, /^\/view\?filename=poster_clip_00001__.+\.png$/);
+});
+
+test("#1718: repeated renders with one source filename sample fresh bytes and upload fresh sheets", async () => {
+  const attempts = [];
+  for (let i = 0; i < 2; i += 1) {
+    const { deps, calls } = makeDeps({
+      buildVideoStoryboard: async (url) => {
+        attempts.push({ url });
+        return sheetBlob({ paintedFrames: 20 });
+      },
+    });
+    await composeRunCompletionFrame(videoPayload(), deps);
+    attempts[i].name = calls.uploads[0]?.name ?? null;
+  }
+  assert.match(attempts[0].url, /[?&]cmcp_storyboard=/);
+  assert.match(attempts[1].url, /[?&]cmcp_storyboard=/);
+  assert.notEqual(attempts[0].url, attempts[1].url, "the source /view cache key must change per render");
+  assert.match(attempts[0].name, /^storyboard_clip_00001__.+\.png$/);
+  assert.match(attempts[1].name, /^storyboard_clip_00001__.+\.png$/);
+  assert.notEqual(attempts[0].name, attempts[1].name, "the temp storyboard ref must change per render");
 });
 
 test("#1485: the video's size HEAD overlaps the sampling instead of following the upload", async () => {

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -357,11 +357,10 @@ test("#269/#468 presentation: a MIXED run (stills + 2 videos) emits EXACTLY ONE 
   assert.equal(frames[0].prompt_id, P, "attributed to the finishing prompt");
   // All outputs ride in the single frame: the still + both storyboard refs.
   const names = frames[0].images.map((m) => m.filename);
-  assert.deepEqual(
-    names,
-    ["final.png", "storyboard_v1.png", "storyboard_v2.png"],
-    "one still + BOTH video storyboards consolidated into the single images array",
-  );
+  assert.equal(names[0], "final.png");
+  assert.match(names[1], /^storyboard_v1_.+\.png$/);
+  assert.match(names[2], /^storyboard_v2_.+\.png$/);
+  assert.equal(names.length, 3, "one still + BOTH video storyboards consolidated into the single images array");
   // The note mentions the still result and both videos in one turn.
   assert.match(frames[0].note, /final\.png/, "note names the still output");
   assert.match(frames[0].note, /v1\.mp4/, "note names the first video");
@@ -404,11 +403,10 @@ test("presentation: a video-only run (2 videos) is still ONE frame", async () =>
     deps,
   );
   assert.equal(frames.length, 1, "two videos, one completion frame");
-  assert.deepEqual(
-    frames[0].images.map((m) => m.filename),
-    ["storyboard_x.png", "storyboard_y.png"],
-    "both storyboards in the single frame",
-  );
+  const names = frames[0].images.map((m) => m.filename);
+  assert.equal(names.length, 2, "both storyboards in the single frame");
+  assert.match(names[0], /^storyboard_x_.+\.png$/);
+  assert.match(names[1], /^storyboard_y_.+\.png$/);
 });
 
 // #209 — the storyboard contact sheet is a panel-generated PREVIEW, never a
@@ -429,14 +427,14 @@ test("#209 storyboard upload requests ComfyUI's temp namespace, never input/", a
     deps,
   );
   assert.equal(uploadCalls.length, 1, "one storyboard upload for the one video");
-  assert.equal(uploadCalls[0].name, "storyboard_clip.png");
+  assert.match(uploadCalls[0].name, /^storyboard_clip_.+\.png$/);
   assert.equal(uploadCalls[0].opts?.type, "temp", "must request the temp namespace, not input/");
 
   // The resulting ImageRef must carry type:"temp" all the way into the sent
   // frame, so the chat preview resolves via /view?...&type=temp — never silently
   // falls back to type:"input" (which would defeat the fix even if the upload
   // call itself requested temp).
-  const storyboardImg = frames[0].images.find((m) => m.filename === "storyboard_clip.png");
+  const storyboardImg = frames[0].images.find((m) => /^storyboard_clip_.+\.png$/.test(m.filename));
   assert.ok(storyboardImg, "storyboard ref must be present in the sent frame");
   assert.equal(storyboardImg.type, "temp");
 });
@@ -515,7 +513,7 @@ test("#609: blind mode (images withheld) — no review request, an explicit proh
   // The storyboard is still produced for the USER (blind blinds the agent, not
   // the panel) — the ref rides the frame; the sendFrame gate strips it.
   assert.ok(
-    frame.images.some((m) => m.filename === "storyboard_clip.png"),
+    frame.images.some((m) => /^storyboard_clip_.+\.png$/.test(m.filename)),
     "the storyboard is still built for the user; only the agent-facing pixels are gated",
   );
 });

--- a/browser_tests/unit/storyboard-cache-identity.test.mjs
+++ b/browser_tests/unit/storyboard-cache-identity.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  appendStoryboardCacheBust,
+  createStoryboardIdentity,
+  storyboardPosterUploadName,
+  storyboardUploadName,
+} from "../../web/js/lib/storyboard-cache-identity.js";
+
+test("#1718 storyboard identities make source URLs and derived names distinct", () => {
+  const first = createStoryboardIdentity();
+  const second = createStoryboardIdentity();
+  assert.notEqual(first, second);
+  assert.notEqual(
+    appendStoryboardCacheBust("/view?filename=clip.mp4&type=temp", first),
+    appendStoryboardCacheBust("/view?filename=clip.mp4&type=temp", second),
+  );
+  assert.match(storyboardUploadName("clip", first), new RegExp(`^storyboard_clip_${first}\\.png$`));
+  assert.match(storyboardPosterUploadName("clip", first), new RegExp(`^poster_clip_${first}\\.png$`));
+});
+
+test("#1718 cache bust preserves URL fragments", () => {
+  const busted = appendStoryboardCacheBust("/view?filename=clip.mp4#frame", "attempt-1");
+  assert.equal(busted, "/view?filename=clip.mp4&cmcp_storyboard=attempt-1#frame");
+});

--- a/browser_tests/unit/video-poster.test.mjs
+++ b/browser_tests/unit/video-poster.test.mjs
@@ -16,9 +16,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import {
+  appendStoryboardCacheBust,
+  createStoryboardIdentity,
+} from "../../web/js/lib/storyboard-cache-identity.js";
 
-const panelSrc = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-const frameSrc = readFileSync(new URL("../../web/js/lib/run-completion-frame.js", import.meta.url), "utf8");
+const panelSrc = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
+const frameSrc = readFileSync(new URL("../../web/js/lib/run-completion-frame.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
 
 function slice(src, from, to) {
   const a = src.indexOf(from);
@@ -106,10 +110,89 @@ test("poster: the upload is best-effort and threaded as a dependency", () => {
     /if \(blob\.posterBlob && typeof applyVideoPoster === "function"\)/,
     "absent poster or absent dep must both degrade silently",
   );
-  assert.match(frameSrc, /poster_\$\{base\}\.png/, "the poster is uploaded beside the sheet");
+  assert.match(
+    frameSrc,
+    /storyboardPosterUploadName\(base, storyboardIdentity\)/,
+    "the poster uses the same per-attempt identity as the sheet",
+  );
   assert.match(frameSrc, /\{ type: "temp" \}/, "into the swept temp namespace, never input/");
+  assert.match(frameSrc, /applyVideoPoster\(sourceUrl, imageViewUrl\(posterRef\)\)/, "the late poster targets the painted card's URL");
   // Both composers paint video cards through the same painter, so both must
   // supply the back-fill or one surface silently keeps the old behaviour.
   const deps = panelSrc.split("applyVideoPoster,").length - 1;
   assert.ok(deps >= 2, `applyVideoPoster must be passed to both composers (found ${deps})`);
+});
+
+test("#1718 production boundary: late poster results stay with their render attempt", () => {
+  // Drive the SHIPPED onExecuted branch, not the cache-name helper. Before the
+  // fix both executions handed paintVideo the same stable /view URL, so the
+  // holder registry treated two cards as one and a late first poster broadcast
+  // into the second card.
+  const onExecutedStart = panelSrc.indexOf("  function onExecuted(ev) {");
+  const onExecutedEnd = panelSrc.indexOf("\n  function onExecError(ev)", onExecutedStart);
+  assert.ok(onExecutedStart >= 0 && onExecutedEnd > onExecutedStart, "could not isolate production onExecuted");
+  const onExecuted = new Function(
+    "imageViewUrl",
+    "isVideoOutput",
+    "isAudioOutput",
+    "paintVideo",
+    "paintAudio",
+    "paintImage",
+    "runCompletion",
+    "stripMisattachedExecutionPreviews",
+    "app",
+    "createStoryboardIdentity",
+    "appendStoryboardCacheBust",
+    `return (${panelSrc.slice(onExecutedStart, onExecutedEnd).trim()});`,
+  )(
+    (m) => `/view?filename=${m.filename}&type=${m.type || "output"}`,
+    () => true,
+    () => false,
+    (url) => painted.push(url),
+    () => {},
+    () => {},
+    { onExecuted: (_promptId, output) => buffered.push(output) },
+    () => {},
+    {},
+    createStoryboardIdentity,
+    appendStoryboardCacheBust,
+  );
+
+  const painted = [];
+  const buffered = [];
+  const video = { filename: "Minimax_00001.mp4", type: "temp" };
+  onExecuted({ detail: { prompt_id: "first", output: { videos: [video] } } });
+  onExecuted({ detail: { prompt_id: "second", output: { videos: [video] } } });
+  assert.equal(painted.length, 2);
+  assert.notEqual(painted[0], painted[1], "each onExecuted card must receive a distinct URL");
+  assert.match(painted[0], /[?&]cmcp_storyboard=/);
+  assert.match(painted[1], /[?&]cmcp_storyboard=/);
+  assert.equal(buffered[0].videos[0].videoUrl, painted[0]);
+  assert.equal(buffered[1].videos[0].videoUrl, painted[1]);
+
+  // Execute the production holder registry against those exact URLs. A late
+  // poster for the first completion must not reach the second holder.
+  const registryStart = panelSrc.indexOf("  const _videoPosters = new Map();");
+  const registerEnd = panelSrc.indexOf("  /** Put a known poster on one holder", registryStart);
+  const applyVideoStart = panelSrc.indexOf("  function applyVideoPoster", registerEnd);
+  const applyVideoEnd = panelSrc.indexOf("  function unmountHolderVideo", applyVideoStart);
+  assert.ok(
+    registryStart >= 0 && registerEnd > registryStart && applyVideoStart > registerEnd && applyVideoEnd > applyVideoStart,
+    "could not isolate production poster registry",
+  );
+  const applied = [];
+  const { registerVideoHolder, applyVideoPoster } = new Function(
+    "applyPosterToHolder",
+    `${panelSrc.slice(registryStart, registerEnd)}\n${panelSrc.slice(applyVideoStart, applyVideoEnd)}\nreturn { registerVideoHolder, applyVideoPoster };`,
+  )((holder, poster) => applied.push({ holder, poster }));
+  const firstHolder = { isConnected: true };
+  const secondHolder = { isConnected: true };
+  registerVideoHolder(painted[0], firstHolder);
+  registerVideoHolder(painted[1], secondHolder);
+  applyVideoPoster(painted[1], "poster-second.png");
+  applyVideoPoster(painted[0], "poster-first.png");
+  assert.deepEqual(applied, [
+    { holder: secondHolder, poster: "poster-second.png" },
+    { holder: firstHolder, poster: "poster-first.png" },
+  ]);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -683,6 +683,7 @@ import {
 } from "./lib/execution-preview-attach.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import { composeShowMediaReply } from "./lib/media-preview.js";
+import { appendStoryboardCacheBust, createStoryboardIdentity } from "./lib/storyboard-cache-identity.js";
 import {
   bindSourcePlayback,
   sourceMediaDuration,
@@ -37121,9 +37122,15 @@ function buildPanel() {
       if (!m || !m.filename) continue;
       const url = imageViewUrl(m);
       if (isVideoOutput(m)) {
-        paintVideo(url, m.filename);
-        // Carry the node id so the deferred storyboard event can name its node.
-        videos.push({ m, nodeId });
+        // #1718 — ComfyUI may overwrite a temp video under the same filename.
+        // The identity must be minted BEFORE paintVideo so the holder registry,
+        // source decode, and late poster callback all address this render only.
+        const storyboardIdentity = createStoryboardIdentity();
+        const videoUrl = appendStoryboardCacheBust(url, storyboardIdentity);
+        paintVideo(videoUrl, m.filename);
+        // Carry the node id so the deferred storyboard event can name its node,
+        // plus the exact URL/identity used by the already-painted card.
+        videos.push({ m, nodeId, videoUrl, storyboardIdentity });
       } else if (isAudioOutput(m)) {
         // Played, never painted as an image — and deliberately NOT added to
         // inlineImages: that list is delivered to the agent as inline image

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -45,6 +45,11 @@
 // names it. That is what makes the remedy actionable rather than decorative.
 
 import { withTimeout } from "./bounded-step.js";
+import {
+  appendStoryboardCacheBust,
+  createStoryboardIdentity,
+  storyboardUploadName,
+} from "./storyboard-cache-identity.js";
 
 /**
  * Whole wall-clock bound for ONE video's preview (size probe + sample + upload).
@@ -432,6 +437,7 @@ export async function composeShowMediaReply(items, deps = {}) {
     const caption = text(item?.caption) || text(item?.filename) || "";
     const { kind, ext } = classifyShowMediaItem(item, text);
     const isVideo = kind === "video";
+    const storyboardIdentity = isVideo ? createStoryboardIdentity() : null;
     let url = null;
     let ref = null;
     let why = null;
@@ -451,6 +457,9 @@ export async function composeShowMediaReply(items, deps = {}) {
       // reference is right there, and the caller would be told to re-send
       // something it already sent correctly.
       if (!url) why = "the panel could not build a view URL for its ComfyUI reference";
+      // #1718 — a temp video can be rerendered in place. The stable /view URL
+      // otherwise lets the browser sample the previous video's bytes.
+      if (isVideo && url) url = appendStoryboardCacheBust(url, storyboardIdentity);
     } else if (typeof item?.dataUrl === "string" && item.dataUrl) {
       url = item.dataUrl;
     }
@@ -589,6 +598,7 @@ export async function composeShowMediaReply(items, deps = {}) {
         url,
         name: name || "video",
         ref,
+        storyboardIdentity,
         // Whether the USER got a player. The no-preview remedy leans on "ask
         // the user"; telling the agent to ask about something the user cannot
         // see is a remedy that does not work from where the caller is.
@@ -958,7 +968,8 @@ async function produceSheet(job, deps) {
     const base = job.name.replace(/\.[^.]+$/, "") || "video";
     // #209 — a panel-generated sheet is not a user input: it goes to ComfyUI's
     // swept temp/ namespace so it cannot accumulate as permanent input litter.
-    const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`, { type: "temp" });
+    const identity = job.storyboardIdentity || createStoryboardIdentity();
+    const ref = await uploadBlobToInput(blob, storyboardUploadName(base, identity), { type: "temp" });
     if (!ref) {
       warn("[cmcp] show_media: storyboard upload failed for", job.name);
       return {

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -24,6 +24,12 @@
 // leaving the segment pending forever.
 import { duplicateCompletionNote } from "./completion-dedupe.js";
 import { withTimeout } from "./bounded-step.js";
+import {
+  appendStoryboardCacheBust,
+  createStoryboardIdentity,
+  storyboardPosterUploadName,
+  storyboardUploadName,
+} from "./storyboard-cache-identity.js";
 
 // #1610 — stills metadata (HEAD /view for size + Image() decode for pixels) is
 // best-effort decoration on the completion note. It is NOT needed to attach the
@@ -591,6 +597,12 @@ async function buildVideoSegment(v, deps) {
   // that can overlap the decode does.
   const produce = async () => {
     try {
+      // #1718 — a rerender can overwrite a temp video under the same filename.
+      // Give the source fetch and every derived artifact one attempt identity so
+      // neither the browser nor ComfyUI's filename-based temp ref can return the
+      // previous run's pixels.
+      const storyboardIdentity = createStoryboardIdentity();
+      const sourceUrl = appendStoryboardCacheBust(imageViewUrl(m), storyboardIdentity);
       // The video's own byte size is wanted only for the note's metadata line.
       // Start its HEAD (bounded at 8 s inside fetchImageBytes) BEFORE the
       // sampling pass so the round trip overlaps the decode instead of being
@@ -605,11 +617,11 @@ async function buildVideoSegment(v, deps) {
       // rejection fell into the segment's catch and cost the agent the sheet.
       let sizeBytes;
       try {
-        sizeBytes = Promise.resolve(fetchImageBytes(imageViewUrl(m))).catch(() => null);
+        sizeBytes = Promise.resolve(fetchImageBytes(sourceUrl)).catch(() => null);
       } catch {
         sizeBytes = Promise.resolve(null);
       }
-      const produced = await buildVideoStoryboard(imageViewUrl(m));
+      const produced = await buildVideoStoryboard(sourceUrl);
       // #1493 — the builder hands back `storyboardFailure({reason})` when it
       // could not sample the video, and that object is TRUTHY: a bare `!blob`
       // test sails straight past it and hands a plain object to
@@ -646,7 +658,7 @@ async function buildVideoSegment(v, deps) {
       // input/) so it never accumulates as permanent input litter. imageViewUrl
       // reads ref.type through to the /view request, so the chat preview still
       // resolves correctly.
-      const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`, { type: "temp" });
+      const ref = await uploadBlobToInput(blob, storyboardUploadName(base, storyboardIdentity), { type: "temp" });
       if (!ref) {
         warn("[cmcp] storyboard: upload failed for", m?.filename);
         return { ref: null, note: noteOnly("couldn't upload its storyboard") };
@@ -707,7 +719,11 @@ async function buildVideoSegment(v, deps) {
       if (blob.posterBlob && typeof applyVideoPoster === "function") {
         void Promise.resolve()
           .then(async () => {
-            const posterRef = await uploadBlobToInput(blob.posterBlob, `poster_${base}.png`, { type: "temp" });
+            const posterRef = await uploadBlobToInput(
+              blob.posterBlob,
+              storyboardPosterUploadName(base, storyboardIdentity),
+              { type: "temp" },
+            );
             if (posterRef) applyVideoPoster(imageViewUrl(m), imageViewUrl(posterRef));
           })
           .catch((err) => {

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -601,8 +601,9 @@ async function buildVideoSegment(v, deps) {
       // Give the source fetch and every derived artifact one attempt identity so
       // neither the browser nor ComfyUI's filename-based temp ref can return the
       // previous run's pixels.
-      const storyboardIdentity = createStoryboardIdentity();
-      const sourceUrl = appendStoryboardCacheBust(imageViewUrl(m), storyboardIdentity);
+      const storyboardIdentity = v?.storyboardIdentity || createStoryboardIdentity();
+      const sourceUrl =
+        v?.videoUrl || appendStoryboardCacheBust(imageViewUrl(m), storyboardIdentity);
       // The video's own byte size is wanted only for the note's metadata line.
       // Start its HEAD (bounded at 8 s inside fetchImageBytes) BEFORE the
       // sampling pass so the round trip overlaps the decode instead of being
@@ -724,7 +725,7 @@ async function buildVideoSegment(v, deps) {
               storyboardPosterUploadName(base, storyboardIdentity),
               { type: "temp" },
             );
-            if (posterRef) applyVideoPoster(imageViewUrl(m), imageViewUrl(posterRef));
+            if (posterRef) applyVideoPoster(sourceUrl, imageViewUrl(posterRef));
           })
           .catch((err) => {
             warn("[cmcp] storyboard: poster upload failed:", err);

--- a/web/js/lib/storyboard-cache-identity.js
+++ b/web/js/lib/storyboard-cache-identity.js
@@ -1,0 +1,38 @@
+// A storyboard is a derived media artifact, so its identity must change when
+// the source is sampled again. ComfyUI's temp refs are filename-based and the
+// browser may cache /view by URL; a stable `storyboard_<source>.png` therefore
+// lets a later render reuse pixels from an earlier one (#1718).
+
+let identitySequence = 0;
+
+/** Create a short, safe identity unique to this panel session and attempt. */
+export function createStoryboardIdentity() {
+  identitySequence += 1;
+  let entropy = "";
+  try {
+    entropy = (globalThis.crypto?.randomUUID?.() || "").replaceAll("-", "").slice(0, 10);
+  } catch {
+    // Date + sequence below still makes attempts unique within this session.
+  }
+  return `${Date.now().toString(36)}-${identitySequence.toString(36)}${entropy ? `-${entropy}` : ""}`;
+}
+
+/** Append an attempt-specific query key without disturbing a URL fragment. */
+export function appendStoryboardCacheBust(url, identity) {
+  if (typeof url !== "string" || !url || typeof identity !== "string" || !identity) return url;
+  const hashAt = url.indexOf("#");
+  const beforeHash = hashAt >= 0 ? url.slice(0, hashAt) : url;
+  const hash = hashAt >= 0 ? url.slice(hashAt) : "";
+  const separator = beforeHash.includes("?") ? (/[?&]$/.test(beforeHash) ? "" : "&") : "?";
+  return `${beforeHash}${separator}cmcp_storyboard=${encodeURIComponent(identity)}${hash}`;
+}
+
+/** Name a generated contact sheet with the identity of the sampling attempt. */
+export function storyboardUploadName(base, identity) {
+  return `storyboard_${String(base || "video")}_${identity}.png`;
+}
+
+/** Name the optional poster with the same identity, avoiding stale card art too. */
+export function storyboardPosterUploadName(base, identity) {
+  return `poster_${String(base || "video")}_${identity}.png`;
+}


### PR DESCRIPTION
## Summary\n- assign each completed video render a unique cache-busted identity\n- carry the identity through storyboard sampling, poster upload, and holder callbacks\n- prevent late same-filename posters from updating newer cards\n\nIssue: #1718\n\nValidation: 174 focused video/storyboard tests, direct unit suite, typecheck, i18n, vocabulary, diff check, and independent review passed.