### PR TITLE
fix(panel): preserve VideoTileLivePlanner ROI state on copy/paste

### DIFF
--- a/browser_tests/unit/copy-paste-layout.test.mjs
+++ b/browser_tests/unit/copy-paste-layout.test.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 import {
   CLIPBOARD_KEY,
   withInMemoryClipboard,
+  withClipboardCopyProvenance,
   getInMemoryClipboard,
   getEffectiveClipboard,
   clearInMemoryClipboard,
@@ -324,12 +325,14 @@ function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
     "snapshotCopyLayout",
     "snapshotCopyWidgetState",
     "withInMemoryClipboard",
+    "withClipboardCopyProvenance",
     "getInMemoryClipboard",
     "patchClipboardLayout",
     "CLIPBOARD_KEY",
     "recordCopiedNodes",
     "recordCopiedLayout",
     "recordCopiedWidgetState",
+    "clearCopiedWidgetState",
     "registryTypePredicate",
     "unregisteredCopiedTypes",
     "formatUnpasteableCopyWarning",
@@ -341,12 +344,14 @@ function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
     snapshotCopyLayout,
     snapshotCopyWidgetState,
     withInMemoryClipboard,
+    withClipboardCopyProvenance,
     getInMemoryClipboard,
     patchClipboardLayout,
     CLIPBOARD_KEY,
     recordCopiedNodes,
     recordCopiedLayout,
     recordCopiedWidgetState,
+    clearCopiedWidgetState,
     registryTypePredicate,
     unregisteredCopiedTypes,
     formatUnpasteableCopyWarning,
@@ -612,6 +617,31 @@ test("#1761 shipped copy+paste preserves VideoTileLivePlanner roi_enabled", () =
     pasted.widgets.find((w) => w.name === "planner_state").value,
     source.widgets.find((w) => w.name === "planner_state").value,
   );
+  clearCopiedWidgetState();
+});
+
+test("#1761 a same-byte native copy invalidates the panel widget snapshot", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  clearCopiedWidgetState();
+  const src = makeFrontend();
+  const source = addVideoTile(src.graph, { roiEnabled: true });
+  const { copy, makePaster, storage } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+
+  copy({ node_ids: [source.id] });
+  const panelClipboard = getInMemoryClipboard();
+  source.widgets.find((w) => w.name === "roi_enabled").value = false;
+
+  // Native Ctrl+C uses the same canvas API, but is outside the panel-owned
+  // provenance scope. The omitted roi_enabled keeps the serialized bytes equal.
+  src.canvas.copyToClipboard([source]);
+  assert.equal(storage.getItem(CLIPBOARD_KEY), panelClipboard, "native copy reproduced identical bytes");
+  assert.equal(getVerifiedWidgetState(panelClipboard), null, "native copy invalidated stale panel state");
+
+  const dst = makeFrontend();
+  const paste = makePaster(dst.graph, dst.canvas, dst.LG);
+  paste({ pos: [500, 500], connect_inputs: false });
+  assert.equal(dst.graph._nodes[0].widgets.find((w) => w.name === "roi_enabled").value, false);
   clearCopiedWidgetState();
 });
 

