### PR TITLE
fix: retain usable schema across refresh failures

### DIFF
--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -830,6 +830,90 @@ test("#1709: a direct schema response crossing refresh cannot authorize a later 
   );
 });
 
+test("#2249: the shipped refresh keeps last-known membership after whole-schema replacement fails", async () => {
+  const comfy = makeComfy();
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  assert.equal(
+    snapshot.record({ ImageScale: {} }, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
+    true,
+  );
+  const register = realRegisterComfyNodeDefs({
+    app: comfy.app,
+    api: {
+      async getNodeDefs() {
+        return NODE_DEFS_NO_ANSWER;
+      },
+      async fetchApi() {
+        return { ok: false, status: 503, json: async () => ({}) };
+      },
+    },
+    objectInfoCache: createObjectInfoCache(),
+    objectInfoSnapshot: snapshot,
+    verifiedNodeDefCache,
+  });
+
+  const verdict = await register(undefined, { runBudgetMs: 100 });
+  assert.equal(verdict.refreshed, false, "the failed replacement does not claim freshness");
+  assert.equal(snapshot.isReplacementPending(), false, "the pending fence settles after failure");
+  const fallback = snapshot.authorize({
+    epoch: 0,
+    generation: verifiedNodeDefCache.generation(),
+    socketDown: false,
+    outcomes: [
+      { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+      { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+    ],
+  });
+  assert.ok(fallback.defs?.ImageScale, "the old whole map remains usable for an existing node");
+});
+
+test("#2249: an empty refresh response retires the old whole snapshot instead of rebinding it", async () => {
+  const comfy = makeComfy();
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  snapshot.record(
+    { ImageScale: {} },
+    {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    },
+  );
+  const register = realRegisterComfyNodeDefs({
+    app: comfy.app,
+    api: {
+      async getNodeDefs() {
+        return {};
+      },
+    },
+    objectInfoCache: createObjectInfoCache(),
+    objectInfoSnapshot: snapshot,
+    verifiedNodeDefCache,
+  });
+
+  await register(undefined, { runBudgetMs: 100 });
+  assert.equal(snapshot.peek().held, false, "an authoritative empty replacement leaves no old membership proof");
+  assert.equal(
+    snapshot.authorize({
+      epoch: 0,
+      generation: verifiedNodeDefCache.generation(),
+      socketDown: false,
+      outcomes: [{ route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER }],
+    }).defs,
+    null,
+    "a later silent probe cannot resurrect a type absent from the empty replacement",
+  );
+});
+
 test("#1709: graph_add_node replaces the old whole cache and snapshot on a changed response", async () => {
   const comfy = makeComfy();
   const oldDefs = { OldNode: { input: { required: {} } } };

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -1623,12 +1623,12 @@ test("#1560 SHIPPED: a route that THREW licenses nothing either — something an
   assert.equal(o.readScopedLicence(), false, "a refused connection is a process that is GONE, not one that is busy");
 });
 
-test("#2249 SHIPPED: a contacted unusable whole route leaves room for exact type-scoped authority", async () => {
+test("#2249 SHIPPED: a gateway timeout leaves room for exact type-scoped authority", async () => {
   const snapshot = createObjectInfoSnapshot();
   const o = buildShippedOracle({
     api: {
       getNodeDefs: undefined,
-      fetchApi: async () => ({ ok: false, status: 503, json: async () => ({}) }),
+      fetchApi: async () => ({ ok: false, status: 504, json: async () => ({}) }),
     },
     snapshot,
     epoch: 5,
@@ -1637,7 +1637,25 @@ test("#2249 SHIPPED: a contacted unusable whole route leaves room for exact type
   assert.equal(
     o.readScopedLicence(),
     true,
-    "a 503 did not establish absence of the requested class, so a live type-scoped answer may decide it",
+    "a proxy gateway timeout did not establish absence of the requested class, so a live type-scoped answer may decide it",
+  );
+});
+
+test("#2249 SHIPPED: mixed nothing-returned plus answered-unusable evidence licenses nothing", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({
+    api: {
+      getNodeDefs: async () => undefined,
+      fetchApi: async () => ({ ok: false, status: 500, json: async () => ({}) }),
+    },
+    snapshot,
+    epoch: 5,
+  });
+  assert.equal(await o.getFreshObjectInfo(), null);
+  assert.equal(
+    o.readScopedLicence(),
+    false,
+    "a returned unusable response is an answer/refusal even when another route returned nothing",
   );
 });
 

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -560,6 +560,48 @@ test("#1223 a good snapshot is not displaced by a later failed fetch", () => {
   assert.ok(snap.authorize({ epoch: 2, socketDown: false, outcomes: silence }).defs);
 });
 
+test("#2249 a failed same-epoch replacement rebinds the last snapshot after fencing it", () => {
+  const snap = createObjectInfoSnapshot();
+  stored(snap, SCHEMA, 7, 11);
+
+  snap.beginReplacement();
+  assert.equal(snap.isReplacementPending(), true);
+  assert.equal(
+    snap.authorize({ epoch: 7, generation: 12, socketDown: false, outcomes: silence }).defs,
+    null,
+    "the old map cannot authorize while the replacement is unresolved",
+  );
+
+  assert.equal(
+    snap.retainAfterReplacementFailure({ epoch: 7, generation: 12, socketDown: false }),
+    true,
+    "a failed refresh rebinds the held map to the retired-proof generation",
+  );
+  const fallback = snap.authorize({ epoch: 7, generation: 12, socketDown: false, outcomes: silence });
+  assert.ok(fallback.defs, "the prior whole observation remains usable after replacement failure");
+  assert.equal(snap.isReplacementPending(), false);
+});
+
+test("#2249 a successful replacement supersedes the retained snapshot", () => {
+  const snap = createObjectInfoSnapshot();
+  stored(snap, { OldNode: {} }, 7, 11);
+  snap.beginReplacement();
+  assert.equal(
+    snap.record({ NewNode: {} }, {
+      observedAtEpoch: 7,
+      currentEpoch: 7,
+      observedAtGeneration: 12,
+      currentGeneration: 12,
+      whole: true,
+    }),
+    true,
+  );
+  const current = snap.authorize({ epoch: 7, generation: 12, socketDown: false, outcomes: silence });
+  assert.equal(Object.prototype.hasOwnProperty.call(current.defs, "OldNode"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(current.defs, "NewNode"), true);
+  assert.equal(snap.isReplacementPending(), false);
+});
+
 test("#1223 clear() retires it — a suspicion of change outranks a stored schema", () => {
   const snap = createObjectInfoSnapshot();
   stored(snap, SCHEMA, 2);
@@ -1579,6 +1621,24 @@ test("#1560 SHIPPED: a route that THREW licenses nothing either — something an
   });
   assert.equal(await o.getFreshObjectInfo(), null);
   assert.equal(o.readScopedLicence(), false, "a refused connection is a process that is GONE, not one that is busy");
+});
+
+test("#2249 SHIPPED: a contacted unusable whole route leaves room for exact type-scoped authority", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({
+    api: {
+      getNodeDefs: undefined,
+      fetchApi: async () => ({ ok: false, status: 503, json: async () => ({}) }),
+    },
+    snapshot,
+    epoch: 5,
+  });
+  assert.equal(await o.getFreshObjectInfo(), null);
+  assert.equal(
+    o.readScopedLicence(),
+    true,
+    "a 503 did not establish absence of the requested class, so a live type-scoped answer may decide it",
+  );
 });
 
 test("#1560 SHIPPED: a LIVE answer leaves the licence false — there is nothing to license", async () => {

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -163,6 +163,28 @@ test("#1560 A: whole /object_info never lands, per-class answers ⇒ a DIRECT wr
   );
 });
 
+test("#2249: an exact type-scoped answer can validate an existing scalar after a non-definitive whole failure", async () => {
+  const reg = loadedRegistry(["ImageScale"]);
+  const node = regNode(2249, "ImageScale", [{ name: "upscale_factor", type: "FLOAT", value: 1 }]);
+  const backend = largeInstall({ defined: ["ImageScale"] });
+  const { set } = await runSetWidget(node, "upscale_factor", 2, {
+    registry: reg,
+    getRegistry: () => reg,
+    // The whole oracle has no usable answer; this is deliberately not registry-only auth.
+    getFreshObjectInfo: async () => null,
+    fetchScopedObjectInfo: async (types) =>
+      fetchTypeScopedObjectInfo(types, {
+        fetchApi: backend.fetchApi,
+        deadlineMs: SCOPED_OBJECT_INFO_DEADLINE_MS,
+      }),
+    wasTypeEverDefined: () => false,
+    ...HOOKS,
+  });
+  assert.equal(set.value, 2, "the exact live class answer validates the existing scalar widget");
+  assert.equal(node.widgets[0].value, 2);
+  assert.deepEqual(backend.perClassCalls(), ["/object_info/ImageScale"]);
+});
+
 test("#1560 A: a PROMOTED nested write asks about ALL THREE types (#716/#821's 'two types') and succeeds", async () => {
   const reg = loadedRegistry(["KSampler"]);
   const { a, b, resolveSource } = nestedFixture(reg, "KSampler");
@@ -313,11 +335,10 @@ test("#1573: an UNLICENSED scoped route issues NOTHING, and the refusal does not
   // paired with the request list that proves what actually happened.
   const src = readFileSync(PANEL_JS, "utf8");
   const UNLICENSED_REASON =
-    "no whole-schema route was both CONTACTED and SILENT, and a type-scoped read " +
-    "may only stand in for one that was — it must never overrule what a route did " +
-    "establish, and it is not a substitute for a route nobody ran";
+    "the whole-schema evidence did not qualify for a type-scoped fallback, which " +
+    "may not overrule an answer or substitute for a route nobody ran";
   assert.ok(
-    src.includes("no whole-schema route was both CONTACTED and SILENT"),
+    src.includes("the whole-schema evidence did not qualify for a type-scoped fallback"),
     "the reason under test is the panel's own, not one invented here",
   );
 
@@ -543,19 +564,22 @@ test("#1560: scopedAuthorizationTypes names EVERY type the fence asks about, fro
   );
 });
 
-test("#1560: the panel WIRES the scoped route, gated on the silence licence and on the command budget", () => {
+test("#1560/#2249: the panel wires scoped authority after a non-definitive whole failure", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   assert.match(src, /fetchScopedObjectInfo:\s*async \(types\) => \{/, "the capability reaches runSetWidget");
   // The licence is DECIDED beside the snapshot's own verdict, on the SAME `outcome.outcomes`,
   // in the same statement — and merely READ at the gate. A second reading of a fact
   // established at a moment is how the two could disagree, and this handler enters
   // `readObjectInfo` more than once (the #1126 live re-ask).
+  const oracle = src.slice(src.indexOf("const fallback = objectInfoSnapshot.authorize"));
+  assert.match(oracle, /outcomes: outcome\?\.outcomes,\s*\}\);/, "uses the oracle's outcome list");
+  assert.match(oracle, /const wholeProbeCanBeNarrowed =/, "classifies the whole outcome before licensing");
   assert.match(
-    src,
-    /outcomes: outcome\?\.outcomes,\s*\}\);[\s\S]{0,500}?scopedReadLicensed = schemaResponseIsCurrent && noBackendAnswerEstablished\(outcome\?\.outcomes\);/,
-    "decided in the same breath as objectInfoSnapshot.authorize, from the same evidence and current-generation fence",
+    oracle,
+    /schemaResponseIsCurrent && authoritativeEmpty !== true && wholeProbeCanBeNarrowed/,
+    "uses the current-generation fence and rejects authoritative whole emptiness",
   );
-  assert.match(src, /if \(!scopedReadLicensed\) \{/, "a route that ANSWERED is never overruled");
+  assert.match(src, /if \(!scopedReadLicensed\) \{/, "an authoritative whole answer is never overruled");
   assert.match(src, /let scopedReadLicensed = false;/, "and it licenses nothing until a read establishes it");
   assert.match(src, /fetchTypeScopedObjectInfo\(types, \{/, "the panel calls the type-scoped reader");
   assert.match(src, /deadlineMs: budget\.bounded\(SCOPED_OBJECT_INFO_DEADLINE_MS\)/, "bounded by what the command has left");

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -573,16 +573,17 @@ test("#1560/#2249: the panel wires scoped authority after a non-definitive whole
   // `readObjectInfo` more than once (the #1126 live re-ask).
   const oracle = src.slice(src.indexOf("const fallback = objectInfoSnapshot.authorize"));
   assert.match(oracle, /outcomes: outcome\?\.outcomes,\s*\}\);/, "uses the oracle's outcome list");
-  assert.match(oracle, /const wholeProbeCanBeNarrowed =/, "classifies the whole outcome before licensing");
   assert.match(
     oracle,
-    /schemaResponseIsCurrent && authoritativeEmpty !== true && wholeProbeCanBeNarrowed/,
-    "uses the current-generation fence and rejects authoritative whole emptiness",
+    /schemaResponseIsCurrent && authoritativeEmpty !== true && noBackendAnswerEstablished\(outcome\?\.outcomes\)/,
+    "uses the shared fail-closed silence predicate and rejects authoritative answers",
   );
   assert.match(src, /if \(!scopedReadLicensed\) \{/, "an authoritative whole answer is never overruled");
   assert.match(src, /let scopedReadLicensed = false;/, "and it licenses nothing until a read establishes it");
   assert.match(src, /fetchTypeScopedObjectInfo\(types, \{/, "the panel calls the type-scoped reader");
   assert.match(src, /deadlineMs: budget\.bounded\(SCOPED_OBJECT_INFO_DEADLINE_MS\)/, "bounded by what the command has left");
+  assert.match(src, /const scopedGeneration = verifiedNodeDefCache\.generation\(\)/, "fences the scoped request at issuance");
+  assert.match(src, /scopedGeneration !== verifiedNodeDefCache\.generation\(\)/, "rejects a scoped answer after schema invalidation");
   assert.match(src, /setWidgetSchemaProvenance = \(\) => "scoped"/, "the reply is told which route answered");
   // The scoped payload must never be filed as a whole observation, in either store.
   const wiring = src.slice(src.indexOf("fetchScopedObjectInfo: async (types)"), src.indexOf("fetchScopedObjectInfo: async (types)") + 1800);

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -887,8 +887,8 @@ test("#1709: authoritative empty retires whole cache and snapshot before ordinar
   assert.equal(widget.value, "new", "the timeout refusal did not write");
   assert.deepEqual(
     calls.slice(-2),
-    ["/object_info", "/object_info"],
-    "the later ordinary read reached both live routes after the cache was retired",
+    ["/object_info", "/object_info/LoadImage"],
+    "the later non-definitive whole failure allowed the exact scoped route before refusal",
   );
 });
 

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -821,6 +821,54 @@ test("#1709: scoped graph_set_widget reads retire proof on definitive presence a
   );
 });
 
+test("#2249: a schema invalidation during a scoped read refuses stale scoped evidence", async () => {
+  const def = { input: { required: { text: ["STRING", {}] } } };
+  const widget = { name: "text", type: "text", value: "before" };
+  const node = {
+    id: 2249,
+    type: "LoadImage",
+    widgets: [widget],
+    constructor: { nodeData: def, comfyClass: "LoadImage" },
+  };
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  const scopedStarted = deferred();
+  const scopedResponse = deferred();
+  const built = realGraphSetWidget({
+    node,
+    verifiedNodeDefCache,
+    registeredNodeTypes: { LoadImage: { nodeData: def, comfyClass: "LoadImage" }, Note: {} },
+    getNodeDefsImpl: async () => undefined,
+    fetchApiImpl: async (route) => {
+      if (route === "/object_info") return { ok: false, status: 504, json: async () => ({}) };
+      if (route === "/object_info/LoadImage") {
+        scopedStarted.resolve();
+        const defs = await scopedResponse.promise;
+        return { ok: true, status: 200, json: async () => defs };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    },
+  });
+
+  const pendingWrite = built.graph_set_widget({
+    node_id: 2249,
+    widget: "text",
+    value: "stale-answer-must-not-land",
+    workflow_uuid: "u",
+  });
+  await scopedStarted.promise;
+  const generationBeforeInvalidation = verifiedNodeDefCache.generation();
+  verifiedNodeDefCache.clear(); // same epoch, equivalent to panel_refresh_nodes invalidation
+  assert.ok(verifiedNodeDefCache.generation() > generationBeforeInvalidation);
+  scopedResponse.resolve({ LoadImage: def });
+
+  await assert.rejects(
+    () => pendingWrite,
+    /Cannot set widget|object_info|refused/i,
+    "a scoped answer crossing schema invalidation cannot authorize the write",
+  );
+  assert.equal(widget.value, "before", "the stale scoped answer did not mutate the widget");
+});
+
 test("#1709: authoritative empty retires whole cache and snapshot before ordinary timeout refusal", async () => {
   const widget = { name: "text", type: "text", value: "old" };
   const node = { id: 212, type: "LoadImage", widgets: [widget] };
@@ -887,8 +935,8 @@ test("#1709: authoritative empty retires whole cache and snapshot before ordinar
   assert.equal(widget.value, "new", "the timeout refusal did not write");
   assert.deepEqual(
     calls.slice(-2),
-    ["/object_info", "/object_info/LoadImage"],
-    "the later non-definitive whole failure allowed the exact scoped route before refusal",
+    ["/object_info", "/object_info"],
+    "the later answered-unusable whole failure refused without trying the scoped route",
   );
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -313,7 +313,6 @@ import {
 import {
   createObjectInfoSnapshot,
   snapshotAuthorizationNote,
-  noBackendAnswerEstablished,
 } from "./lib/object-info-snapshot.js";
 import { fetchTypeScopedObjectInfo, SCOPED_OBJECT_INFO_DEADLINE_MS } from "./lib/scoped-object-info.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
@@ -1478,6 +1477,7 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // preloaded input. The explicit marker is narrowly supplied by that caller; arbitrary
   // preloaded refresh payloads remain ineligible for whole-schema cache/snapshot authority.
   const preloadedWholeSchema = runOpts?.preloadedWholeSchema === true;
+  const replacementMayReplaceWholeSnapshot = !preloadedDefs || preloadedWholeSchema;
   let defsRegistered = false;
   let comboApiPresent = false;
   let comboRan = false;
@@ -1534,12 +1534,13 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // have fetched and failed closed. Retiring it up front costs one extra fetch and cannot
   // be wrong in the dangerous direction.
   objectInfoCache.invalidate();
-  // #1223 — retire the last-observed snapshot on the SAME event and for the SAME reason.
-  // This function runs exactly when something suspects the schema moved, and a snapshot
-  // that survived a suspicion would authorize writes the burst cache has already been told
-  // not to. Re-recorded below if this run's fetch succeeds, so the cost of being wrong here
-  // is one refused write during an outage, not a stale authorization.
-  objectInfoSnapshot.clear();
+  // #2249 — fence the last-observed snapshot while this replacement is unresolved, but do
+  // not destroy it before the new whole map succeeds. If both whole routes fail, the old
+  // membership-only map is still the only usable evidence for an existing scalar widget;
+  // object-info-snapshot.js re-binds it to the post-invalidation generation only after this
+  // run has conclusively failed. Reconnect handlers still clear it outright because a new
+  // backend process is the one event that can change the type set.
+  objectInfoSnapshot.beginReplacement?.();
   if (typeof verifiedNodeDefCache !== "undefined") verifiedNodeDefCache.clear();
   // #1223 — the epoch this run STARTED on, captured before any fetch. The recording below
   // is refused if a reconnect lands while the fetch is in flight, so a pre-restart schema
@@ -1943,18 +1944,20 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     if ((!preloadedDefs || preloadedWholeSchema) && refreshResponseIsCurrent) {
       // A direct refresh fetch, or graph_add_node's explicitly verified whole payload, is
       // not an objectInfoCache read. Keep its current answer as the burst authority and
-      // retire the snapshot before recording the replacement, so a timeout cannot use the
-      // prior map or membership set. The refresh invalidation above happens first, so this
-      // is the post-refresh generation rather than the add's pre-refresh fence.
+      // replace the held snapshot only after the response has passed the epoch/generation
+      // fences. The refresh invalidation above happens first, so this is the post-refresh
+      // generation rather than the add's pre-refresh fence.
       if (!objectInfoCache.replace(defs)) objectInfoCache.invalidate();
-      objectInfoSnapshot.clear();
-      objectInfoSnapshot.record(defs, {
+      const snapshotRecorded = objectInfoSnapshot.record(defs, {
         observedAtEpoch: runStartedAtEpoch,
         currentEpoch: runStartedAtEpoch,
         observedAtGeneration: runStartedAtGeneration,
         currentGeneration: runStartedAtGeneration,
         whole: true,
       });
+      // `{}` or an unreadable object is an authoritative non-schema response for this
+      // refresh, not a failed replacement that can resurrect the prior membership map.
+      if (!snapshotRecorded) objectInfoSnapshot.clear();
     }
     // #1275 — snapshot the live graph BEFORE the first mutating phase. Everything
     // from here to the combo phase calls into frontend and extension code
@@ -2236,6 +2239,21 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     didThrow = true;
     console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
   } finally {
+    // #2249 — a failed refresh must not turn a previously usable whole snapshot into a
+    // permanent refusal. The pending flag remains set when no current whole response was
+    // recorded; only then may the snapshot rebind to the generation advanced at refresh
+    // start. If the socket/epoch moved, retainAfterReplacementFailure clears it instead.
+    if (
+      replacementMayReplaceWholeSnapshot &&
+      typeof objectInfoSnapshot.retainAfterReplacementFailure === "function" &&
+      objectInfoSnapshot.isReplacementPending?.() === true
+    ) {
+      objectInfoSnapshot.retainAfterReplacementFailure({
+        epoch: backendReconnectEpoch,
+        generation: verifiedNodeDefCache.generation(),
+        socketDown: comfyBackendSocketDown,
+      });
+    }
     // Trust the live combos for suppressing missing-asset candidates ONLY when BOTH an
     // authoritative /object_info payload was actually obtained this call AND the combo
     // lists were refreshed from it. refreshComboInNodes resolving alone is not proof —
@@ -16046,11 +16064,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // its refusal, so the message would name routes another call tried. Declared in the
     // handler's own scope, so each invocation reports what IT observed.
     let oracleFailures = [];
-    // #1560 — may the TYPE-SCOPED last resort be consulted at all?
+    // #1560/#2249 — may the TYPE-SCOPED last resort be consulted at all?
     //
-    // Only when no whole-map route ANSWERED. A route that threw, returned a non-gateway
-    // status, or expressed deny-all as `{}` must never be overruled by a broader per-class
-    // read — the one direction object-info-oracle.js's own note forbids.
+    // A whole-map failure does not establish the requested class is absent. Once a
+    // non-throwing route has been contacted, an exact successful `/object_info/<class>`
+    // response can be authoritative for this write when the whole route timed out,
+    // returned nothing, or returned an unusable response. The one answer it must never
+    // overrule is an authoritative whole empty map (`{}`), which explicitly says deny-all;
+    // a thrown route remains a refusal because it does not provide safe evidence either way.
     //
     // CAPTURED WHERE THE SNAPSHOT MAKES THE SAME JUDGEMENT, from the SAME `outcome.outcomes`
     // in the same statement — never re-read from a variable later. Storing the tag list and
@@ -16424,8 +16445,20 @@ const GRAPH_TOOL_EXECUTORS = {
           socketDown: comfyBackendIsDown(),
           outcomes: outcome?.outcomes,
         });
-        // #1560 — the SAME evidence, read ONCE, in the same statement as the snapshot's.
-        scopedReadLicensed = schemaResponseIsCurrent && noBackendAnswerEstablished(outcome?.outcomes);
+        // #1560/#2249 — the SAME evidence, read ONCE, in the same statement as the
+        // snapshot's. A contacted but unusable whole route leaves the requested class
+        // unanswered; the type-scoped response below can answer that narrower question.
+        // An authoritative empty whole map is the explicit deny-all exception. A list with
+        // only NOT_ATTEMPTED routes licenses nothing, and a retired/reconnected response
+        // cannot be promoted into either route.
+        const wholeProbeCanBeNarrowed =
+          Array.isArray(outcome?.outcomes) &&
+          outcome.outcomes.some((entry) =>
+            ["no-answer", "nothing-returned", "answered-unusable"].includes(entry?.kind),
+          ) &&
+          !outcome.outcomes.some((entry) => entry?.kind === "threw");
+        scopedReadLicensed =
+          schemaResponseIsCurrent && authoritativeEmpty !== true && wholeProbeCanBeNarrowed;
         if (fallback.defs) {
           // Held for the reply. The write is about to be reported as SUCCEEDED and VERIFIED,
           // and it was verified against a schema nobody could re-fetch — an agent that is
@@ -16472,13 +16505,13 @@ const GRAPH_TOOL_EXECUTORS = {
       //
       // TWO GATES, both here rather than in the lib, because only this file holds the facts.
       //
-      //   1. THE SILENCE LICENCE, decided beside the snapshot's own verdict on the SAME
-      //      `outcome.outcomes` and merely READ here. A client that returned an empty schema
-      //      has expressed deny-all, and a broader per-class read must never overrule it. A
-      //      timeout, a client that returned NOTHING, or a proxy's 504 leave the question
-      //      unanswered — those, and only those, may be asked again by another route. It is
-      //      false until a read establishes it, so an unwired or never-run oracle licenses
-      //      nothing.
+      //   1. THE NARROW-QUESTION LICENCE, decided beside the snapshot's own verdict on the
+      //      SAME `outcome.outcomes` and merely READ here. A client that returned an empty
+      //      schema has expressed deny-all, and a broader per-class read must never overrule
+      //      it. A contacted route that timed out, returned an unusable response, or
+      //      returned NOTHING leaves the requested class unanswered; the exact type-scoped
+      //      route may establish it. A thrown route remains refused, and an unwired or
+      //      never-attempted oracle licenses nothing.
       //   2. WHAT THE COMMAND HAS LEFT. The whole-map attempt has already spent most of the
       //      budget by the time this runs (measured on the reported shape: 15,015 ms of a 20s
       //      oracle deadline), so this takes `budget.bounded` like every other step and
@@ -16490,27 +16523,37 @@ const GRAPH_TOOL_EXECUTORS = {
       // the fence's own trust root.
       fetchScopedObjectInfo: async (types) => {
         if (!scopedReadLicensed) {
-          // STATE WHAT WAS OBSERVED, not one cause of it. `noBackendAnswerEstablished` is
-          // false for FOUR different things — a route ANSWERED something unusable, a route
-          // THREW, the outcome list was empty, or every route was NOT_ATTEMPTED — and naming
-          // only the first asserts an event that did not happen in the other three. A refusal
-          // that reports a cause it did not establish is #982's own defect, and the reporter
-          // of #1560 went looking at a backend that was answering fine because of exactly
-          // that. (#1223 makes a similar over-specific claim one sentence earlier in the same
-          // refusal; that one is pre-existing and is not touched here.)
+          // STATE WHAT WAS OBSERVED, not one cause of it. The licence is false for several
+          // distinct cases — a route answered authoritatively, a route threw, the outcome
+          // list was empty, or every route was NOT_ATTEMPTED — and naming only one asserts an
+          // event that did not happen in the others. A refusal that reports a cause it did
+          // not establish is #982's own defect.
           return {
             defs: null,
             covered: [],
             reason:
-              "no whole-schema route was both CONTACTED and SILENT, and a type-scoped read " +
-              "may only stand in for one that was — it must never overrule what a route did " +
-              "establish, and it is not a substitute for a route nobody ran",
+              "the whole-schema evidence did not qualify for a type-scoped fallback, which " +
+              "may not overrule an answer or substitute for a route nobody ran",
           };
         }
+        const scopedEpoch = backendReconnectEpoch;
         const scoped = await fetchTypeScopedObjectInfo(types, {
           fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
           deadlineMs: budget.bounded(SCOPED_OBJECT_INFO_DEADLINE_MS),
         });
+        // The per-class route is authoritative only for the backend connection that
+        // answered it. A reconnect or a down socket during this await makes that response
+        // as stale as a whole-map response spanning the same event; do not use it to
+        // authorize, retire proofs, or diagnose a removed type.
+        if (scopedEpoch !== backendReconnectEpoch || comfyBackendIsDown()) {
+          return {
+            defs: null,
+            covered: [],
+            reason:
+              "the backend reconnected or went down while the type-scoped /object_info " +
+              "read was in flight, so its answer cannot authorize this write",
+          };
+        }
         if (Array.isArray(scoped.covered)) {
           for (const classType of scoped.covered) {
             if (typeof classType === "string" && classType) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -313,6 +313,7 @@ import {
 import {
   createObjectInfoSnapshot,
   snapshotAuthorizationNote,
+  noBackendAnswerEstablished,
 } from "./lib/object-info-snapshot.js";
 import { fetchTypeScopedObjectInfo, SCOPED_OBJECT_INFO_DEADLINE_MS } from "./lib/scoped-object-info.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
@@ -16066,12 +16067,11 @@ const GRAPH_TOOL_EXECUTORS = {
     let oracleFailures = [];
     // #1560/#2249 — may the TYPE-SCOPED last resort be consulted at all?
     //
-    // A whole-map failure does not establish the requested class is absent. Once a
-    // non-throwing route has been contacted, an exact successful `/object_info/<class>`
-    // response can be authoritative for this write when the whole route timed out,
-    // returned nothing, or returned an unusable response. The one answer it must never
-    // overrule is an authoritative whole empty map (`{}`), which explicitly says deny-all;
-    // a thrown route remains a refusal because it does not provide safe evidence either way.
+    // A whole-map failure does not establish the requested class is absent. When every
+    // contacted route only timed out or returned nothing, an exact successful
+    // `/object_info/<class>` response can be authoritative for this write. An
+    // answered-unusable route is an answer/refusal, not silence; a thrown route and an
+    // authoritative whole empty map (`{}`) likewise cannot be overruled.
     //
     // CAPTURED WHERE THE SNAPSHOT MAKES THE SAME JUDGEMENT, from the SAME `outcome.outcomes`
     // in the same statement — never re-read from a variable later. Storing the tag list and
@@ -16446,19 +16446,11 @@ const GRAPH_TOOL_EXECUTORS = {
           outcomes: outcome?.outcomes,
         });
         // #1560/#2249 — the SAME evidence, read ONCE, in the same statement as the
-        // snapshot's. A contacted but unusable whole route leaves the requested class
-        // unanswered; the type-scoped response below can answer that narrower question.
-        // An authoritative empty whole map is the explicit deny-all exception. A list with
-        // only NOT_ATTEMPTED routes licenses nothing, and a retired/reconnected response
-        // cannot be promoted into either route.
-        const wholeProbeCanBeNarrowed =
-          Array.isArray(outcome?.outcomes) &&
-          outcome.outcomes.some((entry) =>
-            ["no-answer", "nothing-returned", "answered-unusable"].includes(entry?.kind),
-          ) &&
-          !outcome.outcomes.some((entry) => entry?.kind === "threw");
+        // snapshot's. The shared predicate is deliberately stricter than "some route was
+        // quiet": an answered-unusable route is an answer/refusal, so a mixed
+        // nothing-returned + answered-unusable result cannot license a narrower read.
         scopedReadLicensed =
-          schemaResponseIsCurrent && authoritativeEmpty !== true && wholeProbeCanBeNarrowed;
+          schemaResponseIsCurrent && authoritativeEmpty !== true && noBackendAnswerEstablished(outcome?.outcomes);
         if (fallback.defs) {
           // Held for the reply. The write is about to be reported as SUCCEEDED and VERIFIED,
           // and it was verified against a schema nobody could re-fetch — an agent that is
@@ -16508,9 +16500,9 @@ const GRAPH_TOOL_EXECUTORS = {
       //   1. THE NARROW-QUESTION LICENCE, decided beside the snapshot's own verdict on the
       //      SAME `outcome.outcomes` and merely READ here. A client that returned an empty
       //      schema has expressed deny-all, and a broader per-class read must never overrule
-      //      it. A contacted route that timed out, returned an unusable response, or
-      //      returned NOTHING leaves the requested class unanswered; the exact type-scoped
-      //      route may establish it. A thrown route remains refused, and an unwired or
+      //      it. Contacted routes that timed out or returned NOTHING leave the requested
+      //      class unanswered; the exact type-scoped route may establish it. An
+      //      answered-unusable or thrown route remains refused, and an unwired or
       //      never-attempted oracle licenses nothing.
       //   2. WHAT THE COMMAND HAS LEFT. The whole-map attempt has already spent most of the
       //      budget by the time this runs (measured on the reported shape: 15,015 ms of a 20s
@@ -16537,20 +16529,25 @@ const GRAPH_TOOL_EXECUTORS = {
           };
         }
         const scopedEpoch = backendReconnectEpoch;
+        const scopedGeneration = verifiedNodeDefCache.generation();
         const scoped = await fetchTypeScopedObjectInfo(types, {
           fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
           deadlineMs: budget.bounded(SCOPED_OBJECT_INFO_DEADLINE_MS),
         });
         // The per-class route is authoritative only for the backend connection that
-        // answered it. A reconnect or a down socket during this await makes that response
-        // as stale as a whole-map response spanning the same event; do not use it to
-        // authorize, retire proofs, or diagnose a removed type.
-        if (scopedEpoch !== backendReconnectEpoch || comfyBackendIsDown()) {
+        // answered it. A reconnect, schema invalidation, or a down socket during this await
+        // makes that response as stale as a whole-map response spanning the same event; do
+        // not use it to authorize, retire proofs, or diagnose a removed type.
+        if (
+          scopedEpoch !== backendReconnectEpoch ||
+          scopedGeneration !== verifiedNodeDefCache.generation() ||
+          comfyBackendIsDown()
+        ) {
           return {
             defs: null,
             covered: [],
             reason:
-              "the backend reconnected or went down while the type-scoped /object_info " +
+              "the backend schema changed or went down while the type-scoped /object_info " +
               "read was in flight, so its answer cannot authorize this write",
           };
         }

--- a/web/js/lib/object-info-snapshot.js
+++ b/web/js/lib/object-info-snapshot.js
@@ -141,6 +141,11 @@ export function createObjectInfoSnapshot() {
   let defs = null;
   let epoch = null;
   let generation = null;
+  // A same-connection refresh retires per-class proof immediately, but its last whole-map
+  // membership observation remains useful if the replacement never answers. Keep that
+  // distinction explicit: while replacement is pending the old map is not authority; once
+  // the replacement fails, it may be re-bound to the new proof generation below.
+  let replacementPending = false;
   // #1582 — have the live whole-map routes already gone silent on THIS connection,
   // after a snapshot was held? The first silent call still has to probe: that is how
   // an answered error keeps refusing, and how a healthy backend still wins. Once
@@ -233,6 +238,7 @@ export function createObjectInfoSnapshot() {
       // A live observation means the whole-map routes answered. The next widget write
       // must be allowed to prefer that live path rather than inheriting a prior silence.
       probesSilent = false;
+      replacementPending = false;
       return true;
     },
 
@@ -267,6 +273,14 @@ export function createObjectInfoSnapshot() {
           reason:
             "the backend ANSWERED the schema probe with something unusable rather than failing " +
             "to answer at all, so this is not the transient silence the last-observed schema covers",
+        };
+      }
+      if (replacementPending) {
+        return {
+          defs: null,
+          reason:
+            "a whole /object_info replacement is still in progress, so the previous " +
+            "schema is held only as a retry fallback until that answer succeeds or fails",
         };
       }
       if (defs === null) {
@@ -319,6 +333,7 @@ export function createObjectInfoSnapshot() {
         : generation;
       return (
         defs !== null &&
+        !replacementPending &&
         !socketDown &&
         Number.isFinite(currentEpoch) &&
         currentEpoch === epoch &&
@@ -352,12 +367,46 @@ export function createObjectInfoSnapshot() {
       return probesSilent === true && this.isReusable(reusableOptions);
     },
 
+    /** Test/diagnostic view of the replacement fence; never exposes the held map. */
+    isReplacementPending() {
+      return replacementPending;
+    },
+
+    /**
+     * Mark the start of a same-connection replacement. The old membership map stays held,
+     * but cannot authorize while the replacement is unresolved.
+     */
+    beginReplacement() {
+      replacementPending = true;
+    },
+
+    /**
+     * Re-bind the held map after a replacement failed without changing the backend epoch.
+     * A down socket, a moved epoch, or an unreadable generation discards it instead.
+     */
+    retainAfterReplacementFailure({ epoch: currentEpoch, generation: currentGeneration, socketDown = false } = {}) {
+      if (
+        defs === null ||
+        socketDown ||
+        !Number.isFinite(currentEpoch) ||
+        currentEpoch !== epoch ||
+        !Number.isFinite(currentGeneration)
+      ) {
+        this.clear();
+        return false;
+      }
+      generation = currentGeneration;
+      replacementPending = false;
+      return true;
+    },
+
     /** Drop it — for anything that knows, or merely suspects, the schema moved. */
     clear() {
       defs = null;
       epoch = null;
       generation = null;
       probesSilent = false;
+      replacementPending = false;
     },
 
     /** Test/diagnostic view. Never used to make a decision. */


### PR DESCRIPTION
## Summary\n\nPanel-side fix for artokun/comfyui-mcp#2249.\n\n- Fence the last-known whole-schema membership snapshot during refresh, retain it only after a same-epoch whole replacement fails, and clear it across reconnect/down or authoritative empty/unusable replacement responses.\n- Keep existing refresh single-flight/coalescing behavior; preserve generation/epoch fences.\n- Permit an exact type-scoped live response only after non-definitive whole-route evidence; authoritative empty answers, thrown routes, reconnects, absent evidence, and insufficient scoped coverage still refuse.\n- Add failure, empty-response, scoped-authority, stale-combo, race, and refresh-coalescing regressions.\n\n## Verification\n\n- npm.cmd run test:unit (pass)\n- npm.cmd run typecheck (pass)\n- npm.cmd run check:scope (pass)\n- git diff --check (pass)\n- lint/build: package has no lint or build scripts\n\nMCP worktree was not modified. Do not merge this PR yet; MCP-side coordination remains separate.