### PR TITLE
release: 0.15.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.73] - 2026-08-24
+
+### Fixed
+- Tolerate live Ideogram derived-widget serializer churn while preserving unrelated drift checks (#2130)
+
 ## [0.15.72] - 2026-08-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.72",
+  "version": "0.15.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.72",
+      "version": "0.15.73",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.72",
+  "version": "0.15.73",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
## Summary
- Release the merged fix for #2130.
- Publish Panel v0.15.73 after green release validation.

## Validation
- npm run typecheck
- npm run check:scope
- git diff --check