### PR TITLE
chore: release v0.15.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.77] - 2026-08-25
+
+### Fixed
+- Recover panel refreshes after concurrent download completions and coalesced trailing refreshes (#1736)
+
 ## [0.15.76] - 2026-08-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.76",
+  "version": "0.15.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.76",
+      "version": "0.15.77",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.76",
+  "version": "0.15.77",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
Release Panel v0.15.77 for merged #1736. Local typecheck, scope check, i18n/vocabulary checks, and full unit suite passed (6,753 passed, 1 todo).