### PR TITLE
fix(panel): defer safe widget edits until queue idle

### DIFF
--- a/browser_tests/unit/deferred-widget-edit.test.mjs
+++ b/browser_tests/unit/deferred-widget-edit.test.mjs
@@ -15,8 +15,13 @@ import {
   isSafeDeferredWidgetValue,
   sameDeferredWidgetValue,
 } from "../../web/js/lib/deferred-widget-edit.js";
+import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
 
 const panelSource = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
+const scopedBatchSeedSource = readFileSync(
+  new URL("../../web/js/lib/scoped-batch-seed.js", import.meta.url),
+  "utf8",
+).replace(/\r\n/g, "\n");
 
 test("#1716 queue status requires both running and pending lists", () => {
   assert.deepEqual(deferredWidgetQueueCounts({ queue_running: [1], queue_pending: [2, 3] }), {
@@ -119,6 +124,49 @@ test("#1716 helper refuses a changed expected value without calling apply", asyn
   edits.close();
 });
 
+test("#1716 overlapping drains apply each parked edit at most once", async () => {
+  const timers = [];
+  const applied = [];
+  let releaseApply;
+  const applyGate = new Promise((resolve) => {
+    releaseApply = resolve;
+  });
+  const edits = createDeferredWidgetEditQueue({
+    readQueue: async () => ({ queue_running: [], queue_pending: [] }),
+    setTimer: (fn) => {
+      timers.push(fn);
+      return fn;
+    },
+    clearTimer: () => {},
+  });
+
+  for (const label of ["first", "second"]) {
+    edits.enqueue({
+      node_id: 3,
+      widget: label,
+      expected_value: "old",
+      value: "new",
+      readCurrent: async () => ({ ok: true, value: "old" }),
+      apply: async () => {
+        applied.push(label);
+        await applyGate;
+      },
+    });
+  }
+
+  const timer = timers.shift();
+  timer();
+  timer();
+  await new Promise((resolve) => setImmediate(resolve));
+  releaseApply();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(applied, ["first", "second"]);
+  assert.equal(edits.pending(), 0);
+  edits.close();
+});
+
 function buildProductionDeferredSafety() {
   const safetyStart = panelSource.indexOf("function deferredWidgetSafetyReason(");
   const safetyEnd = panelSource.indexOf("\n\nconst GRAPH_TOOL_EXECUTORS", safetyStart);
@@ -126,6 +174,7 @@ function buildProductionDeferredSafety() {
   const safety = new Function(
     "isSafeDeferredWidgetValue",
     "sameDeferredWidgetValue",
+    "resolvePromotedInnerTarget",
     "classifyMiniMaxH3DirectorWrite",
     "classifyLtxTimelineWrite",
     "classifyPromptRelayTimelineWrite",
@@ -136,6 +185,7 @@ function buildProductionDeferredSafety() {
   )(
     isSafeDeferredWidgetValue,
     sameDeferredWidgetValue,
+    resolvePromotedInnerTarget,
     () => null,
     () => null,
     () => null,
@@ -271,6 +321,50 @@ test("#1716 production graph_set_widget refuses callback-driven widgets before p
   assert.equal(run.deferredQueue.pending(), 0);
   assert.equal(node.widgets[0].value, "old");
   run.deferredQueue.close();
+});
+
+test("#1716 production classifier refuses afterQueued-only widgets", async () => {
+  assert.match(scopedBatchSeedSource, /widget\.beforeQueued\?\./);
+  assert.match(scopedBatchSeedSource, /executeWidgetsCallback\(queuedNodes, ['"]afterQueued['"]/);
+  const node = {
+    id: 7,
+    type: "CustomPrompt",
+    widgets: [{ name: "text", value: "old", afterQueued: () => {} }],
+  };
+  const run = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+  });
+  await assert.rejects(run.call(), /queue-time or composite behavior/);
+  assert.equal(run.deferredQueue.pending(), 0);
+  assert.equal(node.widgets[0].value, "old");
+  run.deferredQueue.close();
+});
+
+test("#1716 production classifier refuses generic promoted subgraph scalar routes", async () => {
+  const node = {
+    id: 7,
+    type: "SubgraphNode",
+    subgraph: { _nodes: [] },
+    inputs: [{ name: "text", _subgraphSlot: { name: "text", linkIds: [] } }],
+    widgets: [{ name: "text", value: "old" }],
+  };
+  const run = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+  });
+  await assert.rejects(run.call(), /promoted\/subgraph route/);
+  assert.equal(run.deferredQueue.pending(), 0);
+  assert.equal(node.widgets[0].value, "old");
+  run.deferredQueue.close();
+});
+
+test("#1716 production classifier still permits an ordinary safe scalar widget", () => {
+  const { safety } = buildProductionDeferredSafety();
+  assert.equal(
+    safety({ type: "KSampler", widgets: [{ name: "text", value: "old" }] }, "text", "new", "old"),
+    null,
+  );
 });
 
 test("#1716 production graph_set_widget refuses a stale expected value", async () => {

--- a/browser_tests/unit/deferred-widget-edit.test.mjs
+++ b/browser_tests/unit/deferred-widget-edit.test.mjs
@@ -1,0 +1,286 @@
+// #1716 — the explicit safe widget deferral path.
+//
+// The helper tests prove the queue semantics. The production-path tests below
+// also extract and execute the shipped `defer_until_idle` branch from
+// GRAPH_TOOL_EXECUTORS.graph_set_widget, so a helper that is never wired into
+// the real command cannot make this suite green.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  createDeferredWidgetEditQueue,
+  deferredWidgetQueueCounts,
+  isSafeDeferredWidgetValue,
+  sameDeferredWidgetValue,
+} from "../../web/js/lib/deferred-widget-edit.js";
+
+const panelSource = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
+
+test("#1716 queue status requires both running and pending lists", () => {
+  assert.deepEqual(deferredWidgetQueueCounts({ queue_running: [1], queue_pending: [2, 3] }), {
+    running: 1,
+    pending: 2,
+  });
+  assert.equal(deferredWidgetQueueCounts({ queue_running: [], queue_pending: [] }).running, 0);
+  assert.equal(deferredWidgetQueueCounts({ queue_running: [] }), null);
+});
+
+test("#1716 helper waits for a fully idle queue, then applies in order", async () => {
+  let now = 100;
+  const timers = [];
+  let queue = { queue_running: ["p1"], queue_pending: [] };
+  const applied = [];
+  const settled = [];
+  const edits = createDeferredWidgetEditQueue({
+    readQueue: async () => queue,
+    now: () => now,
+    setTimer: (fn) => {
+      timers.push(fn);
+      return timers.length;
+    },
+    clearTimer: () => {},
+    onSettled: (outcome) => settled.push(outcome),
+  });
+
+  const first = edits.enqueue({
+    node_id: 3,
+    widget: "text",
+    expected_value: "old",
+    value: "new",
+    readCurrent: () => ({ ok: true, value: "old" }),
+    apply: async () => {
+      applied.push("first");
+      return { value: "new" };
+    },
+  });
+  const second = edits.enqueue({
+    node_id: 3,
+    widget: "text",
+    expected_value: "old",
+    value: "later",
+    readCurrent: () => ({ ok: true, value: "old" }),
+    apply: async () => {
+      applied.push("second");
+      return { value: "later" };
+    },
+  });
+  assert.equal(edits.pending(), 2);
+  assert.equal(timers.length, 1, "the queue uses one shared poll timer");
+
+  timers.shift()();
+  await Promise.resolve();
+  assert.deepEqual(applied, [], "a running render keeps both edits parked");
+  assert.equal(edits.pending(), 2);
+
+  queue = { queue_running: [], queue_pending: [] };
+  timers.shift()();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(applied, ["first", "second"]);
+  assert.equal(edits.pending(), 0);
+  assert.deepEqual(settled.map((row) => [row.receipt, row.status]), [
+    [first.receipt, "applied"],
+    [second.receipt, "applied"],
+  ]);
+  edits.close();
+});
+
+test("#1716 helper refuses a changed expected value without calling apply", async () => {
+  const timers = [];
+  let applied = 0;
+  let outcome;
+  const edits = createDeferredWidgetEditQueue({
+    readQueue: async () => ({ queue_running: [], queue_pending: [] }),
+    setTimer: (fn) => {
+      timers.push(fn);
+      return timers.length;
+    },
+    clearTimer: () => {},
+    onSettled: (row) => {
+      outcome = row;
+    },
+  });
+  edits.enqueue({
+    node_id: 3,
+    widget: "text",
+    expected_value: "old",
+    value: "new",
+    readCurrent: () => ({ ok: true, value: "user changed" }),
+    apply: async () => {
+      applied += 1;
+    },
+  });
+  timers.shift()();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(applied, 0);
+  assert.equal(outcome.status, "refused");
+  assert.match(outcome.error, /changed while the edit was deferred/);
+  edits.close();
+});
+
+function buildProductionDeferredSafety() {
+  const safetyStart = panelSource.indexOf("function deferredWidgetSafetyReason(");
+  const safetyEnd = panelSource.indexOf("\n\nconst GRAPH_TOOL_EXECUTORS", safetyStart);
+  assert.ok(safetyStart >= 0 && safetyEnd > safetyStart, "shipped safety classifier not found");
+  const safety = new Function(
+    "isSafeDeferredWidgetValue",
+    "sameDeferredWidgetValue",
+    "classifyMiniMaxH3DirectorWrite",
+    "classifyLtxTimelineWrite",
+    "classifyPromptRelayTimelineWrite",
+    "classifyRgthreeFastGroupsWrite",
+    "classifyIdeogram4PromptBuilderWrite",
+    "classifyMiniMaxH3PromptBuilderWrite",
+    `${panelSource.slice(safetyStart, safetyEnd)}\nreturn deferredWidgetSafetyReason;`,
+  )(
+    isSafeDeferredWidgetValue,
+    sameDeferredWidgetValue,
+    () => null,
+    () => null,
+    () => null,
+    () => null,
+    () => null,
+    () => null,
+  );
+
+  const handlerStart = panelSource.indexOf("  async graph_set_widget({", safetyEnd);
+  const branchEnd = panelSource.indexOf("    const enforceDeferredExpected", handlerStart);
+  assert.ok(handlerStart >= 0 && branchEnd > handlerStart, "shipped graph_set_widget branch not found");
+  const branch = `${panelSource.slice(handlerStart, branchEnd)}\n    throw new Error("fallthrough");\n  }`;
+  return { safety, branch };
+}
+
+function runProductionDeferredBranch({ node, queuePayload, expected = "old", value = "new" }) {
+  const { safety, branch } = buildProductionDeferredSafety();
+  let currentQueuePayload = queuePayload;
+  const timers = [];
+  const applyCalls = [];
+  const graph = {
+    _nodes: [node],
+    getNodeById: (id) => (id === node.id ? node : null),
+  };
+  const deferredQueue = createDeferredWidgetEditQueue({
+    readQueue: async () => currentQueuePayload,
+    setTimer: (fn) => {
+      timers.push(fn);
+      return fn;
+    },
+    clearTimer: () => {},
+  });
+  const executor = new Function(
+    "SET_WIDGET_COMMAND_BUDGET_MS",
+    "makeCommandBudget",
+    "monotonicNow",
+    "getGraphCtx",
+    "resolveNode",
+    "classifyMiniMaxH3DirectorWrite",
+    "miniMaxH3DirectorPromptRefusal",
+    "deferredWidgetSafetyReason",
+    "deferredWidgetQueueCounts",
+    "readQueueForDeferredWidgetEdit",
+    "getDeferredWidgetEditQueue",
+    "sameDeferredWidgetValue",
+    "GRAPH_TOOL_EXECUTORS",
+    `const executors = { ${branch} }; return executors.graph_set_widget;`,
+  )(
+    30_000,
+    () => ({ bounded: (fn) => fn, remaining: () => 30_000 }),
+    () => 0,
+    () => ({ app: {}, graph, rootGraph: graph, LG: {} }),
+    (g, id) => g.getNodeById(id),
+    () => null,
+    () => "refused",
+    safety,
+    deferredWidgetQueueCounts,
+    async () => queuePayload,
+    () => deferredQueue,
+    sameDeferredWidgetValue,
+    {
+      graph_set_widget: async (args) => {
+        applyCalls.push(args);
+        node.widgets[0].value = value;
+        return { applied: true };
+      },
+    },
+  );
+  return {
+    executor,
+    deferredQueue,
+    timers,
+    applyCalls,
+    setQueue: (next) => {
+      currentQueuePayload = next;
+    },
+    call: () => executor({
+      node_id: node.id,
+      widget: "text",
+      value,
+      expected_value: expected,
+      defer_until_idle: true,
+    }),
+  };
+}
+
+test("#1716 production graph_set_widget parks a safe scalar edit while render is running", async () => {
+  const node = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "old" }] };
+  const run = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+  });
+  const result = await run.call();
+  assert.equal(result.deferred, true);
+  assert.equal(result.status, "waiting_for_queue_idle");
+  assert.equal(run.deferredQueue.pending(), 1);
+  assert.equal(node.widgets[0].value, "old", "parking the edit must not mutate the live graph");
+  run.deferredQueue.close();
+});
+
+test("#1716 production graph_set_widget replays the parked edit after the queue drains", async () => {
+  const node = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "old" }] };
+  const run = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+  });
+  const parked = await run.call();
+  assert.equal(parked.deferred, true);
+  assert.equal(run.timers.length, 1);
+
+  run.setQueue({ queue_running: [], queue_pending: [] });
+  run.timers.shift()();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(node.widgets[0].value, "new");
+  assert.equal(run.applyCalls.length, 1, "the production executor must be called once at drain");
+  assert.equal(run.applyCalls[0].defer_replay, true);
+  assert.equal(run.deferredQueue.pending(), 0);
+  run.deferredQueue.close();
+});
+
+test("#1716 production graph_set_widget refuses callback-driven widgets before parking", async () => {
+  const node = {
+    id: 7,
+    type: "CustomPrompt",
+    widgets: [{ name: "text", value: "old", callback: () => {} }],
+  };
+  const run = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+  });
+  await assert.rejects(run.call(), /callback-driven mutation/);
+  assert.equal(run.deferredQueue.pending(), 0);
+  assert.equal(node.widgets[0].value, "old");
+  run.deferredQueue.close();
+});
+
+test("#1716 production graph_set_widget refuses a stale expected value", async () => {
+  const node = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "current" }] };
+  const run = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+    expected: "old",
+  });
+  await assert.rejects(run.call(), /changed before it could be deferred/);
+  assert.equal(run.deferredQueue.pending(), 0);
+  run.deferredQueue.close();
+});

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -36,7 +36,8 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
   const original = { id: 7, type: "OtherLoraLoader" };
   let liveTarget = original;
   let resolvedId;
