### PR TITLE
fix: describe graph_get_virtual_types activity

### DIFF
--- a/browser_tests/unit/describe-command-i18n.test.mjs
+++ b/browser_tests/unit/describe-command-i18n.test.mjs
@@ -67,6 +67,18 @@ test("English is unchanged by being keyed — same words, both plural forms", ()
   assert.equal(say("graph_auto_layout", { node_count: 1, columns: 4 }), "Auto-arranged 1 node (4 columns)");
 });
 
+test("#1776 graph_get_virtual_types renders a user-facing counted activity card", () => {
+  __setCatalogForTest("en", {});
+  assert.equal(
+    describeCommand("graph_get_virtual_types", {}, { ok: true, result: { virtual_type_count: 1 } }).text,
+    "Checked UI-only node types — 1 type",
+  );
+  const many = describeCommand("graph_get_virtual_types", {}, { ok: true, result: { virtual_type_count: 4 } });
+  assert.equal(many.icon, "pi-eye");
+  assert.equal(many.text, "Checked UI-only node types — 4 types");
+  assert.doesNotMatch(many.text, /graph_get_virtual_types/);
+});
+
 test("a number that is not a count never selects a plural form", () => {
   // `{n}` on the batch multiplier, not `{count}` — a numeric `count` is what switches `tr`
   // into plural lookup, so a stray rename here would start silently picking forms.

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -725,6 +725,8 @@
       "read_subgraph_nodes_one": "Read subgraph “{title}” — {count} node",
       "read_subgraph_nodes_other": "Read subgraph “{title}” — {count} nodes",
       "read_the_docs": "📖 Read the docs",
+      "read_virtual_types_one": "Checked UI-only node types — {count} type",
+      "read_virtual_types_other": "Checked UI-only node types — {count} types",
       "reasoning_effort_set_to_effort_for_model": "Reasoning effort set to {effort} for {model} (nearest level this model supports).",
       "recently_used": "Recently used",
       "recommended": "Recommended",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -28757,6 +28757,15 @@ function describeCommand(cmd, msg, reply) {
       return { icon: "pi-save", text: tr("panel.workflow_saved", "Saved “{workflow}”", { workflow: r.workflow }) };
     case "workflow_save_as":
       return { icon: "pi-save", text: tr("panel.workflow_saved_as", "Saved as “{workflow}”", { workflow: r.workflow }) };
+    case "graph_get_virtual_types":
+      return {
+        icon: "pi-eye",
+        text: tr(
+          "panel.read_virtual_types",
+          { one: "Checked UI-only node types — {count} type", other: "Checked UI-only node types — {count} types" },
+          { count: r.virtual_type_count },
+        ),
+      };
     default:
       // `cmd` is the raw tool name (an identifier). #1310 — do NOT dump the raw
       // reply payload: that is how graph_query's budget_overrun / groups_omitted


### PR DESCRIPTION
## Summary\n- add a user-facing activity-card description for graph_get_virtual_types\n- use the returned irtual_type_count with the panel's existing translated plural convention\n- cover singular/plural rendering and raw-command suppression in the focused describeCommand tests\n\nFixes #1776\n\n## Validation\n- 
ode --test browser_tests/unit/describe-command-i18n.test.mjs browser_tests/unit/virtual-registry.test.mjs\n- 
pm.cmd run i18n:check\n- 
pm.cmd run typecheck\n- 
ode --check web/js/comfyui-mcp-panel.js\n- git diff --check\n\nThe panel scope gate was attempted but could not run because this fresh worktree has no local 
ode_modules/typescript.