### PR TITLE
fix(panel#1725): expose terminal refresh status

### DIFF
--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -359,6 +359,11 @@ test("#635: the shipping registerComfyNodeDefs returns its verdict through the p
     /const runIsCurrent =\s*!comfyBackendSocketDown &&\s*runStartedAtEpoch === backendReconnectEpoch &&\s*runStartedAtGeneration === verifiedNodeDefCache\.generation\(\);/,
   );
   assert.match(body, /reason: NODE_DEF_REFRESH_REASONS\.REFRESH_SUPERSEDED/);
+  assert.match(
+    body,
+    /if \(comboCompletionPending && verdict\?\.refreshed === true && verdict\?\.combo_refresh_confirmed === false\) \{[\s\S]*publishEarlyResult/,
+    "a locally complete schema verdict is observable before late combo completion, without releasing the fence",
+  );
   // #1193 — the two inputs must stay SEPARATE all the way to the verdict. Merging them
   // into one flag would make an abandoned-but-locally-rebuilt run indistinguishable from
   // a confirmed one, which is the distinction the disclosure exists to carry.

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -748,6 +748,51 @@ test("#1725: refresh_nodes returns the completed schema verdict while late combo
   assert.equal(built.runs.length, 2, "a retry after settlement starts one fresh forced refresh");
 });
 
+test("#1725: an early verdict cannot outrun a reconnect successor queued in the next turn", async () => {
+  const lateCompletion = deferred();
+  const terminal = {
+    refreshed: true,
+    reason: "refreshed",
+    combo_refresh_confirmed: false,
+    combo_refresh_note: "the frontend combo refresh is still settling",
+  };
+  let built;
+  let successorQueued = false;
+  let successorRefresh;
+  built = realRefreshNodes({
+    budgetMs: 25,
+    runHook: async ({ index, control }) => {
+      if (index > 0) return { refreshed: true, reason: "refreshed" };
+      control.publishEarlyResult?.(terminal);
+      // Model the ComfyUI reconnected listener arriving after publication but before the
+      // acknowledgement continuation composes its reply. The late combo mutation still
+      // owns the slot, so this force call queues a successor rather than starting run 2.
+      queueMicrotask(() => {
+        successorQueued = true;
+        successorRefresh = built.refreshComfyNodeDefs(undefined, { force: true });
+      });
+      control.deferCompletion(lateCompletion.promise);
+      return terminal;
+    },
+  });
+
+  const first = await withWatchdog(
+    () => built.refresh_nodes(),
+    1500,
+    "refresh_nodes returned before the reconnect successor race settled",
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(successorQueued, true, "the reconnect successor was queued after publication");
+  assert.equal(built.runs.length, 1, "the successor remains behind the fenced late mutation");
+  assert.notEqual(built.getInFlight(), null, "the original late mutation still owns the slot");
+  assert.equal(first.value.reason, "refresh_still_running");
+  assert.equal(first.value.refreshed, false, "MCP must not receive an early schema-ready verdict");
+
+  lateCompletion.resolve();
+  await successorRefresh;
+  assert.equal(built.runs.length, 2, "the queued successor starts only after the fence releases");
+});
+
 test("#1680: with no refresh in flight, refresh_nodes starts its own forced run", async () => {
   const built = realRefreshNodes({ startInFlight: false, budgetMs: 500 });
   const { value } = await withWatchdog(

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -702,6 +702,52 @@ test("#1695: repeated retries share one pending completion and eventually succee
   await built.inFlightStarted?.catch(() => {});
 });
 
+test("#1725: refresh_nodes returns the completed schema verdict while late combo work stays fenced", async () => {
+  const lateCompletion = deferred();
+  const terminal = {
+    refreshed: true,
+    reason: "refreshed",
+    combo_refresh_confirmed: false,
+    combo_refresh_note: "the frontend combo refresh is still settling",
+  };
+  const built = realRefreshNodes({
+    budgetMs: 25,
+    runHook: async ({ index, control }) => {
+      // This is the production shape after /object_info and registration have completed:
+      // the panel has a terminal schema verdict, but refreshComboInNodes() still owns a
+      // shared frontend mutation and must remain behind the single-flight fence.
+      if (index > 0) return { refreshed: true, reason: "refreshed" };
+      control.publishEarlyResult?.(terminal);
+      control.deferCompletion(lateCompletion.promise);
+      return terminal;
+    },
+  });
+
+  const first = await withWatchdog(
+    () => built.refresh_nodes(),
+    1500,
+    "refresh_nodes did not expose the completed schema verdict",
+  );
+  assert.deepEqual(first.value, {
+    ok: true,
+    refreshed: true,
+    combo_refresh_confirmed: false,
+    combo_refresh_note: terminal.combo_refresh_note,
+  });
+  assert.notEqual(built.getInFlight(), null, "late combo mutation remains fenced");
+  assert.equal(built.runs.length, 1, "the terminal acknowledgement does not start a successor");
+
+  lateCompletion.resolve({ refreshed: true, reason: "refreshed" });
+  await new Promise((resolve) => setImmediate(resolve));
+  const settled = await withWatchdog(
+    () => built.refresh_nodes(),
+    1500,
+    "retry after late combo completion did not settle",
+  );
+  assert.deepEqual(settled.value, { ok: true, refreshed: true });
+  assert.equal(built.runs.length, 2, "a retry after settlement starts one fresh forced refresh");
+});
+
 test("#1680: with no refresh in flight, refresh_nodes starts its own forced run", async () => {
   const built = realRefreshNodes({ startInFlight: false, budgetMs: 500 });
   const { value } = await withWatchdog(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2367,6 +2367,13 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // The deferred combo completion returns the same verdict after updating its authoritative
   // phase state, including any graph-loss/placeholder disclosures added above.
   initialRefreshVerdict = verdict;
+  // #1725 — once /object_info and node registration have produced a terminal schema verdict,
+  // expose it to panel_refresh_nodes even when the frontend combo mutation still owns the
+  // single-flight slot. The coalescer keeps the late mutation fenced; this is only the
+  // caller-facing status, so a retry or a graph mutation cannot start a competing refresh.
+  if (comboCompletionPending && verdict?.refreshed === true && verdict?.combo_refresh_confirmed === false) {
+    runControl?.publishEarlyResult?.(verdict);
+  }
   return verdict;
 }
 
@@ -12001,6 +12008,10 @@ const GRAPH_TOOL_EXECUTORS = {
     const verdict = await refreshComfyNodeDefs(undefined, {
       force: true,
       joinInFlight: true,
+      // #1725 — a completed /object_info + registration verdict may be available while a
+      // late combo mutation remains fenced. Surface that terminal status without releasing
+      // the shared refresh slot or allowing a competing successor.
+      allowEarlyResult: true,
       joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,
       // #1562 — the run announces this handoff after /object_info and yields one turn
       // before registration, so this caller can return its structured retryable verdict

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -114,23 +114,40 @@ async function joinBounded(current, joinMs, withTimeout) {
  * `abandonBeforeLocalWork` also lets a caller stop at the explicit handoff immediately
  * before a run begins synchronous schema work; the run itself is not cancelled.
  */
-async function waitForRun(runHandle, ms, withTimeout, abandonBeforeLocalWork = false) {
+async function waitForRun(
+  runHandle,
+  ms,
+  withTimeout,
+  abandonBeforeLocalWork = false,
+  allowEarlyResult = false,
+) {
   const run = runHandle.promise;
-  if (ms === null) return run;
+  const earlyResult = allowEarlyResult ? runHandle.result : null;
+  if (ms === null) return earlyResult ? Promise.race([run, earlyResult]) : run;
   // An abandoned wait is not a reason to turn the run's failure into an unhandled rejection.
   run.catch(() => {});
+  earlyResult?.catch(() => {});
   if (!(ms > 0)) return REFRESH_JOIN_ABANDONED;
   const runOutcome = Promise.resolve(run).then(
     (value) => ({ value }),
     (err) => ({ err }),
   );
+  const observedOutcome = earlyResult
+    ? Promise.race([
+        runOutcome,
+        Promise.resolve(earlyResult).then(
+          (value) => ({ value }),
+          (err) => ({ err }),
+        ),
+      ])
+    : runOutcome;
   const settled = await withTimeout(
     abandonBeforeLocalWork
       ? Promise.race([
-          runOutcome,
+          observedOutcome,
           runHandle.beforeLocalWork.then(() => ({ beforeLocalWork: true })),
         ])
-      : runOutcome,
+      : observedOutcome,
     ms,
     () => null,
   );
@@ -167,7 +184,9 @@ async function waitForRun(runHandle, ms, withTimeout, abandonBeforeLocalWork = f
 //                                carries the pre-local-work handoff used by a bounded caller,
 //                                plus `deferCompletion(promise)` for work that may outlive
 //                                the register function's observation budget but still owns
-//                                shared refresh state.
+//                                shared refresh state, and `publishEarlyResult(result)` for
+//                                an optional terminal observation before that deferred work
+//                                releases the slot.
 //   withTimeout                : the repo's ONE bounding primitive (bounded-step.js),
 //                                injected rather than imported so this module stays a
 //                                pure coordinator and a test can drive the clock. Omit it
@@ -182,6 +201,11 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     let yieldBeforeLocalWork = !!abandonBeforeLocalWork;
     let nextCompletion = null;
     let deferredCompletion = null;
+    let earlyResultResolve;
+    let earlyResultPublished = false;
+    const earlyResult = new Promise((resolve) => {
+      earlyResultResolve = resolve;
+    });
     let announceBeforeLocalWork;
     const beforeLocalWork = new Promise((resolve) => {
       announceBeforeLocalWork = resolve;
@@ -208,6 +232,14 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         const next = Promise.resolve(completionPromise);
         deferredCompletion = deferredCompletion ? deferredCompletion.then(() => next) : next;
         return next;
+      },
+      // A refresh may have a terminal schema verdict while a late frontend mutation still
+      // owns the single-flight slot. Publish that observation separately: callers may opt
+      // into the verdict, but the completion promise remains fenced until the mutation ends.
+      publishEarlyResult: (result) => {
+        if (earlyResultPublished) return;
+        earlyResultPublished = true;
+        earlyResultResolve(result);
       },
     };
     const p = (async () => {
@@ -247,18 +279,25 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       (value) => (nextCompletion ? nextCompletion.promise : value),
       (err) => (nextCompletion ? nextCompletion.promise : Promise.reject(err)),
     );
+    const observedCompletion = earlyResult.then(
+      (value) => (nextCompletion ? nextCompletion.result : value),
+      (err) => (nextCompletion ? nextCompletion.result : Promise.reject(err)),
+    );
     // The completion chain is an optional observation handle. Mark its rejection handled
     // until an acknowledgement caller elects to await it; the original run promise still
     // preserves the caller-visible rejection semantics for ordinary/coalesced paths.
     completion.catch(() => {});
-    const handle = { promise: p, beforeLocalWork, requestEarlyYield };
+    observedCompletion.catch(() => {});
+    const handle = { promise: p, result: earlyResult, beforeLocalWork, requestEarlyYield };
     handle.completion = {
       promise: completion,
+      result: observedCompletion,
       requestEarlyYield,
     };
     handle.attachNextCompletion = attachNextCompletion;
     p.beforeLocalWork = beforeLocalWork;
     p.requestEarlyYield = requestEarlyYield;
+    p.result = earlyResult;
     p.completion = handle.completion;
     p.attachNextCompletion = attachNextCompletion;
     setInFlight(p);
@@ -308,6 +347,15 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
           joined.requestEarlyYield?.();
         }
         const joinedPromise = joined.promise ?? joined;
+        if (joinInFlight && opts?.allowEarlyResult === true) {
+          try {
+            return await waitForRun(joined, joinMs, withTimeout, false, true);
+          } catch {
+            // Preserve #1680's fail-closed joined-run behavior for a run that rejected
+            // before publishing its optional terminal observation.
+            return;
+          }
+        }
         if (!(await joinBounded(joinedPromise, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
         // #1680 — an acknowledgement caller needs the run's freshness verdict, not just
         // proof that the promise settled. Ordinary payload-less joins intentionally retain
@@ -373,6 +421,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
           // successor after this one starts; exposing only the raw promise would let an older
           // acknowledgement report success while that later run is still in flight.
           promise: queued.then((handle) => handle.completion?.promise ?? handle.promise),
+          result: queued.then((handle) => handle.completion?.result ?? handle.result),
           beforeLocalWork: queued.then((handle) => handle.beforeLocalWork),
           requestEarlyYield: () => {
             earlyYieldRequested = true;
@@ -380,7 +429,13 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         };
         current.attachNextCompletion?.(trailing);
       }
-      return waitForRun(trailing, joinMs, withTimeout, abandonBeforeLocalWork);
+      return waitForRun(
+        trailing,
+        joinMs,
+        withTimeout,
+        abandonBeforeLocalWork,
+        opts?.allowEarlyResult === true,
+      );
     }
     // #1351 — nothing in flight, so `joinMs` has no join to bound. It still bounds THIS
     // run: the 8.0× measurement was a 2,251 ms own run against a 280 ms bound with the
@@ -392,6 +447,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       joinMs,
       withTimeout,
       abandonBeforeLocalWork,
+      opts?.allowEarlyResult === true,
     );
   };
 }

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -122,22 +122,26 @@ async function waitForRun(
   allowEarlyResult = false,
 ) {
   const run = runHandle.promise;
-  const earlyResult = allowEarlyResult ? runHandle.result : null;
+  // Use the run's own early result, not the completion-chain result. The latter is a
+  // one-shot promise that can resolve to this run before a reconnect attaches its forced
+  // successor; the synchronous successor check below then keeps that stale observation
+  // fail-closed.
+  const earlyResult = allowEarlyResult ? (runHandle.earlyResult ?? runHandle.result) : null;
   if (ms === null) return earlyResult ? Promise.race([run, earlyResult]) : run;
   // An abandoned wait is not a reason to turn the run's failure into an unhandled rejection.
   run.catch(() => {});
   earlyResult?.catch(() => {});
   if (!(ms > 0)) return REFRESH_JOIN_ABANDONED;
   const runOutcome = Promise.resolve(run).then(
-    (value) => ({ value }),
-    (err) => ({ err }),
+    (value) => ({ value, source: "run" }),
+    (err) => ({ err, source: "run" }),
   );
   const observedOutcome = earlyResult
     ? Promise.race([
         runOutcome,
         Promise.resolve(earlyResult).then(
-          (value) => ({ value }),
-          (err) => ({ err }),
+          (value) => ({ value, source: "early" }),
+          (err) => ({ err, source: "early" }),
         ),
       ])
     : runOutcome;
@@ -154,6 +158,12 @@ async function waitForRun(
   if (settled === null) return REFRESH_JOIN_ABANDONED;
   if (settled?.beforeLocalWork === true) return REFRESH_JOIN_ABANDONED;
   if ("err" in settled) throw settled.err;
+  // A forced reconnect successor may have been attached after the early promise resolved
+  // but before this bounded caller resumed. The old verdict is no longer authoritative;
+  // return the existing retryable status rather than reporting schema-ready over a queued
+  // post-reconnect run. If the successor settled first, `runOutcome` above already wins and
+  // forwards its result.
+  if (settled.source === "early" && runHandle.hasSuccessor?.()) return REFRESH_JOIN_ABANDONED;
   return settled.value;
 }
 
@@ -266,6 +276,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       yieldBeforeLocalWork = true;
       nextCompletion?.requestEarlyYield?.();
     };
+    const hasSuccessor = () => nextCompletion !== null;
     const attachNextCompletion = (next) => {
       nextCompletion = next;
       if (yieldBeforeLocalWork) next?.requestEarlyYield?.();
@@ -288,16 +299,27 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     // preserves the caller-visible rejection semantics for ordinary/coalesced paths.
     completion.catch(() => {});
     observedCompletion.catch(() => {});
-    const handle = { promise: p, result: earlyResult, beforeLocalWork, requestEarlyYield };
+    const handle = {
+      promise: p,
+      result: earlyResult,
+      earlyResult,
+      beforeLocalWork,
+      requestEarlyYield,
+      hasSuccessor,
+    };
     handle.completion = {
       promise: completion,
       result: observedCompletion,
+      earlyResult,
       requestEarlyYield,
+      hasSuccessor,
     };
     handle.attachNextCompletion = attachNextCompletion;
     p.beforeLocalWork = beforeLocalWork;
     p.requestEarlyYield = requestEarlyYield;
     p.result = earlyResult;
+    p.earlyResult = earlyResult;
+    p.hasSuccessor = hasSuccessor;
     p.completion = handle.completion;
     p.attachNextCompletion = attachNextCompletion;
     setInFlight(p);
@@ -407,6 +429,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       }
       if (!trailing) {
         let earlyYieldRequested = abandonBeforeLocalWork;
+        let queuedHandle = null;
         const queued = (async () => {
           try {
             await current;
@@ -414,7 +437,8 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
             /* the in-flight refresh failed — run our own anyway */
           }
           trailing = null;
-          return startRun(undefined, runOpts, earlyYieldRequested);
+          queuedHandle = startRun(undefined, runOpts, earlyYieldRequested);
+          return queuedHandle;
         })();
         trailing = {
           // Follow the successor's own completion chain. A forced refresh can queue another
@@ -422,6 +446,8 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
           // acknowledgement report success while that later run is still in flight.
           promise: queued.then((handle) => handle.completion?.promise ?? handle.promise),
           result: queued.then((handle) => handle.completion?.result ?? handle.result),
+          earlyResult: queued.then((handle) => handle.completion?.earlyResult ?? handle.result),
+          hasSuccessor: () => queuedHandle?.hasSuccessor?.() === true,
           beforeLocalWork: queued.then((handle) => handle.beforeLocalWork),
           requestEarlyYield: () => {
             earlyYieldRequested = true;


### PR DESCRIPTION
Fixes #1725

## What changed
- Reproduces the reconnect path where /object_info and node registration finish, but a late refreshComboInNodes() mutation keeps the refresh single-flight slot occupied.
- Exposes that terminal schema verdict to panel_refresh_nodes only while no forced successor is attached.
- If a reconnect successor is attached after early publication but before the acknowledgement resumes, returns the existing refresh_still_running status instead of a stale refreshed:true schema-ready verdict.
- Keeps the late combo mutation and reconnect successor behind the existing single-flight completion fence.

## Validation
- npm.cmd run typecheck
- npm.cmd run check:scope
- npm.cmd run test:unit (6713 tests, 6712 passed, 1 todo)
- Focused refresh coalescing / refresh_nodes / reapply / node-definition tests pass (97 tests).