### PR TITLE
chore: release v0.15.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.78] - 2026-08-24
+
+### Fixed
+- Join in-flight panel refreshes through download completion handoff instead of returning `refresh_still_running` (#1758)
+
 ## [0.15.77] - 2026-08-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.77",
+  "version": "0.15.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.77",
+      "version": "0.15.78",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.77",
+  "version": "0.15.78",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
Release v0.15.78 bundles merged Panel refresh fix #1758. Local typecheck, scope, i18n, vocabulary, and unit suite passed: 6754 passed, 0 failed, 1 todo.