### PR TITLE
Fix stale Save-As copied_from after panel_load_workflow (#1762)

### DIFF
--- a/browser_tests/load-save-as-copied-from.spec.ts
+++ b/browser_tests/load-save-as-copied-from.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * #1762 — `panel_load_workflow` replaces the live graph in the current tab while
+ * keeping that tab's ComfyWorkflow object/path. A following Save-As must not report
+ * the tab's old filename as the loaded graph's source.
+ */
+import { test, expect, deleteSavedWorkflow } from './fixtures/panelTest'
+import { routeWorktreeSource } from './fixtures/worktreeSource'
+
+test.beforeEach(async ({ context }) => {
+  await routeWorktreeSource(context)
+})
+
+test('load-then-Save-As reports unknown copied_from provenance instead of the stale tab name', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  test.setTimeout(120_000)
+  const cleanup: string[] = []
+  try {
+    await panel.goto()
+    await panel.setBridgeUrl(mockBridge.url)
+    await panel.openSidebar()
+    await panel.connect()
+
+    // Give the source tab a real saved filename so the regression is specifically the
+    // stale copied_from field, not first-save handling.
+    const added = await mockBridge.command('graph_add_node', { class_type: 'VAEDecode' })
+    expect(added.ok, `the setup graph edit must succeed: ${added.error || ''}`).toBe(true)
+    const first = await mockBridge.command('workflow_save', {})
+    expect(first.ok, `the setup save must succeed: ${first.error || ''}`).toBe(true)
+    const original = String(first.result?.workflow || '')
+    expect(original).toBeTruthy()
+    cleanup.push(original)
+
+    // This is the production graph replacement used by panel_load_workflow. An empty UI
+    // graph is enough here: the source tab contains VAEDecode, and the loaded graph is empty.
+    const loaded = await mockBridge.command('graph_load', {
+      graph: {
+        last_node_id: 0,
+        last_link_id: 0,
+        nodes: [],
+        links: [],
+        groups: [],
+        config: {},
+        extra: {},
+        version: 0.4
+      }
+    })
+    expect(loaded.ok, `panel_load_workflow's graph replacement must succeed: ${loaded.error || ''}`).toBe(true)
+    expect(loaded.result?.loaded).toBe(true)
+    expect(loaded.result?.node_count).toBe(0)
+
+    const outline = await mockBridge.command('graph_outline', {})
+    expect(outline.ok, `the loaded graph must remain the active graph: ${outline.error || ''}`).toBe(true)
+    expect(outline.result?.node_count).toBe(0)
+
+    const copyName = `e2e-1762-${Date.now()}`
+    const saved = await mockBridge.command('workflow_save', { name: copyName })
+    expect(saved.ok, `the Save-As must succeed: ${saved.error || ''}`).toBe(true)
+    cleanup.push(copyName)
+    expect(saved.result?.saved_as).toBe(true)
+    expect(saved.result?.copied_from).toBeNull()
+    expect(saved.result?.copied_from).not.toBe(original)
+  } finally {
+    for (const name of cleanup.reverse()) {
+      try {
+        await deleteSavedWorkflow(page, name)
+      } catch {
+        // Best-effort cleanup must not mask the production-path assertion.
+      }
+    }
+  }
+})

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -156,6 +156,31 @@ test('Save-As with a new name COPIES and leaves the original file on disk (#226)
   assert.equal(saved, 'Bar')
 })
 
