### PR TITLE
chore: release v0.15.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.75] - 2026-08-24
+
+### Fixed
+- Keep Panel run receipts route-bound and exactly-once across reconnects, remounts, and late queue delivery (#1728)
+- Redact credential-like values through graph outlines and subgraph provenance, including shared aliases (#1729)
+- Refresh live asset membership before API-upload missing-asset validation (#1733)
+
 ## [0.15.74] - 2026-08-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.74",
+  "version": "0.15.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.74",
+      "version": "0.15.75",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.74",
+  "version": "0.15.75",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
Release v0.15.75.\n\nIncludes merged fixes for route-bound exactly-once Panel run receipts (#1728), graph outline/subgraph credential redaction including aliases (#1729), and live missing-asset refresh before API upload validation (#1733).\n\nRelease gates: scope, typecheck, and unit suite passed (6,732 passed, 1 todo); lint CI is green.