### PR TITLE
Fix panel refresh stuck after concurrent downloads

### DIFF
--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -350,7 +350,7 @@ test("#635: the shipping registerComfyNodeDefs returns its verdict through the p
   assert.match(body, /return describeNodeDefRefresh\(\{/, "the run verdict is returned");
   assert.match(
     body,
-    /nodeDefsRefreshConfirmed =\s*runIsCurrent && !comboCompletionPending && !didThrow && !!defs && \(comboRan \|\| comboAbandonedAfterRebuild\);/,
+    /nodeDefsRefreshConfirmed =\s*runIsCurrent &&\s*!comboCompletionPending &&\s*!didThrow &&\s*!!defs &&\s*\(comboRan \|\| \(!comboFailed && \(comboRebuiltLocally \|\| comboAbandonedAfterRebuild\)\)\);/,
     "the shared global stays a strict boolean, and #1193 admits the panel's OWN completed " +
       "combo rebuild as the second way the live lists became current",
   );
@@ -367,7 +367,16 @@ test("#635: the shipping registerComfyNodeDefs returns its verdict through the p
   // #1193 — the two inputs must stay SEPARATE all the way to the verdict. Merging them
   // into one flag would make an abandoned-but-locally-rebuilt run indistinguishable from
   // a confirmed one, which is the distinction the disclosure exists to carry.
-  assert.match(body, /comboRebuiltLocally: comboAbandonedAfterRebuild,/, "the verdict is told which one held");
+  assert.match(
+    body,
+    /comboRebuiltLocally: comboRebuiltLocally \|\| comboAbandonedAfterRebuild,/,
+    "the verdict is told which local rebuild held",
+  );
+  assert.match(
+    body,
+    /comboRefreshSkipped:\s*comboApiPresent && comboRebuiltLocally && runOpts\?\.skipDuplicateComboRefresh === true,/,
+    "the verdict discloses a skipped duplicate call",
+  );
   // #1193 — the disclosure is gated on the sweep having COVERED the graph, never on it
   // merely having finished. `comboRebuild.completed` alone is true for a sweep that walked
   // past every V2 combo on the graph, and granting the claim there suppresses a genuine

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -16,6 +16,7 @@ import {
   collectAllGraphs,
   comboRebuildCovered,
   isStaleAssetCandidate as isStaleAssetCandidateLib,
+  reapplyDefsToLiveNodes,
   resolveMissingModelDirectory,
 } from "../../web/js/lib/asset-staleness.js";
 import { withoutFrontendVirtualTypes } from "../../web/js/lib/frontend-virtual-nodes.js";
@@ -55,7 +56,13 @@ const RELAY = 3000;
 const FETCH_MS = 2080;
 const BLOCK_MS = 1500;
 
-function buildRun({ appValue, apiValue, withTimeoutImpl = withTimeout, runBudgetMs = 9000 }) {
+function buildRun({
+  appValue,
+  apiValue,
+  reapplyDefsToLiveNodesImpl = () => {},
+  withTimeoutImpl = withTimeout,
+  runBudgetMs = 9000,
+}) {
   const body = extractFunction("async function registerComfyNodeDefs(");
   const names = [
     "app", "api", "recordObjectInfoTypes", "reapplyDefsToLiveNodes", "comboRebuildCovered",
@@ -69,7 +76,7 @@ function buildRun({ appValue, apiValue, withTimeoutImpl = withTimeout, runBudget
   const vals = {
     app: appValue, api: apiValue,
     recordObjectInfoTypes: () => ({}),
-    reapplyDefsToLiveNodes: () => {},
+    reapplyDefsToLiveNodes: reapplyDefsToLiveNodesImpl,
     comboRebuildCovered,
     describeNodeDefRefresh,
     NODE_DEF_REFRESH_REASONS,
@@ -163,6 +170,20 @@ function deferred() {
   let resolve;
   const promise = new Promise((r) => { resolve = r; });
   return { promise, resolve };
+}
+
+async function withWatchdog(promise, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(label)), 1500);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 test("#1562: refresh_nodes answers before synchronous reapply and keeps registration single-flight", async () => {
@@ -337,6 +358,90 @@ test("#1695: late combo work is fenced before reconnect successor and collector 
   collector.setRefreshConfirmed(built.getConfirmed());
   assert.equal(collector.collectMissingAssets().models.length, 0, "collectMissingAssets sees only the settled successor");
   assert.equal(inFlight, null, "the fenced lifecycle returns to idle");
+});
+
+test("#1736: covered local combo rebuild avoids a stuck duplicate and recovers after concurrent completion", async () => {
+  const firstFetch = deferred();
+  const recoveryFetch = deferred();
+  const defs = {
+    TestLoader: {
+      input: { required: { model: [["fresh.safetensors"], {}] } },
+    },
+  };
+  const comboWidget = { name: "model", options: { values: ["stale.safetensors"] } };
+  const rootGraph = {
+    _nodes: [{ type: "TestLoader", widgets: [comboWidget], constructor: {} }],
+  };
+  let fetches = 0;
+  let comboCalls = 0;
+  let backgroundPhase = true;
+  const appValue = {
+    graph: rootGraph,
+    registerNodesFromDefs: async () => {},
+    refreshComboInNodes: () => {
+      comboCalls += 1;
+      return backgroundPhase ? new Promise(() => {}) : Promise.resolve();
+    },
+  };
+  const apiValue = {
+    getNodeDefs: async () => {
+      fetches += 1;
+      if (fetches === 1) await firstFetch.promise;
+      if (fetches === 3) await recoveryFetch.promise;
+      return defs;
+    },
+  };
+  const built = buildRun({
+    appValue,
+    apiValue,
+    reapplyDefsToLiveNodesImpl: reapplyDefsToLiveNodes,
+    runBudgetMs: 100,
+  });
+  let inFlight = null;
+  const refreshComfyNodeDefs = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (value) => { inFlight = value; },
+    runRegister: built.registerComfyNodeDefs,
+    withTimeout,
+  });
+  const refresh_nodes = buildRefreshNodes({ refreshComfyNodeDefs, commandBudget: 150 });
+
+  const background = refreshComfyNodeDefs(undefined, {
+    force: true,
+    skipDuplicateComboRefresh: true,
+  });
+  const acknowledgement = refresh_nodes();
+  const completion = refreshComfyNodeDefs(undefined, {
+    force: true,
+    skipDuplicateComboRefresh: true,
+  });
+  firstFetch.resolve();
+
+  const reply = await withWatchdog(acknowledgement, "panel_refresh_nodes stayed stuck");
+  await withWatchdog(Promise.all([background, completion]), "concurrent refresh completion stayed stuck");
+  backgroundPhase = false;
+  assert.deepEqual(reply, {
+    ok: true,
+    refreshed: true,
+    combo_refresh_confirmed: false,
+    combo_refresh_note:
+      "Node definitions WERE re-registered from a fresh /object_info, and the panel rebuilt every " +
+      "combo widget's option list on the live graph from that same payload. The frontend's duplicate " +
+      "refreshComboInNodes() call was skipped because those lists are already current.",
+  });
+  assert.equal(comboCalls, 0, "a covered local rebuild does not start the duplicate frontend refresh");
+  assert.deepEqual(comboWidget.options.values, ["fresh.safetensors"]);
+  assert.equal(inFlight, null, "the concurrent completion releases the shared slot");
+
+  const recoveryRun = refreshComfyNodeDefs(undefined, { force: true });
+  const recoveredPromise = refresh_nodes();
+  recoveryFetch.resolve();
+  const recovered = await withWatchdog(recoveredPromise, "refresh_nodes did not recover after completion");
+  await withWatchdog(recoveryRun, "the recovery refresh did not complete");
+  assert.equal(recovered.ok, true);
+  assert.equal(recovered.refreshed, true);
+  assert.equal(comboCalls, 1, "recovery may use the normal frontend confirmation path");
+  assert.equal(inFlight, null, "the recovery run also returns the slot to idle");
 });
 
 test("#1562: a later bounded caller upgrades an already-queued trailing run", async () => {

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -11,6 +11,7 @@ import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/j
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { fetchWholeObjectInfo, TRANSPORT_OUTCOME } from "../../web/js/lib/object-info-oracle.js";
+import { reconcileCompletedDownloads } from "../../web/js/lib/download-refresh.js";
 import { describeNodeDefRefresh, NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
 import {
   collectAllGraphs,
@@ -170,6 +171,20 @@ function deferred() {
   let resolve;
   const promise = new Promise((r) => { resolve = r; });
   return { promise, resolve };
+}
+
+const ON_DOWNLOADS_BODY = extractFunction("onDownloads(list)");
+
+function buildOnDownloads(refreshComfyNodeDefs) {
+  const factory = new Function(
+    "reconcileCompletedDownloads",
+    "refreshComfyNodeDefs",
+    "renderDownloads",
+    `let seenDoneDownloads = new Set();
+     const executors = {${ON_DOWNLOADS_BODY}};
+     return executors.onDownloads;`,
+  );
+  return factory(reconcileCompletedDownloads, refreshComfyNodeDefs, () => {});
 }
 
 async function withWatchdog(promise, label) {
@@ -360,7 +375,7 @@ test("#1695: late combo work is fenced before reconnect successor and collector 
   assert.equal(inFlight, null, "the fenced lifecycle returns to idle");
 });
 
-test("#1736: covered local combo rebuild avoids a stuck duplicate and recovers after concurrent completion", async () => {
+test("#1736: download completion upgrades a queued no-skip refresh and recovers", async () => {
   const firstFetch = deferred();
   const recoveryFetch = deferred();
   const defs = {
@@ -380,6 +395,7 @@ test("#1736: covered local combo rebuild avoids a stuck duplicate and recovers a
     registerNodesFromDefs: async () => {},
     refreshComboInNodes: () => {
       comboCalls += 1;
+      if (comboCalls === 1) return Promise.resolve();
       return backgroundPhase ? new Promise(() => {}) : Promise.resolve();
     },
   };
@@ -406,19 +422,16 @@ test("#1736: covered local combo rebuild avoids a stuck duplicate and recovers a
   });
   const refresh_nodes = buildRefreshNodes({ refreshComfyNodeDefs, commandBudget: 150 });
 
-  const background = refreshComfyNodeDefs(undefined, {
-    force: true,
-    skipDuplicateComboRefresh: true,
-  });
+  const current = refreshComfyNodeDefs(undefined, { force: true });
+  const reconnect = refreshComfyNodeDefs(undefined, { force: true });
+  const onDownloads = buildOnDownloads(refreshComfyNodeDefs);
+  onDownloads([{ id: "d1", status: "downloading" }]);
+  onDownloads([{ id: "d1", status: "done" }]);
   const acknowledgement = refresh_nodes();
-  const completion = refreshComfyNodeDefs(undefined, {
-    force: true,
-    skipDuplicateComboRefresh: true,
-  });
   firstFetch.resolve();
 
   const reply = await withWatchdog(acknowledgement, "panel_refresh_nodes stayed stuck");
-  await withWatchdog(Promise.all([background, completion]), "concurrent refresh completion stayed stuck");
+  await withWatchdog(Promise.all([current, reconnect]), "concurrent refresh completion stayed stuck");
   backgroundPhase = false;
   assert.deepEqual(reply, {
     ok: true,
@@ -429,7 +442,7 @@ test("#1736: covered local combo rebuild avoids a stuck duplicate and recovers a
       "combo widget's option list on the live graph from that same payload. The frontend's duplicate " +
       "refreshComboInNodes() call was skipped because those lists are already current.",
   });
-  assert.equal(comboCalls, 0, "a covered local rebuild does not start the duplicate frontend refresh");
+  assert.equal(comboCalls, 1, "download completion upgrades the queued run before its duplicate frontend refresh");
   assert.deepEqual(comboWidget.options.values, ["fresh.safetensors"]);
   assert.equal(inFlight, null, "the concurrent completion releases the shared slot");
 
@@ -440,7 +453,7 @@ test("#1736: covered local combo rebuild avoids a stuck duplicate and recovers a
   await withWatchdog(recoveryRun, "the recovery refresh did not complete");
   assert.equal(recovered.ok, true);
   assert.equal(recovered.refreshed, true);
-  assert.equal(comboCalls, 1, "recovery may use the normal frontend confirmation path");
+  assert.equal(comboCalls, 2, "recovery may use the normal frontend confirmation path");
   assert.equal(inFlight, null, "the recovery run also returns the slot to idle");
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1457,6 +1457,11 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // sweep had already rebuilt the lists. Narrower than `comboRebuild.completed`, and
   // deliberately so: see the note where it is set.
   let comboAbandonedAfterRebuild = false;
+  // #1736 — when the panel's own sweep covered every live combo, the frontend's
+  // refreshComboInNodes() would only repeat the same work with another /object_info
+  // request. Keep that duplicate operation out of the single-flight lifecycle: a
+  // frontend promise that never settles must not strand every later refresh_nodes call.
+  let comboRebuiltLocally = false;
   let phase = "fetch";
   // #1180 — ONE deadline for this whole run. Every bounded phase below draws from what is
   // left of it, so the run's cost is this budget rather than the sum of numbers that each
@@ -1966,6 +1971,7 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
       // #1193 — the third argument records what this sweep OBSERVABLY did (#1172 made it
       // rebuild every combo's option list from `defs`). The combo phase below reads it.
       if (rootGraph) reapplyDefsToLiveNodes(rootGraph, defs, comboRebuild);
+      comboRebuiltLocally = comboRebuildCovered(comboRebuild);
     }
     // Hand back the time the unbounded local work took. After this, what remains of the
     // deadline is what remains of the WAITING allowance, which is what the phase below
@@ -1975,7 +1981,14 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     // models resolve and stale entries clear (#185/#181/#223).
     phase = "combo";
     comboApiPresent = typeof a.refreshComboInNodes === "function";
-    if (comboApiPresent) {
+    if (comboApiPresent && comboRebuiltLocally && runOpts?.skipDuplicateComboRefresh === true) {
+      // #1736 — reapplyDefsToLiveNodes() has already rebuilt every live combo from
+      // this run's authoritative payload. Calling refreshComboInNodes() here would
+      // re-fetch the same schema and can remain pending behind concurrent downloads,
+      // leaving the shared refresh slot stuck forever. The local rebuild is the
+      // observed freshness proof, so no duplicate frontend operation is needed.
+      phase = "done";
+    } else if (comboApiPresent) {
       // #1180 — BOUNDED, and this was the fifth place the same mistake had to be found.
       // The fetch phase above is bounded, but `refreshComboInNodes()` issues its own
       // /object_info request (see the note at the combo-trust check), so a connection that
@@ -2089,7 +2102,10 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
               runStartedAtEpoch === backendReconnectEpoch &&
               runStartedAtGeneration === verifiedNodeDefCache.generation();
             nodeDefsRefreshConfirmed =
-              currentRun && !didThrow && !!defs && (comboRan || comboAbandonedAfterRebuild);
+              currentRun &&
+              !didThrow &&
+              !!defs &&
+              (comboRan || (!comboFailed && (comboRebuiltLocally || comboAbandonedAfterRebuild)));
             const lateVerdict = buildRefreshVerdict?.();
             if (!lateVerdict || !initialRefreshVerdict) return initialRefreshVerdict;
             // The late phase can revise only combo freshness. Preserve disclosures produced
@@ -2214,7 +2230,11 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
       runStartedAtEpoch === backendReconnectEpoch &&
       runStartedAtGeneration === verifiedNodeDefCache.generation();
     nodeDefsRefreshConfirmed =
-      runIsCurrent && !comboCompletionPending && !didThrow && !!defs && (comboRan || comboAbandonedAfterRebuild);
+      runIsCurrent &&
+      !comboCompletionPending &&
+      !didThrow &&
+      !!defs &&
+      (comboRan || (!comboFailed && (comboRebuiltLocally || comboAbandonedAfterRebuild)));
   }
   // RETURN this run's own verdict so a caller can trust the combo based on the result
   // of ITS refresh, independent of the shared nodeDefsRefreshConfirmed global — which a
@@ -2236,7 +2256,9 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
         comboRan,
         // #1193 — the panel's own sweep, reported separately from the frontend's call so the
         // verdict can say which one made the dropdowns current.
-        comboRebuiltLocally: comboAbandonedAfterRebuild,
+        comboRebuiltLocally: comboRebuiltLocally || comboAbandonedAfterRebuild,
+        comboRefreshSkipped:
+          comboApiPresent && comboRebuiltLocally && runOpts?.skipDuplicateComboRefresh === true,
         comboWaitMs,
         phase,
         didThrow,
@@ -35773,7 +35795,15 @@ function buildPanel() {
       // fresh fetch that reflects the just-landed file (#396 completion race).
       const { nextSeen, newlyDone } = reconcileCompletedDownloads(list, seenDoneDownloads);
       seenDoneDownloads = nextSeen;
-      if (newlyDone.length) void refreshComfyNodeDefs(undefined, { force: true });
+      if (newlyDone.length) {
+        void refreshComfyNodeDefs(undefined, {
+          force: true,
+          // #1736 — this background refresh already fetched the authoritative schema and
+          // re-applies every live combo locally. Do not launch the duplicate frontend call
+          // that can remain pending forever while concurrent downloads are draining.
+          skipDuplicateComboRefresh: true,
+        });
+      }
     },
     // Live RunPod pod status → the host pill + open control modal.
     onRunpodStatus(frame) {

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -71,6 +71,8 @@ function detailSuffix(thrown) {
  *                              // this panel did and counted. Both false is "stale";
  *                              // collapsing them into one flag is what made an abandoned
  *                              // frontend call read as stale combos it had already fixed.
+ *   comboRefreshSkipped?: boolean, // #1736 — the panel skipped the duplicate frontend call
+ *                              // because that local rebuild already covered every live combo.
  *   comboWaitMs?: number|null, // the bound the combo phase was actually given, so an
  *                              // abandoned phase can say whether it was STARVED by a slow
  *                              // fetch or given its whole allowance and still hung
@@ -101,6 +103,7 @@ export function describeNodeDefRefresh({
   comboApiPresent,
   comboRan,
   comboRebuiltLocally = false,
+  comboRefreshSkipped = false,
   comboWaitMs = null,
   phase = "done",
   didThrow,
@@ -282,11 +285,14 @@ export function describeNodeDefRefresh({
         combo_refresh_confirmed: false,
         combo_refresh_note:
           `${registrationClause}, and the panel rebuilt every combo widget's option list ` +
-          "on the live graph from that same payload. The frontend's own refreshComboInNodes() " +
-          "had not answered when this run stopped waiting for it" +
-          (comboWaitMs ? ` (it was given ${comboWaitMs}ms)` : "") +
-          " — it is still running and will re-apply the same definitions when it finishes. " +
-          "The dropdown lists are current; only that call's completion is unconfirmed.",
+          (comboRefreshSkipped
+            ? "on the live graph from that same payload. The frontend's duplicate " +
+              "refreshComboInNodes() call was skipped because those lists are already current."
+            : "on the live graph from that same payload. The frontend's own refreshComboInNodes() " +
+              "had not answered when this run stopped waiting for it" +
+              (comboWaitMs ? ` (it was given ${comboWaitMs}ms)` : "") +
+              " — it is still running and will re-apply the same definitions when it finishes. " +
+              "The dropdown lists are current; only that call's completion is unconfirmed."),
       };
     }
     // Nothing rebuilt the lists — neither the frontend's call nor this panel's sweep

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -190,7 +190,8 @@ async function waitForRun(
 //   runRegister(preloadedDefs, runOpts, runControl) : performs the actual (idempotent)
 //                                registration; its own cleanup must NOT clear the slot —
 //                                the coalescer owns the slot lifecycle. `runOpts` is the
-//                                caller's `{ runBudgetMs }`, forwarded verbatim. `runControl`
+//                                caller's `{ runBudgetMs, preloadedWholeSchema,
+//                                skipDuplicateComboRefresh }`, forwarded verbatim. `runControl`
 //                                carries the pre-local-work handoff used by a bounded caller,
 //                                plus `deferCompletion(promise)` for work that may outlive
 //                                the register function's observation budget but still owns
@@ -346,10 +347,14 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     // #1562 — the caller's RUN allowance, forwarded to every `startRun` below. Built here,
     // once, so no branch can start a run under a different budget than its siblings.
     const runOpts =
-      opts && (Number.isFinite(opts.runBudgetMs) || opts.preloadedWholeSchema === true)
+      opts &&
+      (Number.isFinite(opts.runBudgetMs) ||
+        opts.preloadedWholeSchema === true ||
+        opts.skipDuplicateComboRefresh === true)
         ? {
             ...(Number.isFinite(opts.runBudgetMs) ? { runBudgetMs: opts.runBudgetMs } : {}),
             ...(opts.preloadedWholeSchema === true ? { preloadedWholeSchema: true } : {}),
+            ...(opts.skipDuplicateComboRefresh === true ? { skipDuplicateComboRefresh: true } : {}),
           }
         : undefined;
     const abandonBeforeLocalWork = !!(opts && opts.abandonBeforeLocalWork);

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -434,6 +434,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       }
       if (!trailing) {
         let earlyYieldRequested = abandonBeforeLocalWork;
+        let queuedRunOpts = runOpts;
         let queuedHandle = null;
         const queued = (async () => {
           try {
@@ -442,7 +443,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
             /* the in-flight refresh failed — run our own anyway */
           }
           trailing = null;
-          queuedHandle = startRun(undefined, runOpts, earlyYieldRequested);
+          queuedHandle = startRun(undefined, queuedRunOpts, earlyYieldRequested);
           return queuedHandle;
         })();
         trailing = {
@@ -457,8 +458,21 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
           requestEarlyYield: () => {
             earlyYieldRequested = true;
           },
+          // #1736 — a later forced caller may carry the skip option that the queued
+          // successor needs before it starts. Preserve the first caller's budget/options,
+          // then monotonically add this freshness optimization; once the successor starts,
+          // `trailing` is cleared and its run options are immutable.
+          upgradeRunOpts: (nextRunOpts) => {
+            if (nextRunOpts?.skipDuplicateComboRefresh !== true) return;
+            queuedRunOpts = { ...(queuedRunOpts ?? {}), skipDuplicateComboRefresh: true };
+          },
         };
         current.attachNextCompletion?.(trailing);
+      } else {
+        // #1736 — the trailing run is shared, but its options are not frozen until the
+        // queued successor begins. A download completion arriving after a no-skip forced
+        // caller must still upgrade that successor to skip the duplicate frontend call.
+        trailing.upgradeRunOpts?.(runOpts);
       }
       return waitForRun(
         trailing,


### PR DESCRIPTION
## Summary
- skip the duplicate frontend combo refresh for completed-download background refreshes when the panel's authoritative local sweep covered every live combo
- preserve manual refresh timeout/error semantics and protect the shared trust flag from combo failures
- add a production-path regression covering concurrent completion, panel_refresh_nodes acknowledgement, slot release, and recovery

Fixes #1736

## Validation
- Focused refresh suite: 104 passed, 0 failed
- Full unit glob: 6,753 passed, 0 failed, 1 todo
- 
pm.cmd run typecheck: passed
- 
pm.cmd run test:unit: stops at check-panel-scope because this fresh worktree lacks local 
ode_modules/typescript; direct full unit glob passed
- No lint script is defined in package.json