### PR TITLE
fix(1750): a slot may not name a link the graph does not have

### DIFF
--- a/browser_tests/unit/describe-command-i18n.test.mjs
+++ b/browser_tests/unit/describe-command-i18n.test.mjs
@@ -75,6 +75,36 @@ test("a number that is not a count never selects a plural form", () => {
   assert.equal(say("graph_screenshot", { width: 1024, height: 768 }), "Captured workflow image (1024×768)");
 });
 
+test("#1750 orphan repair renders a repair card and preserves its warning", () => {
+  __setCatalogForTest("en", {});
+  const warning =
+    'nothing was disconnected — the input carried link id 21, which the graph link store did not have. The panel cleared it.';
+  const card = describeCommand(
+    "graph_disconnect",
+    {},
+    {
+      ok: true,
+      result: {
+        cleared_orphan_link: { node_id: 79, input: "source_latent_b", link_id: 21 },
+        warning,
+      },
+    },
+  );
+
+  assert.equal(card.icon, "pi-exclamation-triangle");
+  assert.equal(card.text, "Cleared orphaned link 79.source_latent_b");
+  assert.equal(card.detail, warning);
+  assert.doesNotMatch(card.text, /undefined/);
+
+  const normal = describeCommand(
+    "graph_disconnect",
+    {},
+    { ok: true, result: { disconnected: { node_id: 79, input: "source_latent" } } },
+  );
+  assert.equal(normal.text, "Disconnected 79.source_latent");
+  assert.equal(normal.detail, undefined);
+});
+
 test("#1690: queued_unknown activity is uncertain, not blocked or duplicate-retry messaging", () => {
   __setCatalogForTest("en", {});
   const card = describeCommand("graph_run", {}, { ok: true, result: {

--- a/browser_tests/unit/disconnect-orphan-link.test.mjs
+++ b/browser_tests/unit/disconnect-orphan-link.test.mjs
@@ -57,6 +57,7 @@ import {
   clearStrandedInputLinks,
   verifyDisconnect,
 } from "../../web/js/lib/disconnect-verify.js";
+import { danglingInputLinks } from "../../web/js/lib/subgraph-conversion-integrity.js";
 
 const panelSrc = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -106,6 +107,7 @@ function buildDisconnect(graph) {
     "clearOrphanedInputLink",
     "clearStrandedInputLinks",
     "verifyDisconnect",
+    "danglingInputLinks",
     `return ({
 ${disconnectSrc}
 }).graph_disconnect;`,
@@ -120,6 +122,7 @@ ${disconnectSrc}
     clearOrphanedInputLink,
     clearStrandedInputLinks,
     verifyDisconnect,
+    danglingInputLinks,
   );
 }
 
@@ -224,6 +227,9 @@ test("#1750 orphaned slot: panel_disconnect CLEARS the reference instead of refu
   assert.equal(res.removed_link, undefined);
   assert.match(res.warning, /nothing was disconnected/i);
   assert.match(res.warning, /No link found in parent graph/);
+  // The ONLY orphan in this graph was the one cleared, so say exactly that.
+  assert.equal(res.remaining_orphan_links, undefined);
+  assert.match(res.warning, /No other input in this graph carries an orphaned link id/);
   // Repaired inside ONE undo envelope, so the "Undoable with Ctrl+Z" contract holds.
   assert.equal(graph.envelopes, 1);
   assert.equal(graph.closedEnvelopes, 1);
@@ -332,4 +338,94 @@ test("#1750 post-condition never covers for a disconnect that did NOT land", () 
   );
   assert.equal(node.inputs[1].link, 15, "the live wire was left alone");
   assert.ok(graph._links.has(15));
+});
+
+// ---------------------------------------------------------------------------
+// codex gate round 1, both P1
+// ---------------------------------------------------------------------------
+
+/**
+ * P1: clearing ONE orphan does not make a graph queueable. #1750's own workflow
+ * carried four (79 source_latent_b/source_image_b, 84/85 image_b), and a reply
+ * that says "queueable again" after the first sends the caller straight back
+ * into the same serializer refusal, with the same message, on a different slot.
+ */
+test("#1750 the reply reports what is STILL orphaned, and never claims queueable", () => {
+  const graph = mkGraph();
+  addNode(graph, 90, [], [{ name: "IMAGE", links: [] }]);
+  addNode(graph, 79, [
+    { name: "source_latent_b", link: 21 },
+    { name: "source_image_b", link: 20 },
+  ]);
+  addNode(graph, 84, [{ name: "image_b", link: 18 }]);
+  addNode(graph, 85, [{ name: "image_b", link: 19 }]);
+  const disconnect = buildDisconnect(graph);
+
+  const res = disconnect({ node_id: 79, input: "source_latent_b" });
+
+  assert.deepEqual(res.cleared_orphan_link, {
+    node_id: 79,
+    input: "source_latent_b",
+    link_id: 21,
+  });
+  assert.deepEqual(res.remaining_orphan_links, [
+    { node_id: 79, input: "source_image_b", link_id: 20 },
+    { node_id: 84, input: "image_b", link_id: 18 },
+    { node_id: 85, input: "image_b", link_id: 19 },
+  ]);
+  assert.match(res.warning, /3 other input\(s\) in this graph still carry an orphaned link id/);
+  assert.match(res.warning, /STILL refused/);
+  assert.doesNotMatch(res.warning, /queueable/);
+
+  // …and clearing the last one says so, rather than staying silent about it.
+  disconnect({ node_id: 79, input: "source_image_b" });
+  disconnect({ node_id: 84, input: "image_b" });
+  const last = disconnect({ node_id: 85, input: "image_b" });
+  assert.equal(last.remaining_orphan_links, undefined);
+  assert.match(last.warning, /No other input in this graph carries an orphaned link id/);
+});
+
+/**
+ * P1: `afterChange()` closes the undo transaction. If it throws, the slot write
+ * still landed but the undo step may never have been recorded — so the reply may
+ * report the repair and may NOT promise Ctrl+Z.
+ */
+test("#1750 a throwing afterChange costs the Ctrl+Z promise, not the repair", () => {
+  const { graph } = orphanedGraph();
+  graph.afterChange = () => {
+    graph.closedEnvelopes += 1;
+    throw new Error("change tracker exploded");
+  };
+  const disconnect = buildDisconnect(graph);
+  const node = graph.getNodeById(79);
+
+  const res = disconnect({ node_id: 79, input: "source_latent_b" });
+
+  assert.equal(node.inputs[2].link, null, "the repair itself landed");
+  assert.deepEqual(res.cleared_orphan_link, {
+    node_id: 79,
+    input: "source_latent_b",
+    link_id: 21,
+  });
+  assert.match(res.warning, /undo envelope did not close cleanly/);
+  assert.match(res.warning, /change tracker exploded/);
+  assert.doesNotMatch(res.warning, /Undoable with Ctrl\+Z/);
+});
+
+test("#1750 a throwing clear is a REFUSAL, not a disclosed success", () => {
+  const { graph } = orphanedGraph();
+  const node = graph.getNodeById(79);
+  // A frozen/proxied slot: the write itself fails, so the orphan is still there.
+  Object.defineProperty(node.inputs[2], "link", {
+    get: () => 21,
+    set: () => {
+      throw new Error("slot is read-only");
+    },
+  });
+  const disconnect = buildDisconnect(graph);
+
+  assert.throws(
+    () => disconnect({ node_id: 79, input: "source_latent_b" }),
+    /could not clear it \(slot is read-only\)/,
+  );
 });

--- a/browser_tests/unit/disconnect-orphan-link.test.mjs
+++ b/browser_tests/unit/disconnect-orphan-link.test.mjs
@@ -373,6 +373,7 @@ test("#1750 the reply reports what is STILL orphaned, and never claims queueable
     { node_id: 84, input: "image_b", link_id: 18, certainly_reached: true },
     { node_id: 85, input: "image_b", link_id: 19, certainly_reached: true },
   ]);
+  assert.equal(res.remaining_orphan_link_count, 3);
   assert.match(res.warning, /3 other input\(s\) in this graph still carry an orphaned link id/);
   assert.match(res.warning, /STILL refused/);
   assert.doesNotMatch(res.warning, /queueable/);
@@ -452,4 +453,22 @@ test("#1750 an orphan on a BYPASSED node is reported without claiming the graph 
   assert.match(res.warning, /only on node\(s\) the serializer may skip/);
   assert.doesNotMatch(res.warning, /STILL refused/);
   assert.doesNotMatch(res.warning, /No other input in this graph/);
+});
+
+test("#1750 the remaining-orphan list is capped, but the COUNT never is", () => {
+  const graph = mkGraph();
+  // 1 target + 25 more orphans. A ten-entry array with no total reads as "that
+  // is all of them" — a silent cap is the same overclaim in a structured field.
+  addNode(graph, 79, [{ name: "source_latent_b", link: 21 }]);
+  for (let i = 0; i < 25; i += 1) {
+    addNode(graph, 100 + i, [{ name: `in_${i}`, link: 500 + i }]);
+  }
+  const disconnect = buildDisconnect(graph);
+
+  const res = disconnect({ node_id: 79, input: "source_latent_b" });
+
+  assert.equal(res.remaining_orphan_links.length, 10);
+  assert.equal(res.remaining_orphan_link_count, 25);
+  assert.match(res.warning, /25 other input\(s\)/);
+  assert.match(res.warning, /, … —/, "the truncated roll says it was truncated");
 });

--- a/browser_tests/unit/disconnect-orphan-link.test.mjs
+++ b/browser_tests/unit/disconnect-orphan-link.test.mjs
@@ -369,9 +369,9 @@ test("#1750 the reply reports what is STILL orphaned, and never claims queueable
     link_id: 21,
   });
   assert.deepEqual(res.remaining_orphan_links, [
-    { node_id: 79, input: "source_image_b", link_id: 20 },
-    { node_id: 84, input: "image_b", link_id: 18 },
-    { node_id: 85, input: "image_b", link_id: 19 },
+    { node_id: 79, input: "source_image_b", link_id: 20, certainly_reached: true },
+    { node_id: 84, input: "image_b", link_id: 18, certainly_reached: true },
+    { node_id: 85, input: "image_b", link_id: 19, certainly_reached: true },
   ]);
   assert.match(res.warning, /3 other input\(s\) in this graph still carry an orphaned link id/);
   assert.match(res.warning, /STILL refused/);
