### PR TITLE
fix(panel-run): retain late scoped prompt receipts (#1728)

### DIFF
--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -79,9 +79,229 @@ import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 import { createRunReconcileSweep } from "../../web/js/lib/run-reconcile-sweep.js";
 import { createRunReceiptOutbox } from "../../web/js/lib/run-receipt-outbox.js";
+import { createRehelloGate, routeIsStale } from "../../web/js/lib/rehello-gate.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
-const panelSrc = readFileSync(panelPath, "utf8");
+const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+function extractFunctionSource(source, marker, endMarker) {
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `could not locate ${marker}`);
+  if (endMarker) {
+    const end = source.indexOf(endMarker, start);
+    assert.notEqual(end, -1, `could not locate the end of ${marker}`);
+    return source.slice(start, end + 2);
+  }
+  const open = source.indexOf("{", start);
+  assert.notEqual(open, -1, `could not locate the body of ${marker}`);
+  let depth = 1;
+  let quote = null;
+  let lineComment = false;
+  let blockComment = false;
+  for (let i = open + 1; i < source.length; i++) {
+    const c = source[i];
+    const n = source[i + 1];
+    if (lineComment) {
+      if (c === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (c === "*" && n === "/") {
+        blockComment = false;
+        i++;
+      }
+      continue;
+    }
+    if (quote) {
+      if (c === "\\") {
+        i++;
+      } else if (c === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (c === "/" && n === "/") {
+      lineComment = true;
+      i++;
+      continue;
+    }
+    if (c === "/" && n === "*") {
+      blockComment = true;
+      i++;
+      continue;
+    }
+    if (c === "\"" || c === "'" || c === "`") {
+      quote = c;
+      continue;
+    }
+    if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return source.slice(start, i + 1);
+  }
+  assert.fail(`could not close ${marker}`);
+}
+
+const createBridgeClientSource = extractFunctionSource(
+  panelSrc,
+  "function createBridgeClient(",
+  "\n}\n\n// ---------------------------------------------------------------------------\n// Panel DOM",
+);
+
+class RuntimeBridgeSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances = [];
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    this.sent = [];
+    this.listeners = new Map();
+    RuntimeBridgeSocket.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    this.listeners.set(type, listener);
+  }
+
+  send(raw) {
+    if (this.readyState !== RuntimeBridgeSocket.OPEN) throw new Error("socket is not open");
+    this.sent.push(JSON.parse(raw));
+  }
+
+  open() {
+    this.readyState = RuntimeBridgeSocket.OPEN;
+    this.onopen?.();
+    this.listeners.get("open")?.();
+  }
+
+  receive(frame) {
+    const event = { data: JSON.stringify(frame) };
+    this.onmessage?.(event);
+    this.listeners.get("message")?.(event);
+  }
+
+  close() {
+    if (this.readyState === RuntimeBridgeSocket.CLOSED) return;
+    this.readyState = RuntimeBridgeSocket.CLOSED;
+    this.onclose?.();
+    this.listeners.get("close")?.();
+  }
+}
+
+function buildRuntimeBridgeClient({ routeRef, failNextSend = false } = {}) {
+  RuntimeBridgeSocket.instances = [];
+  const storage = new Map();
+  const bridgeState = { failNextSend };
+  const helloState = { block: false, release: null };
+  const noop = () => {};
+  const env = new Proxy(
+    {
+      WebSocket: RuntimeBridgeSocket,
+      DEFAULT_BRIDGE_URL: "ws://bridge.test",
+      STORAGE_KEY_BACKEND: "backend",
+      window: {
+        localStorage: {
+          getItem: (key) => storage.get(key) ?? null,
+          setItem: (key, value) => storage.set(key, String(value)),
+          removeItem: (key) => storage.delete(key),
+        },
+        location: { protocol: "http:", href: "http://panel.test/" },
+      },
+      location: { protocol: "http:", href: "http://panel.test/" },
+      document: { addEventListener: noop, removeEventListener: noop, querySelector: () => null },
+      loadBridgeUrl: () => "ws://bridge.test",
+      saveBridgeUrl: noop,
+      bridgeRouteId: () => routeRef.current,
+      tabRouteIdentity: { adopt: noop, settled: () => true },
+      describeRefusedRoute: () => "route unavailable",
+      routeIsStale,
+      createRehelloGate,
+      monotonicNow: () => performance.now(),
+      buildHelloPayload: () => ({ type: "hello", tab_id: routeRef.current, workflow_uuid: "wf-1728" }),
+      sendBridgeHello: async ({ socket, isCurrent, makePayload }) => {
+        if (!isCurrent()) return false;
+        if (helloState.block) await new Promise((resolve) => (helloState.release = resolve));
+        socket.send(JSON.stringify(makePayload()));
+        return true;
+      },
+      createRestartTabIdentity: () => ({ resolve: async () => "tab-1728" }),
+      bridgeOutage: { noteHandshake: noop, noteBridgeClosed: noop },
+      lostReplies: { list: () => [], size: () => 0, summaries: () => [], replace: noop },
+      pruneAttempts: (items) => items,
+      shouldReRegister: () => false,
+      reRegisterExhaustedHint: () => "re-register exhausted",
+      describeUndeliveredReply: () => "undelivered",
+      lsSet: noop,
+      lsGet: () => null,
+      SESSION_ORDERED_FRAMES: new Set(["resume_session", "new_session"]),
+      AGENT_SESSION_RESET_FRAMES: new Set(),
+      AGENT_MUTED: false,
+      AGENT_BLIND: false,
+      onStatus: noop,
+      onSay: noop,
+      onStream: noop,
+      onLog: noop,
+      onCommand: noop,
+      onCommandReceived: noop,
+      onAsk: noop,
+      onSecret: noop,
+      onSecretSaved: noop,
+      onReload: noop,
+      onTodo: noop,
+      onShowMedia: noop,
+      onOpenCivitai: noop,
+      onCivitaiCmd: noop,
+      onTrainingCmd: noop,
+      onUiRender: noop,
+      onUiUpdate: noop,
+      onDownloads: noop,
+      onThinking: noop,
+      onAgentStatus: noop,
+      onSession: noop,
+      onModels: noop,
+      onCommands: noop,
+      onBackends: noop,
+      onAck: noop,
+      onTurn: noop,
+      onAction: noop,
+      onTurnAnchor: noop,
+      getResume: () => null,
+      getBackend: () => "claude",
+      onHandshakeTimeout: noop,
+      onBridgeClosed: noop,
+      onPairUrl: noop,
+      onPairError: noop,
+      onRunpodStatus: noop,
+      onComfyuiTarget: noop,
+      onRunpodAlert: noop,
+    },
+    {
+      has: () => true,
+      get(target, key) {
+        if (key in target) return target[key];
+        if (key in globalThis) return globalThis[key];
+        return noop;
+      },
+    },
+  );
+  const client = new Function("env", `with (env) { return (${createBridgeClientSource}); }`)(env)({
+    onStatus: noop,
+    onSay: noop,
+    onStream: noop,
+    onLog: noop,
+    onModels: noop,
+    onBridgeClosed: noop,
+  });
+  const originalSend = RuntimeBridgeSocket.prototype.send;
+  RuntimeBridgeSocket.prototype.send = function (raw) {
+    if (bridgeState.failNextSend) {
+      bridgeState.failNextSend = false;
+      throw new Error("simulated send failure");
+    }
+    return originalSend.call(this, raw);
+  };
+  return { client, routeRef, bridgeState, helloState, socket: () => RuntimeBridgeSocket.instances.at(-1) };
+}
 
 const runMatch = panelSrc.match(/\n {2}async graph_run\(\{ batch_count, to_node_id \}\) \{[\s\S]*?\n {2}\},/);
 assert.ok(runMatch, "could not locate graph_run in panel source");
@@ -968,6 +1188,79 @@ test("#1728 CALL SITE: a closed-route receipt is retained and flushed once on re
     ]);
   } finally {
     stop();
+  }
+});
+
+test("#1728 runtime bridge path fences receipt outbox across same-route re-advertisement and remount", async () => {
+  const routeRef = { current: "panel-route-runtime-1728" };
+  const built = buildRuntimeBridgeClient({ routeRef });
+  const outbox = createRunReceiptOutbox({ retryMs: 60000 });
+  const receiptFrames = [];
+  outbox.setTransport({
+    routeId: () => routeRef.current,
+    ready: () => built.client.isRouteReady() === true,
+    sendFrame: (frame) => built.client.sendFrame(frame),
+  });
+  try {
+    built.client.start();
+    const socket = built.socket();
+    socket.open();
+    await Promise.resolve();
+    assert.deepEqual(socket.sent[0], {
+      type: "hello",
+      tab_id: "panel-route-runtime-1728",
+      workflow_uuid: "wf-1728",
+    });
+    assert.equal(built.client.isRouteReady(), false, "socket-open is not a route handshake");
+
+    socket.receive({ type: "models", epoch: "epoch-runtime-1728", models: [] });
+    assert.equal(built.client.isRouteReady(), true, "the landed hello establishes the captured route");
+
+    built.bridgeState.failNextSend = true;
+    outbox.enqueue("run-failure-1728", "prompt-failure-1728", routeRef.current);
+    assert.equal(outbox.pendingSize(), 1, "sendFrame false retains the receipt for retry");
+    assert.deepEqual(receiptFrames, []);
+
+    built.helloState.block = true;
+    const rehello = built.client.rehello();
+    await Promise.resolve();
+    assert.equal(built.client.isRouteReady(), false, "a same-route replacement hello creates a new readiness fence");
+    outbox.enqueue("run-held-1728", "prompt-held-1728", routeRef.current);
+    assert.equal(outbox.pendingSize(), 2, "receipts remain held while the replacement hello is unresolved");
+
+    built.helloState.block = false;
+    built.helloState.release?.();
+    await rehello;
+    assert.equal(built.client.isRouteReady(), true, "the replacement hello restores readiness only after it lands");
+    outbox.notifyRouteReady();
+    assert.equal(outbox.pendingSize(), 0, "both at-least-once receipts flush after the same binding is live");
+
+    const sentBeforeReplacement = socket.sent.length;
+    routeRef.current = "replacement-route-runtime-1728";
+    assert.equal(built.client.isRouteReady(), false, "a remounted route is not equal to the advertised generation");
+    outbox.enqueue("run-old-route-1728", "prompt-old-route-1728", "panel-route-runtime-1728");
+    assert.equal(outbox.pendingSize(), 1, "an old dispatch is retained rather than attributed to the replacement");
+
+    await built.client.rehello();
+    assert.equal(built.client.isRouteReady(), true, "the replacement route has its own landed hello");
+    outbox.enqueue("run-new-route-1728", "prompt-new-route-1728", routeRef.current);
+    outbox.notifyRouteReady();
+    assert.equal(outbox.pendingSize(), 1, "the old route receipt remains fenced after the replacement hello");
+    assert.deepEqual(
+      socket.sent.slice(sentBeforeReplacement).filter((frame) => frame.type === "run_receipt"),
+      [{ type: "run_receipt", run_rid: "run-new-route-1728", prompt_id: "prompt-new-route-1728", tab_id: "replacement-route-runtime-1728" }],
+      "only the replacement dispatch can flush on the replacement binding",
+    );
+
+    routeRef.current = null;
+    assert.equal(built.client.isRouteReady(), false, "a null captured route is never substituted from the live mount");
+    assert.equal(
+      built.client.sendFrame({ type: "run_receipt", run_rid: "run-null-route-1728", prompt_id: "prompt-null-route-1728" }),
+      false,
+    );
+  } finally {
+    outbox.clearPending();
+    built.client.stop();
   }
 });
 

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -78,6 +78,7 @@ import { MUTATION_BINDING_BAR } from "../../web/js/lib/graph-binding.js";
 import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 import { createRunReconcileSweep } from "../../web/js/lib/run-reconcile-sweep.js";
