### PR TITLE
release: 0.15.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.72] - 2026-08-24
+
+### Fixed
+- Isolate storyboard posters per render to prevent stale same-filename results (#1718)
+
 ## [0.15.71] - 2026-08-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.70",
+  "version": "0.15.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.70",
+      "version": "0.15.72",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.70",
+  "version": "0.15.72",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
## Release\n- publish Panel v0.15.72\n- include per-render storyboard poster identity fix (#1718)\n\nValidation: typecheck, panel scope gate, and diff checks passed.