@@ -428,4 +428,28 @@ test("#1750 a throwing clear is a REFUSAL, not a disclosed success", () => {
     () => disconnect({ node_id: 79, input: "source_latent_b" }),
     /could not clear it \(slot is read-only\)/,
   );
+});
+
+/**
+ * The same overclaim one step down: an orphan on a node the serializer may SKIP
+ * (bypassed / muted / virtual) is real corruption, but this module does not model
+ * whether it is reached — so it may not be narrated as "the graph is refused".
+ * `danglingInputLinks` already draws that line with `certainly_reached`; the reply
+ * has to respect it.
+ */
+test("#1750 an orphan on a BYPASSED node is reported without claiming the graph is refused", () => {
+  const graph = mkGraph();
+  addNode(graph, 79, [{ name: "source_latent_b", link: 21 }]);
+  const bypassed = addNode(graph, 84, [{ name: "image_b", link: 18 }]);
+  bypassed.mode = 4; // LGraphEventMode.BYPASS
+  const disconnect = buildDisconnect(graph);
+
+  const res = disconnect({ node_id: 79, input: "source_latent_b" });
+
+  assert.deepEqual(res.remaining_orphan_links, [
+    { node_id: 84, input: "image_b", link_id: 18, certainly_reached: false },
+  ]);
+  assert.match(res.warning, /only on node\(s\) the serializer may skip/);
+  assert.doesNotMatch(res.warning, /STILL refused/);
+  assert.doesNotMatch(res.warning, /No other input in this graph/);
 });