-  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, node) {
+  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, node, defer_replay) {
+      const enforceDeferredExpected = defer_replay === true;
       return ({ ${fenceProperty} }).assertTargetStillCurrent;
     };`;
   let makeFence;
@@ -59,7 +60,7 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
     },
     () => {},
     "workflow_uuid",
-  )("7:subgraph", "OtherLoraLoader", undefined, original);
+  )("7:subgraph", "OtherLoraLoader", undefined, original, undefined);
 
   fence();
   assert.equal(resolvedId, "7:subgraph");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12405,6 +12405,19 @@ function deferredWidgetSafetyReason(node, widgetName, value, expectedValue) {
   if (!isSafeDeferredWidgetValue(value) || !isSafeDeferredWidgetValue(expectedValue)) {
     return "the deferred path accepts only scalar widget values";
   }
+  let promotedResolution;
+  try {
+    // The normal writer resolves this route to an inner widget and synchronizes
+    // one or more parent rails. A deferred scalar replay cannot carry that
+    // multi-object transaction, so refuse every recognized promotion before it
+    // can fall through to the host widget by name.
+    promotedResolution = resolvePromotedInnerTarget(node, widgetName, () => null);
+  } catch {
+    return `widget "${widgetName}" has an unreadable promoted/subgraph route; the deferred path fails closed`;
+  }
+  if (promotedResolution?.promoted) {
+    return `widget "${widgetName}" is a promoted/subgraph route and cannot be deferred safely`;
+  }
   const target = Array.isArray(node.widgets)
     ? node.widgets.find((candidate) => candidate?.name === widgetName)
     : null;
@@ -12421,6 +12434,7 @@ function deferredWidgetSafetyReason(node, widgetName, value, expectedValue) {
   }
   if (
     typeof target.beforeQueued === "function" ||
+    typeof target.afterQueued === "function" ||
     typeof target.serializeValue === "function" ||
     Array.isArray(target.linkedWidgets) && target.linkedWidgets.length > 0 ||
     typeof target.options?.values === "function"

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -356,6 +356,12 @@ import {
   releaseReconnectScopePin,
 } from "./lib/reconnect-scope-fence.js";
 import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "./lib/set-widget.js";
+import {
+  createDeferredWidgetEditQueue,
+  deferredWidgetQueueCounts,
+  isSafeDeferredWidgetValue,
+  sameDeferredWidgetValue,
+} from "./lib/deferred-widget-edit.js";
 import { declaredInputNames, runRemoveWidget } from "./lib/remove-widget.js";
 import {
   filterServerConfirmedInputSubfolderCandidates,
@@ -797,6 +803,30 @@ import {
 
 let app = null;
 let api = null;
+// #1716 — created lazily so an old panel mount carries no timer. The queue is
+// explicitly opt-in; ordinary graph_set_widget calls remain behind the MCP
+// pre-dispatch mutation fence.
+let deferredWidgetEditQueue = null;
+
+async function readQueueForDeferredWidgetEdit() {
+  if (!api?.fetchApi) throw new Error("ComfyUI queue is not reachable");
+  const response = await api.fetchApi("/queue");
+  if (response?.ok === false) throw new Error("ComfyUI queue did not answer");
+  return response?.json ? response.json() : null;
+}
+
+function getDeferredWidgetEditQueue() {
+  if (deferredWidgetEditQueue) return deferredWidgetEditQueue;
+  deferredWidgetEditQueue = createDeferredWidgetEditQueue({
+    readQueue: readQueueForDeferredWidgetEdit,
+  });
+  return deferredWidgetEditQueue;
+}
+
+function retireDeferredWidgetEditQueue(reason) {
+  deferredWidgetEditQueue?.close(reason);
+  deferredWidgetEditQueue = null;
+}
 // #1585 — setup() is invoked by ComfyUI after registerExtension, AND by us
 // when the tab API is already live (a poller that missed the setup wave).
 // First successful entry wins; a second call is a no-op so the tab cannot
@@ -2507,6 +2537,9 @@ function setupListeners() {
     // while the backend is away can be applied and then wiped by the incoming
     // restore.
     api.addEventListener("reconnecting", () => {
+      retireDeferredWidgetEditQueue(
+        "the backend reconnected while the widget edit was deferred; nothing was applied",
+      );
       nodeDefsRefreshConfirmed = false;
       comfyBackendSocketDown = true;
       comfyBackendOutage.noteDown(landedHelloCount); // #654 — open the outage clock on the FIRST down signal.
@@ -12356,6 +12389,74 @@ function lateWorkflowSaveReceipts() {
   return Array.from(lateSaveReceipts.values()).map((receipt) => ({ ...receipt }));
 }
 
+/**
+ * #1716 — classify the only widget writes that may be replayed after a queue
+ * drain. This is intentionally narrower than the normal widget writer:
+ * callback/queue-hook/composite widgets can have side effects beyond assigning
+ * one absolute scalar, so a deferred request must refuse them before it is
+ * parked. The expected value is the optimistic-concurrency check for the time
+ * spent waiting; without it a deferred edit could overwrite a user's change.
+ */
+function deferredWidgetSafetyReason(node, widgetName, value, expectedValue) {
+  if (!node || typeof node !== "object") return "the target node is unavailable";
+  if (typeof widgetName !== "string" || !widgetName || widgetName.includes(".")) {
+    return "the deferred path requires one concrete widget name";
+  }
+  if (!isSafeDeferredWidgetValue(value) || !isSafeDeferredWidgetValue(expectedValue)) {
+    return "the deferred path accepts only scalar widget values";
+  }
+  const target = Array.isArray(node.widgets)
+    ? node.widgets.find((candidate) => candidate?.name === widgetName)
+    : null;
+  if (!target) return `widget "${widgetName}" is not present on the target node`;
+  if (!isSafeDeferredWidgetValue(target.value) || target.value === null) {
+    return `widget "${widgetName}" does not hold a replay-safe scalar value`;
+  }
+  if (!sameDeferredWidgetValue(target.value, expectedValue)) {
+    return `widget "${widgetName}" changed before it could be deferred; re-read it and retry`;
+  }
+  if (value === null) return "the deferred path cannot replay a null widget value";
+  if (typeof target.callback === "function") {
+    return `widget "${widgetName}" has a callback-driven mutation and cannot be deferred safely`;
+  }
+  if (
+    typeof target.beforeQueued === "function" ||
+    typeof target.serializeValue === "function" ||
+    Array.isArray(target.linkedWidgets) && target.linkedWidgets.length > 0 ||
+    typeof target.options?.values === "function"
+  ) {
+    return `widget "${widgetName}" has queue-time or composite behavior and cannot be deferred safely`;
+  }
+  const linkedInput = (node.inputs ?? []).find(
+    (input) => input?.name === widgetName && input.link != null,
+  );
+  if (linkedInput) return `widget "${widgetName}" is driven by a link and cannot be deferred safely`;
+
+  // These routes deliberately do more than assign one widget. Replaying one
+  // field later would either omit its companion state or drive a custom editor
+  // from the wrong source of truth.
+  const specialClassifiers = [
+    ["MiniMaxH3Director", () => classifyMiniMaxH3DirectorWrite(node, widgetName)],
+    ["LTXDirector", () => classifyLtxTimelineWrite(node, widgetName)],
+    ["PromptRelayEncodeTimeline", () => classifyPromptRelayTimelineWrite(node, widgetName)],
+    ["rgthree Fast Groups", () => classifyRgthreeFastGroupsWrite(node, widgetName)],
+    ["Ideogram4PromptBuilderKJ", () => classifyIdeogram4PromptBuilderWrite(node, widgetName)],
+    ["MiniMaxH3PromptBuilder", () => classifyMiniMaxH3PromptBuilderWrite(node, widgetName)],
+  ];
+  for (const [label, classify] of specialClassifiers) {
+    let kind = null;
+    try {
+      kind = classify();
+    } catch {
+      return `${label} classification was unreadable; the deferred path fails closed`;
+    }
+    if (kind !== null && kind !== undefined) {
+      return `${label} uses a composite or derived widget route and cannot be deferred safely`;
+    }
+  }
+  return null;
+}
+
 const GRAPH_TOOL_EXECUTORS = {
   // Read-only MCP get_image relay. It accepts only a ComfyUI file reference,
   // fetches same-origin /view bytes, and never paints into the panel chat.
@@ -15814,6 +15915,10 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async graph_set_widget({ node_id, widget, value, workflow_uuid, builder_state, expected_node_type }) {
+    // Keep the established handler signature stable for the source-level
+    // wiring checks; these fields are an explicit protocol extension, not new
+    // positional arguments.
+    const { defer_until_idle, expected_value, defer_replay } = arguments[0] ?? {};
     // #1413 — ONE deadline for the whole command, taken BEFORE anything awaits, so the
     // bounded steps inside it compose instead of adding (#1192, #671). The step this
     // exists for is the stale-combo recovery's refresh join below: reached only after
@@ -15822,12 +15927,105 @@ const GRAPH_TOOL_EXECUTORS = {
     const budget = makeCommandBudget(SET_WIDGET_COMMAND_BUDGET_MS, monotonicNow);
     const { app, graph, LG, rootGraph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
-    // #1679: MiniMaxH3Director's prompt is regenerated from its in-memory builderState.
-    // Refuse this exact derived widget immediately after synchronous target resolution,
-    // before the generic authorization/refresh awaits or any graph mutation can begin.
+    // #1679 — keep derived MiniMax prompt writes refused before the first
+    // await, including when a caller asks for deferral. Deferral must never
+    // become a side door around an existing production safety refusal.
     if (classifyMiniMaxH3DirectorWrite(node, widget) === "derived") {
       throw new Error(miniMaxH3DirectorPromptRefusal(widget, node.id));
     }
+    if (defer_until_idle !== undefined && typeof defer_until_idle !== "boolean") {
+      throw new Error("graph_set_widget defer_until_idle must be a boolean");
+    }
+    if (defer_replay === true && defer_until_idle === true) {
+      throw new Error("graph_set_widget cannot combine defer_until_idle with an internal replay");
+    }
+    if (defer_until_idle === true) {
+      const safetyReason = deferredWidgetSafetyReason(node, widget, value, expected_value);
+      if (safetyReason) {
+        throw new Error(
+          `graph_set_widget cannot defer "${String(widget)}" on node ${node?.id ?? node_id}: ${safetyReason}`,
+        );
+      }
+      if (sameDeferredWidgetValue(node.widgets.find((candidate) => candidate?.name === widget)?.value, value)) {
+        return {
+          deferred: false,
+          applied: false,
+          unchanged: true,
+          node_id: node.id,
+          widget,
+          value,
+        };
+      }
+      let queueCounts;
+      try {
+        queueCounts = deferredWidgetQueueCounts(await readQueueForDeferredWidgetEdit());
+      } catch {
+        queueCounts = null;
+      }
+      if (!queueCounts) {
+        throw new Error(
+          `graph_set_widget could not confirm ComfyUI's queue state; nothing was deferred or applied. ` +
+            `Retry with defer_until_idle:true when the queue can be read.`,
+        );
+      }
+      if (queueCounts.running === 0 && queueCounts.pending === 0) {
+        // There is no queue to wait for. Still use the replay expectation at
+        // runSetWidget's final synchronous boundary, because a new render or
+        // user edit may begin during the schema preflight.
+        return GRAPH_TOOL_EXECUTORS.graph_set_widget({
+          node_id,
+          widget,
+          value,
+          workflow_uuid,
+          builder_state,
+          expected_node_type: node.type,
+          expected_value,
+          defer_replay: true,
+        });
+      }
+      const deferredGraph = graph;
+      const deferredRootGraph = rootGraph;
+      const deferredNode = node;
+      return getDeferredWidgetEditQueue().enqueue({
+        node_id: node.id,
+        widget,
+        expected_value,
+        value,
+        readCurrent: () => {
+          let current;
+          try {
+            current = getGraphCtx();
+          } catch {
+            return { ok: false, error: "the active canvas is no longer readable" };
+          }
+          if (current.graph !== deferredGraph || current.rootGraph !== deferredRootGraph) {
+            return { ok: false, error: "the viewed workflow or graph scope changed while the edit was deferred" };
+          }
+          const liveNode = resolveNode(current.graph, node_id);
+          const liveWidget = liveNode?.widgets?.find((candidate) => candidate?.name === widget);
+          if (!liveNode || liveNode !== deferredNode || liveNode.type !== deferredNode.type || !liveWidget) {
+            return { ok: false, error: "the target node changed or disappeared while the edit was deferred" };
+          }
+          const safetyReason = deferredWidgetSafetyReason(liveNode, widget, value, expected_value);
+          if (safetyReason) {
+            return { ok: false, error: `the widget is no longer replay-safe: ${safetyReason}` };
+          }
+          return { ok: true, value: liveWidget.value };
+        },
+        apply: () =>
+          GRAPH_TOOL_EXECUTORS.graph_set_widget({
+            node_id,
+            widget,
+            value,
+            workflow_uuid,
+            builder_state,
+            expected_node_type: deferredNode.type,
+            expected_value,
+            defer_replay: true,
+          }),
+      });
+    }
+    const enforceDeferredExpected = defer_replay === true;
     // #982 — PER-REQUEST, not module state (codex). A concurrent refresh or a second
     // widget write would otherwise overwrite this between one request's failed fetch and
     // its refusal, so the message would name routes another call tried. Declared in the