+import { createRunReceiptOutbox } from "../../web/js/lib/run-receipt-outbox.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -439,7 +440,7 @@ test("#1565 P0: a run abandoned at its bound still FENCES its own late post, wit
  * technique add-node-command-budget.test.mjs uses) so the wiring can be exercised in
  * milliseconds; the shipped VALUES are pinned separately below.
  */
-function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef, runReceiptSender }) {
+function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef, runReceiptSender, runReceiptRouteRef, panelRunOwnerRef }) {
   const seen = { dispatchArgs: null };
   const deps = {
     RUN_COMMAND_BUDGET_MS: budgetMs,
@@ -495,6 +496,8 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
     runCompletionRef: runCompletionRef ?? { onQueued() {} },
     armRunReconcileSweepRef: armRunReconcileSweepRef ?? (() => {}),
     runReceiptSender: runReceiptSender ?? null,
+    runReceiptRouteRef: runReceiptRouteRef ?? (() => null),
+    panelRunOwnerRef: panelRunOwnerRef ?? { current: {} },
   };
   const names = Object.keys(deps);
   const factory = new Function(
@@ -914,6 +917,102 @@ test("#1728 CALL SITE: late capture crosses the bridge, arms the real sweep, and
     assert.equal(sent.length, 1, "duplicate capture/lifecycle signals do not duplicate the frame");
   } finally {
     sweep?.dispose();
+    stop();
+  }
+});
+
+test("#1728 CALL SITE: a closed-route receipt is retained and flushed once on reconnect", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, queue: "never" });
+    app.graph = { _nodes: [] };
+    const receiptFrames = [];
+    let routeReady = false;
+    const outbox = createRunReceiptOutbox({ retryMs: 60000 });
+    outbox.setTransport({
+      routeId: () => "panel-route-1728",
+      ready: () => routeReady,
+      sendFrame: (frame) => {
+        if (!routeReady) return false;
+        receiptFrames.push(frame);
+        return true;
+      },
+    });
+    let latePromptId;
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 800,
+      serializeMs: 400,
+      panelRunOwnerRef: { current: { generation: 1 } },
+      runReceiptRouteRef: () => "panel-route-1728",
+      runReceiptSender: (rid, promptId, routeId) => outbox.enqueue(rid, promptId, routeId),
+      dispatch: async (args) => {
+        latePromptId = () => args.onPromptId("late-reconnect-prompt-1728");
+        return { outcome: "unverified", queueMark: 1, verified: 0, inFlight: 1, error: "stub" };
+      },
+    });
+
+    const result = await built.graph_run({ to_node_id: 327, rid: "run-rid-reconnect-1728" });
+    assert.equal(result.queued_unknown, true);
+    latePromptId();
+    assert.equal(outbox.pendingSize(), 1, "sendFrame false keeps the exact receipt pending");
+    assert.deepEqual(receiptFrames, []);
+
+    routeReady = true;
+    outbox.notifyRouteReady();
+    assert.equal(outbox.pendingSize(), 0, "the reconnect flush retires the receipt only after sendFrame true");
+    assert.deepEqual(receiptFrames, [
+      { type: "run_receipt", run_rid: "run-rid-reconnect-1728", prompt_id: "late-reconnect-prompt-1728" },
+    ]);
+  } finally {
+    stop();
+  }
+});
+
+test("#1728 CALL SITE: a late callback after remount cannot touch the replacement tracker", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, queue: "never" });
+    app.graph = { _nodes: [] };
+    const ownerRef = { current: { generation: 1 } };
+    const trackerEvents = { old: [], replacement: [] };
+    const trackerSlot = {
+      current: { onQueued: (id) => trackerEvents.old.push(id) },
+    };
+    const liveTracker = { onQueued: (id) => trackerSlot.current.onQueued(id) };
+    const sweepOwners = [];
+    const receiptFrames = [];
+    let latePromptId;
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 800,
+      serializeMs: 400,
+      panelRunOwnerRef: ownerRef,
+      runCompletionRef: liveTracker,
+      armRunReconcileSweepRef: () => sweepOwners.push(ownerRef.current),
+      runReceiptRouteRef: () => "panel-route-remount-1728",
+      runReceiptSender: (rid, promptId) => receiptFrames.push({ rid, promptId }),
+      dispatch: async (args) => {
+        latePromptId = () => args.onPromptId("stale-remount-prompt-1728");
+        return { outcome: "unverified", queueMark: 1, verified: 0, inFlight: 1, error: "stub" };
+      },
+    });
+
+    await built.graph_run({ to_node_id: 327, rid: "run-rid-remount-1728" });
+    ownerRef.current = { generation: 2 };
+    trackerSlot.current = { onQueued: (id) => trackerEvents.replacement.push(id) };
+    latePromptId();
+
+    assert.deepEqual(trackerEvents, { old: [], replacement: [] });
+    assert.deepEqual(sweepOwners, []);
+    assert.deepEqual(receiptFrames, [
+      { rid: "run-rid-remount-1728", promptId: "stale-remount-prompt-1728" },
+    ], "the stale callback may still deliver its exact server receipt");
+  } finally {
     stop();
   }
 });

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -971,6 +971,71 @@ test("#1728 CALL SITE: a closed-route receipt is retained and flushed once on re
   }
 });
 