+test('#1762 a Save-As can suppress an unproven source filename after an in-place graph replacement', async () => {
+  const active = {
+    path: 'workflows/OldGraph.json',
+    filename: 'OldGraph.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false,
+  }
+  const svc = makeService({ files: [active.path], active })
+  const details = {}
+
+  await saveActiveWorkflow(svc, 'LoadedGraph', {
+    details,
+    copySourceName: () => null,
+  })
+
+  assert.equal(details.mode, 'save-as-copy')
+  assert.equal(details.copiedFrom, null)
+  assert.deepEqual(describeSaveOutcome(details), {
+    saved_as: true,
+    copied_from: null,
+  })
+  assert.ok(svc.disk.has(active.path), 'the stale workflow path remains preserved by the copy route')
+})
+
 test('save-in-place (same name) overwrites the same file, no copy', async () => {
   const active = {
     path: 'workflows/Foo.json',

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3283,6 +3283,39 @@ const _priorTempWorkflowIds = new WeakMap();
 
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
+// `graph_load` replaces the graph while intentionally keeping the active workflow object
+// and its path/fence identity. The object therefore remains the save destination, but its
+// filename is no longer proof of the loaded graph's source. Keep that provenance state on
+// the bound object, not in the mutable active pointer, so a later Save-As cannot repeat the
+// stale filename as `copied_from` (#1762).
+const _workflowGraphProvenanceUnknown = new WeakSet();
+
+function markWorkflowGraphProvenanceUnknown(wf) {
+  try {
+    const raw = rawWorkflowObject(wf);
+    if (raw && typeof raw === "object") _workflowGraphProvenanceUnknown.add(raw);
+  } catch {
+    // Provenance bookkeeping must never fail a graph load.
+  }
+}
+
+function workflowGraphProvenanceIsUnknown(wf) {
+  try {
+    const raw = rawWorkflowObject(wf);
+    return Boolean(raw && typeof raw === "object" && _workflowGraphProvenanceUnknown.has(raw));
+  } catch {
+    return false;
+  }
+}
+
+function clearWorkflowGraphProvenanceUnknown(wf) {
+  try {
+    const raw = rawWorkflowObject(wf);
+    if (raw && typeof raw === "object") _workflowGraphProvenanceUnknown.delete(raw);
+  } catch {
+    // Provenance bookkeeping must never fail an otherwise successful operation.
+  }
+}
 
 // r11 P0 — every access to the per-object identity store keys on the RAW
 // workflow object. Service lists and reads hand out Vue proxies, and a WeakMap
@@ -6964,6 +6997,12 @@ async function programmaticSave(name) {
   // existed (a never-persisted tab whose classification was inconclusive), and throwing
   // would be a false data-loss error on a legitimate first save.
   const preSourcePath = expectWf?.path ?? null;
+  // Some focused contract tests extract this function without the module-scope
+  // provenance registry. In that harness the only safe answer is the existing
+  // filename; production always has the helper bound.
+  const graphProvenanceUnknown =
+    typeof workflowGraphProvenanceIsUnknown === "function" &&
+    workflowGraphProvenanceIsUnknown(expectWf);
   let preExisted = null; // true = confirmed 200, false = confirmed 404, null = unknown
   if (preSourcePath) {
     try {
@@ -6986,6 +7025,11 @@ async function programmaticSave(name) {
     // and refuses a first save whose canvas provably belongs to another workflow.
     canvasBinding: describeLiveCanvasBinding,
     details,
+    // #1762 — graph_load keeps the active workflow object/path for save-in-place, but
+    // replaces the graph without a trustworthy source filename. Do not let the old tab
+    // name leak into copied_from; a later successful in-place save re-establishes it.
+    copySourceName: ({ workflow, currentName }) =>
+      graphProvenanceUnknown && sameWorkflowObject(workflow, expectWf) ? null : currentName,
     repaintCanvas: async (copy, targetPath) => {
       const repainted = await repaintSaveAsCanvas(copy, targetPath, {
         canvasFence: (workflow, phase) => canvasFence({ workflow, phase }),
@@ -7012,6 +7056,9 @@ async function programmaticSave(name) {
     // runs only once the 400 shape is already recognised.
     readSaveFailureCause: (path) => readSaveFailureCause(path, api),
   });
+  if (details.mode === "in-place" && typeof clearWorkflowGraphProvenanceUnknown === "function") {
+    clearWorkflowGraphProvenanceUnknown(expectWf);
+  }
   // The repaint path only previews the destination identity because a failed copy must
   // not leave a reusable path alias behind. Commit it after saveActiveWorkflow has
   // completed its persistence/read-back proof; the produced record is the copy this save
@@ -14886,6 +14933,9 @@ const GRAPH_TOOL_EXECUTORS = {
         // canvas too, and must be as undoable as any other graph edit this turn.
         captureGraphSnapshot(null, "before loading an API-format workflow");
         await app.loadApiJson(apiClone, "graph_load.json");
+        if (typeof markWorkflowGraphProvenanceUnknown === "function") {
+          markWorkflowGraphProvenanceUnknown(apiTargetWorkflow);
+        }
         // COMPARE WHAT ARRIVED. A missing node type is an uninstalled pack, and a
         // load that quietly drops nodes and reports success is the exact failure
         // this codebase keeps fixing — the graph then fails at QUEUE time, with a
@@ -14989,6 +15039,9 @@ const GRAPH_TOOL_EXECUTORS = {
       }
     } finally {
       isolation?.restore();
+    }
+    if (typeof markWorkflowGraphProvenanceUnknown === "function") {
+      markWorkflowGraphProvenanceUnknown(activeWorkflow);
     }
     // A blank-canvas load has no workflow object before the call. The frontend
     // may create one as part of loadGraphData, but a tab switch during that await
@@ -20587,6 +20640,15 @@ const GRAPH_TOOL_EXECUTORS = {
         );
       }
       throw failOpenRebindUnknown(rebindFailed);
+    }
+    // A first open loads the named file, and an explicit stale reload re-read it from
+    // disk; either operation re-establishes graph provenance for a workflow previously
+    // replaced by graph_load. Merely switching to an already-open in-memory tab does not.
+    if (
+      (!wasOpen || reloaded) &&
+      typeof clearWorkflowGraphProvenanceUnknown === "function"
+    ) {
+      clearWorkflowGraphProvenanceUnknown(target);
     }
     const receipt = noteOpenAttempt({
       cmd: "workflow_open",

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -569,6 +569,9 @@ export async function saveActiveWorkflow(
     // a stale-operation refusal, never permission to restore a predecessor.
     canvasFence,
     operationFence,
+    // Optional Save-As disclosure hook. It receives `{ workflow, currentName }` and
+    // returns the source name to report; `null` means the graph provenance is unknown.
+    copySourceName,
   } = {},
 ) {
   const wf = svc?.activeWorkflow;
@@ -663,6 +666,17 @@ export async function saveActiveWorkflow(
 
   const wasUnsaved = wf.isTemporary === true || wf.isPersisted === false;
   const currentName = baseName(wf.filename);
+  // An in-place graph replacement can leave the workflow object bound to its old path.
+  // Keep that path for the safe copy route, but do not disclose the old filename as the
+  // graph's source unless the caller can still prove that provenance.
+  let reportedCopySource = currentName;
+  if (typeof copySourceName === "function") {
+    try {
+      reportedCopySource = copySourceName({ workflow: wf, currentName });
+    } catch {
+      reportedCopySource = null;
+    }
+  }
   // Only mint a fresh auto-name for a genuinely placeholder ("Unsaved Workflow"
   // / "Untitled …") workflow. A named-but-unsaved workflow saves under its name.
   const needsAutoName = wasUnsaved && isDefaultWorkflowName(currentName);
@@ -814,7 +828,7 @@ export async function saveActiveWorkflow(
       recordOutcome(details, "save-as-copy", {
         sourcePath,
         targetPath: finalTargetPath,
-        copiedFrom: currentName,
+        copiedFrom: reportedCopySource,
         sourceExternal: true, // absolute external path — not /userdata-verifiable
       });
       return await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
@@ -922,7 +936,7 @@ export async function saveActiveWorkflow(
       recordOutcome(details, cls === "never-persisted" ? "first-save" : "save-as-copy", {
         sourcePath,
         targetPath: finalTargetPath,
-        copiedFrom: cls === "never-persisted" ? undefined : currentName,
+        copiedFrom: cls === "never-persisted" ? undefined : reportedCopySource,
       });
       // Capture POSITIVE pre-copy DISK evidence of the source, so the post-copy
       // backstop can only fire on a CONFIRMED 200 → 404 (a genuine move). An in-memory


### PR DESCRIPTION
Fixes #1762

## Summary

- Track graph provenance separately from the active workflow object's save path.
- Mark the bound workflow provenance unknown after UI/API graph_load replaces its graph in place.
- Let Save-As report copied_from: null when the source filename is no longer proven to describe the loaded graph.
- Clear the marker after a disk-backed workflow open/reload or a successful in-place save.
- Add a production-path Playwright regression covering load-then-Save-As in the same tab, plus focused save-unit coverage.

## Validation

- node --test browser_tests/unit/workflow-save.test.mjs browser_tests/unit/load-workflow-subgraph-widgets.test.mjs: 105 passed.
- Full node --test browser_tests/unit/*.test.mjs: 6,771 passed, 1 existing todo.
- i18n checks, i18n render checks, and tool vocabulary check: passed.
- JavaScript syntax checks: passed.
- TypeScript scope check using the populated sibling dependency: 0 unresolved non-vendor names.
- Playwright discovery: 92 tests listed, including the new #1762 spec.
- Focused Playwright execution is blocked because no ComfyUI is running at http://localhost:8188 (ERR_CONNECTION_REFUSED).

## Commit

16bba6921bf1f55fbcbdca05df7ae1753c78cb50