### PR TITLE
fix(1739): an abandoned /object_info stops occupying the backend it starved

### DIFF
--- a/browser_tests/unit/object-info-abandoned-request.test.mjs
+++ b/browser_tests/unit/object-info-abandoned-request.test.mjs
@@ -1,0 +1,408 @@
+/**
+ * #1739 — on an install with 8534 node types `panel_set_widget` refused EVERY write, and
+ * the refusal said the type-scoped `/object_info/<Type>` read had timed out on a URL the
+ * reporter measured by hand at 1.2–12 ms, reproducibly, on the same machine at the same
+ * time. Run with `node --test`.
+ *
+ * The measurements from the report:
+ *
+ *     GET /object_info                     -> 200  16.08 s   51,957,409 bytes
+ *     GET /object_info/CyberpunkWindowNode -> 200   0.0013 s       6,821 bytes
+ *
+ * THE TYPE-SCOPED READ WAS NOT SLOW. It was queued behind two whole-map computations the
+ * PANEL had left running on a backend that can only do one thing at a time. ComfyUI's own
+ * `server.py`:
+ *
+ *     @routes.get("/object_info")
+ *     async def get_object_info(request):
+ *         asset_seeder.start(...)
+ *         with folder_paths.cache_helper:
+ *             out = {}
+ *             for x in nodes.NODE_CLASS_MAPPINGS:
+ *                 out[x] = node_info(x)
+ *             return web.json_response(out)
+ *
+ *     @routes.get("/object_info/{node_class}")        # twelve lines below it
+ *     async def get_object_info_node(request): ...
+ *
+ * There is no `await` anywhere in the first body. It blocks aiohttp's single event loop for
+ * as long as it runs, and while it runs the second route cannot be served at all. So the
+ * ONE route that can answer an install this size was starved by the two that provably
+ * cannot — and #1560's last resort, written for exactly this backend, never got a turn.
+ *
+ * The oracle now CANCELS its raw `GET /object_info` when it stops waiting on it. That
+ * request is pure cost on such a backend: it is only issued after the client route has
+ * already spent its whole share, so it starts behind a computation of the identical
+ * document that is still running, and its own share is smaller than the one that just
+ * expired. Dropping it hands the loop back to the question that can be answered.
+ *
+ * THE BACKEND BELOW IS A MODEL, AND ITS ONE ASSUMPTION IS STATED. A queued request that is
+ * aborted before the loop reaches it is never dispatched (aiohttp reads a closed
+ * connection); a request the loop has ALREADY started keeps the loop until its synchronous
+ * body returns, because nothing can cancel a Python `for` loop from the client side. Both
+ * halves are modelled, and the second is why `getNodeDefs` — which takes no signal and goes
+ * first — is not cancelled and does not need to be.
+ *
+ * Everything runs on a VIRTUAL clock so the SHIPPED constants can be used verbatim: a test
+ * that rescales the budgets proves something about numbers the panel does not have.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  fetchWholeObjectInfo,
+  OBJECT_INFO_DEADLINE_MS,
+  TRANSPORT_OUTCOME,
+} from "../../web/js/lib/object-info-oracle.js";
+import {
+  fetchTypeScopedObjectInfo,
+  SCOPED_OBJECT_INFO_DEADLINE_MS,
+} from "../../web/js/lib/scoped-object-info.js";
+import { noBackendAnswerEstablished } from "../../web/js/lib/object-info-snapshot.js";
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const HOOKS = { beforeChange() {}, afterChange() {}, setDirty() {} };
+
+/** The reporter's own numbers, so the arithmetic below is theirs and not an invention. */
+const WHOLE_MAP_MS = 16080;
+const PER_CLASS_MS = 12;
+const REPORTED_TYPE = "CyberpunkWindowNode";
+
+// ─────────────────────────────────────── virtual clock ───────────────────────────────────
+
+/**
+ * A monotonic clock plus the `{setTimer, clearTimer}` pair `bounded-step.js` accepts, so
+ * every wait in this file — the oracle's, the scoped read's, and the fake backend's own
+ * work — is measured against ONE timeline that the test advances by hand.
+ */
+function makeVirtualClock() {
+  let now = 0;
+  let seq = 0;
+  const pending = new Map();
+  return {
+    now: () => now,
+    at: () => now,
+    timers: {
+      setTimer(fn, delay) {
+        const id = (seq += 1);
+        pending.set(id, { at: now + Math.max(0, Number(delay) || 0), fn, seq: id });
+        return id;
+      },
+      clearTimer(id) {
+        pending.delete(id);
+      },
+    },
+    hasTimers: () => pending.size > 0,
+    /** Fire the single earliest timer, ties broken by arming order. */
+    advance() {
+      let pick = null;
+      for (const [id, t] of pending) {
+        if (!pick || t.at < pick.t.at || (t.at === pick.t.at && t.seq < pick.t.seq)) pick = { id, t };
+      }
+      if (!pick) return false;
+      pending.delete(pick.id);
+      now = Math.max(now, pick.t.at);
+      pick.t.fn();
+      return true;
+    },
+  };
+}
+
+const turn = () => new Promise((resolve) => setImmediate(resolve));
+
+/**
+ * Run `promise` to completion, advancing the virtual clock whenever nothing else can make
+ * progress. A settle-check between every step is what keeps a test from firing timers the
+ * production code has already cleared.
+ */
+async function drive(clock, promise) {
+  let settled = false;
+  let value;
+  let failure = null;
+  promise.then(
+    (v) => {
+      settled = true;
+      value = v;
+    },
+    (e) => {
+      settled = true;
+      failure = e ?? new Error("rejected with no value");
+    },
+  );
+  for (let guard = 0; guard < 100000; guard += 1) {
+    await turn();
+    if (settled) break;
+    if (!clock.advance()) {
+      await turn();
+      if (settled) break;
+      if (!clock.hasTimers()) throw new Error(`nothing left to run at t=${clock.now()}ms and nothing settled`);
+    }
+  }
+  if (!settled) throw new Error("the driven promise never settled");
+  if (failure) throw failure;
+  return value;
+}
+
+// ─────────────────────────────────── the modelled backend ────────────────────────────────
+
+/**
+ * ComfyUI as it actually serves these two routes: ONE lane, first come first served, and a
+ * whole-map request that owns the lane for its entire computation.
+ */
+function singleLaneComfyUI(clock, { defined = [REPORTED_TYPE] } = {}) {
+  const queue = [];
+  let running = null;
+  /** Routes in the order the event loop actually RAN them. */
+  const served = [];
+  /** Routes that were abandoned before the loop ever reached them. */
+  const dropped = [];
+  const wholeSchema = Object.fromEntries(defined.map((t) => [t, { input: { required: {} } }]));
+
+  const pump = () => {
+    if (running || queue.length === 0) return;
+    const job = queue.shift();
+    running = job;
+    served.push(job.route);
+    clock.timers.setTimer(() => {
+      running = null;
+      job.resolve(job.respond());
+      pump();
+    }, job.cost);
+  };
+
+  const enqueue = (route, cost, respond, signal) =>
+    new Promise((resolve, reject) => {
+      const job = { route, cost, respond, resolve, reject };
+      queue.push(job);
+      if (signal) {
+        const onAbort = () => {
+          const i = queue.indexOf(job);
+          // ALREADY RUNNING is deliberately a no-op: a synchronous Python handler cannot be
+          // cancelled from here, so the lane stays held until its body returns.
+          if (i < 0) return;
+          queue.splice(i, 1);
+          dropped.push(route);
+          const err = new Error("The operation was aborted.");
+          err.name = "AbortError";
+          reject(err);
+        };
+        if (signal.aborted) onAbort();
+        else signal.addEventListener("abort", onAbort);
+      }
+      pump();
+    });
+
+  const perClassBody = (type) => (defined.includes(type) ? { [type]: { input: { required: {} } } } : {});
+
+  return {
+    served,
+    dropped,
+    wholeSchema,
+    /** The frontend client's whole-map read. Takes no signal — it is the frontend's own. */
+    getNodeDefs: () => enqueue("/object_info", WHOLE_MAP_MS, () => wholeSchema, undefined),
+    fetchApi: (route, init) => {
+      const signal = init?.signal;
+      if (route === "/object_info") {
+        return enqueue(route, WHOLE_MAP_MS, () => ({ ok: true, status: 200, json: async () => wholeSchema }), signal);
+      }
+      const m = /^\/object_info\/(.+)$/.exec(route);
+      if (!m) return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+      const type = decodeURIComponent(m[1]);
+      return enqueue(
+        route,
+        PER_CLASS_MS,
+        () => ({ ok: true, status: 200, json: async () => perClassBody(type) }),
+        signal,
+      );
+    },
+  };
+}
+
+/** The panel's own wiring, in shape: the whole-map oracle, then the licensed scoped read. */
+function panelShapedCapabilities(clock, backend) {
+  let outcomes = [];
+  return {
+    outcomesNow: () => outcomes,
+    getFreshObjectInfo: async () => {
+      const result = await fetchWholeObjectInfo({
+        getNodeDefs: () => backend.getNodeDefs(),
+        fetchApi: (route, init) => backend.fetchApi(route, init),
+        deadlineMs: OBJECT_INFO_DEADLINE_MS,
+        timers: clock.timers,
+        now: clock.now,
+      });
+      outcomes = result.outcomes ?? [];
+      return result.defs;
+    },
+    fetchScopedObjectInfo: async (types) => {
+      if (!noBackendAnswerEstablished(outcomes)) {
+        return { defs: null, covered: [], reason: "a whole-schema route ANSWERED rather than going silent" };
+      }
+      return fetchTypeScopedObjectInfo(types, {
+        fetchApi: (route, init) => backend.fetchApi(route, init),
+        deadlineMs: SCOPED_OBJECT_INFO_DEADLINE_MS,
+        timers: clock.timers,
+      });
+    },
+  };
+}
+
+function regEntry() {
+  const ctor = function NodeCtor() {};
+  ctor.nodeData = { input: { required: {} } };
+  return ctor;
+}
+
+// ────────────────────────────────────────── tests ────────────────────────────────────────
+
+test("#1739 the reported install: the write the reporter could never land now lands", async () => {
+  const clock = makeVirtualClock();
+  const backend = singleLaneComfyUI(clock);
+  const caps = panelShapedCapabilities(clock, backend);
+  const reg = { [REPORTED_TYPE]: regEntry() };
+  const node = {
+    id: 58,
+    type: REPORTED_TYPE,
+    widgets: [{ name: "width", type: "INT", value: 512 }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+
+  const { set } = await drive(
+    clock,
+    runSetWidget(node, "width", 768, {
+      registry: reg,
+      getRegistry: () => reg,
+      getFreshObjectInfo: caps.getFreshObjectInfo,
+      fetchScopedObjectInfo: caps.fetchScopedObjectInfo,
+      wasTypeEverDefined: () => false,
+      ...HOOKS,
+    }),
+  );
+
+  assert.equal(set.value, 768, "the #458 fence authorized the write from the type-scoped read");
+  assert.equal(node.widgets[0].value, 768);
+
+  // WHAT THE BACKEND ACTUALLY DID, which is the whole claim of this issue.
+  assert.deepEqual(
+    backend.dropped,
+    ["/object_info"],
+    "the abandoned whole-map request was dropped before the event loop ever reached it",
+  );
+  assert.deepEqual(
+    backend.served,
+    ["/object_info", `/object_info/${REPORTED_TYPE}`],
+    "the loop ran the client route's fetch and then the per-class read — never a SECOND " +
+      "whole map, which is the 16 s of blocking that used to starve the read that works",
+  );
+  assert.ok(
+    clock.now() < OBJECT_INFO_DEADLINE_MS + SCOPED_OBJECT_INFO_DEADLINE_MS,
+    `the whole ladder settled at t=${clock.now()}ms, inside the command's window`,
+  );
+});
+
+test("#1739 both whole-map routes still report SILENCE, so the scoped read stays licensed", async () => {
+  const clock = makeVirtualClock();
+  const backend = singleLaneComfyUI(clock);
+  const result = await drive(
+    clock,
+    fetchWholeObjectInfo({
+      getNodeDefs: () => backend.getNodeDefs(),
+      fetchApi: (route, init) => backend.fetchApi(route, init),
+      deadlineMs: OBJECT_INFO_DEADLINE_MS,
+      timers: clock.timers,
+      now: clock.now,
+    }),
+  );
+  assert.equal(result.defs, null, "no whole map landed — fail closed, unchanged");
+  assert.deepEqual(
+    result.outcomes.map((o) => o.kind),
+    [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.NO_ANSWER],
+    "cancelling a request we stopped waiting on must not turn SILENCE into an ANSWER — " +
+      "the scoped read and #1223's snapshot are both licensed on exactly that difference",
+  );
+  assert.ok(
+    noBackendAnswerEstablished(result.outcomes),
+    "the silence licence the type-scoped route needs still holds after the cancel",
+  );
+});
+
+test("#1739 an AbortError from the cancelled route never escapes the oracle", async () => {
+  // The oracle documents that every failure path returns `defs: null`, and two callers await
+  // it with no catch of their own. Cancelling introduces a NEW rejection into that path.
+  const clock = makeVirtualClock();
+  const backend = singleLaneComfyUI(clock);
+  const result = await drive(
+    clock,
+    fetchWholeObjectInfo({
+      getNodeDefs: null,
+      fetchApi: (route, init) => backend.fetchApi(route, init),
+      deadlineMs: OBJECT_INFO_DEADLINE_MS,
+      timers: clock.timers,
+      now: clock.now,
+    }),
+  );
+  assert.equal(result.defs, null);
+  assert.ok(
+    result.failures.some((f) => /GET \/object_info did not answer/.test(f)),
+    "the refusal still names the route that went silent, not the abort we issued ourselves",
+  );
+});
+
+test("#1739 a fetchApi that takes only a route is called exactly as before", async () => {
+  // Every test double in this repo, and three of the panel's own wirings before this change,
+  // declare `(route) => ...`. Threading an init must not change what they observe.
+  const seen = [];
+  const schema = { KSampler: { input: {} } };
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: null,
+    fetchApi: async (...args) => {
+      seen.push(args);
+      return { ok: true, status: 200, json: async () => schema };
+    },
+  });
+  assert.deepEqual(result.defs, schema, "the fallback still answers");
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0][0], "/object_info");
+});
+
+test("#1739 a runtime with no AbortController still fetches, and still fails closed", async () => {
+  const original = globalThis.AbortController;
+  // eslint-disable-next-line no-global-assign
+  delete globalThis.AbortController;
+  try {
+    const seen = [];
+    const schema = { KSampler: { input: {} } };
+    const result = await fetchWholeObjectInfo({
+      getNodeDefs: null,
+      fetchApi: async (route, init) => {
+        seen.push({ route, init });
+        return { ok: true, status: 200, json: async () => schema };
+      },
+    });
+    assert.deepEqual(result.defs, schema);
+    assert.equal(seen[0].init, undefined, "no controller means no init — never a half-built one");
+  } finally {
+    globalThis.AbortController = original;
+  }
+});
+
+test("#1739 the PANEL forwards the init at every whole-map wiring, or the cancel is inert", async () => {
+  // A one-line wiring change is invisible to a helper-level test: the oracle can cancel
+  // perfectly while `api.fetchApi(route)` drops the signal on the floor and the reporter
+  // sees no change at all. This asserts the CALL SITES.
+  const src = readFileSync(PANEL_JS, "utf8");
+  // The EXACT option literal every one of these wirings is written as, so this cannot
+  // false-fire on some unrelated `(route) => api.fetchApi(route)` elsewhere in the file.
+  const dropped = `fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null`;
+  const forwards = `fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null`;
+  assert.equal(
+    src.includes(dropped),
+    false,
+    "an /object_info wiring that drops the second argument silently disables the cancel",
+  );
+  const forwarded = src.split(forwards).length - 1;
+  assert.ok(forwarded >= 5, `expected every oracle/scoped wiring to forward the init, found ${forwarded}`);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1739,7 +1739,7 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
           // out of the HTTP cache with the pre-install schema — which would be worse than
           // failing, since it would report refreshed:true over the definitions the caller
           // just installed a pack to replace.
-          fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+          fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
           // WHAT IS LEFT OF THE RUN, not of the fetch phase. The fetch phase's own share
           // has by definition been spent by the route that just failed, so sizing this from
           // it hands the second transport the 1ms floor — a bound that only a synchronous
@@ -12174,7 +12174,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const observedAtGeneration = verifiedNodeDefCache.generation();
     const { defs, authoritativeEmpty, failures } = await fetchWholeObjectInfo({
       getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
-      fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+      fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
     });
     // #1223 — file it. A reader that successfully obtains a whole schema and drops it on the
     // floor leaves the next render-time widget edit refused for want of the very map this
@@ -15566,7 +15566,7 @@ const GRAPH_TOOL_EXECUTORS = {
             // write fails closed on the same path, inside the window.
             return fetchWholeObjectInfo({
               getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
-              fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+              fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
               deadlineMs: budget.bounded(
                 reuseSnapshot &&
                   typeof objectInfoSnapshot.isReusable === "function" &&
@@ -15747,7 +15747,7 @@ const GRAPH_TOOL_EXECUTORS = {
           };
         }
         const scoped = await fetchTypeScopedObjectInfo(types, {
-          fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+          fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
           deadlineMs: budget.bounded(SCOPED_OBJECT_INFO_DEADLINE_MS),
         });
         if (Array.isArray(scoped.covered)) {
@@ -16032,7 +16032,7 @@ const GRAPH_TOOL_EXECUTORS = {
           liveSchemaGeneration = verifiedNodeDefCache.generation();
           return fetchWholeObjectInfo({
             getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
-            fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+            fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
           });
         })(),
       { stamp: () => backendReconnectEpoch },

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -354,6 +354,79 @@ export const TRANSPORT_OUTCOME = Object.freeze({
 const GATEWAY_STATUSES = Object.freeze([504]);
 
 /**
+ * #1739 — a request this oracle has STOPPED LISTENING TO must stop OCCUPYING the backend.
+ *
+ * `bounded-step.js` says in its own header that it "does not CANCEL the work it bounds",
+ * and for every other caller that is the right contract — the caller is composing a reply,
+ * not managing a pipeline's lifetime. This route is the one place where it is not, and the
+ * reason is in ComfyUI's own `server.py`:
+ *
+ *     @routes.get("/object_info")
+ *     async def get_object_info(request):
+ *         asset_seeder.start(...)
+ *         with folder_paths.cache_helper:
+ *             out = {}
+ *             for x in nodes.NODE_CLASS_MAPPINGS:   # 8534 types on the report
+ *                 out[x] = node_info(x)
+ *             return web.json_response(out)         # json.dumps of ~52 MB
+ *
+ * There is NO `await` anywhere in that body. It is a coroutine that blocks aiohttp's single
+ * event loop for as long as it runs — measured at 16.08 s on the reporting install — and
+ * while it runs the backend cannot answer ANY other request, including the per-class
+ * `/object_info/{node_class}` route defined twelve lines below it.
+ *
+ * That is what made #1560's type-scoped last resort — the one route that CAN answer a
+ * backend this size — report a timeout on a URL the reporter measured at 1.2 ms by hand.
+ * It was not slow. It was queued behind two whole-map computations THIS MODULE had left
+ * running on a single-threaded server after abandoning both of them.
+ *
+ * The second one is pure cost and is provably unreachable on such a backend: it is only
+ * issued after the client route has already spent its whole share, so on a backend that
+ * serializes it starts behind a computation of the IDENTICAL document that is still
+ * running, and its own share is smaller than the one that just expired. It cannot answer;
+ * it can only add another full computation to the loop, and the type-scoped read issued
+ * moments later is what pays for it.
+ *
+ * WHY THE CLIENT ROUTE IS NOT ALSO CANCELLED: `api.getNodeDefs()` is the frontend's own
+ * method and takes no signal. Nothing here can reach the request it made. That route is
+ * FIRST, so it is not the one blocking the fallback — it is the work the fallback is
+ * queued behind — and cancelling the fallback is what frees the loop for the next question.
+ *
+ * ABORTING IS BEST-EFFORT AND NEVER LOAD-BEARING. A runtime with no `AbortController`
+ * (`live-combo-availability.js` guards for the same one) simply passes no init and behaves
+ * exactly as before, and every failure of the cancel itself is swallowed: a module that
+ * documents "every failure path returns `defs: null`" must not start throwing out of its
+ * own cleanup.
+ */
+function createRouteCancellation() {
+  let controller = null;
+  try {
+    if (typeof AbortController === "function") controller = new AbortController();
+  } catch {
+    controller = null;
+  }
+  let init;
+  try {
+    init = controller ? { signal: controller.signal } : undefined;
+  } catch {
+    init = undefined;
+  }
+  return {
+    // `undefined` rather than `{}` so a `fetchApi` that never took a second argument — every
+    // test double in this repo, and the panel's own wiring before this change — is called
+    // exactly as it was.
+    init,
+    cancel() {
+      try {
+        controller?.abort();
+      } catch {
+        // A cancellation that throws must never replace the answer this route produced.
+      }
+    },
+  };
+}
+
+/**
  * Fetch the whole `/object_info` schema, trying the frontend client first and the raw
  * HTTP route second.
  *
@@ -637,7 +710,14 @@ export async function fetchWholeObjectInfo({
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
   // client call does not — it is the one they ran by hand to show the backend was fine.
   if (typeof fetchApi === "function") {
-    const { outcome, grant: fallbackMs } = await runStep(() => fetchApi("/object_info"), FALLBACK_RESPONSE_SHARE);
+    // #1739 — see `createRouteCancellation`. The init is threaded through `fetchApi` so a
+    // caller that forwards it (the panel does, to `api.fetchApi(route, init)`) can have this
+    // request dropped the moment the oracle stops waiting on it.
+    const httpRoute = createRouteCancellation();
+    const { outcome, grant: fallbackMs } = await runStep(
+      () => fetchApi("/object_info", httpRoute.init),
+      FALLBACK_RESPONSE_SHARE,
+    );
     const kind = outcomeKind(outcome);
     if (kind === "not-tried") {
       // TRUTHFUL ABOUT WHAT WAS NOT DONE. Saying this route "did not answer" when no
@@ -691,6 +771,11 @@ export async function fetchWholeObjectInfo({
           TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
           describeFailure("GET /object_info returned an unreadable response", err),
         );
+        // #1739 — the ONE early return out of this branch that leaves a body unread. The
+        // two below it return after `res.json()` has already settled, where the cancel the
+        // end of this block performs is a no-op; this one would otherwise leave a 52 MB
+        // download running against a backend the caller is about to ask another question of.
+        httpRoute.cancel();
         return { [CACHE_OUTCOME]: true, defs: null, failures, outcomes };
       }
       if (!responseOk) {
@@ -757,6 +842,16 @@ export async function fetchWholeObjectInfo({
         }
       }
     }
+    // #1739 — ONE unconditional cancel covering every path that reaches here: the response
+    // that never came, the body that never came, the body that was never attempted, the
+    // non-OK reply whose body is never read, and the parse that failed. Written as a single
+    // statement AFTER the chain rather than repeated inside each arm, so a branch added
+    // later cannot forget it — the failure this fixes is precisely a request nobody
+    // remembered to stop.
+    //
+    // A no-op on every path where the body WAS consumed, which is why the two early returns
+    // above it need nothing: `abort()` after a response is fully read does nothing at all.
+    httpRoute.cancel();
   } else {
     record("http", TRANSPORT_OUTCOME.NOT_ATTEMPTED, "no fetchApi is wired for the fallback route");
   }


### PR DESCRIPTION
Fixes #1739

## The reported failure

On an 8534-type install, **every** `panel_set_widget` was refused, and the refusal claimed
the type-scoped `/object_info/<Type>` read had timed out — on a URL the reporter measured
by hand at 1.2–12 ms, reproducibly, on the same machine at the same time:

```
GET /object_info                     -> 200  16.08s   51,957,409 bytes
GET /object_info/CyberpunkWindowNode -> 200   0.0013s       6,821 bytes
```

## Root cause: the panel starves its own working route

The type-scoped read was not slow. It was queued behind two whole-map computations **this
panel** had left running on a backend that can only do one thing at a time.

ComfyUI's own `server.py`:

```python
@routes.get("/object_info")
async def get_object_info(request):
    asset_seeder.start(...)
    with folder_paths.cache_helper:
        out = {}
        for x in nodes.NODE_CLASS_MAPPINGS:     # 8534 types on the report
            out[x] = node_info(x)
        return web.json_response(out)           # json.dumps of ~52 MB

@routes.get("/object_info/{node_class}")        # twelve lines below it
async def get_object_info_node(request): ...
```

There is **no `await` anywhere in the first body**. It blocks aiohttp's single event loop
for its entire run — the reporter's 16.08 s — and while it runs the backend cannot serve
*any* other request, including the per-class route. The reporter's curl timings were taken
with nothing else in flight; the panel's were taken with two whole-map computations sitting
on that loop.

So the reporter's head-of-line-blocking guess is right, but the queue is on the **server**,
not in the browser's `api.getNodeDefs()`.

The panel's second whole-map request is pure cost on such a backend, and provably
unreachable: it is only issued *after* the client route has spent its whole share, so it
starts behind a computation of the identical document that is still running, and its own
share is smaller than the one that just expired. It cannot answer. It can only add another
full computation to the loop — and #1560's type-scoped last resort, issued moments later
and written for exactly this backend, is what pays for it.

## The change

`fetchWholeObjectInfo` now **cancels its raw `GET /object_info` when it stops waiting on
it**, and the panel forwards the init so `api.fetchApi(route, init)` carries the signal.
The abandoned request is dropped before the event loop ever reaches it, and the loop is
handed back to the question that can be answered.

`api.getNodeDefs()` is deliberately **not** cancelled: it is the frontend's own method and
takes no signal, and it goes first — it is the work the fallback was queued behind, not the
thing blocking the fallback.

Three files: the oracle (+1 helper, +2 cancel calls), five call-site wirings in the panel,
and one test file.

## Where the load-bearing claims are — please check these

1. **`web/js/lib/object-info-oracle.js:854`** — the unconditional `httpRoute.cancel()` after
   the branch. It is written once *after* the if/else chain rather than in each arm, on the
   argument that every path reaching it either never got a body or already consumed one.
   The two early returns above it (`usableDefs` / `authoritativeEmpty`) skip it on purpose,
   because `abort()` after a fully-read response is a no-op. If that reasoning is wrong for
   any arm, this leaks the request it exists to stop.
2. **Silence must stay silence.** #1223's snapshot and #1560's type-scoped read are both
   licensed on `noBackendAnswerEstablished` — a route that *answered* something unusable may
   never be overruled. Cancelling introduces a new rejection into that path, and if it were
   recorded as a `THREW` outcome instead of `NO_ANSWER` it would silently disable both
   fallbacks. Pinned by test 2; worth re-checking by eye.
3. **The backend model in the test.** It asserts one thing that cannot be proven from here:
   a queued request aborted before dispatch is never run (aiohttp reads a closed connection),
   while a request the loop has already *started* keeps the loop until its synchronous body
   returns. The second half is why `getNodeDefs` is not cancelled. If the first half is
   wrong, the fix does nothing on the reporter's machine — it still cannot make anything
   worse, but it would not help either.
4. **A named trade.** Before this change, an abandoned 52 MB body kept downloading and could
   in principle land in the browser's HTTP cache for a later request to reuse. It is
   aborted now, so it cannot. That reuse was speculative (the panel's own #716 burst cache is
   the real dedupe, and it stores parsed defs), and it only applies on backends where the
   current behaviour is already a permanent refusal — but it is a real difference and is not
   hidden.

## Evidence

**Reproduced by execution, then fixed — mutation-verified.** With the `httpRoute.cancel()`
line deleted, the new test drives the *real* `runSetWidget` ladder against a single-lane
backend on the *shipped* constants (20 000 ms oracle deadline, 5 000 ms scoped deadline,
16 080 ms whole-map compute) and produces the reporter's error verbatim:

```
Error: Cannot set widget on node 58 ("CyberpunkWindowNode"): cannot verify the node type
against the ComfyUI backend — no usable /object_info schema was obtained. A type-scoped
/object_info read did not stand in for the whole-schema routes either — the type-scoped
/object_info reads (CyberpunkWindowNode) did not all answer within 5000ms. ...
```

With the line restored, the write lands and the backend log shows the abandoned whole map
was dropped before the loop reached it. Everything runs on a virtual clock so the shipped
constants are used verbatim — a test that rescales the budgets proves something about
numbers the panel does not have.

**The call site is pinned too.** A one-line wiring change is invisible to a helper-level
test: the oracle can cancel perfectly while `api.fetchApi(route)` drops the signal on the
floor. Reverting a single wiring back to `(route) => api.fetchApi(route)` fails test 6 —
verified.

- `npm run test:unit` — **6710 pass, 0 fail, 1 todo** (includes `check-panel-scope` OK,
  i18n, tool-vocabulary)
- `npx tsc --noEmit` — clean
- Rebased onto `d8d84f19` and re-run green.

**Browser gate: NOT run, and I could not run it.** `playwright.config.ts` requires a real
ComfyUI at `localhost:8188` (it does not start one); nothing is listening in 8180–8210 on
this machine, and this run was told not to start one. So this PR does **not** carry e2e
coverage. Mitigating: the changed path only fires when both whole-schema routes time out,
which does not happen against a healthy local ComfyUI, so the suite would have exercised
the unchanged path either way.

## Deliberately not done

- **The reporter's fix #2 — scale the whole-schema budget.** There is a real defect here
  and it is worth stating precisely: the 20 000 ms deadline is split 10 000 / 5 000 / 5 000,
  so **no single route can ever spend more than 10 s** and a backend whose whole map takes
  11–20 s is unreachable even though the budget nominally covers it. Fixing it means writes
  that cost ~16 s each, which does not fit under `SET_WIDGET_COMMAND_BUDGET_MS` (25 000)
  alongside the 8 000 ms history-seed wait. That is a budget redesign, not a one-round
  change, and it is a separate reviewable decision.
- **The reporter's fix #1 as literally written — try the type-scoped route FIRST.** It
  would work, and it regresses healthy installs: the whole map is what populates #1223's
  snapshot and the `wasTypeEverDefined` trust root, and a scoped map deliberately cannot.
  Gating it on remembered per-connection silence is the honest version, and it touches
  #1582's skip mechanism — again a separate decision.
- **The reporter's fix #3 — report observed size/duration in the refusal.** The refusal
  wording is deliberately restricted to what the code observed; on a route that timed out,
  the panel has observed neither a size nor a duration, so it would be asserting something
  it did not establish. That is the #982 defect this file spends three screens avoiding.
- `panel_refresh_nodes` on such an install is unhelped, exactly as `object-info-oracle.js`
  already documents for #1560. It needs a whole map that lands.
- No CHANGELOG entry: this repo's changelog is written by the release commit, not by fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