--- a/browser_tests/unit/copy-paste-layout.test.mjs
+++ b/browser_tests/unit/copy-paste-layout.test.mjs
@@ -46,10 +46,15 @@ import {
   snapshotGroupLayout,
   collectCopySelection,
   snapshotCopyLayout,
+  snapshotCopyWidgetState,
   patchClipboardLayout,
   parseClipboardLayout,
   recordCopiedLayout,
   getVerifiedLayout,
+  recordCopiedWidgetState,
+  getVerifiedWidgetState,
+  clearCopiedWidgetState,
+  applyCopiedWidgetState,
   clearCopiedLayout,
   pairCopiedToPasted,
   layoutOrigin,
@@ -60,6 +65,7 @@ import {
 import { groupMemberNodes, groupBoundsOf } from "../../web/js/lib/group-geometry.js";
 
 const LORA = "Power Lora Loader (rgthree)";
+const VIDEO_TILE = "VideoTileLivePlanner";
 const BRANCH_YS = [-20, 640, 1300, 1960, 2620];
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -116,7 +122,7 @@ function LGraphGroup(title) {
   this.flags = {};
 }
 
-/** Frontend double that reproduces both #1294 bugs. */
+/** Frontend double that reproduces the clipboard bugs in the production path. */
 function makeFrontend({ loseLoraPos = true, pasteGroups = true } = {}) {
   let nextNodeId = 1;
   let nextGroupId = 1;
@@ -156,7 +162,20 @@ function makeFrontend({ loseLoraPos = true, pasteGroups = true } = {}) {
         if (it && typeof it.type === "string") {
           // BUG: clone/serialize loses unique pos on Power Lora Loader.
           const pos = loseLoraPos && it.type === LORA ? [0, 0] : [...it.pos];
-          nodes.push({ id: it.id, type: it.type, pos, flags: { ...(it.flags || {}) } });
+          const serialized = {
+            id: it.id,
+            type: it.type,
+            pos,
+            flags: { ...(it.flags || {}) },
+          };
+          if (it.widgets?.length) {
+            serialized.widgets_values = [];
+            for (const [i, widget] of it.widgets.entries()) {
+              if (widget.serialize === false) continue;
+              serialized.widgets_values[i] = widget.value;
+            }
+          }
+          nodes.push(serialized);
         } else if (it && (it._bounding || it.bounding)) {
           const b = it._bounding || it.bounding;
           groups.push({
@@ -200,6 +219,18 @@ function makeFrontend({ loseLoraPos = true, pasteGroups = true } = {}) {
           size: [200, 80],
           flags: { ...(info.flags || {}) },
         };
+        if (info.type === VIDEO_TILE) {
+          node.widgets = [
+            {
+              name: "planner_state",
+              serialize: true,
+              value: info.widgets_values?.[0] ?? "{}",
+            },
+            // LiteGraph's configure skips serialize:false widgets, so the
+            // clone's default remains false until the panel restores it.
+            { name: "roi_enabled", serialize: false, value: false },
+          ];
+        }
         // BUG: configure ignores pos on Power Lora Loader — they keep the
         // createNode default, then the same translation stacks them.
         if (loseLoraPos && info.type === LORA) node.pos = [0, 0];
@@ -223,7 +254,32 @@ function makeFrontend({ loseLoraPos = true, pasteGroups = true } = {}) {
       }
     },
   };
-  return { graph, canvas, LG: { LGraphGroup, registered_node_types: { [LORA]: {}, KSampler: {} } } };
+  return {
+    graph,
+    canvas,
+    LG: { LGraphGroup, registered_node_types: { [LORA]: {}, KSampler: {}, [VIDEO_TILE]: {} } },
+  };
+}
+
+function addVideoTile(graph, { id = 1, roiEnabled = true } = {}) {
+  const node = {
+    id,
+    type: VIDEO_TILE,
+    pos: [100, 100],
+    size: [300, 120],
+    flags: {},
+    widgets: [
+      {
+        name: "planner_state",
+        serialize: true,
+        value: JSON.stringify({ roi_enabled: roiEnabled, tiles: [{ x: 1, y: 2 }] }),
+      },
+      // This is the DOM-backed state that the native clone/configure path omits.
+      { name: "roi_enabled", serialize: false, value: roiEnabled },
+    ],
+  };
+  graph._nodes.push(node);
+  return node;
 }
 
 function addBranch(graph, index, y) {
@@ -266,12 +322,14 @@ function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
     "getGraphCtx",
     "collectCopySelection",
     "snapshotCopyLayout",
+    "snapshotCopyWidgetState",
     "withInMemoryClipboard",
     "getInMemoryClipboard",
     "patchClipboardLayout",
     "CLIPBOARD_KEY",
     "recordCopiedNodes",
     "recordCopiedLayout",
+    "recordCopiedWidgetState",
     "registryTypePredicate",
     "unregisteredCopiedTypes",
     "formatUnpasteableCopyWarning",
@@ -281,12 +339,14 @@ function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
     () => ({ graph: srcGraph, canvas: srcCanvas, LG: srcLG }),
     collectCopySelection,
     snapshotCopyLayout,
+    snapshotCopyWidgetState,
     withInMemoryClipboard,
     getInMemoryClipboard,
     patchClipboardLayout,
     CLIPBOARD_KEY,
     recordCopiedNodes,
     recordCopiedLayout,
+    recordCopiedWidgetState,
     registryTypePredicate,
     unregisteredCopiedTypes,
     formatUnpasteableCopyWarning,
@@ -299,6 +359,8 @@ function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
       "getGraphCtx",
       "getEffectiveClipboard",
       "getVerifiedLayout",
+      "getVerifiedWidgetState",
+      "applyCopiedWidgetState",
       "parseClipboardLayout",
       "withInMemoryClipboard",
       "resolvePasteDest",
@@ -318,6 +380,8 @@ function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
       () => ({ graph: dstGraph, canvas: dstCanvas, LG: dstLG }),
       getEffectiveClipboard,
       getVerifiedLayout,
+      getVerifiedWidgetState,
+      applyCopiedWidgetState,
       parseClipboardLayout,
       withInMemoryClipboard,
       resolvePasteDest,
@@ -444,6 +508,28 @@ test("getVerifiedLayout is fingerprint-guarded like the node snapshot", () => {
   clearCopiedLayout();
 });
 
+test("#1761 omitted widget state is fingerprint-guarded and restores false verbatim", () => {
+  clearCopiedWidgetState();
+  const state = snapshotCopyWidgetState({
+    nodes: [
+      {
+        id: 1,
+        type: VIDEO_TILE,
+        widgets: [{ name: "roi_enabled", serialize: false, value: false }],
+      },
+    ],
+  });
+  recordCopiedWidgetState(state, "fp-a");
+  assert.equal(getVerifiedWidgetState("fp-b"), null);
+  const target = {
+    type: VIDEO_TILE,
+    widgets: [{ name: "roi_enabled", serialize: false, value: true }],
+  };
+  assert.equal(applyCopiedWidgetState([target], getVerifiedWidgetState("fp-a")), 1);
+  assert.equal(target.widgets[0].value, false);
+  clearCopiedWidgetState();
+});
+
 test("layoutOrigin is the top-left of nodes and groups", () => {
   assert.deepEqual(
     layoutOrigin(
@@ -500,6 +586,33 @@ test("#1294 shipped copy+paste keeps groups and distinct branch y-positions", ()
   const deltas = loraYs.slice(1).map((y, i) => y - loraYs[i]);
   const expected = BRANCH_YS.slice(1).map((y, i) => y - BRANCH_YS[i]);
   assert.deepEqual(deltas, expected, "one consistent translation — relative branch spacing held");
+});
+
+test("#1761 shipped copy+paste preserves VideoTileLivePlanner roi_enabled", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  clearCopiedWidgetState();
+  const src = makeFrontend();
+  const source = addVideoTile(src.graph, { roiEnabled: true });
+  const { copy, makePaster } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+
+  const copied = copy({ node_ids: [source.id] });
+  assert.equal(copied.copied, 1);
+  const clipboard = JSON.parse(getInMemoryClipboard());
+  assert.equal(clipboard.nodes[0].widgets_values[0], source.widgets[0].value);
+  assert.equal(clipboard.nodes[0].widgets_values.length, 1, "native clone omitted roi_enabled");
+
+  const dst = makeFrontend();
+  const paste = makePaster(dst.graph, dst.canvas, dst.LG);
+  const result = paste({ pos: [500, 500], connect_inputs: false });
+  assert.equal(result.pasted_count, 1);
+  const pasted = dst.graph._nodes[0];
+  assert.equal(pasted.widgets.find((w) => w.name === "roi_enabled").value, true);
+  assert.equal(
+    pasted.widgets.find((w) => w.name === "planner_state").value,
+    source.widgets.find((w) => w.name === "planner_state").value,
+  );
+  clearCopiedWidgetState();
 });
 
 test("#1294 still recreates groups when LiteGraph paste drops them", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -574,10 +574,14 @@ import {
 import {
   collectCopySelection,
   snapshotCopyLayout,
+  snapshotCopyWidgetState,
   patchClipboardLayout,
   parseClipboardLayout,
   recordCopiedLayout,
   getVerifiedLayout,
+  recordCopiedWidgetState,
+  getVerifiedWidgetState,
+  applyCopiedWidgetState,
   applyPastedLayout,
   resolvePasteDest,
 } from "./lib/copy-paste-layout.js";
@@ -21706,6 +21710,7 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     if (typeof canvas.selectItems === "function") canvas.selectItems(selection.items);
     const layout = snapshotCopyLayout(graph, selection);
+    const widgetState = snapshotCopyWidgetState(selection);
     // panel#500: copyToClipboard persists the payload in localStorage, which
     // throws QuotaExceededError ("The quota has been exceeded.") once a large
     // multi-node selection overflows the ~5–10 MB quota — the copy then failed
@@ -21736,6 +21741,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const fingerprint = getInMemoryClipboard();
     recordCopiedNodes(selection.nodes, fingerprint);
     recordCopiedLayout(layout, fingerprint);
+    recordCopiedWidgetState(widgetState, fingerprint);
     // #286: never report a clean copy that can't round-trip. Any copied node
     // whose type is unregistered on THIS frontend (uninstalled custom-node pack)
     // will be silently dropped by a later paste — the destination is the same
@@ -21788,6 +21794,7 @@ const GRAPH_TOOL_EXECUTORS = {
     try {
       withInMemoryClipboard(storage, () => canvas.pasteFromClipboard(options));
       const pastedNodes = (graph._nodes ?? []).filter((n) => !before.has(n.id));
+      applyCopiedWidgetState(pastedNodes, getVerifiedWidgetState(rawClipboard));
       // #1411 — LiteGraph's paste configures properties VERBATIM from the
       // clipboard payload, so a copied node (e.g. one cut from an older,
       // unsanitized workflow, or a native Ctrl+C of an externally-authored

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -567,6 +567,7 @@ import {
 import { planComposerPaste, orphanAttachmentTokens } from "./lib/composer-paste.js";
 import {
   withInMemoryClipboard,
+  withClipboardCopyProvenance,
   getInMemoryClipboard,
   getEffectiveClipboard,
   CLIPBOARD_KEY,
@@ -581,6 +582,7 @@ import {
   getVerifiedLayout,
   recordCopiedWidgetState,
   getVerifiedWidgetState,
+  clearCopiedWidgetState,
   applyCopiedWidgetState,
   applyPastedLayout,
   resolvePasteDest,
@@ -21725,12 +21727,14 @@ const GRAPH_TOOL_EXECUTORS = {
       storage = null;
     }
     withInMemoryClipboard(storage, () => {
-      canvas.copyToClipboard(selection.items);
-      const raw = storage && typeof storage.getItem === "function" ? storage.getItem(CLIPBOARD_KEY) : getInMemoryClipboard();
-      const patched = patchClipboardLayout(raw, layout);
-      if (patched && patched !== raw && storage && typeof storage.setItem === "function") {
-        storage.setItem(CLIPBOARD_KEY, patched);
-      }
+      withClipboardCopyProvenance(canvas, clearCopiedWidgetState, () => {
+        canvas.copyToClipboard(selection.items);
+        const raw = storage && typeof storage.getItem === "function" ? storage.getItem(CLIPBOARD_KEY) : getInMemoryClipboard();
+        const patched = patchClipboardLayout(raw, layout);
+        if (patched && patched !== raw && storage && typeof storage.setItem === "function") {
+          storage.setItem(CLIPBOARD_KEY, patched);
+        }
+      });
     });
     // Snapshot the copied node types (plus a fingerprint of the clipboard
     // payload AFTER the copy) so the next graph_paste_nodes can detect any node
@@ -41407,6 +41411,7 @@ function buildPanel() {
     setChatSurface: cmcpSetChatSurface, // A2UI seam: widen/restore the chat surface
     destroy() {
       launcherStartGeneration += 1;
+      clearCopiedWidgetState();
       try {
         recognition?.stop();
       } catch {

--- a/web/js/lib/clipboard-store.js
+++ b/web/js/lib/clipboard-store.js
@@ -103,6 +103,49 @@ function methodOwner(obj, name) {
   return null;
 }
 
+// A content fingerprint cannot distinguish a native copy that happens to
+// produce the same bytes. Keep provenance on the copy method itself instead:
+// panel copies run under _panelCopyDepth, while any later unmarked copy clears
+// the caller's panel-owned snapshot through onNativeCopy.
+const _copyGuards = new WeakMap();
+let _panelCopyDepth = 0;
+
+/**
+ * Run a panel-owned copy and arm the canvas method to invalidate panel-owned
+ * clipboard metadata when a later native copy uses the same canvas/prototype.
+ * The wrapper deliberately stays installed for the clipboard's lifetime so a
+ * byte-identical native rewrite cannot be mistaken for the old panel copy.
+ */
+export function withClipboardCopyProvenance(canvas, onNativeCopy, fn) {
+  if (!canvas || typeof canvas.copyToClipboard !== "function") return fn();
+  const owner = methodOwner(canvas, "copyToClipboard");
+  if (!owner || typeof owner.copyToClipboard !== "function") return fn();
+
+  const existing = _copyGuards.get(owner);
+  if (!existing || existing.wrapper !== owner.copyToClipboard) {
+    const original = owner.copyToClipboard;
+    const wrapper = function (...args) {
+      if (_panelCopyDepth === 0) {
+        try {
+          onNativeCopy?.();
+        } catch {
+          // Snapshot invalidation is advisory; never break native copy.
+        }
+      }
+      return original.apply(this, args);
+    };
+    owner.copyToClipboard = wrapper;
+    _copyGuards.set(owner, { wrapper });
+  }
+
+  _panelCopyDepth++;
+  try {
+    return fn();
+  } finally {
+    _panelCopyDepth--;
+  }
+}
+
 /**
  * Run `fn` (a synchronous LiteGraph copy or paste) with the clipboard key of
  * `storage` backed by the in-memory store. Returns `fn()`'s result. If

--- a/web/js/lib/copy-paste-layout.js
+++ b/web/js/lib/copy-paste-layout.js
@@ -172,6 +172,92 @@ export function snapshotCopyLayout(graph, selection) {
   };
 }
 
+/**
+ * Snapshot live values for widgets that LiteGraph deliberately omits from its
+ * node serialization. DOM-backed custom widgets commonly set
+ * `serialize:false`; their values otherwise fall back to the widget default on
+ * a clipboard clone/configure cycle.
+ */
+export function snapshotCopyWidgetState(selection) {
+  const nodes = [];
+  for (const node of selection?.nodes ?? []) {
+    const widgets = [];
+    for (const widget of node?.widgets ?? []) {
+      if (!widget || widget.serialize !== false || typeof widget.name !== "string") continue;
+      try {
+        widgets.push({ name: widget.name, value: cloneWidgetValue(widget.value) });
+      } catch {
+        // A widget with an unreadable value is not safe to replay onto a new node.
+      }
+    }
+    if (widgets.length) {
+      nodes.push({
+        id: node?.id,
+        type: typeof node?.type === "string" ? node.type : null,
+        widgets,
+      });
+    }
+  }
+  return { nodes };
+}
+
+function cloneWidgetValue(value) {
+  if (value == null || typeof value !== "object") return value;
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
+let _widgetStateSnapshot = { nodes: [] };
+let _widgetStateFingerprint = null;
+
+/** Record omitted live widget values alongside the copied clipboard bytes. */
+export function recordCopiedWidgetState(state, fingerprint = null) {
+  _widgetStateSnapshot = {
+    nodes: [...(state?.nodes ?? [])],
+  };
+  _widgetStateFingerprint = fingerprint;
+  return _widgetStateSnapshot;
+}
+
+/** Test hook / explicit clear. */
+export function clearCopiedWidgetState() {
+  _widgetStateSnapshot = { nodes: [] };
+  _widgetStateFingerprint = null;
+}
+
+/** Return omitted widget values only while the clipboard is byte-identical. */
+export function getVerifiedWidgetState(currentFingerprint) {
+  if (
+    _widgetStateFingerprint != null &&
+    currentFingerprint != null &&
+    currentFingerprint === _widgetStateFingerprint
+  ) {
+    return _widgetStateSnapshot;
+  }
+  return null;
+}
+
+/** Restore omitted widget values onto the freshly pasted nodes. */
+export function applyCopiedWidgetState(pastedNodes, state) {
+  if (!state?.nodes?.length) return 0;
+  const pairs = pairCopiedToPasted(state.nodes, pastedNodes);
+  let restored = 0;
+  for (const { copied, pasted } of pairs) {
+    for (const saved of copied.widgets ?? []) {
+      const widget = (pasted?.widgets ?? []).find((w) => w?.name === saved.name);
+      if (!widget || widget.serialize !== false) continue;
+      try {
+        widget.value = cloneWidgetValue(saved.value);
+        restored++;
+      } catch {
+        // Do not make a successful paste fail because one custom widget rejects
+        // a value that its own setter cannot accept.
+      }
+    }
+  }
+  return restored;
+}
+
 // Live layout recorded at copy time, paired with the same fingerprint
 // paste-report uses. Trusted only while the clipboard still holds our payload —
 // a native Ctrl+C in between replaces the bytes and invalidates this snapshot.


### PR DESCRIPTION
## Summary
- preserve live values for widgets omitted by LiteGraph serialization during panel copy/paste
- restore them by node type/order and widget name only while the clipboard fingerprint matches
- add production-path regression coverage for VideoTileLivePlanner roi_enabled, including false-state handling

## Verification
- node --test browser_tests/unit/copy-paste-layout.test.mjs
- npm.cmd run typecheck
- npm.cmd run check:scope
- npm.cmd run test:unit (6772 passed, 1 todo)
- git diff --check

Fixes #1761