--- a/browser_tests/unit/disconnect-orphan-link.test.mjs
+++ b/browser_tests/unit/disconnect-orphan-link.test.mjs
@@ -1,0 +1,335 @@
+/**
+ * #1750 — `panel_disconnect` and ORPHANED input link ids.
+ *
+ * REPORT: four optional inputs on the bundled krea2-identity-edit workflow
+ * (node 79 `source_latent_b`/`source_image_b`, nodes 84/85 `image_b`) ended up
+ * naming link ids 21/20/18/19 that `graph.links` no longer held. Every later
+ * `panel_run` died in the frontend's serializer with
+ *
+ *     No link found in parent graph for id [79] slot [2] source_latent_b
+ *
+ * and `panel_graph_outline` showed those inputs as cleanly DISCONNECTED, because
+ * it resolves through the link store and a slot naming a link the store does not
+ * have resolves to nothing.
+ *
+ * MECHANISM, read from ComfyUI_frontend 1.48.7 (the version installed here),
+ * not inferred:
+ *
+ *   ExecutableNodeDTO.resolveInput  — `if (input.linkId == null) return`, then
+ *     `const link = this.graph.getLink(input.linkId)` and
+ *     `if (!link) throw new InvalidLinkError('No link found in parent graph …')`.
+ *
+ * So the serializer refuses on `slot.link != null && store has no record` — the
+ * exact shape both tests below build. It is checked for EVERY input of a node the
+ * serializer does not skip, so one such slot makes the whole workflow unqueueable.
+ *
+ * TWO defects, and they are separate:
+ *
+ *  1. THE GRAPH COULD NOT BE REPAIRED. `describeInputLink` returns null both for
+ *     an unconnected slot and for an orphaned one, so `graph_disconnect` answered
+ *     the #668 refusal — "is not connected … no retry is needed" — about the one
+ *     reference that was breaking every run. The only tool that can clear a
+ *     slot's link declined to clear it, and nothing else in the panel showed it.
+ *     This is reachable from any saved workflow already in that state, which is
+ *     where #1750's reporter was left.
+ *
+ *  2. THE POST-CONDITION WAS ASSUMED. litegraph's `disconnectInput` nulls the
+ *     slot BEFORE it touches the store, so the two normally cannot disagree — but
+ *     the graph #1750 saved held exactly that disagreement, so the panel now
+ *     ASSERTS the post-condition after its own mutation instead of trusting it,
+ *     and repairs (and discloses) what the assertion catches.
+ *
+ * These tests run the REAL shipped `graph_disconnect`, extracted from
+ * web/js/comfyui-mcp-panel.js and given litegraph-shaped doubles, with the REAL
+ * verification helpers injected — so deleting the fix from the panel source (not
+ * merely from the helper module) fails them.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  snapshotGraphState,
+  describeInputLink,
+  orphanedInputLinkId,
+  clearOrphanedInputLink,
+  clearStrandedInputLinks,
+  verifyDisconnect,
+} from "../../web/js/lib/disconnect-verify.js";
+
+const panelSrc = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+/** The method source between its signature line and the first `  },` line. */
+function sliceMethod(signature) {
+  const lines = panelSrc.split("\n");
+  const start = lines.findIndex((l) => l === signature);
+  assert.ok(start >= 0, `could not locate "${signature}" in the panel source`);
+  const end = lines.findIndex((l, i) => i > start && l === "  },");
+  assert.ok(end > start, `could not locate the end of "${signature}"`);
+  return lines.slice(start, end + 1).join("\n");
+}
+
+const disconnectSrc = sliceMethod("  graph_disconnect({ node_id, input }) {");
+
+function resolveNode(graph, id) {
+  const n = graph.getNodeById(id);
+  if (!n) throw new Error(`No node with id ${id}`);
+  return n;
+}
+
+function resolveSlot(slots, ref, kind) {
+  const list = slots ?? [];
+  if (typeof ref === "number") {
+    if (ref < 0 || ref >= list.length) throw new Error(`no ${kind} slot ${ref}`);
+    return ref;
+  }
+  const i = list.findIndex((s) => s?.name === ref);
+  if (i === -1) throw new Error(`no ${kind} named ${ref}`);
+  return i;
+}
+
+/** Build the REAL shipped executor over a graph double. Every helper it calls is
+ *  the real module — a stub there would let the extracted method pass against a
+ *  checker that always agreed with it. */
+function buildDisconnect(graph) {
+  const factory = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "resolveSlot",
+    "snapshotGraphState",
+    "describeInputLink",
+    "orphanedInputLinkId",
+    "clearOrphanedInputLink",
+    "clearStrandedInputLinks",
+    "verifyDisconnect",
+    `return ({
+${disconnectSrc}
+}).graph_disconnect;`,
+  );
+  return factory(
+    () => ({ graph, canvas: {}, app: {}, rootGraph: graph, LG: {} }),
+    resolveNode,
+    resolveSlot,
+    snapshotGraphState,
+    describeInputLink,
+    orphanedInputLinkId,
+    clearOrphanedInputLink,
+    clearStrandedInputLinks,
+    verifyDisconnect,
+  );
+}
+
+/**
+ * `LGraph` holds `_links: Map<LinkId, LLink>` keyed by NUMBER and exposes `links`
+ * as a proxy over it whose methods are bound straight through. Modelled faithfully
+ * so a string/number key confusion in the helpers cannot pass here and fail on a
+ * real graph.
+ */
+function mkGraph() {
+  const map = new Map();
+  const isIndex = (prop) => typeof prop === "string" && /^(?:0|[1-9]\d*)$/.test(prop);
+  const proxy = new Proxy(map, {
+    get(target, prop) {
+      if (isIndex(prop)) return target.get(Number(prop));
+      const v = Reflect.get(target, prop, target);
+      return typeof v === "function" ? v.bind(target) : v;
+    },
+    has: (target, prop) => (isIndex(prop) ? target.has(Number(prop)) : Reflect.has(target, prop)),
+    ownKeys: (target) => [...target.keys()].map(String),
+    getOwnPropertyDescriptor(target, prop) {
+      if (isIndex(prop) && target.has(Number(prop))) {
+        return { value: target.get(Number(prop)), enumerable: true, configurable: true };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  });
+  const graph = {
+    _links: map,
+    links: proxy,
+    _nodes: [],
+    envelopes: 0,
+    closedEnvelopes: 0,
+    dirty: 0,
+    getNodeById: (id) => graph._nodes.find((n) => String(n.id) === String(id)) ?? null,
+    getLink: (id) => map.get(id) ?? null,
+    beforeChange() {
+      graph.envelopes += 1;
+    },
+    afterChange() {
+      graph.closedEnvelopes += 1;
+    },
+    setDirtyCanvas() {
+      graph.dirty += 1;
+    },
+  };
+  return graph;
+}
+
+function addNode(graph, id, inputs, outputs = []) {
+  const node = { id, inputs, outputs, graph };
+  graph._nodes.push(node);
+  return node;
+}
+
+function addLink(graph, id, origin, originSlot, target, targetSlot) {
+  graph._links.set(id, {
+    id,
+    origin_id: origin,
+    origin_slot: originSlot,
+    target_id: target,
+    target_slot: targetSlot,
+  });
+}
+
+/**
+ * The #1750 shape, reduced from the bundled krea2-identity-edit workflow: node 79
+ * Krea2EditModelPatch with `source_latent` (link 15, live) and `source_latent_b`
+ * (link 21) — where 21 is the id the store no longer holds. Slot indices and
+ * names are the workflow's own, so the fixture and the report describe the same
+ * input.
+ */
+function orphanedGraph() {
+  const graph = mkGraph();
+  const producer = addNode(graph, 78, [], [{ name: "LATENT", links: [15] }]);
+  addNode(graph, 79, [
+    { name: "model", link: null },
+    { name: "source_latent", link: 15 },
+    { name: "source_latent_b", link: 21 },
+  ]);
+  addLink(graph, 15, 78, 0, 79, 1);
+  return { graph, producer };
+}
+
+test("#1750 orphaned slot: panel_disconnect CLEARS the reference instead of refusing", () => {
+  const { graph } = orphanedGraph();
+  const disconnect = buildDisconnect(graph);
+  const node = graph.getNodeById(79);
+
+  const res = disconnect({ node_id: 79, input: "source_latent_b" });
+
+  // The reference the frontend serializer refuses is gone.
+  assert.equal(node.inputs[2].link, null);
+  assert.equal(orphanedInputLinkId(graph, node, 2), null);
+  // Reported as what it was — an orphan cleared, NOT a wire removed.
+  assert.deepEqual(res.cleared_orphan_link, {
+    node_id: 79,
+    input: "source_latent_b",
+    link_id: 21,
+  });
+  assert.equal(res.disconnected, undefined);
+  assert.equal(res.removed_link, undefined);
+  assert.match(res.warning, /nothing was disconnected/i);
+  assert.match(res.warning, /No link found in parent graph/);
+  // Repaired inside ONE undo envelope, so the "Undoable with Ctrl+Z" contract holds.
+  assert.equal(graph.envelopes, 1);
+  assert.equal(graph.closedEnvelopes, 1);
+  assert.ok(graph.dirty >= 1);
+  // Untouched: the live wire on the neighbouring slot, and the link store.
+  assert.equal(node.inputs[1].link, 15);
+  assert.ok(graph._links.has(15));
+});
+
+test("#1750: a genuinely unconnected input is still REFUSED, not silently 'repaired'", () => {
+  const { graph } = orphanedGraph();
+  const disconnect = buildDisconnect(graph);
+
+  assert.throws(
+    () => disconnect({ node_id: 79, input: "model" }),
+    /is not connected/,
+    "an input with link == null has nothing to clear — #668's refusal must stand",
+  );
+  // The refusal is a refusal: no envelope was opened, nothing was written.
+  assert.equal(graph.envelopes, 0);
+  assert.equal(graph.getNodeById(79).inputs[2].link, 21, "the unrelated orphan is left alone");
+});
+
+test("#1750: a LIVE link is never cleared by the orphan path", () => {
+  const { graph } = orphanedGraph();
+  const disconnect = buildDisconnect(graph);
+  const node = graph.getNodeById(79);
+  // Model litegraph faithfully: null the slot, THEN drop the record.
+  node.disconnectInput = (slot) => {
+    const id = node.inputs[slot].link;
+    node.inputs[slot].link = null;
+    graph._links.delete(id);
+    const out = graph.getNodeById(78).outputs[0];
+    out.links = out.links.filter((l) => l !== id);
+    return true;
+  };
+
+  const res = disconnect({ node_id: 79, input: "source_latent" });
+
+  assert.deepEqual(res.disconnected, { node_id: 79, input: "source_latent" });
+  assert.deepEqual(res.removed_link, { node_id: 78, output: "LATENT" });
+  assert.equal(res.cleared_orphan_link, undefined, "no orphan existed on this slot");
+  assert.equal(res.warning, undefined);
+  assert.equal(node.inputs[1].link, null);
+});
+
+/**
+ * The end state #1750 SAVED: the link is out of the store and the slot still names
+ * it. This is not litegraph's own ordering (it nulls the slot first) — it is the
+ * disagreement the report observed on four optional inputs, reproduced here so the
+ * panel's post-condition is exercised by the same shape the workflow was in.
+ */
+function strandingGraph() {
+  const graph = mkGraph();
+  addNode(graph, 78, [], [{ name: "LATENT", links: [15] }]);
+  const target = addNode(graph, 79, [
+    { name: "model", link: null },
+    { name: "source_latent", link: 15 },
+  ]);
+  addLink(graph, 15, 78, 0, 79, 1);
+  target.disconnectInput = (slot) => {
+    const id = target.inputs[slot].link;
+    graph._links.delete(id);
+    const out = graph.getNodeById(78).outputs[0];
+    out.links = out.links.filter((l) => l !== id);
+    // …and the slot is NOT nulled. Exactly what the saved workflow held.
+    return true;
+  };
+  return graph;
+}
+
+test("#1750 post-condition: a slot left naming the removed link is cleared and disclosed", () => {
+  const graph = strandingGraph();
+  const disconnect = buildDisconnect(graph);
+  const node = graph.getNodeById(79);
+
+  const res = disconnect({ node_id: 79, input: "source_latent" });
+
+  // Without the repair this call THROWS: verifyDisconnect sees the slot still
+  // naming link 15 and reports the disconnect as not clean.
+  assert.equal(node.inputs[1].link, null, "the stranded reference is gone");
+  assert.deepEqual(res.disconnected, { node_id: 79, input: "source_latent" });
+  assert.deepEqual(res.cleared_orphan_link, {
+    node_id: 79,
+    link_id: 15,
+    inputs: ["source_latent"],
+  });
+  // Repaired, but never silently: the caller is told the graph needed fixing.
+  assert.match(res.warning, /still named it/);
+  assert.match(res.warning, /No link found in parent/);
+});
+
+test("#1750 post-condition never covers for a disconnect that did NOT land", () => {
+  const graph = strandingGraph();
+  const node = graph.getNodeById(79);
+  // The record survives AND the slot still names it — the wire is simply still
+  // there. Repairing the slot here would convert #668's loud disclosure into a
+  // false success, so the repair must decline.
+  node.disconnectInput = () => true;
+  const disconnect = buildDisconnect(graph);
+
+  assert.throws(
+    () => disconnect({ node_id: 79, input: "source_latent" }),
+    /did not complete cleanly/,
+    "#668's disclosure must still fire when the link is untouched",
+  );
+  assert.equal(node.inputs[1].link, 15, "the live wire was left alone");
+  assert.ok(graph._links.has(15));
+});

--- a/browser_tests/unit/disconnect-verify.test.mjs
+++ b/browser_tests/unit/disconnect-verify.test.mjs
@@ -16,6 +16,9 @@ import assert from "node:assert/strict";
 import {
   snapshotGraphState,
   describeInputLink,
+  orphanedInputLinkId,
+  clearOrphanedInputLink,
+  clearStrandedInputLinks,
   verifyDisconnect,
 } from "../../web/js/lib/disconnect-verify.js";
 
@@ -281,4 +284,78 @@ test("string-vs-number node ids across the boundary are not false positives", ()
   const v = verifyDisconnect(g2, g2.getNodeById(7), before, null);
   assert.deepEqual(v.missingNodes, []);
   assert.deepEqual(v.addedNodes, []);
+});
+
+// ---------------------------------------------------------------------------
+// #1750 — orphaned input link ids (a slot naming a link the store does not have)
+// ---------------------------------------------------------------------------
+
+test("#1750 orphanedInputLinkId tells the THREE slot states apart", () => {
+  const g = reproGraph();
+  const n121 = g.getNodeById(121);
+  // Connected to a link the store HAS: not an orphan.
+  assert.equal(orphanedInputLinkId(g, n121, 0), null);
+  // Genuinely unconnected: not an orphan either.
+  n121.inputs.push({ name: "mask", link: null });
+  assert.equal(orphanedInputLinkId(g, n121, 1), null);
+  // Naming a link the store does NOT have: the #1750 shape.
+  n121.inputs.push({ name: "image_b", link: 404 });
+  assert.equal(orphanedInputLinkId(g, n121, 2), 404);
+  // describeInputLink answers null for the last two alike — which is exactly why
+  // the caller cannot decide between repair and refusal from that answer.
+  assert.equal(describeInputLink(g, n121, 1), null);
+  assert.equal(describeInputLink(g, n121, 2), null);
+});
+
+test("#1750 clearOrphanedInputLink clears ONLY a reference the store cannot resolve", () => {
+  const g = reproGraph();
+  const n121 = g.getNodeById(121);
+  // A live wire is untouchable: nulling it here would strand the origin output's
+  // own `links` entry instead — the same corruption, pointed the other way.
+  assert.equal(clearOrphanedInputLink(g, n121, 0), null);
+  assert.equal(n121.inputs[0].link, 1);
+
+  n121.inputs.push({ name: "image_b", link: 404 });
+  assert.equal(clearOrphanedInputLink(g, n121, 1), 404);
+  assert.equal(n121.inputs[1].link, null);
+  // Idempotent: a second call has nothing left to clear.
+  assert.equal(clearOrphanedInputLink(g, n121, 1), null);
+});
+
+test("#1750 clearStrandedInputLinks repairs every slot naming a REMOVED link", () => {
+  const g = reproGraph();
+  const n121 = g.getNodeById(121);
+  // The link is gone from the store; two slots still name it (a boundary cascade
+  // can shift `node.inputs`, so the whole array is scanned, not one index).
+  delete g.links[1];
+  n121.inputs.push({ name: "image_b", link: 1 });
+  const cleared = clearStrandedInputLinks(g, n121, 1);
+  assert.deepEqual(cleared, [
+    { slot: 0, name: "image", link_id: 1 },
+    { slot: 1, name: "image_b", link_id: 1 },
+  ]);
+  assert.equal(n121.inputs[0].link, null);
+  assert.equal(n121.inputs[1].link, null);
+});
+
+test("#1750 clearStrandedInputLinks declines while the store still HAS the link", () => {
+  const g = reproGraph();
+  const n121 = g.getNodeById(121);
+  // The wire is still there — the disconnect did not land. Repairing the slot
+  // would turn #668's disclosure into a false success.
+  assert.deepEqual(clearStrandedInputLinks(g, n121, 1), []);
+  assert.equal(n121.inputs[0].link, 1);
+  assert.deepEqual(clearStrandedInputLinks(g, n121, null), []);
+});
+
+test("#1750 helpers read the modern Map store, not just the legacy record", () => {
+  const n = node(2, [{ name: "image", link: 9 }]);
+  const g = { _nodes: [node(1), n], _links: new Map(), getNodeById: () => null };
+  // Map-keyed by NUMBER, as LGraph keys it: a stringified lookup must not miss.
+  g._links.set(9, { id: 9, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  assert.equal(orphanedInputLinkId(g, n, 0), null);
+  assert.deepEqual(clearStrandedInputLinks(g, n, 9), []);
+  g._links.delete(9);
+  assert.equal(orphanedInputLinkId(g, n, 0), 9);
+  assert.deepEqual(clearStrandedInputLinks(g, n, 9), [{ slot: 0, name: "image", link_id: 9 }]);
 });

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -396,6 +396,7 @@
       "clear_failed": "clear failed",
       "cleared_canvas_nodes_one": "Cleared canvas — removed {count} node (one Ctrl+Z restores all)",
       "cleared_canvas_nodes_other": "Cleared canvas — removed {count} nodes (one Ctrl+Z restores all)",
+      "cleared_orphan_link": "Cleared orphaned link {slot}",
       "clearing": "Clearing…",
       "click_to_copy": "Click to copy",
       "click_to_preview": "Click to preview",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15258,11 +15258,20 @@ const GRAPH_TOOL_EXECUTORS = {
       // same reason, with the same message. Report the rest instead of implying
       // there is no rest. One level only, like every other reader of this
       // helper: it does not descend into subgraph definitions.
+      //
+      // Split the same way subgraphConversionIntegrity splits it, and for the
+      // same reason: `certainly_reached` is the only subset the serializer
+      // PROVABLY resolves. An orphan on a bypassed/muted/virtual node is real
+      // corruption but its reachability is not modelled here, so it may not be
+      // narrated as "the graph is refused" — that would be the same overclaim
+      // one step down.
       const stillOrphaned = danglingInputLinks(graph);
-      const orphanRoll = stillOrphaned
-        .slice(0, 10)
-        .map((o) => `node ${o.node_id} input "${o.name ?? o.slot}" (link ${o.link_id})`)
-        .join(", ");
+      const certainOrphans = stillOrphaned.filter((o) => o.certainly_reached);
+      const roll = (list) =>
+        list
+          .slice(0, 10)
+          .map((o) => `node ${o.node_id} input "${o.name ?? o.slot}" (link ${o.link_id})`)
+          .join(", ") + (list.length > 10 ? ", …" : "");
       // Deliberately NOT reported as `disconnected`: no wire was removed, because
       // none existed. What changed is that the slot no longer names a link that
       // does not exist.
@@ -15274,6 +15283,7 @@ const GRAPH_TOOL_EXECUTORS = {
                 node_id: o.node_id,
                 input: o.name ?? o.slot,
                 link_id: o.link_id,
+                certainly_reached: o.certainly_reached,
               })),
             }
           : {}),
