### PR TITLE
fix(panel): join in-flight node refreshes

### DIFF
--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -115,6 +115,42 @@ test("#1680: a forced payload-less caller can explicitly join an in-flight refre
   assert.equal(registered.length, 1, "the opt-in joins the existing run without a trailing pass");
 });
 
+test("#1758: an acknowledgement owner waits through its own local-work handoff", async () => {
+  const handoff = deferred();
+  const release = deferred();
+  let inFlight = null;
+  let runs = 0;
+  const coalescer = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (value) => { inFlight = value; },
+    runRegister: async (_defs, _opts, control) => {
+      runs += 1;
+      control.beforeLocalWork?.();
+      handoff.resolve();
+      await release.promise;
+      return { refreshed: true };
+    },
+    withTimeout,
+  });
+
+  const acknowledgement = coalescer(undefined, {
+    force: true,
+    joinInFlight: true,
+    abandonBeforeLocalWork: true,
+    joinMs: 500,
+  });
+  await handoff.promise;
+  let settled = false;
+  void acknowledgement.then(() => { settled = true; });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false, "the acknowledgement must not abandon its own shared refresh at handoff");
+
+  release.resolve();
+  assert.deepEqual(await acknowledgement, { refreshed: true });
+  assert.equal(runs, 1, "the acknowledgement owns one refresh, with no competing registration");
+  assert.equal(inFlight, null, "the joined lifecycle returns to idle after completion");
+});
+
 test("#1695: deferred completion fences the slot and forwards its final verdict", async () => {
   const late = deferred();
   let inFlight = null;

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -609,12 +609,12 @@ test("#1680: refresh_nodes replies at its budget instead of waiting for the join
   assert.equal(built.runs.length, 1, "a timed-out join must not create a trailing refresh");
 });
 
-test("#1680: a joined acknowledgement yields before delayed synchronous registration", async () => {
+test("#1758: a joined acknowledgement waits through synchronous registration", async () => {
   const gate = deferred();
   const localWorkMs = 100;
   const built = realRefreshNodes({
     holdFirstRun: gate.promise,
-    budgetMs: 1,
+    budgetMs: 500,
     runHook: async ({ control }) => {
       const handoff = control.beforeLocalWork?.();
       if (handoff) await handoff;
@@ -633,12 +633,12 @@ test("#1680: a joined acknowledgement yields before delayed synchronous registra
   const { value, elapsed } = await withWatchdog(
     () => pending,
     500,
-    "refresh_nodes waited through the joined refresh's synchronous work",
+    "refresh_nodes did not join through the shared refresh's synchronous work",
   );
-  assert.equal(value.reason, "refresh_still_running");
+  assert.deepEqual(value, { ok: true, refreshed: true });
   assert.ok(
-    elapsed < localWorkMs,
-    `replied in ${elapsed}ms instead of blocking through ${localWorkMs}ms of local work`,
+    elapsed >= localWorkMs,
+    `replied in ${elapsed}ms instead of joining through ${localWorkMs}ms of local work`,
   );
 
   await built.inFlightStarted?.catch(() => {});
@@ -984,5 +984,10 @@ test("#1404: the shipped call site passes the budget — the helper alone cannot
     refreshNodesMatch[0],
     /refreshComfyNodeDefs\(undefined, \{[\s\S]*?force: true,[\s\S]*?joinInFlight: true,[\s\S]*?joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,[\s\S]*?runBudgetMs: REFRESH_NODES_RUN_BUDGET_MS,\s*\}\)/,
     "refresh_nodes must join an existing run, bound its wait, and state the run's allowance",
+  );
+  assert.match(
+    refreshNodesMatch[0],
+    /joinInFlight: true,[\s\S]*?abandonBeforeLocalWork: true,/,
+    "refresh_nodes must give the coalescer its acknowledgement handoff contract (#1758)",
   );
 });

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -1,7 +1,7 @@
-// panel#1562 recurrence: a large /object_info can finish just before the refresh
-// caller's budget, then synchronous schema registration blocks the timer that should
-// produce the retryable verdict. The verdict must cross the relay before that local work,
-// while the single-flight run remains alive and owns registration until it finishes.
+// panel#1758: a large /object_info can finish just before panel_refresh_nodes observes the
+// shared run, then synchronous schema registration begins. The acknowledgement must join
+// that production refresh through registration/reapply and return its settled verdict, while
+// the single-flight run remains the only owner of the mutation.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -53,7 +53,6 @@ const nodeDefsBudgetLeft = (deadline, share = 1) => Math.max(1, Math.floor((dead
 const cacheSpy = { invalidate: () => {}, replace: () => true, read: async (f) => f() };
 const snapshotSpy = { clear: () => {}, record: () => true };
 const COMMAND_BUDGET = 2500;
-const RELAY = 3000;
 const FETCH_MS = 2080;
 const BLOCK_MS = 1500;
 
@@ -201,10 +200,11 @@ async function withWatchdog(promise, label) {
   }
 }
 
-test("#1562: refresh_nodes answers before synchronous reapply and keeps registration single-flight", async () => {
-  // Scaled 10:1 from the report: fetch finishes inside the caller's wait, but fetch plus
-  // synchronous registration exceeds the relay. A retry is issued before the first run's
-  // handoff timer, so an overlapping registration would be observable.
+test("#1758: refresh_nodes joins through production registration and reapply", async () => {
+  // Scaled from the report: the /object_info response lands before the synchronous
+  // registration/reapply phase, which blocks the event loop. A joined acknowledgement must
+  // still return the completed refresh rather than converting that handoff into
+  // refresh_still_running.
   const TYPES = 5635;
   const defs = {};
   for (let i = 0; i < TYPES; i += 1) defs[`Type${i}`] = { input: {}, output: [] };
@@ -245,28 +245,21 @@ test("#1562: refresh_nodes answers before synchronous reapply and keeps registra
   const reply = await refresh_nodes();
   const elapsed = performance.now() - startedAt;
 
-  assert.ok(elapsed < RELAY, `structured reply arrived at ${Math.round(elapsed)}ms, past ${RELAY}ms relay`);
+  assert.ok(
+    elapsed >= BLOCK_MS,
+    `the acknowledgement must observe production local work before replying; elapsed ${Math.round(elapsed)}ms`,
+  );
   assert.deepEqual(
-    { ok: reply.ok, refreshed: reply.refreshed, reason: reply.reason },
-    { ok: true, refreshed: false, reason: "refresh_still_running" },
+    { ok: reply.ok, refreshed: reply.refreshed },
+    { ok: true, refreshed: true },
   );
   assert.equal(
     registrationCalls,
-    0,
-    "the caller must reply before registerNodesFromDefs/reapply can block the main thread",
+    1,
+    "the joined acknowledgement must wait for registerNodesFromDefs/reapply to finish",
   );
-
-  // This retry sees the still-live first promise and subscribes to its completion. The
-  // acknowledgement path must return that run's settled verdict without queueing a second
-  // forced pass.
-  const retryReply = await refresh_nodes();
-  assert.equal(retryReply.refreshed, true, "the retry observes the completed first refresh");
-  while (inFlight) {
-    const current = inFlight;
-    await current;
-  }
-  assert.equal(registrationCalls, 1, "the retry joined the first run instead of queueing another");
   assert.equal(maxConcurrentRegistrations, 1, "registration passes must remain single-flight");
+  assert.equal(inFlight, null, "the joined production refresh returns the slot to idle");
 });
 
 test("#1695: late combo work is fenced before reconnect successor and collector trust", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12304,10 +12304,10 @@ const GRAPH_TOOL_EXECUTORS = {
   // #635: a non-fresh verdict now says WHY (reason) and what to do about it
   // (remedy) — a bare {ok:true, refreshed:false} was indistinguishable from a
   // no-op and left the caller guessing whether the call did anything.
-  // #1404: BOUNDED. This one await is the whole command, and unbounded it is the
-  // composition `graph_add_node`'s budget note describes — a forced call pays an in-flight
-  // run AND its own, serially, which does not fit the 30,000 ms window this command is
-  // relayed in. See REFRESH_NODES_COMMAND_BUDGET_MS.
+  // #1404: BOUNDED. This one await is the whole command. When a refresh is already in
+  // flight, #1680 joins that completion; when idle, the forced run is bounded directly, so
+  // this command never creates a serial in-flight-plus-trailing wait beyond the relay window.
+  // See REFRESH_NODES_COMMAND_BUDGET_MS.
   // #1680 — when a refresh already owns the single-flight slot, this command is an
   // acknowledgement of that work: subscribe to it instead of queueing a second
   // trailing run. When the slot is empty, force:true still starts a fresh refresh.
@@ -12320,9 +12320,11 @@ const GRAPH_TOOL_EXECUTORS = {
       // the shared refresh slot or allowing a competing successor.
       allowEarlyResult: true,
       joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,
-      // #1562 — the run announces this handoff after /object_info and yields one turn
-      // before registration, so this caller can return its structured retryable verdict
-      // before synchronous schema work blocks the relay timer.
+      // #1758 — panel_refresh_nodes is itself the acknowledgement for this refresh. The
+      // coalescer lets this acknowledgement join an existing run, and when the slot is
+      // empty it suppresses this early-handoff escape for the run it starts itself. The
+      // command budget still bounds the wait, and the slot remains single-flight if it is
+      // reached.
       abandonBeforeLocalWork: true,
       // #1562 — and the RUN this command starts gets an allowance that outlasts that wait,
       // so the JOIN is what ends the command. Without this line the run gives up first and

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -357,7 +357,13 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
             ...(opts.skipDuplicateComboRefresh === true ? { skipDuplicateComboRefresh: true } : {}),
           }
         : undefined;
-    const abandonBeforeLocalWork = !!(opts && opts.abandonBeforeLocalWork);
+    // #1758 — `joinInFlight` is the acknowledgement contract used by
+    // panel_refresh_nodes. If the slot is empty at the exact call boundary, this invocation
+    // becomes the refresh owner; it must still wait through its own registration/reapply
+    // handoff rather than returning refresh_still_running merely because it was asked to
+    // join when possible. Other bounded callers retain the explicit early-handoff behavior.
+    const abandonBeforeLocalWork =
+      !!(opts && opts.abandonBeforeLocalWork) && !joinInFlight;
     const remaining = () => (joinMs === null ? null : joinMs - (Date.now() - startedAt));
     const current = getInFlight();
     if (current) {


### PR DESCRIPTION
## Summary\n\nFixes #1758. panel_refresh_nodes now treats joinInFlight as an acknowledgement contract: it joins an existing refresh and, when it owns the idle slot, waits through its own registration/reapply handoff instead of returning efresh_still_running. Other bounded refresh callers retain their early-handoff behavior.\n\n## Validation\n\n- Focused refresh suites: 56 passed, 0 failed\n- 
pm.cmd run typecheck\n- 
pm.cmd run test:unit: 6,754 passed, 0 failed, 1 todo\n- Added coalescer race coverage plus production efresh_nodes registration/reapply and event/probe recovery coverage\n\nNot merged.