### PR TITLE
fix(panel): redact secret widget values from graph reads (#1729)

### DIFF
--- a/browser_tests/unit/graph-find-nodes.test.mjs
+++ b/browser_tests/unit/graph-find-nodes.test.mjs
@@ -14,6 +14,7 @@ import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
 import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
 import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
+import { redactWidgetValue } from "../../web/js/lib/widget-secret-redaction.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 
@@ -54,6 +55,7 @@ const summarizeNode = (() => {
     "duplicateWidgetRows",
     "controlAfterGenerateModes",
     "drivenWidgetsFor",
+    "redactWidgetValue",
     `${source}; return summarizeNode;`,
   )(
     virtualFedInputs,
@@ -63,6 +65,7 @@ const summarizeNode = (() => {
     duplicateWidgetRows,
     controlAfterGenerateModes,
     drivenWidgetsFor,
+    redactWidgetValue,
   );
 })();
 

--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -15,6 +15,7 @@ import {
   clampDetailWidgetCap,
   capSummaryWidgets,
   clipCompactValue,
+  clipLine,
   compactClipNote,
   drivenTag,
   drivenWidgetsFor,
@@ -22,6 +23,7 @@ import {
   isLineProtected,
   truncationTail,
 } from "../../web/js/lib/graph-read.js";
+import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
 
 const PANEL_JS = join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js");
 const source = readFileSync(PANEL_JS, "utf8");
@@ -75,6 +77,25 @@ const graph = {
       inputs: [],
       outputs: [],
     },
+    {
+      id: 82,
+      type: "Credentialed Bypassed Node",
+      title: "Credentialed Bypassed Node",
+      mode: 4,
+      widgets: [
+        {
+          name: "settings",
+          value: {
+            visible: "visible setting",
+            api_key: "compact-api-key",
+            nested: [{ privateKey: "compact-private-key" }, "Bearer abcdefghijklmnop"],
+          },
+        },
+        { name: "prompt", value: "visible prompt" },
+      ],
+      inputs: [],
+      outputs: [],
+    },
   ],
 };
 
@@ -111,7 +132,9 @@ const dependencyNames = [
   "isLineProtected",
   "truncationTail",
   "clipCompactValue",
+  "clipLine",
   "compactClipNote",
+  "redactWidgetValue",
 ];
 const graphQuery = new Function(
   ...dependencyNames,
@@ -139,7 +162,9 @@ const graphQuery = new Function(
   isLineProtected,
   truncationTail,
   clipCompactValue,
+  clipLine,
   compactClipNote,
+  redactWidgetValue,
 );
 
 function detailRows(result) {
@@ -196,3 +221,18 @@ test("#1681 shipped graph_query preserves a fitting quote-heavy object at the op
   assert.deepEqual(row.widgets.text, graph._nodes[3].widgets[0].value);
   assert.equal(JSON.stringify(row.widgets.text), JSON.stringify(graph._nodes[3].widgets[0].value));
 });
+
+test("#1729 shipped graph_query compact redacts nested secrets and preserves bypass/ordinary values", () => {
+  const result = query({ ids: [82], fields: "compact" });
+  const line = result.text.split("\n").find((entry) => entry.startsWith("#82 "));
+  assert.ok(line, "the compact query must return the bypassed node");
+  assert.match(line, /#82 Credentialed Bypassed Node \[bypass\]/);
+  assert.match(line, /visible=|visible setting/);
+  assert.match(line, /prompt=visible prompt/);
+  assert.match(line, new RegExp(escapeRegex(REDACTED_WIDGET_VALUE)));
+  assert.doesNotMatch(line, /compact-api-key|compact-private-key|Bearer abcdefghijklmnop/);
+});
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/browser_tests/unit/panel-graph-outline-redaction.test.mjs
+++ b/browser_tests/unit/panel-graph-outline-redaction.test.mjs
@@ -1,0 +1,109 @@
+// #1729 — execute the production graph_outline rendering fragment. A helper-only
+// test would miss the direct outline path, which formats live widget values itself
+// instead of going through summarizeNode.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { displayLabel } from "../../web/js/lib/slot-labels.js";
+import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+function handlerBody(src, sig) {
+  const start = src.indexOf(sig);
+  assert.notEqual(start, -1, `${sig} must exist`);
+  const after = start + sig.length;
+  const next = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  return src.slice(start, next ? after + next.index : src.length);
+}
+
+function productionFormatter(body) {
+  const start = body.indexOf("const fmtVal = (v, node, widgetName) => {");
+  const end = body.indexOf("const modeTag", start);
+  assert.ok(start >= 0 && end > start, "the outline formatter must remain in the production handler");
+  const source = body.slice(start, end);
+  return new Function(
+    "redactWidgetValue",
+    "NOTE_NODE_TYPES",
+    `let outlineClipped = 0; let outlineClippedNoteIds = []; ${source}; return fmtVal;`,
+  )(redactWidgetValue, new Set(["Note", "MarkdownNote"]));
+}
+
+function productionRenderNodeLines(body, fmtVal, node) {
+  const start = body.indexOf("const renderNodeLines = (level) => {");
+  const end = body.indexOf("// The FLOOR rung", start);
+  assert.ok(start >= 0 && end > start, "the outline node renderer must remain in the production handler");
+  const source = body.slice(start, end);
+  const sorted = [node];
+  const byId = new Map([[node.id, node]]);
+  const render = new Function(
+    "sorted",
+    "byId",
+    "groupOf",
+    "title_",
+    "controlAfterGenerateEntries",
+    "drivenWidgetsFor",
+    "virtualFedInputs",
+    "displayLabel",
+    "virtualSourceTag",
+    "drivenTag",
+    "fmtVal",
+    "modeTag",
+    "outTag",
+    "readStoredLink",
+    "liveLinkTargetInput",
+    "graph",
+    `${source}; return renderNodeLines;`,
+  )(
+    sorted,
+    byId,
+    new Map(),
+    (value) => String(value ?? ""),
+    () => [],
+    () => ({}),
+    () => ({}),
+    displayLabel,
+    () => "",
+    () => "",
+    fmtVal,
+    (n) => ({ 2: " [mute]", 4: " [bypass]" }[n.mode] ?? ""),
+    (n) => (n.constructor?.nodeData?.output_node ? " [OUTPUT]" : ""),
+    () => null,
+    () => null,
+    { links: {} },
+  );
+  return render("full");
+}
+
+test("#1729 graph_outline redacts a bypassed API-key widget in its live node renderer", () => {
+  const body = handlerBody(readFileSync(PANEL_JS, "utf8"), "graph_outline({");
+  assert.match(body, /fmtVal\(w\.value, n, w\.name\)/, "the outline passes the widget name to its formatter");
+
+  const secret = "live-api-key-should-never-reach-the-outline-1234567890";
+  const node = {
+    id: 1729,
+    type: "GPT Image",
+    title: "GPT Image",
+    mode: 4,
+    widgets: [
+      { name: "api_key", value: secret },
+      { name: "prompt", value: "visible prompt" },
+    ],
+    inputs: [],
+    outputs: [],
+  };
+  const lines = productionRenderNodeLines(body, productionFormatter(body), node);
+  assert.equal(lines.length, 1, "the bypassed node remains in the outline");
+  assert.match(lines[0], /1729  GPT Image \[bypass\]/, "bypass semantics remain visible");
+  assert.match(lines[0], new RegExp(`api_key="?${escapeRegex(REDACTED_WIDGET_VALUE)}"?`));
+  assert.match(lines[0], /prompt=visible prompt/, "ordinary visible widget values remain intact");
+  assert.ok(!lines.join("\n").includes(secret), "the credential is absent from the outline text");
+});
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -92,11 +92,13 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
   assert.ok(start >= 0 && end > start, "graph_get_subgraph handler must remain extractable");
   const method = src.slice(start, end).replace(/,\s*$/, "");
   const graph = {};
+  const sharedParentValue = { value: "SECRET" };
   const parent = {
     id: 173,
     title: "Reusable secret node",
     widgets: [
-      { name: "apiKey", value: "live-parent-api-key" },
+      { name: "ordinarySettings", value: sharedParentValue },
+      { name: "apiKey", value: sharedParentValue },
       {
         name: "instanceSettings",
         value: {
@@ -133,7 +135,8 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
   const out = getSubgraph({ node_id: 173 });
   assert.deepEqual(out.subgraph_of, { node_id: 173, title: "Reusable secret node" });
   assert.deepEqual(out.instance_widgets, {
-    apiKey: REDACTED_WIDGET_VALUE,
+    ordinarySettings: { value: "SECRET" },
+    apiKey: { value: REDACTED_WIDGET_VALUE },
     instanceSettings: {
       visible: "keep this setting",
       api_key: REDACTED_WIDGET_VALUE,
@@ -141,7 +144,11 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     },
     prompt: "visible prompt",
   });
+  assert.notStrictEqual(
+    out.instance_widgets.ordinarySettings,
+    out.instance_widgets.apiKey,
+    "production provenance must split ordinary and sensitive alias contexts",
+  );
   assert.deepEqual(out.nodes, [{ id: 166, mode: 4, inputs: [], outputs: [] }]);
-  assert.ok(!JSON.stringify(out).includes("live-parent-api-key"));
   assert.ok(!JSON.stringify(out).includes("nested-private-key"));
 });

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { subgraphValueProvenance } from "../../web/js/lib/subgraph-value-provenance.js";
+import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
 
 /**
  * #636 (minor) — panel_get_subgraph(173) reported inner node 166 value "MiniMax_H3"
@@ -76,17 +77,71 @@ test("no promotion-to-inner-widget PAIRING is asserted", () => {
 });
 
 // ── WIRING ────────────────────────────────────────────────────────────────
-test("WIRING: graph_get_subgraph spreads the provenance block", async () => {
-  // graph_get_subgraph is a module-private handler needing a live graph, so the
-  // wiring is pinned at source. Without the spread, both values are still returned
-  // by the two tools with nothing explaining the difference — #636's minor item.
+test("WIRING: production graph_get_subgraph redacts instance provenance", async () => {
+  // Execute the module-private handler's source fragment. A source-only assertion
+  // would miss a sanitizer applied to the wrong object, while a helper-only test
+  // would miss this alternate structured-read path entirely.
   const { readFile } = await import("node:fs/promises");
   const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.match(src, /import \{ subgraphValueProvenance \} from "\.\/lib\/subgraph-value-provenance\.js";/);
-  const fn = src.slice(src.indexOf("graph_get_subgraph({ node_id }) {"));
-  const body = fn.slice(0, fn.indexOf("async graph_add_node("));
-  assert.ok(body.includes("...subgraphValueProvenance(node),"),
-    "the reply must carry the provenance block");
-  // It must describe the PARENT instance, not one of the inner nodes.
-  assert.ok(body.includes("subgraphValueProvenance(node)"), "must be passed the parent node");
+  assert.match(src, /const safeProvenance = redactWidgetValue\("", subgraphValueProvenance\(node\)\);/);
+  assert.match(src, /\.\.\.safeProvenance,/);
+
+  const start = src.indexOf("graph_get_subgraph({ node_id }) {");
+  const end = src.indexOf("async graph_add_node(", start);
+  assert.ok(start >= 0 && end > start, "graph_get_subgraph handler must remain extractable");
+  const method = src.slice(start, end).replace(/,\s*$/, "");
+  const graph = {};
+  const parent = {
+    id: 173,
+    title: "Reusable secret node",
+    widgets: [
+      { name: "apiKey", value: "live-parent-api-key" },
+      {
+        name: "instanceSettings",
+        value: {
+          visible: "keep this setting",
+          api_key: "nested-api-key",
+          values: [{ privateKey: "nested-private-key" }, "Bearer abcdefghijklmnop"],
+        },
+      },
+      { name: "prompt", value: "visible prompt" },
+    ],
+    subgraph: { _nodes: [{ id: 166, mode: 4, inputs: [], outputs: [] }] },
+  };
+  const getSubgraph = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "describeActiveGraph",
+    "subgraphValueProvenance",
+    "redactWidgetValue",
+    "MAX_STATE_NODES",
+    "fixedCapNote",
+    "summarizeNode",
+    `return ({${method}}).graph_get_subgraph;`,
+  )(
+    () => ({ graph }),
+    () => parent,
+    () => ({ graph: "root" }),
+    subgraphValueProvenance,
+    redactWidgetValue,
+    50,
+    () => "truncation note",
+    (node) => ({ id: node.id, mode: node.mode, inputs: node.inputs, outputs: node.outputs }),
+  );
+
+  const out = getSubgraph({ node_id: 173 });
+  assert.deepEqual(out.subgraph_of, { node_id: 173, title: "Reusable secret node" });
+  assert.deepEqual(out.instance_widgets, {
+    apiKey: REDACTED_WIDGET_VALUE,
+    instanceSettings: {
+      visible: "keep this setting",
+      api_key: REDACTED_WIDGET_VALUE,
+      values: [{ privateKey: REDACTED_WIDGET_VALUE }, REDACTED_WIDGET_VALUE],
+    },
+    prompt: "visible prompt",
+  });
+  assert.deepEqual(out.nodes, [{ id: 166, mode: 4, inputs: [], outputs: [] }]);
+  assert.ok(!JSON.stringify(out).includes("live-parent-api-key"));
+  assert.ok(!JSON.stringify(out).includes("nested-private-key"));
 });

--- a/browser_tests/unit/summarize-duplicate-widgets.test.mjs
+++ b/browser_tests/unit/summarize-duplicate-widgets.test.mjs
@@ -26,6 +26,7 @@ import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
 import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
 import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
+import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const TOGGLE = "RGTHREE_TOGGLE_AND_NAV";
@@ -56,6 +57,7 @@ const summarizeNode = (() => {
     "duplicateWidgetRows",
     "controlAfterGenerateModes",
     "drivenWidgetsFor",
+    "redactWidgetValue",
     `${fn}; return summarizeNode;`,
   )(
     virtualFedInputs,
@@ -65,6 +67,7 @@ const summarizeNode = (() => {
     duplicateWidgetRows,
     controlAfterGenerateModes,
     drivenWidgetsFor,
+    redactWidgetValue,
   );
 })();
 
@@ -155,4 +158,27 @@ test("#1402 a widget named __proto__ is reported, not thrown on", () => {
     assert.deepEqual(JSON.parse(JSON.stringify(summary.duplicate_widgets))[name].map((r) => r.value), [1, 2]);
   }
   assert.equal({}.polluted, undefined, "nothing leaked onto Object.prototype");
+});
+
+test("#1729 summarizeNode redacts a bypassed API-key widget while preserving graph shape", () => {
+  const secret = "sk-proj-should-never-reach-the-agent-1234567890";
+  const summary = summarizeNode({
+    id: 1729,
+    type: "GPT Image",
+    title: "GPT Image",
+    mode: 4,
+    widgets: [
+      { name: "api_key", value: secret },
+      { name: "prompt", value: "visible prompt" },
+    ],
+    inputs: [{ name: "image", type: "IMAGE", link: null }],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+  });
+
+  assert.equal(summary.mode, "bypass", "bypass remains visible");
+  assert.equal(summary.widgets.api_key, REDACTED_WIDGET_VALUE);
+  assert.equal(summary.widgets.prompt, "visible prompt", "ordinary visible values remain intact");
+  assert.deepEqual(summary.inputs, [{ slot: 0, name: "image", type: "IMAGE", connected_from: null }]);
+  assert.deepEqual(summary.outputs, [{ slot: 0, name: "IMAGE", type: "IMAGE", links: 0 }]);
+  assert.ok(!JSON.stringify(summary).includes(secret), "the credential is absent from the serialized read");
 });

--- a/browser_tests/unit/summarize-duplicate-widgets.test.mjs
+++ b/browser_tests/unit/summarize-duplicate-widgets.test.mjs
@@ -182,3 +182,46 @@ test("#1729 summarizeNode redacts a bypassed API-key widget while preserving gra
   assert.deepEqual(summary.outputs, [{ slot: 0, name: "IMAGE", type: "IMAGE", links: 0 }]);
   assert.ok(!JSON.stringify(summary).includes(secret), "the credential is absent from the serialized read");
 });
+
+test("#1729 production structured summary and duplicate rows redact nested credentials", () => {
+  const first = "first-api-key";
+  const second = "second-api-key";
+  const summary = summarizeNode({
+    id: 1730,
+    type: "Credentialed Bypassed Node",
+    title: "Credentialed Bypassed Node",
+    mode: 4,
+    widgets: [
+      {
+        name: "settings",
+        value: {
+          visible: "visible setting",
+          credentialValue: "nested-credential",
+          values: [{ privateKey: "nested-private-key" }, "sk-proj-1234567890123456"],
+        },
+      },
+      { name: "api_key", value: first },
+      { name: "api_key", value: second },
+      { name: "prompt", value: "visible prompt" },
+    ],
+    inputs: [{ name: "image", type: "IMAGE", link: null }],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+  });
+
+  assert.deepEqual(summary.widgets.settings, {
+    visible: "visible setting",
+    credentialValue: REDACTED_WIDGET_VALUE,
+    values: [{ privateKey: REDACTED_WIDGET_VALUE }, REDACTED_WIDGET_VALUE],
+  });
+  assert.equal(summary.widgets.api_key, REDACTED_WIDGET_VALUE);
+  assert.deepEqual(
+    summary.duplicate_widgets.api_key.map((row) => row.value),
+    [REDACTED_WIDGET_VALUE, REDACTED_WIDGET_VALUE],
+  );
+  assert.equal(summary.widgets.prompt, "visible prompt");
+  assert.equal(summary.mode, "bypass");
+  assert.deepEqual(summary.inputs, [{ slot: 0, name: "image", type: "IMAGE", connected_from: null }]);
+  assert.deepEqual(summary.outputs, [{ slot: 0, name: "IMAGE", type: "IMAGE", links: 0 }]);
+  assert.ok(!JSON.stringify(summary).includes(first));
+  assert.ok(!JSON.stringify(summary).includes("nested-private-key"));
+});

--- a/browser_tests/unit/widget-secret-redaction.test.mjs
+++ b/browser_tests/unit/widget-secret-redaction.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  redactWidgetValue,
+  REDACTED_WIDGET_VALUE,
+} from "../../web/js/lib/widget-secret-redaction.js";
+
+test("#1729 redacts conventional credential widget names", () => {
+  for (const name of ["api_key", "openaiApiKey", "access-token", "bearer", "token"]) {
+    assert.equal(redactWidgetValue(name, "credential-value"), REDACTED_WIDGET_VALUE, name);
+  }
+  assert.equal(redactWidgetValue("api_key", ""), "", "an unconfigured key stays visibly empty");
+  assert.equal(redactWidgetValue("token_count", 128), 128, "ordinary token counters remain visible");
+});
+
+test("#1729 redacts unmistakable key/header values even under an ordinary widget name", () => {
+  assert.equal(
+    redactWidgetValue("provider", "sk-proj-1234567890123456"),
+    REDACTED_WIDGET_VALUE,
+  );
+  assert.equal(
+    redactWidgetValue("header", "Bearer abcdefghijklmnop"),
+    REDACTED_WIDGET_VALUE,
+  );
+});
+
+test("#1729 preserves ordinary visible widget values and does not mutate them", () => {
+  const value = "Use the phrase 'api_key' in the prompt; this is not a credential.";
+  assert.equal(redactWidgetValue("prompt", value), value);
+  const object = { toggled: true };
+  assert.equal(redactWidgetValue("toggle", object), object);
+});

--- a/browser_tests/unit/widget-secret-redaction.test.mjs
+++ b/browser_tests/unit/widget-secret-redaction.test.mjs
@@ -83,3 +83,25 @@ test("#1729 recursively redacts nested credential keys and secret-shaped scalars
   });
   assert.equal(JSON.stringify(value), before, "redaction must not mutate the live widget value");
 });
+
+test("#1729 does not reuse an ordinary alias for a sensitive-key alias", () => {
+  // The ordinary traversal reaches this object first. The sensitive traversal must
+  // still get its own context, or shared.value crosses the api_key boundary raw.
+  const shared = { value: "SECRET" };
+  const safe = redactWidgetValue("config", { ordinary: shared, api_key: shared });
+
+  assert.equal(safe.ordinary.value, "SECRET", "ordinary visible values remain intact");
+  assert.equal(safe.api_key.value, REDACTED_WIDGET_VALUE, "the sensitive alias is redacted");
+  assert.notStrictEqual(safe.ordinary, safe.api_key, "different redaction contexts cannot share output");
+  assert.equal(shared.value, "SECRET", "the live aliased value is not mutated");
+});
+
+test("#1729 preserves aliases and cycles within one redaction context", () => {
+  const shared = { value: "visible" };
+  const cycle = { value: "visible" };
+  cycle.self = cycle;
+  const safe = redactWidgetValue("config", { left: shared, right: shared, cycle });
+
+  assert.strictEqual(safe.left, safe.right, "same-context aliases remain aliases");
+  assert.strictEqual(safe.cycle.self, safe.cycle, "same-context cycles remain finite and cyclic");
+});

--- a/browser_tests/unit/widget-secret-redaction.test.mjs
+++ b/browser_tests/unit/widget-secret-redaction.test.mjs
@@ -7,7 +7,21 @@ import {
 } from "../../web/js/lib/widget-secret-redaction.js";
 
 test("#1729 redacts conventional credential widget names", () => {
-  for (const name of ["api_key", "openaiApiKey", "access-token", "bearer", "token"]) {
+  for (const name of [
+    "credential",
+    "credentials",
+    "credentialValue",
+    "secret_key",
+    "secretKey",
+    "private_key",
+    "privateKey",
+    "api_key",
+    "apiKeys",
+    "openaiApiKey",
+    "access-token",
+    "bearer",
+    "token",
+  ]) {
     assert.equal(redactWidgetValue(name, "credential-value"), REDACTED_WIDGET_VALUE, name);
   }
   assert.equal(redactWidgetValue("api_key", ""), "", "an unconfigured key stays visibly empty");
@@ -29,5 +43,43 @@ test("#1729 preserves ordinary visible widget values and does not mutate them", 
   const value = "Use the phrase 'api_key' in the prompt; this is not a credential.";
   assert.equal(redactWidgetValue("prompt", value), value);
   const object = { toggled: true };
-  assert.equal(redactWidgetValue("toggle", object), object);
+  assert.deepEqual(redactWidgetValue("toggle", object), object);
+  assert.deepEqual(object, { toggled: true });
+});
+
+test("#1729 recursively redacts nested credential keys and secret-shaped scalars", () => {
+  const value = {
+    prompt: "visible prompt",
+    nested: {
+      credential: "credential-value",
+      secretKey: "secret-value",
+      private_key: "private-value",
+      apiKeys: ["api-key-value"],
+      token_count: 3,
+      request: [
+        { label: "visible label", api_key: "nested-api-key" },
+        { label: "visible provider", value: "sk-proj-1234567890123456" },
+        "Bearer abcdefghijklmnop",
+      ],
+    },
+  };
+  const before = JSON.stringify(value);
+  const safe = redactWidgetValue("config", value);
+
+  assert.deepEqual(safe, {
+    prompt: "visible prompt",
+    nested: {
+      credential: REDACTED_WIDGET_VALUE,
+      secretKey: REDACTED_WIDGET_VALUE,
+      private_key: REDACTED_WIDGET_VALUE,
+      apiKeys: [REDACTED_WIDGET_VALUE],
+      token_count: 3,
+      request: [
+        { label: "visible label", api_key: REDACTED_WIDGET_VALUE },
+        { label: "visible provider", value: REDACTED_WIDGET_VALUE },
+        REDACTED_WIDGET_VALUE,
+      ],
+    },
+  });
+  assert.equal(JSON.stringify(value), before, "redaction must not mutate the live widget value");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13659,13 +13659,16 @@ const GRAPH_TOOL_EXECUTORS = {
     const sub = node.subgraph;
     if (!sub) throw new Error(`Node ${node.id} (${node.type}) is not a subgraph`);
     const inner = [...(sub._nodes ?? sub.nodes ?? [])];
+    // #1729 — provenance is a second structured-read path: its raw instance_widgets
+    // map must follow the same recursive credential redaction as node summaries.
+    const safeProvenance = redactWidgetValue("", subgraphValueProvenance(node));
     return {
       viewing: describeActiveGraph(graph),
       subgraph_of: { node_id: node.id, title: node.title },
       // #636 — the inner nodes below are the DEFINITION's; the parent instance's
       // promoted widgets can override them. Carry both, labelled, so a legitimate
       // per-instance override cannot be misread as stale data.
-      ...subgraphValueProvenance(node),
+      ...safeProvenance,
       node_count: inner.length,
       truncated: inner.length > MAX_STATE_NODES,
       ...(inner.length > MAX_STATE_NODES

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -257,6 +257,7 @@ import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
 import { installSidebarRenderWatchdog } from "./lib/sidebar-render-watchdog.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { duplicateWidgetRows } from "./lib/widget-rows.js";
+import { redactWidgetValue } from "./lib/widget-secret-redaction.js";
 import { pickAdvertisedBridgeUrl, acceptableLoopbackBridgeUrl } from "./lib/advertised-bridge-url.js";
 import {
   DEFAULT_BRIDGE_URL,
@@ -10759,7 +10760,7 @@ async function revertGraphSnapshotByMid(mid) {
 function summarizeNode(node) {
   const widgets = {};
   for (const w of node.widgets ?? []) {
-    if (w && typeof w.name === "string") widgets[w.name] = w.value;
+    if (w && typeof w.name === "string") widgets[w.name] = redactWidgetValue(w.name, w.value);
   }
   // #1402: several widgets can legitimately share ONE name — every toggle row of
   // rgthree's Fast Groups Bypasser/Muter is named `RGTHREE_TOGGLE_AND_NAV`. The
@@ -12584,8 +12585,9 @@ const GRAPH_TOOL_EXECUTORS = {
      * quote/backslash-dense value can render slightly longer than 60; that costs a few
      * characters against max_chars and cannot reintroduce a forgeable tag (codex).
      */
-    const fmtVal = (v, node) => {
-      const s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
+    const fmtVal = (v, node, widgetName) => {
+      const safeValue = redactWidgetValue(widgetName, v);
+      const s = String(typeof safeValue === "string" ? safeValue : JSON.stringify(safeValue) ?? "").replace(/\s+/g, " ");
       let clipped = s;
       if (s.length > 60) {
         outlineClipped++;
@@ -12658,7 +12660,7 @@ const GRAPH_TOOL_EXECUTORS = {
             .map((w) => {
               // At "no_values" the widget NAMES still tell an agent what is configurable;
               // the VALUES are the bulk of the bytes, so they go first.
-              const base = level === "full" ? `${w.name}=${fmtVal(w.value, n)}` : w.name;
+              const base = level === "full" ? `${w.name}=${fmtVal(w.value, n, w.name)}` : w.name;
               // The NAME stays the addressable key and stays first — panel_set_widget
               // takes the name, not the label — with the label annotated beside it in the
               // same bracket idiom as [after_gen=…] and [bypass].
@@ -13008,9 +13010,12 @@ const GRAPH_TOOL_EXECUTORS = {
       if (op === "<=") return l <= r;
       return false;
     };
-    const widgetsOf = (n) => {
+    const widgetsOf = (n, redactValues = false) => {
       const out = {};
-      for (const w of n.widgets ?? []) if (w && typeof w.name === "string") out[w.name] = w.value;
+      for (const w of n.widgets ?? []) {
+        if (w && typeof w.name === "string")
+          out[w.name] = redactValues ? redactWidgetValue(w.name, w.value) : w.value;
+      }
       return out;
     };
     const matched = candidates.filter((n) => {
@@ -13194,7 +13199,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // #1181: virtually-fed promoted inputs get the tag that says the stored
         // value executes — drivenTag would claim the opposite.
         const vFed = virtualFedInputs(n);
-        const w = Object.entries(widgetsOf(n))
+        const w = Object.entries(widgetsOf(n, true))
           .map(([k, v]) => {
             // ONE cap across the row (see compactValueCap above). A per-widget cap that
             // varied as a budget drained made the clip note incoherent: values cut at

--- a/web/js/lib/widget-rows.js
+++ b/web/js/lib/widget-rows.js
@@ -34,6 +34,7 @@
 // Extracted so the derivation is unit-tested against the SAME code summarizeNode runs.
 
 import { displayLabel } from "./slot-labels.js";
+import { redactWidgetValue } from "./widget-secret-redaction.js";
 
 /**
  * Map of widget NAME → every widget carrying that name, for names carried by MORE THAN
@@ -49,7 +50,8 @@ import { displayLabel } from "./slot-labels.js";
  *     of one name routinely carry DIFFERENT labels — the rgthree toggle rows are named
  *     alike and labelled per group — and the name-keyed `widget_labels` map can hold
  *     only one of them.
- *   * `value` — this occurrence's own value, unwrapped exactly as stored.
+ *   * `value` — this occurrence's own agent-facing value; credential-shaped values are
+ *     redacted, while ordinary values remain as stored.
  *
  * Occurrences are in canvas order, so the LAST entry for a name is the one the
  * name-keyed `widgets` map ended up holding; the earlier ones are what it dropped.
@@ -82,7 +84,7 @@ export function duplicateWidgetRows(node) {
     out.get(widget.name).push({
       index,
       ...(label != null ? { label } : {}),
-      value: widget.value,
+      value: redactWidgetValue(widget.name, widget.value),
     });
   }
   return Object.fromEntries(out);

--- a/web/js/lib/widget-secret-redaction.js
+++ b/web/js/lib/widget-secret-redaction.js
@@ -1,0 +1,33 @@
+// Agent-facing graph reads must not echo credentials stored in workflow widgets.
+// Keep this deliberately narrow: ordinary prompt/model/path values remain visible,
+// while conventional credential field names and unmistakable key/header values do not.
+
+export const REDACTED_WIDGET_VALUE = "[REDACTED]";
+
+const SENSITIVE_WIDGET_NAME_RE =
+  /(?:^|_)(?:api_key|apikey|access_token|refresh_token|auth_token|authentication_token|authorization|bearer|token|secret|password|passwd)$/;
+
+// Value-based coverage is intentionally limited to formats that are useful to catch
+// without treating arbitrary prose as a credential. The field-name checks above cover
+// provider-specific API-key widgets; these patterns catch an unhelpfully named field.
+const SECRET_VALUE_RE = /(?:^|[\s"'=:`])(?:sk-[A-Za-z0-9][A-Za-z0-9._-]{15,}|bearer\s+[A-Za-z0-9._~+/=-]{16,})/i;
+
+function normalizeWidgetName(name) {
+  return String(name ?? "")
+    .replace(/([a-z])([A-Z])/g, "$1_$2")
+    .trim()
+    .replace(/[\s-]+/g, "_")
+    .toLowerCase();
+}
+
+/** Return a safe agent-facing value without mutating the live widget. */
+export function redactWidgetValue(name, value) {
+  const normalizedName = normalizeWidgetName(name);
+  if (SENSITIVE_WIDGET_NAME_RE.test(normalizedName)) {
+    // Empty/null values carry no secret and preserving them avoids changing useful
+    // state information such as an unconfigured optional API-key input.
+    return value == null || value === "" ? value : REDACTED_WIDGET_VALUE;
+  }
+  if (typeof value === "string" && SECRET_VALUE_RE.test(value)) return REDACTED_WIDGET_VALUE;
+  return value;
+}

--- a/web/js/lib/widget-secret-redaction.js
+++ b/web/js/lib/widget-secret-redaction.js
@@ -5,29 +5,88 @@
 export const REDACTED_WIDGET_VALUE = "[REDACTED]";
 
 const SENSITIVE_WIDGET_NAME_RE =
-  /(?:^|_)(?:api_key|apikey|access_token|refresh_token|auth_token|authentication_token|authorization|bearer|token|secret|password|passwd)$/;
+  /(?:^|_)(?:credentials?|secret(?:_keys?)?|private_keys?|api_keys?|apikeys?|access_token|refresh_token|auth_token|authentication_token|authorization|bearer|password|passwd|client_secrets?)(?:_|$)/;
+const TOKEN_WIDGET_NAME_RE = /(?:^|_)tokens?(?:$|_(?:value|values|string|header|headers))/;
 
 // Value-based coverage is intentionally limited to formats that are useful to catch
 // without treating arbitrary prose as a credential. The field-name checks above cover
 // provider-specific API-key widgets; these patterns catch an unhelpfully named field.
-const SECRET_VALUE_RE = /(?:^|[\s"'=:`])(?:sk-[A-Za-z0-9][A-Za-z0-9._-]{15,}|bearer\s+[A-Za-z0-9._~+/=-]{16,})/i;
+const SECRET_VALUE_RE =
+  /(?:^|[\s"'=:`])(?:sk-[A-Za-z0-9][A-Za-z0-9._-]{15,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{16,}|AIza[0-9A-Za-z_-]{20,}|bearer\s+[A-Za-z0-9._~+/=-]{16,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})/i;
 
 function normalizeWidgetName(name) {
   return String(name ?? "")
-    .replace(/([a-z])([A-Z])/g, "$1_$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
     .trim()
-    .replace(/[\s-]+/g, "_")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
     .toLowerCase();
+}
+
+function isSensitiveName(name) {
+  const normalized = normalizeWidgetName(name);
+  return SENSITIVE_WIDGET_NAME_RE.test(normalized) || TOKEN_WIDGET_NAME_RE.test(normalized);
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function redactSensitiveValue(value, seen) {
+  // Empty optional credential inputs are useful state and do not contain a secret.
+  if (value == null || value === "") return value;
+  if (Array.isArray(value) && value.length === 0) return value;
+  if (isPlainObject(value) && Object.keys(value).length === 0) return value;
+  if (Array.isArray(value) || isPlainObject(value)) return redactNestedValue(value, seen, true);
+  return REDACTED_WIDGET_VALUE;
+}
+
+function setEnumerable(out, key, value) {
+  // defineProperty keeps an attacker-controlled `__proto__` key as data.
+  Object.defineProperty(out, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+function redactNestedValue(value, seen, redactScalars = false) {
+  if (typeof value === "string") {
+    return redactScalars || SECRET_VALUE_RE.test(value) ? REDACTED_WIDGET_VALUE : value;
+  }
+  if (redactScalars && (typeof value === "number" || typeof value === "boolean")) {
+    return REDACTED_WIDGET_VALUE;
+  }
+  if (!Array.isArray(value) && !isPlainObject(value)) return value;
+  if (seen.has(value)) return seen.get(value);
+
+  const out = Array.isArray(value)
+    ? new Array(value.length)
+    : Object.create(Object.getPrototypeOf(value) === null ? null : Object.prototype);
+  seen.set(value, out);
+
+  let changed = false;
+  for (const key of Object.keys(value)) {
+    const original = value[key];
+    const next = isSensitiveName(key)
+      ? redactSensitiveValue(original, seen)
+      : redactNestedValue(original, seen, redactScalars);
+    if (next !== original) changed = true;
+    setEnumerable(out, key, next);
+  }
+  if (!changed) {
+    seen.set(value, value);
+    return value;
+  }
+  return out;
 }
 
 /** Return a safe agent-facing value without mutating the live widget. */
 export function redactWidgetValue(name, value) {
-  const normalizedName = normalizeWidgetName(name);
-  if (SENSITIVE_WIDGET_NAME_RE.test(normalizedName)) {
-    // Empty/null values carry no secret and preserving them avoids changing useful
-    // state information such as an unconfigured optional API-key input.
-    return value == null || value === "" ? value : REDACTED_WIDGET_VALUE;
-  }
-  if (typeof value === "string" && SECRET_VALUE_RE.test(value)) return REDACTED_WIDGET_VALUE;
-  return value;
+  if (isSensitiveName(name)) return redactSensitiveValue(value, new WeakMap());
+  if (typeof value === "string") return SECRET_VALUE_RE.test(value) ? REDACTED_WIDGET_VALUE : value;
+  return redactNestedValue(value, new WeakMap());
 }

--- a/web/js/lib/widget-secret-redaction.js
+++ b/web/js/lib/widget-secret-redaction.js
@@ -53,6 +53,25 @@ function setEnumerable(out, key, value) {
   });
 }
 
+function memoKey(redactScalars) {
+  return redactScalars ? "sensitive" : "ordinary";
+}
+
+function memoGet(seen, value, redactScalars) {
+  const entries = seen.get(value);
+  const key = memoKey(redactScalars);
+  return entries && Object.hasOwn(entries, key) ? entries[key] : undefined;
+}
+
+function memoSet(seen, value, redactScalars, result) {
+  let entries = seen.get(value);
+  if (!entries) {
+    entries = Object.create(null);
+    seen.set(value, entries);
+  }
+  entries[memoKey(redactScalars)] = result;
+}
+
 function redactNestedValue(value, seen, redactScalars = false) {
   if (typeof value === "string") {
     return redactScalars || SECRET_VALUE_RE.test(value) ? REDACTED_WIDGET_VALUE : value;
@@ -61,12 +80,16 @@ function redactNestedValue(value, seen, redactScalars = false) {
     return REDACTED_WIDGET_VALUE;
   }
   if (!Array.isArray(value) && !isPlainObject(value)) return value;
-  if (seen.has(value)) return seen.get(value);
+  const memoized = memoGet(seen, value, redactScalars);
+  if (memoized !== undefined) return memoized;
 
   const out = Array.isArray(value)
     ? new Array(value.length)
     : Object.create(Object.getPrototypeOf(value) === null ? null : Object.prototype);
-  seen.set(value, out);
+  // A shared object may be reached once through an ordinary key and once through
+  // a credential-like key. Keep a separate in-progress result for each context so
+  // the first traversal cannot satisfy the second with an unsanitized alias.
+  memoSet(seen, value, redactScalars, out);
 
   let changed = false;
   for (const key of Object.keys(value)) {
@@ -78,7 +101,7 @@ function redactNestedValue(value, seen, redactScalars = false) {
     setEnumerable(out, key, next);
   }
   if (!changed) {
-    seen.set(value, value);
+    memoSet(seen, value, redactScalars, value);
     return value;
   }
   return out;


### PR DESCRIPTION
## Summary

- Redact conventional credential widget names and unmistakable sk-... / Bearer ... values in agent-facing graph-read projections.
- Apply redaction to the direct panel_graph_outline renderer, structured node summaries, duplicate widget rows, and compact panel_query_graph rows.
- Preserve node count, bypass/mute mode, widget names, ordinary values, and graph connectivity.

## Verification

- 
pm.cmd run check:scope`n- 
pm.cmd run typecheck`n- 
pm.cmd run test:unit — 6717 passed, 1 todo
- Focused #1729 production-path and redaction tests — 4 passed after final fixture check

Fixes #1729