@@ -15282,11 +15292,17 @@ const GRAPH_TOOL_EXECUTORS = {
           `id ${clearedOrphan}, which the graph's link store has no record of, and that ` +
           `ORPHANED reference is what ComfyUI rejects with "No link found in parent graph" ` +
           `when the workflow is queued. The panel cleared it (#1750). ` +
-          (stillOrphaned.length
-            ? `${stillOrphaned.length} other input(s) in this graph still carry an orphaned ` +
-              `link id — ${orphanRoll}${stillOrphaned.length > 10 ? ", …" : ""} — so the graph ` +
-              `is STILL refused until each of those is cleared too (panel_disconnect on each). `
-            : `No other input in this graph carries an orphaned link id. `) +
+          (certainOrphans.length
+            ? `${certainOrphans.length} other input(s) in this graph still carry an orphaned ` +
+              `link id on a node the serializer resolves — ${roll(certainOrphans)} — so the ` +
+              `graph is STILL refused until each of those is cleared too (panel_disconnect ` +
+              `on each). `
+            : stillOrphaned.length
+              ? `${stillOrphaned.length} other input(s) in this graph carry an orphaned link ` +
+                `id — ${roll(stillOrphaned)} — but only on node(s) the serializer may skip ` +
+                `(bypassed, muted, or virtual), so whether the graph is refused depends on ` +
+                `whether those are reached. Clear them the same way if it is. `
+              : `No other input in this graph carries an orphaned link id. `) +
           (repairEnvelopeErr
             ? `The change landed, but the undo envelope did not close cleanly ` +
               `(${repairEnvelopeErr?.message ?? repairEnvelopeErr}), so Ctrl+Z may not revert ` +

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15285,6 +15285,11 @@ const GRAPH_TOOL_EXECUTORS = {
                 link_id: o.link_id,
                 certainly_reached: o.certainly_reached,
               })),
