### PR TITLE
fix(panel): tolerate Ideogram derived widget stamp churn

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -1229,27 +1229,40 @@ test("#572 integration: the scoped-run result SURFACES the drift-uncovered input
 test("#2130 integration: dispatchScopedRun accepts a queue-time Ideogram derived-widget rewrite", async () => {
   const stop = keepAlive();
   try {
-    const stampedOutput = {
-      ...OUR_OUTPUT,
-      "14": {
-        class_type: "Ideogram4PromptBuilderKJ",
-        inputs: { elements_data: "old regions", high_level_description: "same subject" },
-      },
-    };
-    const queuedOutput = {
-      ...OUR_OUTPUT,
-      "14": {
-        class_type: "Ideogram4PromptBuilderKJ",
-        inputs: { elements_data: "new regions", high_level_description: "same subject" },
-      },
-    };
     const server = makeServer();
     const apiTarget = { fetchApi: server };
-    const app = makeFrontend({ shape: "shim", apiTarget, output: stampedOutput });
-    app.graph = { _nodes: [ideogramBuilderNode(14)] };
+    const node = ideogramBuilderNode(14);
+    const elementsWidget = node.widgets.find((widget) => widget.name === "elements_data");
+    const oldRegions = JSON.stringify([{ x: 0, y: 0, w: 0.2, h: 0.2, type: "old" }]);
+    const newRegions = JSON.stringify([{ x: 0.1, y: 0.1, w: 0.3, h: 0.3, type: "new" }]);
+    let serializeCalls = 0;
+    elementsWidget.serializeValue = () => {
+      serializeCalls++;
+      return serializeCalls === 1 ? oldRegions : newRegions;
+    };
+    const graph = { _nodes: [node] };
+    const serializeGraph = () => {
+      const inputs = Object.fromEntries(
+        node.widgets.map((widget) => [
+          widget.name,
+          typeof widget.serializeValue === "function" ? widget.serializeValue() : widget.value,
+        ]),
+      );
+      return {
+        ...OUR_OUTPUT,
+        "14": { class_type: node.type, inputs },
+      };
+    };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    app.graph = graph;
+    // This mirrors the production boundary: dispatchScopedRun fingerprints the
+    // live graph through graphToPrompt(), then queuePrompt builds the actual
+    // /prompt body from a second graphToPrompt() serialization.
+    app.graphToPrompt = async () => ({ output: serializeGraph(), workflow: {} });
     app.queuePrompt = async (number, batch, arg) => {
       const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
-      const body = frontendBody({ output: queuedOutput, number, targets: targets?.length ? targets : null });
+      const queued = await app.graphToPrompt();
+      const body = frontendBody({ output: queued.output, number, targets: targets?.length ? targets : null });
       app.posted.push(body);
       await apiTarget.fetchApi("/prompt", {
         method: "POST",
@@ -1259,10 +1272,14 @@ test("#2130 integration: dispatchScopedRun accepts a queue-time Ideogram derived
       return true;
     };
     const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(serializeCalls, 2, "the stamp and queue-time prompt each invoke elements_data.serializeValue");
     assert.equal(result.outcome, "dispatched", "the derived queue-time rewrite is not mistaken for graph drift");
     assert.equal(server.calls.length, 1, "the verified scoped prompt reaches ComfyUI once");
     assert.deepEqual(result.volatileInputs, ["14 elements_data"]);
-    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+    const sent = JSON.parse(server.calls[0].options.body);
+    assert.equal(sent.prompt["14"].inputs.elements_data, newRegions, "the second serializer result reached /prompt");
+    assert.equal(sent.prompt["14"].inputs.high_level_description, "same subject", "ordinary widget input is serialized too");
+    assert.deepEqual(sent.partial_execution_targets, ["14"]);
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -571,6 +571,67 @@ test("#2099 promptContentHash: VHS date-template substitution is stable, ordinar
 });
 
 // ---------------------------------------------------------------------------
+// #2130 — KJNodes' Ideogram4PromptBuilderKJ derives the executable
+// `elements_data` input from its editor state through a live serializeValue.
+// Only that exact node + field + mechanism is excluded; arbitrary serializers,
+// other widgets, and other node types remain drift-covered.
+// ---------------------------------------------------------------------------
+
+const ideogramBuilderNode = (id, { withSerializer = true, type = "Ideogram4PromptBuilderKJ" } = {}) => ({
+  id,
+  type,
+  widgets: [
+    { name: "elements_data", value: "old regions", ...(withSerializer ? { serializeValue: () => "new regions" } : {}) },
+    { name: "high_level_description", value: "same subject", serializeValue: () => "same subject" },
+  ],
+});
+
+test("#2130 collectVolatileInputs: only the live Ideogram derived elements_data serializer is volatile", () => {
+  const root = {
+    _nodes: [
+      ideogramBuilderNode(14),
+      ideogramBuilderNode(15, { withSerializer: false }),
+      ideogramBuilderNode(16, { type: "OtherPromptBuilder" }),
+      { id: 17, type: "Ideogram4PromptBuilderKJ", widgets: [{ name: "style_palette_data", serializeValue: () => "palette" }] },
+      { id: 18, type: "Ideogram4PromptBuilderKJ", widgets: [{ name: "elements_data", serializeValue: "not callable" }] },
+    ],
+  };
+  assert.deepEqual(
+    [...collectVolatileInputs(root)].sort(),
+    ["14 elements_data"],
+    "the exclusion is keyed by node type, exact field, and callable live serializer",
+  );
+});
+
+test("#2130 promptContentHash: the derived field may settle, but sibling inputs and other nodes still refuse drift", () => {
+  const volatileInputs = collectVolatileInputs({ _nodes: [ideogramBuilderNode(14)] });
+  const stamped = {
+    "14": { class_type: "Ideogram4PromptBuilderKJ", inputs: { elements_data: "old regions", high_level_description: "same subject" } },
+    "9": { class_type: "SaveImage", inputs: { filename_prefix: "same" } },
+  };
+  const atHash = promptContentHash(stamped, volatileInputs);
+  const body = (builderInputs, filenamePrefix = "same") => JSON.stringify({ prompt: {
+    "14": { class_type: "Ideogram4PromptBuilderKJ", inputs: builderInputs },
+    "9": { class_type: "SaveImage", inputs: { filename_prefix: filenamePrefix } },
+  } });
+  assert.equal(
+    promptContentHashFromBody(body({ elements_data: "new regions", high_level_description: "same subject" }), volatileInputs),
+    atHash,
+    "the known queue-time derived value no longer false-refuses the scoped run",
+  );
+  assert.notEqual(
+    promptContentHashFromBody(body({ elements_data: "new regions", high_level_description: "changed subject" }), volatileInputs),
+    atHash,
+    "a sibling user input on the same node remains drift-covered",
+  );
+  assert.notEqual(
+    promptContentHashFromBody(body({ elements_data: "new regions", high_level_description: "same subject" }, "changed"), volatileInputs),
+    atHash,
+    "an input on another node remains drift-covered",
+  );
+});
+
+// ---------------------------------------------------------------------------
 // #1331 — the FOURTH volatility mechanism: after reconnect, leftover values of
 // link-driven converted widgets (MiniMax H3 clip/vae/model/length, …) settle
 // between the pre-dispatch stamp and the POST body. The #1050 single retry
@@ -1160,6 +1221,48 @@ test("#572 integration: the scoped-run result SURFACES the drift-uncovered input
       ["3 control_after_generate", "3 seed"],
       "the run reports exactly which inputs were NOT drift-covered for this run",
     );
+  } finally {
+    stop();
+  }
+});
+
+test("#2130 integration: dispatchScopedRun accepts a queue-time Ideogram derived-widget rewrite", async () => {
+  const stop = keepAlive();
+  try {
+    const stampedOutput = {
+      ...OUR_OUTPUT,
+      "14": {
+        class_type: "Ideogram4PromptBuilderKJ",
+        inputs: { elements_data: "old regions", high_level_description: "same subject" },
+      },
+    };
+    const queuedOutput = {
+      ...OUR_OUTPUT,
+      "14": {
+        class_type: "Ideogram4PromptBuilderKJ",
+        inputs: { elements_data: "new regions", high_level_description: "same subject" },
+      },
+    };
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget, output: stampedOutput });
+    app.graph = { _nodes: [ideogramBuilderNode(14)] };
+    app.queuePrompt = async (number, batch, arg) => {
+      const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+      const body = frontendBody({ output: queuedOutput, number, targets: targets?.length ? targets : null });
+      app.posted.push(body);
+      await apiTarget.fetchApi("/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return true;
+    };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "dispatched", "the derived queue-time rewrite is not mistaken for graph drift");
+    assert.equal(server.calls.length, 1, "the verified scoped prompt reaches ComfyUI once");
+    assert.deepEqual(result.volatileInputs, ["14 elements_data"]);
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
   } finally {
     stop();
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17647,14 +17647,15 @@ const GRAPH_TOOL_EXECUTORS = {
       accept.fixed_seed_nodes = repeatingRgthreeSeeds(rgthreeSeeds);
       accept.fixed_seed_note = fixedSeedNote;
     }
-    // #572/#1124/#1331/#2099 — TRUTHFUL drift-coverage note for a scoped run: the drift
+    // #572/#1124/#1331/#2099/#2130 — TRUTHFUL drift-coverage note for a scoped run: the drift
     // hash excluded the inputs that mutate at queue time by the known
     // mechanisms — beforeQueued carriers + their linked, serialized targets
     // (e.g. a control_after_generate seed reroll), the seed of an ARMED
     // rgthree Seed node (no hook: rgthree substitutes inside its own
     // api.queuePrompt patch), leftover values of link-driven converted
     // widgets (clip/vae/model settling after reconnect), UE broadcast targets,
-    // and VHS date-template filename_prefix values. A user edit to exactly THOSE
+    // and VHS date-template filename_prefix values, plus the known
+    // Ideogram4PromptBuilderKJ elements_data editor serializer. A user edit to exactly THOSE
     // inputs during the queue window
     // is indistinguishable from the queue-time mutation (accepted residual),
     // so the result names the uncovered inputs instead of implying full-graph
@@ -17673,7 +17674,8 @@ const GRAPH_TOOL_EXECUTORS = {
           "control_after_generate seed reroll), an extension that rewrites the prompt in " +
           "its own api.queuePrompt patch (an armed Seed (rgthree) node), a leftover " +
           "link-driven widget value settling after reconnect (clip/vae/model), or a " +
-          "VHS_VideoCombine date-template filename_prefix — so they were " +
+          "VHS_VideoCombine date-template filename_prefix, or the known " +
+          "Ideogram4PromptBuilderKJ elements_data editor serializer — so they were " +
           "excluded from this run's graph-drift check: a user edit to exactly these inputs " +
           "during the queue window is indistinguishable from that mutation and would NOT " +
           "have been caught. Every other input was drift-covered.",

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -105,7 +105,9 @@ import { withTimeout } from "./bounded-step.js";
 //    rewritten by an extension's own api.queuePrompt patch, which carry no hook
 //    at all — rgthree's armed Seed node, #1124; plus leftover values of
 //    link-driven converted widgets that settle from the widget default to the
-//    incoming link after reconnect — MiniMax H3 clip/vae/model, #1331), which change
+//    incoming link after reconnect — MiniMax H3 clip/vae/model, #1331), and known
+//    serializer-backed derived fields such as Ideogram4PromptBuilderKJ's
+//    elements_data (#2130), which change
 //    between any two serializations of the SAME graph by design (#572: the
 //    exclusion must reach the hook's serialized TARGET, not just the
 //    unserialized control the hook hangs on), and (b) inputs whose value the
@@ -247,7 +249,9 @@ const fnv1aHex = (s) =>
  *     collectVolatileInputs knows about: a `beforeQueued` hook (stock seed
  *     widgets re-rolled by their linked control_after_generate, third-party hook
  *     widgets), or an extension rewriting the outgoing prompt in its own
- *     `api.queuePrompt` patch (rgthree's armed Seed node, #1124). Those change
+ *     `api.queuePrompt` patch (rgthree's armed Seed node, #1124), or a known
+ *     serializer-backed derived widget (Ideogram4PromptBuilderKJ's
+ *     `elements_data`, #2130). Those change
  *     between any two serializations of the SAME graph by design, so hashing
  *     them would refuse our own dispatch. Exclusions are PER-NODE pairs
  *     (prompt node id + input name, r8): an edit to a NON-hook node's
@@ -427,7 +431,7 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
 /**
  * The "execId inputName" pairs whose values MUTATE AT QUEUE TIME — after our
  * pre-dispatch stamp and before the POST body is built — collected from the live
- * root graph and every nested subgraph. FIVE signals, one per mechanism: a
+ * root graph and every nested subgraph. SIX signals, one per mechanism: a
  * widget-level `beforeQueued` hook (#572), an extension that patches
  * `api.queuePrompt` and rewrites the outgoing prompt directly (rgthree's armed
  * Seed node, #1124 — invisible to any widget scan, matched by node identity),
@@ -438,7 +442,9 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
  * serialized form flips from the stale widget default to the incoming link,
  * or the leftover filename itself settles, while the canvas is idle), plus
  * VHS_VideoCombine filename_prefix date templates (#2099), which the frontend
- * resolves at queue time.
+ * resolves at queue time, and the known Ideogram4PromptBuilderKJ `elements_data`
+ * serializer-backed editor state (#2130), which can be rewritten while the prompt
+ * is serialized.
  * execId is the flattened prompt id: String(node.id) at root, the
  * colon-joined subgraph-instance path for nested nodes ("10:15:359") — the
  * same path buildNodeExecutionId produces, so pairs line up with the keys of
@@ -517,6 +523,28 @@ function vhsQueueTimeFilenamePrefixInput(node) {
     }
   }
   return null;
+}
+
+/**
+ * #2130 — KJNodes' Ideogram4PromptBuilderKJ owns `elements_data` through its
+ * editor-backed `serializeValue` implementation. The widget is executable prompt
+ * input, so this is deliberately NOT a general "any serializeValue" exemption:
+ * only the measured node type + field + live serializer qualify. A later build
+ * that drops the override is drift-covered automatically.
+ *
+ * Returns the exact serialized input name, or null when the current node does
+ * not prove the queue-time-derived mechanism.
+ */
+function ideogramQueueTimeDerivedInput(node) {
+  if (node?.type !== "Ideogram4PromptBuilderKJ") return null;
+  try {
+    const widget = (node.widgets ?? []).find((w) => w?.name === "elements_data");
+    return typeof widget?.serializeValue === "function" ? "elements_data" : null;
+  } catch {
+    // An unreadable serializer accessor is not proof of queue-time mutation;
+    // keep the input drift-covered rather than widening the exclusion.
+    return null;
+  }
 }
 
 export function collectVolatileInputs(rootGraph) {
@@ -608,6 +636,12 @@ export function collectVolatileInputs(rootGraph) {
       // drift coverage.
       const vhsFilenamePrefixInput = vhsQueueTimeFilenamePrefixInput(node);
       if (vhsFilenamePrefixInput != null) addPair(execId, vhsFilenamePrefixInput);
+      // #2130 — THE SIXTH VOLATILITY SIGNAL. This exact KJNodes field is a
+      // derived editor write-back whose live serializeValue can change the
+      // prompt during queue-time serialization. Keep every other serializer-
+      // backed input drift-covered.
+      const ideogramDerivedInput = ideogramQueueTimeDerivedInput(node);
+      if (ideogramDerivedInput != null) addPair(execId, ideogramDerivedInput);
       if (node.subgraph) walk(node.subgraph, execId);
     }
   };


### PR DESCRIPTION
## Summary

- Treat only `Ideogram4PromptBuilderKJ.elements_data` with its live `serializeValue` as queue-time volatile for run-to-node drift attribution.
- Keep arbitrary serializers, other widgets, sibling inputs, and other node types drift-covered.
- Surface the known residual through the existing `drift_coverage` disclosure.

Related: artokun/comfyui-mcp#2130

## Validation

- `node --test browser_tests/unit/run-scope-guard.test.mjs` (136 passed)
- `node --test browser_tests/unit/ideogram4-prompt-builder.test.mjs` (19 passed)
- `git diff --check` passed
- `scripts/check-panel-scope.mjs` could not run because this fresh worktree has no `node_modules/typescript`