### PR TITLE
fix(panel): resolve panel_set_widget against live node list (#1759)

### DIFF
--- a/browser_tests/unit/node-scope-locator.test.mjs
+++ b/browser_tests/unit/node-scope-locator.test.mjs
@@ -353,9 +353,10 @@ test("WIRING: resolveNode builds its error through describeMissingNode", async (
   const body = fn.slice(0, fn.indexOf("function normalizeLegacyNodeId"));
   assert.ok(body.includes("describeMissingNode(nodeId, rootGraph, viewingRoot, graph)"),
     "the failure path must go through the locator with the live graph so current ids can be named");
-  // The lookup itself must be unchanged — this is diagnostics only, never a wider search.
-  assert.ok(body.includes("graph.getNodeById(canonicalNodeId(nodeId))"),
-    "resolution must still be scoped to the current graph");
+  // The lookup remains scoped to the current graph, but now follows the live
+  // node list before consulting its possibly stale id index (#1759).
+  assert.ok(body.includes("resolveLiveNode(graph, nodeId)"),
+    "resolution must use the current graph's live-node resolver");
   // And the diagnostic must not be able to break the call.
   assert.ok(body.includes("} catch {"), "reading the root must be guarded");
   // graph_save_subgraph used to throw the bare prefix and skip the locator, so a

--- a/browser_tests/unit/outline-mutation-scope-reconnect.test.mjs
+++ b/browser_tests/unit/outline-mutation-scope-reconnect.test.mjs
@@ -23,7 +23,7 @@ import {
   resolveRailNode,
 } from "../../web/js/lib/subgraph-scope.js";
 import { describeMissingNode } from "../../web/js/lib/node-scope-locator.js";
-import { canonicalNodeId } from "../../web/js/lib/node-id.js";
+import { canonicalNodeId, resolveLiveNode } from "../../web/js/lib/node-id.js";
 import { withWorkflowUuid } from "../../web/js/lib/graph-view-identity.js";
 import {
   rememberAutoLayoutScope,
@@ -250,11 +250,12 @@ function buildShippedScopeTools(app) {
 
   const resolveNode = new Function(
     "canonicalNodeId",
+    "resolveLiveNode",
     "resolveRailNode",
     "getGraphCtx",
     "describeMissingNode",
     `${panelFunctionSource(PANEL_SRC, "resolveNode", "normalizeLegacyNodeId")}\nreturn resolveNode;`,
-  )(canonicalNodeId, resolveRailNode, getGraphCtx, describeMissingNode);
+  )(canonicalNodeId, resolveLiveNode, resolveRailNode, getGraphCtx, describeMissingNode);
 
   return { getGraphCtx, describeActiveGraph, resolveNode };
 }

--- a/browser_tests/unit/panel-set-widget-live-node-id.test.mjs
+++ b/browser_tests/unit/panel-set-widget-live-node-id.test.mjs
@@ -1,0 +1,102 @@
+// #1759 — panel_set_widget must resolve the same live node that the graph
+// readers enumerate after H3One workflow activity, even when LiteGraph's id
+// index still points at the previous occupant of that id.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolveLiveNode } from "../../web/js/lib/node-id.js";
+
+const panelPath = new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url);
+const panelSource = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+const resolverStart = panelSource.indexOf("function resolveNode(graph, nodeId) {");
+const resolverEnd = panelSource.indexOf("\n\n// The consolidated editor", resolverStart);
+assert.ok(resolverStart >= 0, "could not locate the shipped resolveNode");
+assert.ok(resolverEnd > resolverStart, "could not locate the shipped resolveNode boundary");
+
+const shippedResolveNode = new Function(
+  "resolveLiveNode",
+  "resolveRailNode",
+  "getGraphCtx",
+  "describeMissingNode",
+  "describeRailNodeTarget",
+  `${panelSource.slice(resolverStart, resolverEnd)}\nreturn resolveNode;`,
+)(
+  resolveLiveNode,
+  () => null,
+  () => ({ rootGraph: null, graph: null }),
+  () => "missing",
+  () => "rail",
+);
+
+const handlerStart = panelSource.indexOf("  async graph_set_widget({");
+const handlerEnd = panelSource.indexOf("\n\n  // artokun/comfyui-mcp#938", handlerStart);
+assert.ok(handlerStart >= 0, "could not locate the shipped graph_set_widget");
+assert.ok(handlerEnd > handlerStart, "could not locate the shipped graph_set_widget boundary");
+
+function shippedPanelSetWidget({ getGraphCtx, classifyTarget }) {
+  return new Function(
+    "SET_WIDGET_COMMAND_BUDGET_MS",
+    "makeCommandBudget",
+    "monotonicNow",
+    "getGraphCtx",
+    "resolveNode",
+    "classifyMiniMaxH3DirectorWrite",
+    "miniMaxH3DirectorPromptRefusal",
+    `const executors = { ${panelSource.slice(handlerStart, handlerEnd)} };\nreturn executors.graph_set_widget;`,
+  )(
+    30_000,
+    () => ({}),
+    () => 0,
+    getGraphCtx,
+    shippedResolveNode,
+    classifyTarget,
+    (widget, nodeId) => `resolved ${nodeId} as the live target`,
+  );
+}
+
+test("#1759 shipped panel_set_widget uses the live node, not a stale id-index occupant", async () => {
+  const liveTarget = {
+    id: 8,
+    type: "LLMSessionChatNode",
+    widgets: [{ name: "system_prompt", value: "old" }],
+  };
+  const staleIndexTarget = {
+    id: 8,
+    type: "MarkdownNote",
+    widgets: [{ name: "text", value: "stale" }],
+  };
+  const graph = {
+    _nodes: [liveTarget],
+    getNodeById(id) {
+      assert.equal(id, 8);
+      return staleIndexTarget;
+    },
+  };
+  let observedTarget = null;
+  const run = shippedPanelSetWidget({
+    getGraphCtx: () => ({ app: {}, graph, rootGraph: graph, LG: {} }),
+    classifyTarget(node) {
+      observedTarget = node;
+      return "derived";
+    },
+  });
+
+  await assert.rejects(
+    run({ node_id: 8, widget: "system_prompt", value: "new" }),
+    /resolved 8 as the live target/,
+  );
+  assert.equal(observedTarget, liveTarget, "the production handler must receive the live-list node");
+  assert.notEqual(observedTarget, staleIndexTarget, "the stale id-index occupant must never be targeted");
+});
+
+test("#1759 does not resurrect a node that only remains in the stale id index", () => {
+  const graph = {
+    _nodes: [{ id: 9, type: "KSampler" }],
+    getNodeById: () => ({ id: 8, type: "MarkdownNote" }),
+  };
+
+  assert.equal(resolveLiveNode(graph, 8), null);
+  assert.throws(() => shippedResolveNode(graph, 8), /missing/);
+});

--- a/browser_tests/unit/rail-id-diagnosis.test.mjs
+++ b/browser_tests/unit/rail-id-diagnosis.test.mjs
@@ -136,6 +136,7 @@ test("WIRING: resolveNode asks WHAT the id is before reporting it missing", asyn
     body.indexOf("describeRailNodeTarget") < body.indexOf("describeMissingNode"),
     "the rail branch must precede the generic miss",
   );
-  // And it stays diagnostics-only: resolution is still the current graph alone.
-  assert.ok(body.includes("graph.getNodeById(canonicalNodeId(nodeId))"));
+  // And it stays diagnostics-only: resolution is still the current graph alone,
+  // with the live-list/index reconciliation covered by #1759.
+  assert.ok(body.includes("resolveLiveNode(graph, nodeId)"));
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -456,7 +456,7 @@ import {
 } from "./lib/queue-prompt-chain.js";
 
 
-import { canonicalNodeId, isQualifiedNodeId } from "./lib/node-id.js";
+import { canonicalNodeId, isQualifiedNodeId, resolveLiveNode } from "./lib/node-id.js";
 import { configureAppMode } from "./lib/configure-app-mode.js";
 import { normalizeCanvasDsInPlace } from "./lib/canvas-ds.js";
 import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
@@ -11242,7 +11242,10 @@ function nodeDescription(node) {
  * exactly as before, including the numeric-string compatibility surface.
  */
 function resolveNode(graph, nodeId) {
-  const node = graph.getNodeById(canonicalNodeId(nodeId));
+  // #1759 — reads enumerate the live node list, while `_nodes_by_id` can retain
+  // a custom node's old occupant after that node pack mutates ids. Resolve from
+  // the same live list first so panel_set_widget cannot edit the wrong node.
+  const node = resolveLiveNode(graph, nodeId);
   // #697 — a node the READS just listed can be unresolvable here: reads span every
   // scope, while a write applies to the graph being VIEWED. Say WHERE it actually is
   // instead of only that it is not here. Diagnostic-only: runs on the failure path,

--- a/web/js/lib/node-id.js
+++ b/web/js/lib/node-id.js
@@ -42,3 +42,24 @@ export function isQualifiedNodeId(nodeId) {
 export function canonicalNodeId(nodeId) {
   return isQualifiedNodeId(nodeId) ? nodeId : Number(nodeId);
 }
+
+/**
+ * #1759 — a custom node can mutate a live node's id without repairing
+ * LiteGraph's `_nodes_by_id` index. Reads enumerate `_nodes`, so using the
+ * index alone can send a write to a stale node with the same id (the reported
+ * H3One → MarkdownNote failure). When the live list is available, it is the
+ * authority; the index is only a compatibility fallback for graph-shaped
+ * doubles/older frontends that do not expose that list.
+ *
+ * A missing live-list match deliberately does not fall back to the index: a
+ * stale index entry is not proof that the node is still present.
+ */
+export function resolveLiveNode(graph, nodeId) {
+  const target = canonicalNodeId(nodeId);
+  const liveNodes = graph?._nodes ?? graph?.nodes;
+  if (Array.isArray(liveNodes)) {
+    const matches = liveNodes.filter((node) => node?.id != null && canonicalNodeId(node.id) === target);
+    return matches.length === 1 ? matches[0] : null;
+  }
+  return graph?.getNodeById?.(target) ?? null;
+}


### PR DESCRIPTION
Fixes #1759\n\n## Summary\n- Resolve panel_set_widget targets from the current graph's live node list before consulting LiteGraph's id index.\n- Refuse stale index-only entries instead of editing the wrong node; retain index fallback for graph shapes without a node list.\n- Add a shipped graph_set_widget regression reproducing the H3One id-8 LLMSessionChatNode vs MarkdownNote stale-index failure.\n\n## Validation\n- npm.cmd run test:unit — 6,773 tests: 6,772 passed, 0 failed, 1 pre-existing todo\n- npm.cmd run typecheck — passed\n- npm.cmd run check:scope — passed\n- npm.cmd run test:e2e:list — 91 tests discovered\n- git diff --check — passed\n\nCommit: 86ac87bf