@@ -16388,17 +16586,37 @@ const GRAPH_TOOL_EXECUTORS = {
           cmd: "graph_set_widget",
           [WORKFLOW_UUID_FIELD]: workflow_uuid,
         });
-        if (expected_node_type === undefined) return;
-        if (typeof expected_node_type !== "string" || !expected_node_type) {
-          throw new Error("graph_set_widget expected_node_type must be a non-empty string");
-        }
+        if (expected_node_type === undefined && !enforceDeferredExpected) return;
         const current = getGraphCtx();
         const liveTarget = resolveNode(current.graph, node_id);
-        if (!liveTarget || liveTarget !== node || liveTarget.type !== expected_node_type) {
+        if (
+          expected_node_type !== undefined &&
+          (typeof expected_node_type !== "string" || !expected_node_type)
+        ) {
+          throw new Error("graph_set_widget expected_node_type must be a non-empty string");
+        }
+        if (
+          expected_node_type !== undefined &&
+          (!liveTarget || liveTarget !== node || liveTarget.type !== expected_node_type)
+        ) {
           throw new Error(
             `panel_set_widget target changed before dispatch: expected ${expected_node_type}, ` +
               `found ${liveTarget?.type ?? "missing"}`,
           );
+        }
+        if (enforceDeferredExpected) {
+          const liveWidget = liveTarget?.widgets?.find((candidate) => candidate?.name === widget);
+          if (
+            !liveTarget ||
+            liveTarget !== node ||
+            !liveWidget ||
+            !sameDeferredWidgetValue(liveWidget.value, expected_value)
+          ) {
+            throw new Error(
+              `panel_set_widget deferred replay refused "${widget}" on node ${node_id}: ` +
+                "the widget changed before the write boundary; nothing was applied",
+            );
+          }
         }
       },
       // Stale-combo retry: reuse the /object_info already fetched for authorization

