### PR TITLE
Fix remote object-info probe deadline

### DIFF
--- a/browser_tests/unit/object-info-probe-budget.test.mjs
+++ b/browser_tests/unit/object-info-probe-budget.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  objectInfoSnapshotProbeDeadline,
+  OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS,
+  OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS,
+} from "../../web/js/lib/object-info-probe-budget.js";
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+test("#1734 keeps loopback object-info silence discovery at the local 2s bound", () => {
+  for (const origin of [
+    "http://127.0.0.1:8188",
+    "http://127.42.0.9:8188",
+    "http://[::1]:8188",
+    "http://localhost:8188",
+  ]) {
+    assert.equal(
+      objectInfoSnapshotProbeDeadline(origin),
+      OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS,
+      origin,
+    );
+  }
+});
+
+test("#1734 gives non-loopback object-info reads the remote 8s bound", () => {
+  for (const origin of [
+    "https://comfy.example.test",
+    "http://192.168.1.20:8188",
+    "https://pod.example.test/proxy/8188",
+  ]) {
+    assert.equal(
+      objectInfoSnapshotProbeDeadline(origin),
+      OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS,
+      origin,
+    );
+  }
+});
+
+test("#1734 treats an unknown origin conservatively without becoming unbounded", () => {
+  for (const origin of [null, undefined, "not a URL", "file:///tmp/panel.html"]) {
+    assert.equal(
+      objectInfoSnapshotProbeDeadline(origin),
+      OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS,
+      String(origin),
+    );
+  }
+  assert.ok(OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS < 25_000);
+});
+
+test("#1734 production wiring selects from the page origin and keeps command bounding", () => {
+  assert.match(
+    PANEL_SRC,
+    /const OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS = objectInfoSnapshotProbeDeadline\(pageComfyOrigin\(\)\);/,
+  );
+  assert.match(PANEL_SRC, /const SET_WIDGET_COMMAND_BUDGET_MS = 25000;/);
+  assert.match(
+    PANEL_SRC,
+    /deadlineMs: budget\.bounded\([\s\S]*?OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS/,
+  );
+});

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -661,6 +661,9 @@ function buildShippedOracle({
   objectInfoCache = createObjectInfoCache(),
   epochDuringFetch = null,
   onFetch = null,
+  snapshotProbeDeadlineMs = 2000,
+  oracleDeadlineMs = 20,
+  realFetchWholeObjectInfo = fetchWholeObjectInfo,
 }) {
   const body = extractSetWidgetOracle();
   const factory = new Function(
@@ -683,6 +686,7 @@ function buildShippedOracle({
     // body closes over and the harness does not provide is a harness that models a panel
     // which does not exist.
     "noBackendAnswerEstablished",
+    "oracleDeadlineMs",
     // `backendReconnectEpoch` MUST be a live mutable binding in the same scope as the
     // extracted body, because the panel's is module state the body re-reads. An earlier
     // version passed it as a frozen value, which made `observedAtEpoch` and the record-time
@@ -705,7 +709,10 @@ function buildShippedOracle({
      // the read is issued — the panel's real hazard is a reconnect landing mid-fetch.
      const fetchWholeObjectInfo = (opts) => {
        onFetch?.(opts);
-       const pending = realFetchWholeObjectInfo({ ...opts, deadlineMs: 20 });
+       const pending = realFetchWholeObjectInfo({
+         ...opts,
+         deadlineMs: oracleDeadlineMs === null ? opts.deadlineMs : oracleDeadlineMs,
+       });
        if (epochDuringFetch !== null) backendReconnectEpoch = epochDuringFetch;
        return pending;
      };
@@ -725,14 +732,15 @@ function buildShippedOracle({
        readIneligibility: () => snapshotIneligibility,
        readFailures: () => oracleFailures,
        readScopedLicence: () => scopedReadLicensed,
+       readProvenance: () => setWidgetSchemaProvenance(),
        readHistory: () => historyRecorded,
      };`,
   );
   return factory(
     api,
     objectInfoCache,
-    fetchWholeObjectInfo,
-     CACHE_OUTCOME,
+    realFetchWholeObjectInfo,
+    CACHE_OUTCOME,
      snapshot,
      verifiedNodeDefCache,
      epoch,
@@ -740,14 +748,27 @@ function buildShippedOracle({
     socketDown,
     objectInfoOracleFailureNote,
     OBJECT_INFO_DEADLINE_MS,
-    2000,
+    snapshotProbeDeadlineMs,
     makeCommandBudget,
     onFetch,
     noBackendAnswerEstablished,
+    oracleDeadlineMs,
   );
 }
 
 const hungApi = { getNodeDefs: () => new Promise(() => {}), fetchApi: () => new Promise(() => {}) };
+
+function schemaOracleForLatency(minimumMs) {
+  return ({ deadlineMs }) =>
+    deadlineMs >= minimumMs
+      ? { [CACHE_OUTCOME]: true, defs: SCHEMA, failures: [], outcomes: [] }
+      : {
+          [CACHE_OUTCOME]: true,
+          defs: null,
+          failures: [`remote schema needs ${minimumMs}ms`],
+          outcomes: silence,
+        };
+}
 
 test("#1223 SHIPPED: a live answer is returned and snapshotted", async () => {
   const snapshot = createObjectInfoSnapshot();
@@ -859,6 +880,122 @@ test("#1582 SHIPPED: the reported case — a held snapshot shortens hung probes"
   assert.deepEqual(deadlines, [2000], "the reusable snapshot caps the serial oracle before the 15s stall");
   assert.match(o.readNote(), /did not answer/);
   assert.equal(o.readFailures().length, 2, "the fallback still discloses both silent routes");
+});
+
+test("#1734 SHIPPED set_widget: a remote high-latency schema gets the larger bounded probe", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  stored(snapshot, SCHEMA, 5);
+  const deadlines = [];
+  const o = buildShippedOracle({
+    api: hungApi,
+    snapshot,
+    snapshotProbeDeadlineMs: 8000,
+    oracleDeadlineMs: null,
+    realFetchWholeObjectInfo: (opts) => {
+      deadlines.push(opts.deadlineMs);
+      return schemaOracleForLatency(3000)(opts);
+    },
+  });
+  const ctor = function NodeCtor() {};
+  ctor.nodeData = { input: { required: {} } };
+  const node = {
+    id: 1734,
+    type: "KSampler",
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    constructor: ctor,
+  };
+
+  const result = await runSetWidget(node, "steps", 30, {
+    registry: { KSampler: ctor },
+    getRegistry: () => ({ KSampler: ctor }),
+    getFreshObjectInfo: o.getFreshObjectInfo,
+    schemaProvenance: () => "live",
+    beforeChange() {},
+    afterChange() {},
+    setDirty() {},
+  });
+
+  assert.equal(result.set.value, 30, "the production write lands after the remote read");
+  assert.deepEqual(deadlines, [8000], "the remote first-silence probe stays bounded at 8s");
+});
+
+test("#1734 SHIPPED set_widget: loopback keeps the short local probe timing", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  stored(snapshot, SCHEMA, 5);
+  const deadlines = [];
+  const o = buildShippedOracle({
+    api: hungApi,
+    snapshot,
+    snapshotProbeDeadlineMs: 2000,
+    oracleDeadlineMs: null,
+    realFetchWholeObjectInfo: (opts) => {
+      deadlines.push(opts.deadlineMs);
+      return schemaOracleForLatency(3000)(opts);
+    },
+  });
+
+  const result = await runSetWidget(
+    {
+      id: 1734,
+      type: "KSampler",
+      widgets: [{ name: "steps", type: "INT", value: 20 }],
+      constructor: { nodeData: { input: { required: {} } } },
+    },
+    "steps",
+    30,
+    {
+      registry: { KSampler: {} },
+      getRegistry: () => ({ KSampler: {} }),
+      getFreshObjectInfo: o.getFreshObjectInfo,
+      schemaProvenance: () => "snapshot",
+      beforeChange() {},
+      afterChange() {},
+      setDirty() {},
+    },
+  );
+
+  assert.equal(result.set.value, 30, "a silent local probe still uses the held snapshot");
+  assert.deepEqual(deadlines, [2000], "loopback keeps the original short discovery window");
+  assert.equal(o.readProvenance(), "snapshot", "the short silent probe falls back to the held snapshot");
+  assert.match(o.readNote(), /Tried one route/i);
+});
+
+test("#1734 SHIPPED: a concurrent refresh fences a late remote probe result", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  stored(snapshot, SCHEMA, 5);
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  let markStarted;
+  const started = new Promise((resolve) => {
+    markStarted = resolve;
+  });
+  let release;
+  const o = buildShippedOracle({
+    api: hungApi,
+    snapshot,
+    verifiedNodeDefCache,
+    snapshotProbeDeadlineMs: 8000,
+    oracleDeadlineMs: null,
+    onFetch: () => markStarted(),
+    realFetchWholeObjectInfo: (opts) => {
+      assert.equal(opts.deadlineMs, 8000);
+      return new Promise((resolve) => {
+        release = () => resolve({ [CACHE_OUTCOME]: true, defs: { ...SCHEMA, RemoteOnly: {} }, failures: [], outcomes: [] });
+      });
+    },
+  });
+
+  const pending = o.getFreshObjectInfo();
+  await started;
+  // This is the production refresh invalidation crossing the outstanding probe.
+  snapshot.clear();
+  verifiedNodeDefCache.clear();
+  release();
+
+  const result = await pending;
+  assert.ok(result.RemoteOnly, "the late response is still returned for diagnostics");
+  assert.equal(o.readProvenance(), "retired", "the response cannot authorize after refresh invalidation");
+  assert.deepEqual(o.readHistory(), [], "the late response is not recorded as current backend truth");
+  assert.equal(snapshot.peek().held, false, "the concurrent refresh keeps the old snapshot retired");
 });
 
 test("#1582 SHIPPED: a second ordinary read does not re-wait on probes that already went silent", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -300,6 +300,7 @@ import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
 import { createSettingsBackendDefault } from "./lib/settings-backend-default.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
+import { objectInfoSnapshotProbeDeadline } from "./lib/object-info-probe-budget.js";
 import {
   fetchWholeObjectInfo,
   objectInfoOracleFailureNote,
@@ -1092,16 +1093,24 @@ function noteOpenAttempt({ cmd, rid, requested, resolved, applied, error }) {
 const NODE_DEFS_FETCH_TIMEOUT_MS = 10000;
 
 /**
- * #1582 — when a same-connection whole-schema snapshot is already held, the FIRST silent
- * call still has to discover that the live routes will not answer. Do not spend the full
- * serial 10s client share plus 5s raw-route share on that discovery. Two seconds still
- * leaves roughly four times the measured warm whole-schema read while keeping the existing
- * fail-closed outcome distinction: an answered bad response refuses, and only actual
- * silence licenses the last-observed snapshot. Once that silence is recorded, later
- * ordinary writes skip the probes entirely (`shouldSkipProbe`) rather than paying this
- * budget again on every widget edit.
+ * #1582/#1734 — when a same-connection whole-schema snapshot is already held, the FIRST
+ * silent call still has to discover that the live routes will not answer. Loopback keeps
+ * the original 2s discovery window. A non-loopback page origin gets 8s because a whole
+ * `/object_info` body is network-bound there; the reported 6MB remote read took ~1.7s
+ * before the oracle split its allowance across the two routes.
+ *
+ * This is still only the oracle's allowance: graph_set_widget passes it through
+ * `budget.bounded(...)`, so the 25s command deadline remains the outer cap. The
+ * fail-closed distinction is unchanged — an answered bad response refuses, and only
+ * actual silence licenses the last-observed snapshot. Once that silence is recorded,
+ * later ordinary writes skip the probes entirely (`shouldSkipProbe`) rather than paying
+ * this budget again on every widget edit.
+ *
+ * Use the page origin, not the optional Remote-URL setting: this is the origin the page's
+ * own `api` client actually reads. Unknown origins take the remote allowance so an
+ * unclassified target cannot be falsely treated as a fast loopback.
  */
-const OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS = 2000;
+const OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS = objectInfoSnapshotProbeDeadline(pageComfyOrigin());
 
 /**
  * #1180 — ONE budget for a whole `registerComfyNodeDefs` run, shared by its phases.

--- a/web/js/lib/object-info-probe-budget.js
+++ b/web/js/lib/object-info-probe-budget.js
@@ -1,0 +1,43 @@
+/**
+ * The first object-info probe on a connection is intentionally short when the
+ * ComfyUI page is local. A non-loopback page origin means the same whole-schema
+ * read crosses a network, so give that discovery window a larger bounded allowance.
+ *
+ * This only selects the probe's allowance. The panel_set_widget command still caps
+ * the actual wait with its one 25s command budget, and the object-info oracle still
+ * refuses answered-but-unusable responses.
+ */
+export const OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS = 2000;
+export const OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS = 8000;
+
+function isLoopbackHostname(hostname) {
+  const host = String(hostname ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "0.0.0.0" ||
+    host.startsWith("127.") ||
+    host === "::" ||
+    host === "::1"
+  );
+}
+
+/**
+ * Select the first-silence allowance from the origin that serves the panel's
+ * ComfyUI API. Unknown or malformed origins take the remote allowance: that is
+ * still bounded, while treating an unclassified target as local would recreate
+ * the false-dead probe this helper exists to prevent.
+ */
+export function objectInfoSnapshotProbeDeadline(origin) {
+  try {
+    const hostname = new URL(origin).hostname;
+    return isLoopbackHostname(hostname)
+      ? OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS
+      : OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS;
+  } catch {
+    return OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS;
+  }
+}


### PR DESCRIPTION
## Summary
- keep the 2s first-silence probe for loopback ComfyUI pages
- use an 8s bounded probe for non-loopback or unknown page origins
- preserve the 25s panel_set_widget command budget and fail-closed answered-response handling
- add shipped production-path tests for remote/local timing and concurrent refresh fencing

Fixes #1734

## Validation
- npm.cmd run test:unit
- npm.cmd run typecheck
- npm.cmd run check:scope
- git diff --check

Not merged.