### PR TITLE
fix(run-to-node): preserve scope through frontend 1.49.6 queue wrappers

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -180,12 +180,15 @@ function makeFrontend({ shape = "shim", defer = false, apiTarget, output = OUR_O
 // Pure helpers
 // ---------------------------------------------------------------------------
 
-test("#556 queuePromptScopeArgs: no scope ⇒ [undefined]; scope ⇒ array first, then options object", () => {
+test("#1782 queuePromptScopeArgs: no scope ⇒ [undefined]; 1.49.6 options carry both queue layers", () => {
   assert.deepEqual(queuePromptScopeArgs(undefined), [undefined]);
   assert.deepEqual(queuePromptScopeArgs([]), [undefined]);
   const [first, second] = queuePromptScopeArgs(["76:34"]);
   assert.deepEqual(first, ["76:34"]);
-  assert.deepEqual(second, { queueNodeIds: ["76:34"] });
+  assert.deepEqual(second, {
+    queueNodeIds: ["76:34"],
+    partialExecutionTargets: ["76:34"],
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -204,7 +207,10 @@ test("#630 queuePromptScopeAttempts: both argument shapes are tried BEFORE the b
   const attempts = queuePromptScopeAttempts(["76:34"]);
   assert.equal(attempts.length, 4);
   assert.deepEqual(attempts[0], { arg: ["76:34"], repair: false });
-  assert.deepEqual(attempts[1], { arg: { queueNodeIds: ["76:34"] }, repair: false });
+  assert.deepEqual(attempts[1], {
+    arg: { queueNodeIds: ["76:34"], partialExecutionTargets: ["76:34"] },
+    repair: false,
+  });
   // #752 — the api layer reads a DIFFERENT key than the store does. Verified in
   // a shipped 1.47.12 bundle: the store destructures `queueNodeIds` and calls
   // `api.queuePrompt(e, m, {partialExecutionTargets: n})`, and only that second
@@ -3732,7 +3738,7 @@ test("#752 WIRING: the graph_run note actually PRINTS the observed body keys", (
   );
 });
 
-test("#752 a build that reads ONLY partialExecutionTargets is served NATIVELY, not by body repair", async () => {
+test("#752/#1782 an API-forwarding queue wrapper receives partialExecutionTargets before body repair", async () => {
   // Two field reports (frontend 1.45.21) queued correctly but via
   // `scope_applied_by: "request_body_repair"` — the fallback carrying the whole
   // feature. Read out of a shipped 1.47.12 bundle, the reason is that the
@@ -3742,7 +3748,8 @@ test("#752 a build that reads ONLY partialExecutionTargets is served NATIVELY, n
   //   api:   ...n?.partialExecutionTargets && {partial_execution_targets: ...}
   //
   // so a build whose app.queuePrompt forwards straight to the api layer ignored
-  // both shapes the panel sent.
+  // both shapes the panel sent. #1782 extends the options attempt with both
+  // keys, so the same call now serves that wrapper without reaching repair.
   const stop = keepAlive()
   try {
   const server = makeServer()
@@ -3753,11 +3760,11 @@ test("#752 a build that reads ONLY partialExecutionTargets is served NATIVELY, n
   assert.equal(result.outcome, "dispatched")
   assert.equal(result.scopeAppliedBy, "frontend", "the scope reached the body through app.queuePrompt, not the repair")
   assert.ok(!result.repaired, "the body-repair fallback must not be needed for this build")
-  // Shapes 1 and 2 are dropped by this build; the third one lands.
-  assert.equal(app.posted.length, 3, "array, queueNodeIds, then the partialExecutionTargets shape")
+  // The positional array is dropped by this wrapper; the dual-key options
+  // object lands before the standalone API compatibility attempt.
+  assert.equal(app.posted.length, 2, "array, then the dual-key 1.49.6 options shape")
   assert.equal(app.posted[0].partial_execution_targets, undefined)
-  assert.equal(app.posted[1].partial_execution_targets, undefined)
-  assert.deepEqual(app.posted[2].partial_execution_targets, ["14"])
+  assert.deepEqual(app.posted[1].partial_execution_targets, ["14"])
   // Exactly one request reaches ComfyUI, carrying exactly node 14's branch.
   assert.equal(server.calls.length, 1, "the two dropped attempts were blocked, not forwarded")
   assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"])
@@ -3765,6 +3772,43 @@ test("#752 a build that reads ONLY partialExecutionTargets is served NATIVELY, n
     stop()
   }
 })
+
+test("#1782 frontend 1.49.6 shapes reach /prompt natively and dropped wrappers still use repair", async () => {
+  const stop = keepAlive();
+  try {
+    for (const [label, shape] of [["positional array", "positional"], ["QueuePromptOptions", "shimless"]]) {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const app = makeFrontend({ shape, apiTarget });
+      const result = await dispatchScopedRun({
+        app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      });
+      assert.equal(result.outcome, "dispatched", `${label}: dispatch succeeds`);
+      assert.equal(result.scopeAppliedBy, "frontend", `${label}: native frontend delivery`);
+      assert.equal(result.repaired, 0, `${label}: body repair is not needed`);
+      assert.equal(server.calls.length, 1, `${label}: exactly one request reaches ComfyUI`);
+      assert.deepEqual(
+        JSON.parse(server.calls[0].options.body).partial_execution_targets,
+        ["14"],
+        `${label}: only the requested execution target is sent`,
+      );
+    }
+
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+    });
+    assert.equal(result.outcome, "dispatched", "a dropping wrapper remains safe and useful");
+    assert.equal(result.scopeAppliedBy, "request_body_repair");
+    assert.equal(result.repaired, 1);
+    assert.equal(server.calls.length, 1);
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
 
 // ---------------------------------------------------------------------------
 // comfyui-mcp#1871 — a run-to-node refused over a node on ANOTHER branch.

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -152,7 +152,11 @@ export const QUEUE_ITEM_TAG = Symbol("cmcp-scoped-run-tag");
  * The ordered list of 3rd-argument shapes to try for app.queuePrompt when a
  * run-to-node scope is requested. The positional array comes first (native on
  * positional builds, normalized by the Array.isArray shim on options builds);
- * the QueuePromptOptions object is next for builds that dropped the shim.
+ * the QueuePromptOptions object is next for builds that dropped the shim. The
+ * object carries both the store-layer `queueNodeIds` key and the API-layer
+ * `partialExecutionTargets` key: ComfyApp 1.49.6 reads the former and translates
+ * it to the latter, while a wrapper that forwards the options directly to the
+ * API can read the latter without needing a separate attempt.
  * `[undefined]` when no scope was requested — a plain full run, exactly the
  * historical call shape.
  *
@@ -179,13 +183,13 @@ export const QUEUE_ITEM_TAG = Symbol("cmcp-scoped-run-tag");
  * a build that does not read it.
  *
  * @param {string[]|undefined} partialTargets
- * @returns {(string[]|{queueNodeIds:string[]}|undefined)[]}
+ * @returns {(string[]|{queueNodeIds:string[],partialExecutionTargets:string[]}|undefined)[]}
  */
 export function queuePromptScopeArgs(partialTargets) {
   if (!Array.isArray(partialTargets) || !partialTargets.length) return [undefined];
   return [
     partialTargets,
-    { queueNodeIds: partialTargets },
+    { queueNodeIds: partialTargets, partialExecutionTargets: partialTargets },
     { partialExecutionTargets: partialTargets },
   ];
 }
@@ -193,7 +197,10 @@ export function queuePromptScopeArgs(partialTargets) {
 /**
  * The ordered DELIVERY ATTEMPTS for a run-to-node scope. The first two hand the
  * scope to `app.queuePrompt` in each of its two documented third-argument
- * shapes. The LAST one hands over the positional array again but also licenses
+ * shapes. The options object carries both the store and API option keys so the
+ * same call works through the 1.49.6 ComfyApp layer and an API-forwarding
+ * wrapper. The remaining API-level compatibility attempt is retained for
+ * wrappers that allow only that key. The LAST one hands over the positional array but also licenses
  * the guard to write `partial_execution_targets` straight into this run's own
  * /prompt body (repairScopeInBody) if it still has not arrived.
  *
@@ -206,16 +213,17 @@ export function queuePromptScopeArgs(partialTargets) {
  * the panel only reaches for the body when the supported routes have failed.
  *
  * @param {string[]|undefined} partialTargets
- * @returns {{arg: string[]|{queueNodeIds:string[]}|undefined, repair: boolean}[]}
+ * @returns {{arg: string[]|{queueNodeIds:string[],partialExecutionTargets:string[]}|{partialExecutionTargets:string[]}|undefined, repair: boolean}[]}
  */
 export function queuePromptScopeAttempts(partialTargets) {
   if (!Array.isArray(partialTargets) || !partialTargets.length) {
     return [{ arg: undefined, repair: false }];
   }
+  const [, optionsArg, apiArg] = queuePromptScopeArgs(partialTargets);
   return [
     { arg: partialTargets, repair: false },
-    { arg: { queueNodeIds: partialTargets }, repair: false },
-    { arg: { partialExecutionTargets: partialTargets }, repair: false },
+    { arg: optionsArg, repair: false },
+    { arg: apiArg, repair: false },
     { arg: partialTargets, repair: true },
   ];
 }


### PR DESCRIPTION
Fixes #1782\n\n## Change\n- carry both frontend 1.49.6 queue option keys (queueNodeIds and partialExecutionTargets) in the options adapter\n- preserve the positional-array and direct API compatibility attempts\n- keep the existing verified equest_body_repair fallback as the final route\n- add focused coverage for both supported queuePrompt shapes, the outgoing partial_execution_targets body, and fallback repair\n\n## Production path\ngraph_run resolves 	o_node_id into partialTargets and calls dispatchScopedRun; the guard invokes pp.queuePrompt(mark, batch, scopeArg) and verifies the outgoing /prompt body before forwarding.\n\n## Validation\n- 
ode --test browser_tests/unit/run-scope-guard.test.mjs — 137 passed\n- 
pm.cmd run test:unit — 6810 passed, 1 existing todo\n- 
pm.cmd run typecheck — passed\n- 
pm.cmd run check:scope — passed\n- 
ode --check over all web/js/**/*.js — passed\n- python -m py_compile __init__.py — passed\n- git diff --check — passed\n\nDo not merge automatically; this PR is implementation-only.