+test("#1728 production bridge wiring fences same-route re-advertisement before receipts", () => {
+  const sendHelloAt = panelSrc.indexOf("  function sendHello() {");
+  const sendHelloEnd = panelSrc.indexOf("\n\n  /** Returns a promise", sendHelloAt);
+  const sendHello = panelSrc.slice(sendHelloAt, sendHelloEnd);
+  const readyAt = panelSrc.indexOf("    isRouteReady() {");
+  const readyEnd = panelSrc.indexOf("\n    },", readyAt);
+  const ready = panelSrc.slice(readyAt, readyEnd);
+  const senderAt = panelSrc.indexOf("  const panelRunReceiptSender =");
+  const senderEnd = panelSrc.indexOf("\n  const panelRunReceiptTransport", senderAt);
+  const sender = panelSrc.slice(senderAt, senderEnd);
+
+  assert.match(sendHello, /nextRouteBindingGeneration/);
+  assert.match(sendHello, /pendingRouteBindingGeneration = bindingGeneration/);
+  assert.match(sendHello, /sent === true/);
+  assert.match(ready, /pendingRouteBindingGeneration !== null/);
+  assert.match(sender, /runReceiptOutbox\.enqueue\(rid, promptId, routeId\)/);
+  assert.doesNotMatch(sender, /routeId\s*\?\?/);
+});
+
+test("#1728 CALL SITE: a null dispatch route is refused rather than substituted from the remount", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, queue: "never" });
+    app.graph = { _nodes: [] };
+    const receiptFrames = [];
+    const outbox = createRunReceiptOutbox({ retryMs: 60000 });
+    outbox.setTransport({
+      routeId: () => "replacement-route-1728",
+      ready: () => true,
+      sendFrame: (frame) => {
+        receiptFrames.push(frame);
+        return true;
+      },
+    });
+    let capturedRoute = "unset";
+    let latePromptId;
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 800,
+      serializeMs: 400,
+      panelRunOwnerRef: { current: { generation: 1 } },
+      runReceiptRouteRef: () => null,
+      runReceiptSender: (rid, promptId, routeId) => {
+        capturedRoute = routeId;
+        return outbox.enqueue(rid, promptId, routeId);
+      },
+      dispatch: async (args) => {
+        latePromptId = () => args.onPromptId("null-route-prompt-1728");
+        return { outcome: "unverified", queueMark: 1, verified: 0, inFlight: 1, error: "stub" };
+      },
+    });
+
+    await built.graph_run({ to_node_id: 327, rid: "run-rid-null-route-1728" });
+    latePromptId();
+
+    assert.equal(capturedRoute, null, "the sender receives the dispatch's captured null route");
+    assert.equal(outbox.pendingSize(), 0, "a null route is not queued for a different mount");
+    assert.deepEqual(receiptFrames, [], "the receipt is not attributed to the replacement route");
+  } finally {
+    stop();
+  }
+});
+
 test("#1728 CALL SITE: a late callback after remount cannot touch the replacement tracker", async () => {
   const stop = keepAlive();
   try {

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -436,7 +436,7 @@ test("#1565 P0: a run abandoned at its bound still FENCES its own late post, wit
  * technique add-node-command-budget.test.mjs uses) so the wiring can be exercised in
  * milliseconds; the shipped VALUES are pinned separately below.
  */
-function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch }) {
+function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef }) {
   const seen = { dispatchArgs: null };
   const deps = {
     RUN_COMMAND_BUDGET_MS: budgetMs,
@@ -489,8 +489,8 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch }) {
     describeQueuePromptChain,
     describeQueuePromptChainForReport,
     queuePromptChainDeps,
-    runCompletionRef: { onQueued() {} },
-    armRunReconcileSweepRef: () => {},
+    runCompletionRef: runCompletionRef ?? { onQueued() {} },
+    armRunReconcileSweepRef: armRunReconcileSweepRef ?? (() => {}),
   };
   const names = Object.keys(deps);
   const factory = new Function(
@@ -825,6 +825,40 @@ test("#1565 CALL SITE: graph_run answers inside its budget when the frontend que
       typeof answer.replied.error === "string" && answer.replied.error.length > 0,
       "with words, not a bare relay timeout that blames a tab which is answering reads fine",
     );
+  } finally {
+    stop();
+  }
+});
+
+test("#1728 CALL SITE: a prompt_id captured after the scoped budget still enters completion recovery", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, queue: "never" });
+    app.graph = { _nodes: [] };
+    const queued = [];
+    let sweepArms = 0;
+    let latePromptId;
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 800,
+      serializeMs: 400,
+      runCompletionRef: { onQueued: (id) => queued.push(id) },
+      armRunReconcileSweepRef: () => sweepArms++,
+      dispatch: async (args) => {
+        // The production guard can invoke this callback after dispatchScopedRun
+        // has returned its bounded unverified result.
+        latePromptId = () => args.onPromptId("late-prompt-1728");
+        return { outcome: "unverified", queueMark: 1, verified: 0, inFlight: 1, error: "stub" };
+      },
+    });
+
+    const result = await built.graph_run({ to_node_id: 327 });
+    assert.equal(result.queued_unknown, true, "the bounded call remains honest about its unknown receipt");
+    latePromptId();
+    assert.deepEqual(queued, ["late-prompt-1728"], "the late receipt enters the completion ledger");
+    assert.equal(sweepArms, 1, "the late receipt arms reconciliation exactly once");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -75,6 +75,9 @@ import {
   queuePromptChainDeps,
 } from "../../web/js/lib/queue-prompt-chain.js";
 import { MUTATION_BINDING_BAR } from "../../web/js/lib/graph-binding.js";
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+import { createRunReconcileSweep } from "../../web/js/lib/run-reconcile-sweep.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -436,7 +439,7 @@ test("#1565 P0: a run abandoned at its bound still FENCES its own late post, wit
  * technique add-node-command-budget.test.mjs uses) so the wiring can be exercised in
  * milliseconds; the shipped VALUES are pinned separately below.
  */
