### PR TITLE
fix(panel): diagnose completion delivery outcomes (#1781)

### DIFF
--- a/browser_tests/unit/completion-delivery-diagnostics.test.mjs
+++ b/browser_tests/unit/completion-delivery-diagnostics.test.mjs
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  classifyCompletionDelivery,
+  completionCompositionDiagnostic,
+  COMPLETION_LATE_COMPOSITION_MS,
+} from "../../web/js/lib/completion-delivery-diagnostics.js";
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+
+test("completion delivery diagnostics distinguish panel-observable outcomes", () => {
+  assert.equal(classifyCompletionDelivery(), "never-sent");
+  assert.equal(classifyCompletionDelivery({ sendAttempted: true }), "transport-failure");
+  assert.equal(
+    classifyCompletionDelivery({
+      sendAttempted: true,
+      transportAccepted: true,
+      compositionMs: COMPLETION_LATE_COMPOSITION_MS + 1,
+    }),
+    "late-composition",
+  );
+  assert.equal(
+    classifyCompletionDelivery({
+      sendAttempted: true,
+      transportAccepted: true,
+      compositionMs: COMPLETION_LATE_COMPOSITION_MS,
+    }),
+    "transport-accepted",
+  );
+});
+
+test("completion frames carry late-composition diagnostics without changing delivery", async () => {
+  let nowMs = 1_000_000_000_000;
+  const frames = [];
+  const deps = {
+    sendFrame: (frame) => {
+      frames.push(frame);
+      return true;
+    },
+    coerceMessageText: (value) => String(value ?? ""),
+    formatDuration: (ms) => `${ms}ms`,
+    formatClock: () => "12:00:00",
+    imageViewUrl: (ref) => `/view?filename=${ref.filename}`,
+    fetchImageBytes: async () => {
+      nowMs += COMPLETION_LATE_COMPOSITION_MS + 1;
+      return 100;
+    },
+    fetchImageDimensions: async () => ({ w: 64, h: 64 }),
+    humanizeBytes: (bytes) => `${bytes} B`,
+    buildVideoStoryboard: async () => null,
+    uploadBlobToInput: async () => null,
+    storyboardFrameCount: () => 1,
+    paintImage: () => {},
+    agentReceivesImages: () => true,
+    now: () => new Date(nowMs),
+    warn: () => {},
+  };
+
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-1781",
+      images: [{ filename: "result.png", type: "output" }],
+      videos: [],
+      durationMs: 1,
+    },
+    deps,
+  );
+
+  assert.equal(frames.length, 1);
+  assert.equal(frame, frames[0]);
+  assert.equal(frame.prompt_id, "p-1781");
+  assert.equal(frame.completion_diagnostics.source, "panel");
+  assert.equal(frame.completion_diagnostics.composition_stage, "late-composition");
+  assert.ok(frame.completion_diagnostics.composition_ms > COMPLETION_LATE_COMPOSITION_MS);
+});
+
+test("composition diagnostics normalize invalid or negative elapsed time", () => {
+  assert.deepEqual(completionCompositionDiagnostic({ compositionMs: -4 }), {
+    source: "panel",
+    composition_ms: 0,
+    composition_stage: "on-time",
+  });
+  assert.deepEqual(completionCompositionDiagnostic({ compositionMs: NaN }), {
+    source: "panel",
+    composition_ms: null,
+    composition_stage: "on-time",
+  });
+});