+              // The COUNT is never truncated, only the list is. A ten-entry array
+              // with nothing saying how many were dropped reads as "that is all of
+              // them", which is the whole class of claim this reply is careful not
+              // to make.
+              remaining_orphan_link_count: stillOrphaned.length,
             }
           : {}),
         warning:

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -515,6 +515,9 @@ import {
 import {
   snapshotGraphState,
   describeInputLink,
+  orphanedInputLinkId,
+  clearOrphanedInputLink,
+  clearStrandedInputLinks,
   verifyDisconnect,
 } from "./lib/disconnect-verify.js";
 import {
@@ -15193,13 +15196,67 @@ const GRAPH_TOOL_EXECUTORS = {
     const inputNamesBefore = (node.inputs ?? []).map((s) => s?.name ?? null);
     const removedLink = describeInputLink(graph, node, inIdx);
     if (!removedLink) {
-      // Nothing to remove: reporting `disconnected` here would fabricate a
-      // mutation that never happened. REFUSE (the graph is untouched).
-      throw new Error(
-        `panel_disconnect: node ${node.id} input "${inputName}" is not connected — ` +
-          `there is no link to remove. Check the live wiring with panel_graph_outline; ` +
-          `if a previous disconnect already removed it, no retry is needed (#668).`,
-      );
+      // #1750 — describeInputLink answers null for TWO different slots, and they
+      // need OPPOSITE handling. `link == null` is genuinely unconnected: the #668
+      // refusal below is right, the graph is untouched, nothing to do. But a slot
+      // whose `link` id has no record in the store is ORPHANED, and that graph is
+      // ALREADY unqueueable — ComfyUI's serializer resolves every input of a live
+      // node and throws `No link found in parent graph for id [...] slot [...]` on
+      // exactly this shape. Refusing there gave #1750's reporter "no retry is
+      // needed" about the one reference that was failing every run, and left the
+      // only tool that can clear a slot's link declining to clear it. Nothing else
+      // shows it either: panel_graph_outline resolves through the link store, so
+      // the input renders as cleanly disconnected. REPAIR it instead of refusing.
+      const orphanLinkId = orphanedInputLinkId(graph, node, inIdx);
+      if (orphanLinkId == null) {
+        // Nothing to remove: reporting `disconnected` here would fabricate a
+        // mutation that never happened. REFUSE (the graph is untouched).
+        throw new Error(
+          `panel_disconnect: node ${node.id} input "${inputName}" is not connected — ` +
+            `there is no link to remove. Check the live wiring with panel_graph_outline; ` +
+            `if a previous disconnect already removed it, no retry is needed (#668).`,
+        );
+      }
+      // Same undo envelope the real mutation uses, so one Ctrl+Z reverts the
+      // repair — the panel's "Undoable with Ctrl+Z" contract does not get an
+      // exemption for a write the user did not know they needed.
+      let repairErr = null;
+      let clearedOrphan = null;
+      graph.beforeChange();
+      try {
+        clearedOrphan = clearOrphanedInputLink(graph, node, inIdx);
+      } catch (err) {
+        repairErr = err;
+      }
+      try {
+        graph.afterChange();
+      } catch (err) {
+        repairErr ??= err;
+      }
+      graph.setDirtyCanvas(true, true);
+      if (clearedOrphan == null || node.inputs?.[inIdx]?.link != null) {
+        throw new Error(
+          `panel_disconnect: node ${node.id} input "${inputName}" carries link id ` +
+            `${orphanLinkId}, which the graph's link store has no record of, and the panel ` +
+            `could not clear it` +
+            (repairErr ? ` (${repairErr?.message ?? repairErr})` : "") +
+            `. Nothing can be queued while that reference stands — ComfyUI refuses the ` +
+            `graph with "No link found in parent graph". Reload the workflow from disk ` +
+            `with panel_load_workflow and redo the edit (#1750).`,
+        );
+      }
+      // Deliberately NOT reported as `disconnected`: no wire was removed, because
+      // none existed. What changed is that the slot no longer names a link that
+      // does not exist.
+      return {
+        cleared_orphan_link: { node_id: node.id, input: inputName, link_id: clearedOrphan },
+        warning:
+          `nothing was disconnected — the input was not wired to anything. It carried link ` +
+          `id ${clearedOrphan}, which the graph's link store has no record of, and that ` +
+          `ORPHANED reference is what ComfyUI rejects with "No link found in parent graph" ` +
+          `when the workflow is queued. The panel cleared it, so the graph is queueable ` +
+          `again (#1750). Undoable with Ctrl+Z.`,
+      };
     }
     const before = snapshotGraphState(graph);
     // The mutation can throw AFTER partially applying (a node hook or the
@@ -15220,6 +15277,18 @@ const GRAPH_TOOL_EXECUTORS = {
       envelopeErr = err;
     }
     graph.setDirtyCanvas(true, true);
+    // #1750 POST-CONDITION: once the link is out of the store, no input slot may
+    // still name it. litegraph's own disconnectInput nulls the slot BEFORE it
+    // touches the store, so this is normally a no-op — but the graph #1750 saved
+    // held the opposite end state (record gone, slot still carrying the id) on
+    // four optional inputs, and a slot in that state makes the whole workflow
+    // unqueueable. Assert the post-condition rather than assume it, and repair
+    // what the assertion catches: leaving it is a "success" that hands back a
+    // graph ComfyUI will refuse. Repairs NOTHING while the store still HAS the
+    // link — that is a disconnect that did not land, and #668's disclosure below
+    // is what must fire for it. Runs BEFORE verifyDisconnect so the verdict
+    // describes the state the caller is actually left in.
+    const strandedSlots = clearStrandedInputLinks(graph, node, removedLink.linkId);
     const verdict = verifyDisconnect(graph, node, before, removedLink.linkId);
     // Shared disclosure bullets: observed post-state facts ONLY — the verifier
     // proves what changed, never why, so no bucket is narrated as a cause.
@@ -15291,17 +15360,36 @@ const GRAPH_TOOL_EXECUTORS = {
     const slotsShifted =
       inputNamesBefore.length !== inputNamesAfter.length ||
       inputNamesBefore.some((n, i) => n !== inputNamesAfter[i]);
+    const warnings = [];
+    if (strandedSlots.length) {
+      warnings.push(
+        `the link was removed from the graph's link store but input ` +
+          `${strandedSlots.map((s) => `"${s.name ?? s.slot}"`).join(", ")} still named it ` +
+          `afterwards — an orphaned reference ComfyUI rejects with "No link found in parent ` +
+          `graph" when the workflow is queued. The panel cleared it as part of this ` +
+          `disconnect (#1750), so no separate repair is needed.`,
+      );
+    }
+    if (slotsShifted) {
+      warnings.push(
+        `the node's input slots changed during the disconnect (count, order, or names ` +
+          `differ) — re-resolve input names with panel_graph_outline before any further ` +
+          `disconnect by index`,
+      );
+    }
     return {
       disconnected: { node_id: node.id, input: inputName },
       removed_link: { node_id: removedLink.node_id, output: removedLink.output },
-      ...(slotsShifted
+      ...(strandedSlots.length
         ? {
-            warning:
-              `the node's input slots changed during the disconnect (count, order, or names ` +
-              `differ) — re-resolve input names with panel_graph_outline before any further ` +
-              `disconnect by index`,
+            cleared_orphan_link: {
+              node_id: node.id,
+              link_id: removedLink.linkId,
+              inputs: strandedSlots.map((s) => s.name ?? s.slot),
+            },
           }
         : {}),
+      ...(warnings.length ? { warning: warnings.join(" ") } : {}),
     };
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15219,43 +15219,79 @@ const GRAPH_TOOL_EXECUTORS = {
       }
       // Same undo envelope the real mutation uses, so one Ctrl+Z reverts the
       // repair — the panel's "Undoable with Ctrl+Z" contract does not get an
-      // exemption for a write the user did not know they needed.
-      let repairErr = null;
+      // exemption for a write the user did not know they needed. The two errors
+      // are kept APART because they mean different things: a clear that threw
+      // means the slot may still be broken, while an envelope that threw means
+      // the write landed but the undo step may not have been recorded, and the
+      // Ctrl+Z promise is the only thing that can no longer be made (the main
+      // mutation path below separates them for the same reason).
+      let clearErr = null;
+      let repairEnvelopeErr = null;
       let clearedOrphan = null;
       graph.beforeChange();
       try {
         clearedOrphan = clearOrphanedInputLink(graph, node, inIdx);
       } catch (err) {
-        repairErr = err;
+        clearErr = err;
       }
       try {
         graph.afterChange();
       } catch (err) {
-        repairErr ??= err;
+        repairEnvelopeErr = err;
       }
       graph.setDirtyCanvas(true, true);
       if (clearedOrphan == null || node.inputs?.[inIdx]?.link != null) {
+        const why = clearErr ?? repairEnvelopeErr;
         throw new Error(
           `panel_disconnect: node ${node.id} input "${inputName}" carries link id ` +
             `${orphanLinkId}, which the graph's link store has no record of, and the panel ` +
             `could not clear it` +
-            (repairErr ? ` (${repairErr?.message ?? repairErr})` : "") +
+            (why ? ` (${why?.message ?? why})` : "") +
             `. Nothing can be queued while that reference stands — ComfyUI refuses the ` +
             `graph with "No link found in parent graph". Reload the workflow from disk ` +
             `with panel_load_workflow and redo the edit (#1750).`,
         );
       }
+      // What is STILL broken. Clearing one slot does not make a graph queueable
+      // — #1750's own workflow carried four orphans — and saying it does would
+      // send the caller to queue a graph the serializer still refuses, for the
+      // same reason, with the same message. Report the rest instead of implying
+      // there is no rest. One level only, like every other reader of this
+      // helper: it does not descend into subgraph definitions.
+      const stillOrphaned = danglingInputLinks(graph);
+      const orphanRoll = stillOrphaned
+        .slice(0, 10)
+        .map((o) => `node ${o.node_id} input "${o.name ?? o.slot}" (link ${o.link_id})`)
+        .join(", ");
       // Deliberately NOT reported as `disconnected`: no wire was removed, because
       // none existed. What changed is that the slot no longer names a link that
       // does not exist.
       return {
         cleared_orphan_link: { node_id: node.id, input: inputName, link_id: clearedOrphan },
+        ...(stillOrphaned.length
+          ? {
+              remaining_orphan_links: stillOrphaned.slice(0, 10).map((o) => ({
+                node_id: o.node_id,
+                input: o.name ?? o.slot,
+                link_id: o.link_id,
+              })),
+            }
+          : {}),
         warning:
           `nothing was disconnected — the input was not wired to anything. It carried link ` +
           `id ${clearedOrphan}, which the graph's link store has no record of, and that ` +
           `ORPHANED reference is what ComfyUI rejects with "No link found in parent graph" ` +
-          `when the workflow is queued. The panel cleared it, so the graph is queueable ` +
-          `again (#1750). Undoable with Ctrl+Z.`,
+          `when the workflow is queued. The panel cleared it (#1750). ` +
+          (stillOrphaned.length
+            ? `${stillOrphaned.length} other input(s) in this graph still carry an orphaned ` +
+              `link id — ${orphanRoll}${stillOrphaned.length > 10 ? ", …" : ""} — so the graph ` +
+              `is STILL refused until each of those is cleared too (panel_disconnect on each). `
+            : `No other input in this graph carries an orphaned link id. `) +
+          (repairEnvelopeErr
+            ? `The change landed, but the undo envelope did not close cleanly ` +
+              `(${repairEnvelopeErr?.message ?? repairEnvelopeErr}), so Ctrl+Z may not revert ` +
+              `it — re-check the input with panel_graph_outline before relying on undo.`
+            : `Undoable with Ctrl+Z.`),
       };
     }
     const before = snapshotGraphState(graph);
@@ -15366,8 +15402,8 @@ const GRAPH_TOOL_EXECUTORS = {
         `the link was removed from the graph's link store but input ` +
           `${strandedSlots.map((s) => `"${s.name ?? s.slot}"`).join(", ")} still named it ` +
           `afterwards — an orphaned reference ComfyUI rejects with "No link found in parent ` +
-          `graph" when the workflow is queued. The panel cleared it as part of this ` +
-          `disconnect (#1750), so no separate repair is needed.`,
+          `graph" when the workflow is queued. The panel cleared THAT reference as part of ` +
+          `this disconnect (#1750); it says nothing about any other input in the graph.`,
       );
     }
     if (slotsShifted) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -27545,6 +27545,15 @@ function describeCommand(cmd, msg, reply) {
           }) + (r.connected?.auto_matched ? tr("panel.connected_auto_matched", " (auto-matched)") : ""),
       };
     case "graph_disconnect":
+      if (r.cleared_orphan_link && !r.disconnected) {
+        return {
+          icon: "pi-exclamation-triangle",
+          text: tr("panel.cleared_orphan_link", "Cleared orphaned link {slot}", {
+            slot: `${r.cleared_orphan_link.node_id}.${r.cleared_orphan_link.input}`,
+          }),
+          detail: r.warning,
+        };
+      }
       return {
         icon: "pi-times-circle",
         text: tr("panel.disconnected_slot", "Disconnected {slot}", {

--- a/web/js/lib/disconnect-verify.js
+++ b/web/js/lib/disconnect-verify.js
@@ -122,11 +122,12 @@ function collectNodeIds(graph, prefix, out) {
  * name the wire's former source (symmetric with graph_connect's replaced_link).
  *
  * A slot whose `link` id has NO record in the graph's link store is a DANGLING
- * reference, not a connection — null is returned so the caller's not-connected
- * refusal covers it (reporting a "removed" wire that never existed would
- * fabricate a mutation). The inverse is fine: the ORIGIN NODE may be gone while
- * its link record still exists, in which case the description falls back to the
- * origin slot index.
+ * reference, not a connection — null is returned so the caller never reports a
+ * "removed" wire that never existed. That null is NOT the same answer as an
+ * unconnected slot's, though: see {@link orphanedInputLinkId}, which tells the
+ * two apart so #1750's repair can run on one and the #668 refusal on the other.
+ * The inverse is fine: the ORIGIN NODE may be gone while its link record still
+ * exists, in which case the description falls back to the origin slot index.
  */
 export function describeInputLink(graph, node, inIdx) {
   const linkId = node?.inputs?.[inIdx]?.link;
@@ -140,6 +141,74 @@ export function describeInputLink(graph, node, inIdx) {
     output: origin?.outputs?.[link.origin_slot]?.name ?? link.origin_slot,
     output_index: link.origin_slot,
   };
+}
+
+/**
+ * The link id `node`'s input `inIdx` carries that the graph's link store has NO
+ * record of — an ORPHANED reference (#1750) — or null when the slot is either
+ * genuinely unconnected (`link == null`) or connected to a link that exists.
+ *
+ * This is the distinction {@link describeInputLink}'s null hides, and the two
+ * states need opposite handling. An unconnected slot is fine and a disconnect of
+ * it is a no-op. An orphaned slot has already made the whole workflow
+ * unqueueable: ComfyUI's serializer resolves every input of a live node and
+ * throws `No link found in parent graph for id [...] slot [...]` on exactly this
+ * shape, while the panel's own outline resolves THROUGH the store and so renders
+ * the input as cleanly disconnected — the corruption is invisible everywhere the
+ * caller would look for it.
+ */
+export function orphanedInputLinkId(graph, node, inIdx) {
+  const linkId = node?.inputs?.[inIdx]?.link;
+  if (linkId == null) return null;
+  return getLinkRecord(graph, linkId) ? null : linkId;
+}
+
+/**
+ * Clear ONE orphaned slot reference: null out `node.inputs[inIdx].link` when it
+ * names a link the store has no record of. Returns the id that was cleared, or
+ * null when there was nothing to clear.
+ *
+ * Re-reads the store at the moment of the write rather than trusting a verdict
+ * taken earlier — a slot pointing at a link that EXISTS is a live wire, and
+ * nulling it here would silently strand the origin output's `links` entry
+ * instead (the same corruption, pointed the other way).
+ */
+export function clearOrphanedInputLink(graph, node, inIdx) {
+  const slot = node?.inputs?.[inIdx];
+  const linkId = slot?.link;
+  if (linkId == null) return null;
+  if (getLinkRecord(graph, linkId)) return null;
+  slot.link = null;
+  return linkId;
+}
+
+/**
+ * Clear every input slot of `node` still naming `linkId` after that link has
+ * been removed from the store — the post-condition a disconnect owes its caller
+ * (#1750). Returns `[{ slot, name, link_id }]` for what was cleared, so the
+ * caller can DISCLOSE the repair instead of absorbing it silently.
+ *
+ * Scans the whole inputs array rather than one index for the same reason
+ * {@link verifyDisconnect} does: a boundary-slot cascade can shift `node.inputs`
+ * under the disconnect, so the requested index may no longer be the slot that
+ * carried the link.
+ *
+ * Returns `[]` — repairing NOTHING — while the store still HAS the link. A slot
+ * naming a live link is a disconnect that did not land, which is #668's
+ * disclosure to make; papering over it here would convert a loud failure into a
+ * quiet one.
+ */
+export function clearStrandedInputLinks(graph, node, linkId) {
+  if (linkId == null) return [];
+  if (getLinkRecord(graph, linkId)) return [];
+  const target = String(linkId);
+  const cleared = [];
+  for (const [slot, input] of (node?.inputs ?? []).entries()) {
+    if (input?.link == null || String(input.link) !== target) continue;
+    input.link = null;
+    cleared.push({ slot, name: input?.name ?? null, link_id: linkId });
+  }
+  return cleared;
 }
 
 /**


### PR DESCRIPTION
Fixes #1750.

## What was wrong

`panel_disconnect` answered #668's refusal — *"is not connected — there is no link to
remove … no retry is needed"* — for an input whose `link` id had **no record in the
graph's link store**. That slot is not unconnected. Read from the frontend installed
here (ComfyUI_frontend 1.48.7), `ExecutableNodeDTO.resolveInput`:

```ts
if (input.linkId == null) return                       // unconnected — fine
const link = this.graph.getLink(input.linkId)
if (!link) throw new InvalidLinkError(
  `No link found in parent graph for id [${this.id}] slot [${slot}] ${input.name}`)
```

It is checked for **every** input of a node the serializer does not skip, so one such
slot makes the whole workflow unqueueable — which is the error #1750 reported verbatim
(`… for id [79] slot [2] source_latent_b`).

Two things were wrong, and they are separate:

1. **The graph could not be repaired.** `describeInputLink` returns `null` for an
   unconnected slot *and* for an orphaned one, so the refusal could not tell them
   apart. The only tool that can clear a slot's link declined to clear it, and told the
   caller no retry was needed about the one reference failing every run. Nothing else
   showed it either: `panel_graph_outline` resolves *through* the link store, so it
   renders an orphaned input as cleanly disconnected — exactly as the report describes.
2. **The post-condition was assumed.** `graph_disconnect` never checked that its own
   mutation left no slot naming the link it removed.

## Where the orphaned ids come from

Not from `disconnectInput` — that nulls `inputs[slot].link` *before* it touches the
store, so those two cannot disagree. It is the **output** side. `LGraphNode.disconnectOutput`,
which `LGraph.remove(node)` calls for every output of a node being deleted:

```ts
const input = target.inputs[link_info.target_slot]   // index recorded on the LINK…
input.link = null                                    // …not the slot the input occupies
…
link_info.disconnect(graph, 'input')                 // → network.links.delete(this.id)
```

`LLink.disconnect` ends in an unconditional `network.links.delete(this.id)`. So when the
recorded `target_slot` is stale, the record is destroyed while the input that actually
carried it is untouched — precisely #1750's end state, and a stale `target_slot` is not
hypothetical in this codebase: #342/#1340 fixed the outline for exactly that, "a stale
target_slot renders nothing instead of fabricating connectivity". In the multi-target
branch there is no `if (input)` guard at all, so an out-of-range index throws mid-loop
and strands the remaining links on that output too.

That fits the report: the four orphans (79 `source_latent_b`/`source_image_b`, 84/85
`image_b`) are the whole *b* reference branch, fed by nodes 90 and 92 — and dropping the
b branch is what the reporter was doing. Krea2EditModelPatch carries eleven inputs, nine
of them optional, which is where an inputs array shifts under a recorded index.

**I did not execute this** — no ComfyUI was running for this task — so treat it as read
from the frontend source, not as a reproduction. It is not what this PR fixes either:
the mechanism is upstream. What this PR fixes is that the panel had no way to clear the
result and no check that it had not produced one.

## What changed

`web/js/lib/disconnect-verify.js` — three helpers: `orphanedInputLinkId` (tells the
three slot states apart), `clearOrphanedInputLink`, `clearStrandedInputLinks`.

`graph_disconnect`:

- **Refusal path.** An orphaned reference is now REPAIRED, in its own
  `beforeChange`/`afterChange` envelope so `Ctrl+Z` still reverts it, and reported as
  `cleared_orphan_link` — deliberately **not** as `disconnected`/`removed_link`, because
  no wire was removed. A genuinely unconnected slot still gets #668's refusal, untouched.
- **After its own mutation.** It now asserts that no input slot still names the removed
  link, repairs what the assertion catches, and DISCLOSES the repair in `warning` +
  `cleared_orphan_link`. It repairs **nothing** while the store still holds the link —
  that is a disconnect that did not land, and #668's disclosure is what must fire there.

## Where to look hardest

- **Reachability is not symmetric between the two halves, and I am not claiming it is.**
  Half 1 is reachable from any workflow already holding an orphan — that is where the
  reporter was left, and it is what unblocks them. Half 2 is a post-condition assertion:
  the case it catches on the target node is two input slots naming the SAME link id
  (`LGraph._removeDuplicateLinks` exists because duplicate-tuple links occur), where
  `disconnectInput` nulls one and deletes the record. Absent that, it is a no-op.
- **The repair must never touch a live wire.** Both helpers re-read the store at the
  moment of the write rather than trusting an earlier verdict; nulling a slot whose link
  exists would strand the origin output's `links` entry instead — the same corruption
  pointed the other way. `M3` below is the mutation that checks this.
- **The reply may not claim more than it measured.** Clearing one orphan does not make
  a graph queueable — #1750's own workflow carried four — so the orphan path reports what
  is STILL orphaned in the graph (`remaining_orphan_links`, capped at ten, via the
  existing `danglingInputLinks`) and says the graph is still refused until each is
  cleared. Likewise an `afterChange()` that throws keeps the repair but costs the Ctrl+Z
  promise, rather than being folded in with a failed clear. Both were codex gate round-1
  P1s. Two more of the same shape were then closed without being asked: only the
  `certainly_reached` subset may be narrated as a refusal (an orphan on a bypassed, muted,
  or virtual node is real corruption whose reachability this module does not model), and
  the list caps at ten while `remaining_orphan_link_count` carries the untruncated total.
- **Reply shape change.** The orphan path returns `cleared_orphan_link` with no
  `disconnected` key. An agent testing `result.disconnected` will not see success; a
  retry then hits the plain "not connected" refusal, which is correct and idempotent.
  The alternative — reusing `disconnected` — would claim a wire removal that did not
  happen, which is the thing #668 exists to prevent. Nothing on either side of the
  bridge reads that key: `panel_disconnect` forwards the reply verbatim.

## Verification

`browser_tests/unit/disconnect-orphan-link.test.mjs` runs the **real shipped
`graph_disconnect`**, extracted from `web/js/comfyui-mcp-panel.js` and given
litegraph-shaped doubles with the real helpers injected — a helper-only test stays green
against an unfixed call site.

Mutation-verified at the call site (each mutation applied to the panel source alone, the
named test required to go red):

| mutation | detected by |
| --- | --- |
| M1 orphan repair removed (refusal restored to #668 only) | `panel_disconnect CLEARS the reference instead of refusing` |
| M2 post-condition assertion removed | `a slot left naming the removed link is cleared and disclosed` |
| M3 post-condition made unconditional (would clear a LIVE link) | `never covers for a disconnect that did NOT land` |
| M4 orphan path reports a wire removal it did not perform | `panel_disconnect CLEARS the reference instead of refusing` |
| M5 remaining-orphan report removed (reply implies the graph is clean) | `reports what is STILL orphaned, and never claims queueable` |
| M6 `afterChange` failure swallowed (Ctrl+Z promised on a broken envelope) | `a throwing afterChange costs the Ctrl+Z promise, not the repair` |
| M7 `certainly_reached` split dropped (bypassed orphan narrated as a refusal) | `an orphan on a BYPASSED node is reported without claiming the graph is refused` |
| M8 truncation count clamped to the cap (a capped list reads as the whole list) | `the remaining-orphan list is capped, but the COUNT never is` |

`npm run test:unit` — 6740 tests, 0 fail, including `check-panel-scope` OK (every name
in the panel resolves) and the tool-vocabulary gate.

**Browser suite NOT run.** No ComfyUI was listening on this machine (8188 and the rest
of the 81xx range all refused), and the Playwright suite requires a real one. This change
alters a bridge command's return value and graph mutation, not any rendered surface, but
I am not implying e2e coverage I do not have.

## Not done

`panel_graph_outline` still hides an orphaned reference — it resolves through the link
store, so the input reads as cleanly disconnected. That is the reason the corruption was
invisible in the first place, and it is worth a follow-up, but it is outside what this
issue asked for and I did not widen the change to cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