--- a/web/js/lib/deferred-widget-edit.js
+++ b/web/js/lib/deferred-widget-edit.js
@@ -1,0 +1,194 @@
+// Explicit, fail-closed deferral for a safe widget edit (#1716).
+//
+// The MCP queue-busy fence still refuses ordinary graph mutations before they
+// reach the panel. This module is the panel-side primitive for the one opt-in
+// exception: a caller may schedule an absolute primitive widget value while
+// ComfyUI is busy, provided the caller also supplies the value it observed.
+// The request is applied only after BOTH queue lists are empty and the same
+// graph, node, widget, and expected value are still present.
+
+export const DEFERRED_WIDGET_EDIT_POLL_MS = 500;
+export const DEFERRED_WIDGET_EDIT_MAX_WAIT_MS = 30 * 60 * 1000;
+
+/** Only JSON scalar values have a simple, idempotent replay meaning here. */
+export function isSafeDeferredWidgetValue(value) {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Equality for the scalar contract, including the distinction between -0 and 0. */
+export function sameDeferredWidgetValue(left, right) {
+  return Object.is(left, right);
+}
+
+export function deferredWidgetQueueCounts(value) {
+  if (!value || typeof value !== "object") return null;
+  const running = Array.isArray(value.queue_running) ? value.queue_running.length : null;
+  const pending = Array.isArray(value.queue_pending) ? value.queue_pending.length : null;
+  if (running === null || pending === null) return null;
+  return { running, pending };
+}
+
+function defaultNow() {
+  return Date.now();
+}
+
+/**
+ * Build the small panel-local queue used by `graph_set_widget`'s opt-in
+ * `defer_until_idle` path.
+ *
+ * Every callback is injected so the queue is executable in production and
+ * deterministic in unit tests. A queue probe that is unreadable is UNKNOWN,
+ * never idle; a target/readback mismatch is a definite refusal and is removed
+ * without calling `apply`.
+ */
+export function createDeferredWidgetEditQueue({
+  readQueue,
+  now = defaultNow,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+  pollMs = DEFERRED_WIDGET_EDIT_POLL_MS,
+  maxWaitMs = DEFERRED_WIDGET_EDIT_MAX_WAIT_MS,
+  onSettled = () => {},
+} = {}) {
+  if (typeof readQueue !== "function") throw new TypeError("readQueue is required");
+
+  const entries = new Map();
+  let sequence = 0;
+  let timer = null;
+  let closed = false;
+
+  function receiptId() {
+    sequence += 1;
+    return `widget-edit-${now()}-${sequence}`;
+  }
+
+  function settle(entry, outcome) {
+    if (!entry || !entries.delete(entry.receipt)) return;
+    entry.status = outcome.status;
+    entry.outcome = outcome;
+    try {
+      onSettled({
+        receipt: entry.receipt,
+        node_id: entry.node_id,
+        widget: entry.widget,
+        ...outcome,
+      });
+    } catch {
+      // A notification failure must not turn a settled edit into an unknown one.
+    }
+  }
+
+  function schedule(delay = pollMs) {
+    if (closed || timer !== null || entries.size === 0) return;
+    timer = setTimer(() => {
+      timer = null;
+      void drain();
+    }, Math.max(0, delay));
+  }
+
+  async function drain() {
+    if (closed || entries.size === 0) return;
+
+    const currentTime = now();
+    for (const entry of entries.values()) {
+      if (currentTime - entry.created_at >= maxWaitMs) {
+        settle(entry, {
+          status: "expired",
+          error: "the deferred widget edit waited too long for ComfyUI's queue to become idle",
+        });
+      }
+    }
+    if (entries.size === 0 || closed) return;
+
+    let counts;
+    try {
+      counts = deferredWidgetQueueCounts(await readQueue());
+    } catch {
+      counts = null;
+    }
+    if (!counts || counts.running > 0 || counts.pending > 0) {
+      schedule();
+      return;
+    }
+
+    // Process in insertion order. Each entry performs its own target and
+    // expected-value read, so two edits to the same widget cannot silently
+    // overwrite one another after the first one lands.
+    for (const entry of [...entries.values()]) {
+      if (closed || !entries.has(entry.receipt)) return;
+      let target;
+      try {
+        target = await entry.readCurrent();
+      } catch {
+        target = { ok: false, error: "the deferred widget edit target could not be read" };
+      }
+      if (!target?.ok) {
+        settle(entry, {
+          status: "refused",
+          error: target?.error || "the deferred widget edit target is no longer current",
+        });
+        continue;
+      }
+      if (!sameDeferredWidgetValue(target.value, entry.expected_value)) {
+        settle(entry, {
+          status: "refused",
+          error:
+            "the widget changed while the edit was deferred; nothing was applied and the edit was not replayed",
+        });
+        continue;
+      }
+      try {
+        const result = await entry.apply();
+        settle(entry, { status: "applied", result });
+      } catch (error) {
+        settle(entry, {
+          status: "failed",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (entries.size) schedule(0);
+  }
+
+  function enqueue({ node_id, widget, expected_value, value, readCurrent, apply } = {}) {
+    if (closed) throw new Error("deferred widget edit queue is closed");
+    if (!isSafeDeferredWidgetValue(expected_value) || !isSafeDeferredWidgetValue(value)) {
+      throw new Error("deferred widget edits require scalar expected_value and value fields");
+    }
+    if (typeof readCurrent !== "function" || typeof apply !== "function") {
+      throw new TypeError("deferred widget edits require readCurrent and apply callbacks");
+    }
+    const receipt = receiptId();
+    entries.set(receipt, {
+      receipt,
+      node_id,
+      widget,
+      expected_value,
+      value,
+      readCurrent,
+      apply,
+      created_at: now(),
+      status: "queued",
+    });
+    schedule(0);
+    return { deferred: true, receipt, status: "waiting_for_queue_idle" };
+  }
+
+  function close(reason = "the panel was replaced before the deferred edit could run") {
+    closed = true;
+    if (timer !== null) {
+      clearTimer(timer);
+      timer = null;
+    }
+    for (const entry of [...entries.values()]) {
+      settle(entry, { status: "refused", error: reason });
+    }
+  }
+
+  return {
+    enqueue,
+    close,
+    pending: () => entries.size,
+  };
+}

--- a/web/js/lib/deferred-widget-edit.js
+++ b/web/js/lib/deferred-widget-edit.js
@@ -57,6 +57,7 @@ export function createDeferredWidgetEditQueue({
   let sequence = 0;
   let timer = null;
   let closed = false;
+  let inFlightDrain = null;
 
   function receiptId() {
     sequence += 1;
@@ -87,7 +88,7 @@ export function createDeferredWidgetEditQueue({
     }, Math.max(0, delay));
   }
 
-  async function drain() {
+  async function drainOnce() {
     if (closed || entries.size === 0) return;
 
     const currentTime = now();
@@ -149,6 +150,35 @@ export function createDeferredWidgetEditQueue({
       }
     }
     if (entries.size) schedule(0);
+  }
+
+  // A timer callback can overlap an earlier async drain (and callers can also
+  // trigger the callback twice in the same turn). Keep one drain authoritative
+  // so every receipt is read, applied, and settled at most once. If the
+  // overlapping callback consumed the pending timer while the first run was
+  // still awaiting the queue probe, start one serialized follow-up afterward.
+  function drain() {
+    if (inFlightDrain) {
+      const active = inFlightDrain;
+      void active.then(
+        () => {
+          if (!closed && entries.size > 0 && timer === null) void drain();
+        },
+        () => {},
+      );
+      return active;
+    }
+    const run = drainOnce();
+    inFlightDrain = run;
+    void run.then(
+      () => {
+        if (inFlightDrain === run) inFlightDrain = null;
+      },
+      () => {
+        if (inFlightDrain === run) inFlightDrain = null;
+      },
+    );
+    return run;
   }
 
   function enqueue({ node_id, widget, expected_value, value, readCurrent, apply } = {}) {


### PR DESCRIPTION
## Summary\n\nFixes #1716.\n\n- Add an explicit defer_until_idle:true path for graph_set_widget.\n- Restrict deferral to one concrete widget with scalar value + scalar xpected_value.\n- Refuse callback-driven, queue-hook, linked, dynamic, composite, and derived widget routes before parking.\n- Wait for both ComfyUI queue_running and queue_pending to drain, then revalidate graph/node/widget identity and the expected value at the write boundary.\n- Retire parked edits on backend reconnect; ordinary widget edits keep the existing fail-closed queue fence.\n\nThe queue-busy fence lives in MCP and runs before Panel dispatch. The paired upstream allowance is PR https://github.com/artokun/comfyui-mcp/pull/2238; it permits only the guarded protocol shape through to this Panel implementation.\n\n## Validation\n\n- 
pm.cmd run test:unit — 6,800 passed, 1 existing todo.\n- 
pm.cmd run check:scope — pass.\n- 
pm.cmd run typecheck — pass.\n- 
pm.cmd run test:e2e:list — 92 tests listed.\n- Focused #1716 production-path tests cover park, replay after drain, callback refusal, and stale expected-value refusal.\n\nThe full Playwright E2E suite was not run because it requires a live ComfyUI + bridge.