### PR TITLE
fix(panel): recover Impact BooleanWidget writes (#1735)

### DIFF
--- a/browser_tests/unit/widget-bound-property.test.mjs
+++ b/browser_tests/unit/widget-bound-property.test.mjs
@@ -268,20 +268,24 @@ test("#1735: an accessor-backed BooleanWidget copy-back deletion is recovered on
     name: "resize_source",
     type: "BOOLEAN",
     options: { property: "resize_source" },
-    get value() {
+    callback() {
+      callbacks += 1;
+    },
+  };
+  // This is the descriptor shape comboBoolMigration installs: an own accessor
+  // with the omitted configurable/enumerable defaults.
+  Object.defineProperty(widget, "value", {
+    get() {
       return stored;
     },
-    set value(next) {
+    set(next) {
       stored = next;
       setterCalls += 1;
       if (setterCalls === 2) {
         throw new TypeError("Cannot delete property 'value' of #<BooleanWidget>");
       }
     },
-    callback() {
-      callbacks += 1;
-    },
-  };
+  });
   const node = {
     id: 1735,
     type: "ImageCompositeMasked",
@@ -297,6 +301,49 @@ test("#1735: an accessor-backed BooleanWidget copy-back deletion is recovered on
   assert.equal(node.properties.resize_source, true, "the bound node property retains the write");
   assert.equal(callbacks, 1, "the standard callback path still runs after recovery");
   assert.equal(set.write_warning, undefined, "the verified Impact Pack setter quirk is not surfaced as a write warning");
+});
+
+test("#1735: a custom accessor that mutates then throws the same deletion error is disclosed, not recovered", () => {
+  let stored = false;
+  let setterCalls = 0;
+  let callbacks = 0;
+  class CustomBooleanWidget {
+    get value() {
+      return stored;
+    }
+    set value(next) {
+      stored = next;
+      setterCalls += 1;
+      if (setterCalls === 2) {
+        throw new TypeError("Cannot delete property 'value' of #<BooleanWidget>");
+      }
+    }
+  }
+  const widget = new CustomBooleanWidget();
+  Object.assign(widget, {
+    name: "resize_source",
+    type: "BOOLEAN",
+    options: { property: "resize_source" },
+    callback() {
+      callbacks += 1;
+    },
+  });
+  const node = {
+    id: 1735,
+    type: "CustomBooleanNode",
+    properties: { resize_source: false },
+    widgets: [widget],
+    setProperty,
+  };
+
+  const set = applyWidgetWrite(node, "resize_source", true, {});
+
+  assert.equal(set.value, true, "read-back may show the mutation, but it is not clean success");
+  assert.equal(widget.value, true, "the custom setter mutated before throwing");
+  assert.equal(node.properties.resize_source, true, "the bound property was mutated before the throw");
+  assert.equal(callbacks, 0, "the callback must not run after an unrecovered setter failure");
+  assert.match(set.write_warning ?? "", /thrown while applying the write/);
+  assert.match(set.write_warning ?? "", /Cannot delete property/);
 });
 
 test("#1735: an accessor-backed BooleanWidget that does not retain still fails closed", () => {

--- a/browser_tests/unit/widget-bound-property.test.mjs
+++ b/browser_tests/unit/widget-bound-property.test.mjs
@@ -260,6 +260,75 @@ test("a bound widget whose `value` is an ACCESSOR still verifies", () => {
   assert.equal(callbacks, 3);
 });
 
+test("#1735: an accessor-backed BooleanWidget copy-back deletion is recovered only after both stores retain", () => {
+  let stored = false;
+  let setterCalls = 0;
+  let callbacks = 0;
+  const widget = {
+    name: "resize_source",
+    type: "BOOLEAN",
+    options: { property: "resize_source" },
+    get value() {
+      return stored;
+    },
+    set value(next) {
+      stored = next;
+      setterCalls += 1;
+      if (setterCalls === 2) {
+        throw new TypeError("Cannot delete property 'value' of #<BooleanWidget>");
+      }
+    },
+    callback() {
+      callbacks += 1;
+    },
+  };
+  const node = {
+    id: 1735,
+    type: "ImageCompositeMasked",
+    properties: { resize_source: false },
+    widgets: [widget],
+    setProperty,
+  };
+
+  const set = applyWidgetWrite(node, "resize_source", true, {});
+
+  assert.equal(set.value, true);
+  assert.equal(widget.value, true, "the accessor-backed widget retains the write");
+  assert.equal(node.properties.resize_source, true, "the bound node property retains the write");
+  assert.equal(callbacks, 1, "the standard callback path still runs after recovery");
+  assert.equal(set.write_warning, undefined, "the verified Impact Pack setter quirk is not surfaced as a write warning");
+});
+
+test("#1735: an accessor-backed BooleanWidget that does not retain still fails closed", () => {
+  let stored = false;
+  const widget = {
+    name: "resize_source",
+    type: "BOOLEAN",
+    options: { property: "resize_source" },
+    get value() {
+      return stored;
+    },
+    set value(next) {
+      if (next === true) throw new TypeError("Cannot delete property 'value' of #<BooleanWidget>");
+      stored = next;
+    },
+  };
+  const node = {
+    id: 1735,
+    type: "ImageCompositeMasked",
+    properties: { resize_source: false },
+    widgets: [widget],
+    setProperty,
+  };
+
+  assert.throws(
+    () => applyWidgetWrite(node, "resize_source", true, {}),
+    /did not retain|thrown while applying the write/,
+  );
+  assert.equal(widget.value, false, "the failed write is rolled back or remains unchanged");
+  assert.equal(node.properties.resize_source, false, "the bound property is not falsely reported as changed");
+});
+
 test("an unrelated failure still rolls the bound property back", () => {
   // The widget's own callback reverts the value, so the write fails on the #240 check.
   // The property must not be left carrying the new value after that rollback.

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -345,6 +345,55 @@ export function isBooleanWidget(widget) {
 }
 
 /**
+ * #1735 — whether `value` is supplied by an accessor somewhere on the widget's
+ * prototype chain. Impact Pack's migrated BooleanWidget uses a non-configurable
+ * value property; its setter can apply the value and then throw when the node's
+ * bound-property copy-back invokes that setter a second time.
+ *
+ * This is deliberately a descriptor check, not a class-name check: custom widgets
+ * are page code and may be minified or wrapped. Descriptor reads are best-effort;
+ * an unreadable prototype is not evidence that the write is recoverable.
+ */
+function hasValueAccessor(widget) {
+  let current = widget;
+  try {
+    while (current && (typeof current === "object" || typeof current === "function")) {
+      const descriptor = Object.getOwnPropertyDescriptor(current, "value");
+      if (descriptor) return typeof descriptor.get === "function" || typeof descriptor.set === "function";
+      current = Object.getPrototypeOf(current);
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+/**
+ * #1735 — the one accessor failure that may be recovered after read-back.
+ *
+ * The initial assignment and the node's property assignment have already happened
+ * before this is called. The caller still runs the ordinary callback/update path, and
+ * the existing widget + bound-property verification remains authoritative. A setter
+ * that throws for any other reason stays a warning/refusal, so this cannot turn an
+ * arbitrary custom-node side-effect failure into a clean success.
+ */
+function isRecoverableBooleanAccessorDelete(widget, expected, err) {
+  if (!isBooleanWidget(widget) || !hasValueAccessor(widget)) return false;
+  let message;
+  try {
+    message = String(err?.message ?? err);
+  } catch {
+    return false;
+  }
+  if (!/^Cannot delete property ['"]value['"]/i.test(message)) return false;
+  try {
+    return Object.is(widget.value, expected);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True for a COMPOSITE widget whose value is a plain object rather than a scalar
  * — e.g. the rgthree Power Lora Loader's `lora_N` rows ({on, lora, strength,
  * strengthTwo, …}). Detected by the CURRENT value's shape (a non-null, non-array
@@ -2171,7 +2220,18 @@ export function applyWidgetWrite(
     // A throw from here is captured by the same catch as everything else in this envelope
     // and stays UNATTRIBUTED — `onPropertyChanged` is a node's own code and this is not
     // the widget-callback invocation #976 can name.
-    if (boundProperty?.reachable) valueNode.setProperty(boundProperty.property, coerced);
+    if (boundProperty?.reachable) {
+      try {
+        valueNode.setProperty(boundProperty.property, coerced);
+      } catch (err) {
+        // #1735: Impact Pack's accessor-backed BooleanWidget can throw after the
+        // property and widget already hold the requested value, when setProperty's
+        // normal copy-back invokes its setter a second time. Continue into the same
+        // callback path only for that exact, verified shape; the read-back below still
+        // fails closed if either store did not actually take the value.
+        if (!isRecoverableBooleanAccessorDelete(valueWidget, expected, err)) throw err;
+      }
+    }
     // Fire the WRITTEN widget's own callback so combo/number side effects run — the
     // same single invocation a manual UI edit of the promoted control performs.
     //

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -345,27 +345,29 @@ export function isBooleanWidget(widget) {
 }
 
 /**
- * #1735 — whether `value` is supplied by an accessor somewhere on the widget's
- * prototype chain. Impact Pack's migrated BooleanWidget uses a non-configurable
- * value property; its setter can apply the value and then throw when the node's
- * bound-property copy-back invokes that setter a second time.
+ * #1735 — whether `value` has the exact accessor shape installed by Impact Pack's
+ * comboBoolMigration. That migration defines an OWN accessor without setting
+ * configurable/enumerable, so the descriptor is non-configurable and non-enumerable;
+ * its setter can apply the value and then throw when the node's bound-property
+ * copy-back invokes that setter a second time.
  *
- * This is deliberately a descriptor check, not a class-name check: custom widgets
- * are page code and may be minified or wrapped. Descriptor reads are best-effort;
- * an unreadable prototype is not evidence that the write is recoverable.
+ * This deliberately does not walk the prototype chain: an ordinary custom accessor
+ * must remain on the existing exception-disclosure path. Descriptor reads are
+ * best-effort; an unreadable or differently shaped property is not evidence that the
+ * write is recoverable.
  */
-function hasValueAccessor(widget) {
-  let current = widget;
+function hasImpactBooleanAccessor(widget) {
   try {
-    while (current && (typeof current === "object" || typeof current === "function")) {
-      const descriptor = Object.getOwnPropertyDescriptor(current, "value");
-      if (descriptor) return typeof descriptor.get === "function" || typeof descriptor.set === "function";
-      current = Object.getPrototypeOf(current);
-    }
+    const descriptor = Object.getOwnPropertyDescriptor(widget, "value");
+    return (
+      descriptor?.configurable === false &&
+      descriptor.enumerable === false &&
+      typeof descriptor.get === "function" &&
+      typeof descriptor.set === "function"
+    );
   } catch {
     return false;
   }
-  return false;
 }
 
 /**
@@ -378,7 +380,7 @@ function hasValueAccessor(widget) {
  * arbitrary custom-node side-effect failure into a clean success.
  */
 function isRecoverableBooleanAccessorDelete(widget, expected, err) {
-  if (!isBooleanWidget(widget) || !hasValueAccessor(widget)) return false;
+  if (!isBooleanWidget(widget) || !hasImpactBooleanAccessor(widget)) return false;
   let message;
   try {
     message = String(err?.message ?? err);


### PR DESCRIPTION
## Summary

Fixes #1735. Recover the accessor-backed/custom BooleanWidget write path when Impact Pack's bound-property copy-back throws `Cannot delete property 'value'` after both the widget and node property already retain the requested value.

The recovery is narrowly gated to Boolean/toggle widgets with a value accessor, the exact deletion error shape, and successful read-back. All other errors retain the existing warning/refusal path, and the existing widget/property verification remains authoritative.

## Tests

- Focused widget-bound-property, widget-write, and node-widget-changed tests
- Pre-fix mutation check: the new regression failed on base
- `npm.cmd run typecheck`
- `npm.cmd run check:scope`
- `npm.cmd run i18n:check`
- Tool vocabulary check
- Full unit suite: 6,735 tests, 6,734 passed, 1 todo, 0 failed

## Scope

- Production: `web/js/lib/widget-write.js`
- Regression tests: `browser_tests/unit/widget-bound-property.test.mjs`

No merge or release performed.