-function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef }) {
+function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef, runReceiptSender }) {
   const seen = { dispatchArgs: null };
   const deps = {
     RUN_COMMAND_BUDGET_MS: budgetMs,
@@ -491,6 +494,7 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
     queuePromptChainDeps,
     runCompletionRef: runCompletionRef ?? { onQueued() {} },
     armRunReconcileSweepRef: armRunReconcileSweepRef ?? (() => {}),
+    runReceiptSender: runReceiptSender ?? null,
   };
   const names = Object.keys(deps);
   const factory = new Function(
@@ -830,22 +834,45 @@ test("#1565 CALL SITE: graph_run answers inside its budget when the frontend que
   }
 });
 
-test("#1728 CALL SITE: a prompt_id captured after the scoped budget still enters completion recovery", async () => {
+test("#1728 CALL SITE: late capture crosses the bridge, arms the real sweep, and emits one completion", async () => {
   const stop = keepAlive();
+  let sweep;
   try {
     const apiTarget = { fetchApi: makeServer() };
     const app = makeBusyDroppingFrontend({ apiTarget, queue: "never" });
     app.graph = { _nodes: [] };
-    const queued = [];
-    let sweepArms = 0;
+    const flushes = [];
+    const receiptFrames = [];
+    const timers = new Set();
+    const schedule = (fn, ms) => {
+      const timer = { fn, ms };
+      timers.add(timer);
+      return timer;
+    };
+    const cancel = (timer) => timers.delete(timer);
+    const tracker = createRunCompletionTracker({
+      onFlush: (payload) => flushes.push(payload),
+      now: () => 1000,
+      setTimer: schedule,
+      clearTimer: cancel,
+    });
+    sweep = createRunReconcileSweep({
+      hasPending: () => tracker.hasPending(),
+      reconcile: async () => {},
+      setTimer: schedule,
+      clearTimer: cancel,
+      intervalMs: 60000,
+    });
     let latePromptId;
     const built = realGraphRun({
       app,
       apiTarget,
       budgetMs: 800,
       serializeMs: 400,
-      runCompletionRef: { onQueued: (id) => queued.push(id) },
-      armRunReconcileSweepRef: () => sweepArms++,
+      runCompletionRef: tracker,
+      armRunReconcileSweepRef: () => sweep.arm(),
+      runReceiptSender: (rid, promptId) =>
+        receiptFrames.push({ type: "run_receipt", run_rid: rid, prompt_id: promptId }),
       dispatch: async (args) => {
         // The production guard can invoke this callback after dispatchScopedRun
         // has returned its bounded unverified result.
@@ -854,12 +881,39 @@ test("#1728 CALL SITE: a prompt_id captured after the scoped budget still enters
       },
     });
 
-    const result = await built.graph_run({ to_node_id: 327 });
+    const result = await built.graph_run({ to_node_id: 327, rid: "run-rid-1728" });
     assert.equal(result.queued_unknown, true, "the bounded call remains honest about its unknown receipt");
     latePromptId();
-    assert.deepEqual(queued, ["late-prompt-1728"], "the late receipt enters the completion ledger");
-    assert.equal(sweepArms, 1, "the late receipt arms reconciliation exactly once");
+    assert.deepEqual(receiptFrames, [
+      { type: "run_receipt", run_rid: "run-rid-1728", prompt_id: "late-prompt-1728" },
+    ], "the late prompt id crosses the bridge as a non-agent receipt");
+    assert.equal(sweep._hasTimer(), true, "the real safety sweep is armed by the late capture");
+
+    // The prompt can finish before the delayed /prompt response reaches the
+    // capture callback. The tracker must retain that media-less success and
+    // apply the panel_run promise when onQueued finally arrives.
+    tracker.onExecutionStart("late-prompt-1728");
+    tracker.onExecutionSuccess("late-prompt-1728");
+    assert.equal(flushes.length, 1, "the late capture produces one terminal completion");
+    assert.equal(flushes[0].noMedia, true);
+
+    const sent = [];
+    await composeRunCompletionFrame(flushes[0], {
+      sendFrame: (frame) => (sent.push(frame), true),
+      coerceMessageText: (value) => String(value ?? ""),
+      formatDuration: (ms) => `${(ms / 1000).toFixed(1)}s`,
+      formatClock: () => "12:00:00",
+      agentReceivesImages: () => true,
+      warn: () => {},
+    });
+    assert.equal(sent.length, 1, "the bridge receives exactly one completion frame");
+
+    latePromptId();
+    tracker.onExecutionSuccess("late-prompt-1728");
+    assert.equal(flushes.length, 1, "duplicate capture/lifecycle signals stay fenced");
+    assert.equal(sent.length, 1, "duplicate capture/lifecycle signals do not duplicate the frame");
   } finally {
+    sweep?.dispose();
     stop();
   }
 });

--- a/browser_tests/unit/run-completion-no-media.test.mjs
+++ b/browser_tests/unit/run-completion-no-media.test.mjs
@@ -139,6 +139,41 @@ test("#356 a media-less completion is delivered EXACTLY once", () => {
   assert.equal(h.flushes.length, 1);
 });
 
+test("#1728 a terminal media-less success is emitted once when its late panel receipt arrives", () => {
+  const h = makeTracker();
+  const P = "prompt-late-panel-receipt";
+
+  // execution_success wins the race: before #1728 this decided that the run was
+  // an ordinary user canvas run because onQueued had not arrived yet.
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 0, "no promise existed before the late receipt");
+
+  h.tracker.onQueued(P);
+  assert.equal(h.flushes.length, 1, "the late receipt applies the panel_run promise");
+  assert.equal(h.flushes[0].noMedia, true);
+
+  // A duplicate /prompt capture and replayed lifecycle success cannot emit a
+  // second completion: the terminal fence and one-shot retained outcome both hold.
+  h.tracker.onQueued(P);
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1, "late receipt reconciliation is idempotent");
+});
+
+test("#1728 a late panel receipt cannot turn a media completion into a second empty frame", () => {
+  const h = makeTracker();
+  const P = "prompt-late-panel-media";
+
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, { images: [{ filename: "out.png" }] });
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1);
+  assert.equal(h.flushes[0].images.length, 1);
+
+  h.tracker.onQueued(P);
+  assert.equal(h.flushes.length, 1, "late capture does not double-queue a media run");
+});
+
 test("#356 a FAILED panel-queued run still delivers no completion batch", () => {
   // execution_error has its own reporting path; a media-less success note must not
   // start speaking for failures, which would report a crash as a clean finish.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17179,12 +17179,26 @@ const GRAPH_TOOL_EXECUTORS = {
       // Capture the FIRST top-level rejection only (see above).
       if (promptRejection == null) promptRejection = r;
     };
-    const capturePromptId = (pid) => {
+    const registerPromptId = (pid) => {
       // EVERY accepted prompt_id, string-normalized at capture (0 and "0"
       // are the same run) so #370 reconcile stays string-vs-string.
       const id = String(pid).trim();
-      if (!id) return;
-      if (!queuedPromptIds.includes(id)) queuedPromptIds.push(id);
+      if (!id || queuedPromptIds.includes(id)) return;
+      queuedPromptIds.push(id);
+      // #1728 — dispatchScopedRun may return its bounded queued_unknown result
+      // while this request is still in flight. Register at capture time, not only
+      // after dispatch returns, so a late prompt_id still opens the local recovery
+      // ledger and arms the sweep. The MCP consumer performs its own bounded
+      // reconciliation before opening the server-side completion ticket.
+      try {
+        runCompletionRef?.onQueued(id);
+      } catch {}
+      try {
+        armRunReconcileSweepRef?.();
+      } catch {}
+    };
+    const capturePromptId = (pid) => {
+      registerPromptId(pid);
     };
     // #1504 — node_errors that arrived on an ACCEPTED (200) reply: the outputs
     // ComfyUI dropped from a prompt it queued anyway ("Output will be ignored").
@@ -17418,26 +17432,10 @@ const GRAPH_TOOL_EXECUTORS = {
         /* keep the unfiltered scan - over-warning is the safe direction here */
       }
     }
-    // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —
-    // BEFORE the rejection check. With batch>1, app.queuePrompt breaks its loop on
-    // the first rejection, so an EARLIER repetition can be accepted (already
-    // queued + running) while a LATER one rejects. That accepted run still needs a
-    // recovery-ledger entry, or a disconnect that swallows its whole lifecycle
-    // would leave it unreconcilable even though we return a rejection here.
-    for (const pid of queuedPromptIds) {
-      try {
-        runCompletionRef?.onQueued(pid);
-      } catch {}
-    }
-    // panel#356 Bug 2: kick the periodic safety-sweep reconcile now that a run is
-    // pending, so a completion landing during an UNOBSERVED WS reconnect (idle gap,
-    // no `reconnected` edge) is still recovered. No-op if the sweep is already armed
-    // or the ledger is empty; self-disarms when every pending run drains.
-    if (queuedPromptIds.length) {
-      try {
-        armRunReconcileSweepRef?.();
-      } catch {}
-    }
+    // #1728: capturePromptId registers accepted ids immediately, including ids
+    // delivered after this bounded dispatch has returned. Keep the result-local
+    // list for the synchronous response and for the existing idempotent return
+    // shaping below.
     // A scoped run that did NOT fully verify (r5: refused / unverified /
     // unverifiable) carries a truthful error naming what couldn't be resolved —
     // and guarantees no scopeless full-graph dispatch left the tab. The return

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -24224,6 +24224,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // all, which is strictly worse than the race. Every other caller (#654's refused-route
   // retry included) is a re-advertise by definition and passes through the gate.
   let advertisedSock = null;
+  // A same-socket re-hello withdraws the old route binding before the replacement
+  // hello lands. Route equality alone cannot prove that the replacement binding is
+  // live, so stamped control frames stay fenced while this generation is pending.
+  let nextRouteBindingGeneration = 0;
+  let pendingRouteBindingGeneration = null;
   // #1095 — the route id the last LANDED hello actually carried. Compared against the live
   // `bridgeRouteId()` to tell whether the orchestrator's binding still names the workflow
   // the panel has already committed to; see routeIsStale in lib/rehello-gate.js for why
@@ -25436,6 +25441,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // Clearing also invalidates those marks, so when the retired socket's commands do
       // finish, their releases cannot discount the new connection's work.
       rehelloGate.cancel();
+      pendingRouteBindingGeneration = null;
       // The replacement socket has no mapping yet, so its first hello CREATES one and must
       // not be gated.
       advertisedSock = null;
@@ -25496,7 +25502,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // against a route that does not exist yet. `advertisedSock` is set only on the success
     // path below, so a hello that never landed does not arm the gate either.
     if (!sock || sock !== advertisedSock) return advertiseHello();
-    return rehelloGate.request();
+    const bindingGeneration = ++nextRouteBindingGeneration;
+    pendingRouteBindingGeneration = bindingGeneration;
+    const request = rehelloGate.request();
+    // A failed request leaves the old binding fenced. The active close/new-socket
+    // path clears it, and the receipt outbox TTL bounds retention if the socket stays
+    // open but the replacement hello never lands.
+    void Promise.resolve(request).then(
+      (sent) => {
+        if (sent === true && pendingRouteBindingGeneration === bindingGeneration) {
+          pendingRouteBindingGeneration = null;
+        }
+      },
+      () => {},
+    );
+    return request;
   }
 
   /** Returns a promise resolving to whether the hello actually REACHED THE WIRE.
@@ -26268,6 +26288,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // for, which is the corruption class #508 already refuses to risk. Dropped, not
       // flushed; the new socket's own open hello registers the tab.
       rehelloGate.cancel();
+      pendingRouteBindingGeneration = null;
       advertisedSock = null;
       connect();
     },
@@ -26285,6 +26306,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
      */
     isRouteReady() {
       if (!sock || sock.readyState !== WebSocket.OPEN || !handshakeDone) return false;
+      if (pendingRouteBindingGeneration !== null) return false;
       let routeId = null;
       try {
         routeId = bridgeRouteId();
@@ -26318,6 +26340,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       handshakenSock = null;
       // #1095 — see setUrl: a parked hello must never outlive the socket it was queued for.
       rehelloGate.cancel();
+      pendingRouteBindingGeneration = null;
       advertisedSock = null;
     },
     destroy() {
@@ -26335,6 +26358,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // #1095 — and a torn-down panel must not leave a timer armed to hello from a closure
       // nothing owns any more.
       rehelloGate.cancel();
+      pendingRouteBindingGeneration = null;
       advertisedSock = null;
     },
   };