--- a/browser_tests/unit/completion-delivery-diagnostics.test.mjs
+++ b/browser_tests/unit/completion-delivery-diagnostics.test.mjs
@@ -10,6 +10,10 @@ import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame
 
 test("completion delivery diagnostics distinguish panel-observable outcomes", () => {
   assert.equal(classifyCompletionDelivery(), "never-sent");
+  assert.equal(
+    classifyCompletionDelivery({ frameEmitted: false }),
+    "empty-no-frame",
+  );
   assert.equal(classifyCompletionDelivery({ sendAttempted: true }), "transport-failure");
   assert.equal(
     classifyCompletionDelivery({
@@ -26,6 +30,32 @@ test("completion delivery diagnostics distinguish panel-observable outcomes", ()
       compositionMs: COMPLETION_LATE_COMPOSITION_MS,
     }),
     "transport-accepted",
+  );
+});
+
+test("an intentionally empty composer result is not classified as never-sent", async () => {
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-1781-empty",
+      images: [],
+      videos: [],
+      durationMs: null,
+      noMedia: false,
+    },
+    {
+      now: () => new Date(1_000_000_000_000),
+      formatClock: () => "12:00:00",
+    },
+  );
+
+  assert.equal(frame, null);
+  assert.equal(
+    classifyCompletionDelivery({ frameEmitted: frame != null }),
+    "empty-no-frame",
+  );
+  assert.notEqual(
+    classifyCompletionDelivery({ frameEmitted: frame != null }),
+    "never-sent",
   );
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -37187,9 +37187,14 @@ function buildPanel() {
           const deliveryStage = classifyCompletionDelivery({
             sendAttempted,
             transportAccepted: framePushed,
+            frameEmitted: frame != null,
             compositionMs: Date.now() - compositionStartedAt,
           });
-          if (deliveryStage !== "transport-accepted" && !AGENT_MUTED) {
+          if (
+            deliveryStage !== "transport-accepted" &&
+            deliveryStage !== "empty-no-frame" &&
+            !AGENT_MUTED
+          ) {
             console.warn("[cmcp] completion delivery diagnostic", {
               prompt_id: promptId,
               stage: deliveryStage,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -696,6 +696,7 @@ import {
   workflowSaveTimeoutObservation,
 } from "./lib/workflow-save-budget.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
+import { classifyCompletionDelivery } from "./lib/completion-delivery-diagnostics.js";
 import {
   clearInheritedExecutionPreview,
   clearStoredExecutionOutputs,
@@ -37125,6 +37126,8 @@ function buildPanel() {
       // the next reconnect recovers it via /history. A confirmed send (or an empty
       // batch that emits no frame) retires it from pending.
       let framePushed = false;
+      let sendAttempted = false;
+      const compositionStartedAt = Date.now();
       // A completed prompt delivers its FULL batch here, exactly once. Compose
       // ONE consolidated agent_event for the whole run — stills AND every video's
       // storyboard folded into a single images+note+metadata turn — so a mixed /
@@ -37151,6 +37154,7 @@ function buildPanel() {
         },
         {
           sendFrame: (frame) => {
+            sendAttempted = true;
             const ok = client.sendFrame(frame);
             if (ok) framePushed = true;
             return ok;
@@ -37180,6 +37184,17 @@ function buildPanel() {
         },
       )
         .then((frame) => {
+          const deliveryStage = classifyCompletionDelivery({
+            sendAttempted,
+            transportAccepted: framePushed,
+            compositionMs: Date.now() - compositionStartedAt,
+          });
+          if (deliveryStage !== "transport-accepted" && !AGENT_MUTED) {
+            console.warn("[cmcp] completion delivery diagnostic", {
+              prompt_id: promptId,
+              stage: deliveryStage,
+            });
+          }
           // frame===null ⇒ empty batch (nothing to deliver) ⇒ delivered. A frame
           // that was pushed ⇒ delivered. A frame that FAILED to push ⇒ re-pend —
           // UNLESS it failed because agents are MUTED, which is intentional,
@@ -37196,6 +37211,16 @@ function buildPanel() {
           pruneRebootMarker();
         })
         .catch((err) => {
+          if (!AGENT_MUTED) {
+            console.warn("[cmcp] completion delivery diagnostic", {
+              prompt_id: promptId,
+              stage: classifyCompletionDelivery({
+                sendAttempted,
+                transportAccepted: framePushed,
+                compositionMs: Date.now() - compositionStartedAt,
+              }),
+            });
+          }
           console.warn("[cmcp] composeRunCompletionFrame failed:", err);
           // Composition threw before/around the send — treat as undelivered so a
           // reconnect can recover the outcome from /history rather than lose it

--- a/web/js/lib/completion-delivery-diagnostics.js
+++ b/web/js/lib/completion-delivery-diagnostics.js
@@ -1,0 +1,47 @@
+// Diagnostics for the panel's completion delivery boundary.
+//
+// The panel can observe composition time and whether the browser accepted a
+// frame with WebSocket.send(). It cannot observe orchestrator receipt: the
+// current bridge has no acknowledgement for agent_event. Keep that distinction
+// explicit so a local transport result is not reported as end-to-end delivery.
+
+export const COMPLETION_LATE_COMPOSITION_MS = 10_000;
+
+/**
+ * Classify the strongest delivery fact available to the panel.
+ *
+ * `transportAccepted` means only that the browser accepted the frame for the
+ * socket. It is intentionally not named "delivered" because the bridge does
+ * not acknowledge agent_event frames today.
+ */
+export function classifyCompletionDelivery({
+  sendAttempted = false,
+  transportAccepted = false,
+  compositionMs = null,
+  lateCompositionMs = COMPLETION_LATE_COMPOSITION_MS,
+} = {}) {
+  if (!sendAttempted) return "never-sent";
+  if (!transportAccepted) return "transport-failure";
+  if (Number.isFinite(compositionMs) && compositionMs > lateCompositionMs) {
+    return "late-composition";
+  }
+  return "transport-accepted";
+}
+
+/**
+ * Add the composition-only part of the diagnostic to a completion frame.
+ * Transport status is added at the send boundary because composition cannot
+ * know whether sendFrame() will accept the frame.
+ */
+export function completionCompositionDiagnostic({
+  compositionMs = null,
+  lateCompositionMs = COMPLETION_LATE_COMPOSITION_MS,
+} = {}) {
+  const normalizedMs = Number.isFinite(compositionMs) ? Math.max(0, compositionMs) : null;
+  return {
+    source: "panel",
+    composition_ms: normalizedMs,
+    composition_stage:
+      normalizedMs != null && normalizedMs > lateCompositionMs ? "late-composition" : "on-time",
+  };
+}

--- a/web/js/lib/completion-delivery-diagnostics.js
+++ b/web/js/lib/completion-delivery-diagnostics.js
@@ -17,9 +17,14 @@ export const COMPLETION_LATE_COMPOSITION_MS = 10_000;
 export function classifyCompletionDelivery({
   sendAttempted = false,
   transportAccepted = false,
+  // A completed flush may intentionally produce no frame (for example, an
+  // ordinary canvas run with no media). That is delivered by lifecycle
+  // contract, not a never-sent transport failure.
+  frameEmitted = true,
   compositionMs = null,
   lateCompositionMs = COMPLETION_LATE_COMPOSITION_MS,
 } = {}) {
+  if (!frameEmitted) return "empty-no-frame";
   if (!sendAttempted) return "never-sent";
   if (!transportAccepted) return "transport-failure";
   if (Number.isFinite(compositionMs) && compositionMs > lateCompositionMs) {

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -24,6 +24,7 @@
 // leaving the segment pending forever.
 import { duplicateCompletionNote } from "./completion-dedupe.js";
 import { withTimeout } from "./bounded-step.js";
+import { completionCompositionDiagnostic } from "./completion-delivery-diagnostics.js";
 import {
   appendStoryboardCacheBust,
   createStoryboardIdentity,
@@ -146,6 +147,8 @@ export async function composeRunCompletionFrame(
           recoveredAgeMs,
         }
       : {};
+  const completionDiagnostics = () =>
+    completionCompositionDiagnostic({ compositionMs: msBetween(composedAt, now()) });
 
   const outImages = []; // consolidated images for the single frame
   const noteSections = []; // note segments joined into the single note
@@ -265,6 +268,7 @@ export async function composeRunCompletionFrame(
           "or other non-media outputs, read them from the run's history entry.",
       ].join("\n\n"),
       metadata: [{ outputs: "none", reason: "no_media", ...recoveryMetadata() }],
+      completion_diagnostics: completionDiagnostics(),
       ...(promptId != null ? { prompt_id: promptId } : {}),
     };
     sendFrame(frame);
@@ -277,6 +281,7 @@ export async function composeRunCompletionFrame(
     images: outImages,
     note: noteSections.join("\n\n"),
     metadata,
+    completion_diagnostics: completionDiagnostics(),
     // Machine-readable attribution: which prompt this completion belongs to, so
     // a delayed prior-run flush can never be mistaken for the current run (#224).
     ...(promptId != null ? { prompt_id: promptId } : {}),


### PR DESCRIPTION
Refs #1781

## Scope

Adds a narrow, panel-owned diagnostic seam for the completion lifecycle:

- completion frames carry `completion_diagnostics` with composition time and a `late-composition` marker when composition exceeds 10 seconds;
- the production flush path logs `never-sent`, `transport-failure`, and `late-composition` outcomes at the panel's observable boundary;
- existing prompt-id fencing, failed-send re-pending, `/history` reconciliation, and mute behavior are unchanged.

## Why no completion acknowledgement/retry protocol is added

The literal current panel transport returns only browser `WebSocket.send()` acceptance. The bridge acknowledges `user_message` frames (`working`/`seen` by `mid`) but has no acknowledgement for `agent_event` completion frames. Retrying after `sendFrame()` returns true could duplicate a valid completion, and adding a new completion-ack frame would invent upstream behavior. End-to-end receipt/fallback timing therefore remains an orchestrator-side boundary; this patch makes the panel-observable failure stage explicit without changing delivery semantics.

## Validation

- Focused completion diagnostics + still metadata tests: 7/7.
- Relevant completion/queue/reconcile lifecycle files: 152/152.
- `npm.cmd run typecheck`: passed.
- `npm.cmd run test:unit`: stopped at the existing scope gate because this fresh worktree has no local `node_modules/typescript`; the standalone typecheck passed.
- `git diff --check`: passed.