### PR TITLE
chore: release v0.15.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.76] - 2026-08-24
+
+### Fixed
+- Preserve Save-As canvas identity through partial restores, tab switches, overlap, and failure cleanup (#939)
+- Scale object-info schema probes for remote ComfyUI origins while preserving bounded fail-closed writes (#1734)
+- Recover accessor-backed Impact BooleanWidget writes without masking same-message setter failures (#1735)
+
 ## [0.15.75] - 2026-08-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.75",
+  "version": "0.15.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.75",
+      "version": "0.15.76",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.75",
+  "version": "0.15.76",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
## Release v0.15.76\n\n- Preserve Save-As canvas identity through partial restores, tab switches, overlap, and failure cleanup (#939).\n- Scale remote object-info schema probes with bounded fail-closed writes (#1734).\n- Recover accessor-backed Impact BooleanWidget writes without masking setter failures (#1735).\n\nRelease gates: typecheck, scope, i18n/vocabulary checks, full unit suite (6,752 passed, 1 todo), and diff check passed. Live Playwright was unavailable because localhost:8188 was not running.