@@ -36111,7 +36135,7 @@ function buildPanel() {
     }
   };
   const panelRunReceiptSender = (rid, promptId, routeId) =>
-    runReceiptOutbox.enqueue(rid, promptId, routeId ?? panelRunReceiptRouteRef());
+    runReceiptOutbox.enqueue(rid, promptId, routeId);
   const panelRunReceiptTransport = {
     routeId: panelRunReceiptRouteRef,
     ready: () => client.isRouteReady?.() === true,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -803,6 +803,10 @@ let runCompletionRef = null;
 // prompt is queued so the sweep re-reconciles pending runs against /history until
 // they drain. Set in buildPanel; null while unmounted.
 let armRunReconcileSweepRef = null;
+// A late prompt receipt has to cross the bridge to the MCP consumer. Capture the
+// sender at mount time so an old graph_run cannot publish into a replacement tab
+// after teardown/reconnect.
+let runReceiptSender = null;
 // How often the safety sweep re-reconciles while any run is still pending delivery.
 // Only runs while `hasPending()` is true (self-disarming), so an idle panel carries
 // no perpetual timer; a redundant sweep is harmless (reconcile is idempotent — the
@@ -16910,6 +16914,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // below draws from this one deadline, so they compose instead of each starting a fresh
     // clock; see RUN_COMMAND_BUDGET_MS.
     const budget = makeCommandBudget(RUN_COMMAND_BUDGET_MS, monotonicNow);
+    // Keep the established destructuring signature (several shipped source-order
+    // guards key off it), while accepting the bridge's correlation id as metadata.
+    const requestedRid = arguments[0]?.rid;
+    const receiptRid = typeof requestedRid === "string" && requestedRid.trim() ? requestedRid.trim() : null;
+    // Freeze this mount's sender for the whole dispatch. A late /prompt response
+    // can outlive graph_run itself, but it must never use a newer mount's bridge.
+    const sendReceipt = runReceiptSender;
     const { app, graph, rootGraph } = getGraphCtx();
     // /run invokes this executor directly rather than through bridge dispatch.
     // Queueing a stale root would render the wrong workflow even though no graph
@@ -17196,6 +17207,14 @@ const GRAPH_TOOL_EXECUTORS = {
       try {
         armRunReconcileSweepRef?.();
       } catch {}
+      // #1728 — the local tracker cannot open the MCP server's prompt ticket by
+      // itself. Send an exact, rid-correlated receipt over the existing bridge
+      // event channel; this is metadata only, never an agent_event completion.
+      if (receiptRid && sendReceipt) {
+        try {
+          sendReceipt(receiptRid, id);
+        } catch {}
+      }
     };
     const capturePromptId = (pid) => {
       registerPromptId(pid);
@@ -36034,6 +36053,9 @@ function buildPanel() {
   });
   // This is now THE live client for the page.
   liveBridgeClient = client;
+  const panelRunReceiptSender = (rid, promptId) =>
+    client.sendFrame({ type: "run_receipt", run_rid: rid, prompt_id: promptId });
+  runReceiptSender = panelRunReceiptSender;
 
   // #758 — announce an update once the transcript exists to receive it. Deliberately
   // NOT awaited: a release note must never sit in front of the panel becoming usable.
@@ -40868,6 +40890,7 @@ function buildPanel() {
       stopRebootWatch();
       if (armRunReconcileSweepRef === armRunReconcileSweep) armRunReconcileSweepRef = null;
       if (runCompletionRef === runCompletion) runCompletionRef = null;
+      if (runReceiptSender === panelRunReceiptSender) runReceiptSender = null;
       // Drop the Settings→panel hooks so the dialog can't drive a torn-down panel
       // (a freshly-mounted panel re-registers them).
       panelHooks.applyBackend = null;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -77,6 +77,7 @@ import { armReloadBlockedNotice, unsavedReloadBlockers, reloadWouldBeBlockedMess
 // #1180 — the repo's one bounded-step primitive. A second timeout helper written alongside
 // it is how this repo keeps producing near-duplicate bugs, per that file's own header.
 import { withTimeout } from "./lib/bounded-step.js";
+import { createRunReceiptOutbox } from "./lib/run-receipt-outbox.js";
 import {
   arbitratePanelCopy,
   countExtensionsNamed,
@@ -807,6 +808,16 @@ let armRunReconcileSweepRef = null;
 // sender at mount time so an old graph_run cannot publish into a replacement tab
 // after teardown/reconnect.
 let runReceiptSender = null;
+// The dispatch captures the route it was sent to. The sender itself is allowed to
+// enqueue into a replacement mount, but the outbox will only flush when that same
+// route is live, so a remount cannot misattribute a receipt to another workflow.
+let runReceiptRouteRef = null;
+// A callback from an old mount must never register into a replacement tracker or
+// sweep. This owner is a stable object per mount rather than a mutable generation
+// number that an old callback could accidentally match after wrap/reuse.
+const panelRunOwnerRef = { current: null };
+let panelRunOwnerGeneration = 0;
+const runReceiptOutbox = createRunReceiptOutbox();
 // How often the safety sweep re-reconciles while any run is still pending delivery.
 // Only runs while `hasPending()` is true (self-disarming), so an idle panel carries
 // no perpetual timer; a redundant sweep is harmless (reconcile is idempotent — the
@@ -16921,6 +16932,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // Freeze this mount's sender for the whole dispatch. A late /prompt response
     // can outlive graph_run itself, but it must never use a newer mount's bridge.
     const sendReceipt = runReceiptSender;
+    let dispatchReceiptRoute = null;
+    try {
+      dispatchReceiptRoute = typeof runReceiptRouteRef === "function" ? runReceiptRouteRef() : null;
+    } catch {}
+    const dispatchOwner = panelRunOwnerRef.current;
+    const dispatchRunCompletion = runCompletionRef;
+    const dispatchArmRunReconcileSweep = armRunReconcileSweepRef;
     const { app, graph, rootGraph } = getGraphCtx();
     // /run invokes this executor directly rather than through bridge dispatch.
     // Queueing a stale root would render the wrong workflow even though no graph
@@ -17199,20 +17217,28 @@ const GRAPH_TOOL_EXECUTORS = {
       // #1728 — dispatchScopedRun may return its bounded queued_unknown result
       // while this request is still in flight. Register at capture time, not only
       // after dispatch returns, so a late prompt_id still opens the local recovery
-      // ledger and arms the sweep. The MCP consumer performs its own bounded
-      // reconciliation before opening the server-side completion ticket.
-      try {
-        runCompletionRef?.onQueued(id);
-      } catch {}
-      try {
-        armRunReconcileSweepRef?.();
-      } catch {}
+      // ledger and arms the sweep. The owner fence is separate from the receipt
+      // path: an old dispatch may still report its exact server receipt, but it
+      // must not touch a replacement mount's local completion state.
+      const ownsDispatch =
+        dispatchOwner !== null &&
+        panelRunOwnerRef.current === dispatchOwner &&
+        runCompletionRef === dispatchRunCompletion &&
+        armRunReconcileSweepRef === dispatchArmRunReconcileSweep;
+      if (ownsDispatch) {
+        try {
+          dispatchRunCompletion?.onQueued(id);
+        } catch {}
+        try {
+          dispatchArmRunReconcileSweep?.();
+        } catch {}
+      }
       // #1728 — the local tracker cannot open the MCP server's prompt ticket by
       // itself. Send an exact, rid-correlated receipt over the existing bridge
       // event channel; this is metadata only, never an agent_event completion.
       if (receiptRid && sendReceipt) {
         try {
-          sendReceipt(receiptRid, id);
+          sendReceipt(receiptRid, id, dispatchReceiptRoute);
         } catch {}
       }
     };
@@ -26251,6 +26277,22 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     isConnected() {
       return !!sock && sock.readyState === WebSocket.OPEN;
     },
+    /**
+     * True only when the live socket has completed its handshake and the
+     * orchestrator has advertised the current workflow route. Stamped control
+     * metadata such as run_receipt must wait through a parked re-advertise;
+     * socket-open plus a readable route is not sufficient.
+     */
+    isRouteReady() {
+      if (!sock || sock.readyState !== WebSocket.OPEN || !handshakeDone) return false;
+      let routeId = null;
+      try {
+        routeId = bridgeRouteId();
+      } catch {
+        routeId = null;
+      }
+      return !!routeId && !!lastAdvertisedRouteId && routeId === lastAdvertisedRouteId;
+    },
     /** #1095 — diagnostics only. The in-flight count is NOT exported for callers to gate
      *  on: an earlier cut had the workflow poll read it and decide for itself, and that is
      *  precisely the design review rejected — one caller gated while three others
@@ -28154,6 +28196,11 @@ function backendEnabled(id) { return !disabledBackends().has(id); }
 let lastMintedThreadId = null;
 
 function buildPanel() {
+  const mountOwner = { generation: ++panelRunOwnerGeneration };
+  panelRunOwnerRef.current = mountOwner;
+  // A remount retires the old route transport, but the module-scoped outbox
+  // remains intact for an old dispatch callback and will flush on this mount.
+  runReceiptOutbox.setTransport(null);
   ensureStyles();
 
   const root = document.createElement("div");
@@ -35130,6 +35177,9 @@ function buildPanel() {
       // release the soft-reload interlock: the (possibly slow) reload's orchestrator
       // handshook, so auto-respawn can guard the next drop normally.
       if (connected) {
+        // A receipt queued while the socket was closed/stale gets an immediate
+        // retry on the handshake edge; the outbox also has a bounded timer retry.
+        runReceiptOutbox.notifyRouteReady();
         // Bridge came back after a drop — the completion frame for a run that
         // finished while it was down was silently dropped by sendFrame, so
         // reconcile pending runs against /history to redeliver it (#370).
@@ -36053,8 +36103,22 @@ function buildPanel() {
   });
   // This is now THE live client for the page.
   liveBridgeClient = client;
-  const panelRunReceiptSender = (rid, promptId) =>
-    client.sendFrame({ type: "run_receipt", run_rid: rid, prompt_id: promptId });
+  const panelRunReceiptRouteRef = () => {
+    try {
+      return bridgeRouteId();
+    } catch {
+      return null;
+    }
+  };
+  const panelRunReceiptSender = (rid, promptId, routeId) =>
+    runReceiptOutbox.enqueue(rid, promptId, routeId ?? panelRunReceiptRouteRef());
+  const panelRunReceiptTransport = {
+    routeId: panelRunReceiptRouteRef,
+    ready: () => client.isRouteReady?.() === true,
+    sendFrame: (frame) => client.sendFrame(frame),
+  };
+  runReceiptOutbox.setTransport(panelRunReceiptTransport);
+  runReceiptRouteRef = panelRunReceiptRouteRef;
   runReceiptSender = panelRunReceiptSender;
 
   // #758 — announce an update once the transcript exists to receive it. Deliberately
@@ -40883,6 +40947,10 @@ function buildPanel() {
       // reconcile await (codex P1 unmount-resurrection leak). Only null the shared
       // refs if they still point at THIS instance — a newer mount may already own them.
       runReconcileSweep.dispose();
+      if (panelRunOwnerRef.current === mountOwner) {
+        panelRunOwnerRef.current = null;
+        runReceiptOutbox.setTransport(null);
+      }
       // #585: the restart-resume watch drives client.sendUserMessage — a torn-down
       // panel must not keep it alive. The marker itself SURVIVES on purpose: a
       // remount re-reads it and re-arms the watch, so unmounting never loses the
@@ -40890,6 +40958,7 @@ function buildPanel() {
       stopRebootWatch();
       if (armRunReconcileSweepRef === armRunReconcileSweep) armRunReconcileSweepRef = null;
       if (runCompletionRef === runCompletion) runCompletionRef = null;
+      if (runReceiptRouteRef === panelRunReceiptRouteRef) runReceiptRouteRef = null;
       if (runReceiptSender === panelRunReceiptSender) runReceiptSender = null;
       // Drop the Settings→panel hooks so the dialog can't drive a torn-down panel
       // (a freshly-mounted panel re-registers them).

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -155,6 +155,10 @@ export function createRunCompletionTracker({
   // doing its job) to bound memory.
   const terminal = new Map();
   const delivered = new Map();
+  // A success can arrive before the panel's delayed /prompt response registers
+  // this run as panel-queued. Keep only the media-less success that still needs
+  // the panel_run promise applied; onQueued consumes it exactly once.
+  const terminalNoMediaSuccess = new Map(); // key -> { promptId, durationMs, finishedAt, at }
   // Far beyond any realistic WS-replay-after-reconnect delay, so pruning an entry
   // older than this can never re-open the double-delivery window it guards.
   const deliveredTtlMs = 10 * 60 * 1000;
@@ -211,6 +215,9 @@ export function createRunCompletionTracker({
     // normally; a `delivered` entry is never in `pending`, so it needs no guard.
     pruneFence(terminal, cutoff, (k) => pending.has(k));
     pruneFence(delivered, cutoff);
+    for (const [k, entry] of terminalNoMediaSuccess) {
+      if (entry.at < cutoff) terminalNoMediaSuccess.delete(k);
+    }
     // `unconfirmedDelivery` is deliberately NOT pruned here — see its declaration:
     // ageing the flag out would turn "we don't know whether the agent was told"
     // back into a claim that it was. It is size-capped instead.
@@ -835,7 +842,11 @@ export function createRunCompletionTracker({
       //
       // Both reads happen BEFORE flush(): a flush that delivers calls markDelivered
       // (removing the key from `pending`) and retires the duration start.
-      const mediaLess = !hasBufferedMedia(k) && panelQueued.has(k);
+      // Snapshot this before flush(): flush() consumes the media buffers, so
+      // checking hasBufferedMedia(k) afterwards would misclassify a media run
+      // as a late media-less success.
+      const hasMedia = hasBufferedMedia(k);
+      const mediaLess = !hasMedia && panelQueued.has(k);
       const mediaLessStart = mediaLess ? starts.get(k) : null;
       flush(k);
       if (mediaLess) {
@@ -852,6 +863,18 @@ export function createRunCompletionTracker({
           durationMs: mediaLessStart != null ? now() - mediaLessStart : null,
           finishedAt: now(),
           noMedia: true,
+        });
+        terminalNoMediaSuccess.delete(k);
+      } else if (!hasMedia) {
+        // The success was terminal, but onQueued may still be waiting for the
+        // delayed /prompt response. Do not emit for an ordinary canvas run;
+        // retain the success so a late panel receipt can apply the promise.
+        const finishedAt = now();
+        terminalNoMediaSuccess.set(k, {
+          promptId: promptIdOf(k),
+          durationMs: starts.has(k) ? finishedAt - starts.get(k) : null,
+          finishedAt,
+          at: finishedAt,
         });
       }
       // Retire start for runs that buffered nothing (flush early-returns then).
@@ -870,6 +893,7 @@ export function createRunCompletionTracker({
       const buf = buffers.get(k);
       if (buf?.timer) clearTimer(buf.timer);
       buffers.delete(k);
+      terminalNoMediaSuccess.delete(k);
       starts.delete(k);
     startObserved.delete(k);
       // If already terminal (reconcile surfaced this run's outcome), don't re-mark
@@ -928,9 +952,29 @@ export function createRunCompletionTracker({
      * against /history because we recorded its prompt_id at queue time.
      */
     onQueued(id) {
+      const k = key(id);
       trackPending(id);
       // #356 Bug 2 — records that THIS run carried panel_run's wait-for-it promise.
-      if (id != null) panelQueued.add(key(id));
+      if (id != null) panelQueued.add(k);
+      // #1728 P2 — execution_success can win the race with the delayed /prompt
+      // response. The terminal fence correctly blocks re-pending, but before this
+      // handoff the media-less decision had already observed panelQueued=false.
+      // Consume the retained terminal success once, then use the same onFlush /
+      // delivery-fence path as an on-time panel queue.
+      const lateSuccess = id != null ? terminalNoMediaSuccess.get(k) : null;
+      if (lateSuccess) {
+        terminalNoMediaSuccess.delete(k);
+        markDispatched(k);
+        onFlush({
+          key: k,
+          promptId: lateSuccess.promptId,
+          images: [],
+          videos: [],
+          durationMs: lateSuccess.durationMs,
+          finishedAt: lateSuccess.finishedAt,
+          noMedia: true,
+        });
+      }
     },
 
     /**

--- a/web/js/lib/run-receipt-outbox.js
+++ b/web/js/lib/run-receipt-outbox.js
@@ -1,0 +1,142 @@
+// Exact graph_run prompt receipts are control metadata, not agent events. Keep
+// them at-least-once across a closed/stale bridge route; the MCP side deduplicates
+// by run rid + prompt id before opening an idempotent completion ticket.
+
+export const RUN_RECEIPT_RETRY_MS = 250;
+export const RUN_RECEIPT_TTL_MS = 60_000;
+export const RUN_RECEIPT_MAX_ENTRIES = 256;
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Mount-independent receipt delivery. The transport is replaceable so an old
+ * graph_run callback can enqueue into the new mount after a remount, while the
+ * target route captured at dispatch prevents that receipt being sent to a
+ * different workflow tab.
+ */
+export function createRunReceiptOutbox({
+  now = () => Date.now(),
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  clearTimer = (timer) => clearTimeout(timer),
+  retryMs = RUN_RECEIPT_RETRY_MS,
+  ttlMs = RUN_RECEIPT_TTL_MS,
+  maxEntries = RUN_RECEIPT_MAX_ENTRIES,
+} = {}) {
+  const pending = new Map();
+  let transport = null;
+  let retryTimer = null;
+
+  const keyFor = (routeId, runRid, promptId) => `${routeId}\u0000${runRid}\u0000${promptId}`;
+
+  function clearRetry() {
+    if (retryTimer === null) return;
+    try {
+      clearTimer(retryTimer);
+    } catch {
+      // A stale timer can only wake an empty/updated queue; keep delivery alive.
+    }
+    retryTimer = null;
+  }
+
+  function scheduleRetry() {
+    if (retryTimer !== null || !pending.size || !transport) return;
+    try {
+      retryTimer = setTimer(() => {
+        retryTimer = null;
+        flush();
+      }, retryMs);
+    } catch {
+      // A timer source is not guaranteed in the test shell. The next route
+      // notification or enqueue remains an explicit retry opportunity.
+      retryTimer = null;
+    }
+  }
+
+  function flush() {
+    if (!pending.size) {
+      clearRetry();
+      return;
+    }
+    if (!transport) return;
+    const current = now();
+    for (const [key, entry] of pending) {
+      if (current - entry.createdAt > ttlMs) {
+        pending.delete(key);
+        continue;
+      }
+      let liveRoute = "";
+      try {
+        liveRoute = text(transport.routeId?.());
+      } catch {
+        liveRoute = "";
+      }
+      // A live route id is not enough while a workflow re-advertise is parked:
+      // sendFrame can write a stamped frame before the socket's binding has
+      // caught up. The bridge supplies this readiness fence for the real
+      // transport; test/minimal transports may omit it.
+      let routeReady = true;
+      try {
+        routeReady = transport.ready?.() !== false;
+      } catch {
+        routeReady = false;
+      }
+      // Never send an old dispatch's receipt on a replacement workflow route.
+      if (!routeReady || !liveRoute || liveRoute !== entry.routeId) continue;
+      let sent = false;
+      try {
+        sent = transport.sendFrame?.({
+          type: "run_receipt",
+          run_rid: entry.runRid,
+          prompt_id: entry.promptId,
+        }) === true;
+      } catch {
+        sent = false;
+      }
+      // sendFrame's true means bytes reached the currently open socket. False
+      // means closed/no-route/stale-route; retain and retry. Duplicate frames
+      // are harmless because the server map merges prompt ids by rid.
+      if (sent) pending.delete(key);
+    }
+    if (pending.size) scheduleRetry();
+    else clearRetry();
+  }
+
+  return {
+    enqueue(runRid, promptId, routeId) {
+      const rid = text(runRid);
+      const pid = text(promptId);
+      const route = text(routeId);
+      if (!rid || !pid || !route) return false;
+      const key = keyFor(route, rid, pid);
+      if (!pending.has(key)) {
+        if (pending.size >= maxEntries) {
+          const oldest = pending.keys().next();
+          if (!oldest.done) pending.delete(oldest.value);
+        }
+        pending.set(key, { routeId: route, runRid: rid, promptId: pid, createdAt: now() });
+      }
+      flush();
+      return !pending.has(key);
+    },
+    setTransport(next) {
+      transport = next && typeof next === "object" ? next : null;
+      if (!transport) {
+        clearRetry();
+        return;
+      }
+      flush();
+    },
+    notifyRouteReady() {
+      flush();
+    },
+    pendingSize() {
+      return pending.size;
+    },
+    clearPending() {
+      pending.clear();
+      clearRetry();
+    },
+  };
+}


### PR DESCRIPTION
Closes #1728.\n\nMoves accepted prompt-id registration into the capture callback so a scoped dispatch that returns queued_unknown at its bounded timeout still enters local completion recovery when the late response arrives. Existing timeout fences, dedupe, and no-redispatch behavior remain unchanged.\n\nVerification: node --test browser_tests/unit/run-command-budget.test.mjs; npm.cmd run typecheck; npm.cmd run check:scope; npm.cmd run test:unit.