### PR TITLE
fix(panel): rebuild fresh SaveVideo dynamic widgets

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -25,6 +25,7 @@ import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
 import { reconcileFreshDynamicWidgets } from "../../web/js/lib/dynamic-widget-reconcile.js";
+import { safeRemoveNode } from "../../web/js/lib/safe-remove-node.js";
 
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -235,6 +236,7 @@ export function addNodeCommandBudgetDeps() {
     addNodeRefreshBusyMessage: (classType) =>
       `HARNESS STUB refusal for "${classType}" — the shipped wording lives in the panel.`,
     reconcileFreshDynamicWidgets,
+    safeRemoveNode,
   };
 }
 

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -24,6 +24,7 @@ import { COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
 import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
+import { reconcileFreshDynamicWidgets } from "../../web/js/lib/dynamic-widget-reconcile.js";
 
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -233,6 +234,7 @@ export function addNodeCommandBudgetDeps() {
     // a hand-copied sentence here would just be a third place for it to drift.
     addNodeRefreshBusyMessage: (classType) =>
       `HARNESS STUB refusal for "${classType}" — the shipped wording lives in the panel.`,
+    reconcileFreshDynamicWidgets,
   };
 }
 

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -66,6 +66,7 @@ import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-c
 import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
 import { reconcileFreshDynamicWidgets } from "../../web/js/lib/dynamic-widget-reconcile.js";
+import { safeRemoveNode } from "../../web/js/lib/safe-remove-node.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -398,6 +399,7 @@ function realGraphAddNode({
     clearInheritedExecutionPreview,
     sanitizeNodeAuxId,
     reconcileFreshDynamicWidgets,
+    safeRemoveNode,
     OBJECT_INFO_SEED_WAIT_MS: 8000,
     ADD_NODE_COMMAND_BUDGET_MS: budgetMs,
     ADD_NODE_POST_REFRESH_RESERVE_MS: reserveMs,

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -65,6 +65,7 @@ import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
+import { reconcileFreshDynamicWidgets } from "../../web/js/lib/dynamic-widget-reconcile.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -396,6 +397,7 @@ function realGraphAddNode({
     addNodeRefreshBusyMessage,
     clearInheritedExecutionPreview,
     sanitizeNodeAuxId,
+    reconcileFreshDynamicWidgets,
     OBJECT_INFO_SEED_WAIT_MS: 8000,
     ADD_NODE_COMMAND_BUDGET_MS: budgetMs,
     ADD_NODE_POST_REFRESH_RESERVE_MS: reserveMs,

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -99,7 +99,27 @@ function backendObjectInfo() {
           format: [["auto", "mp4"], { default: "auto" }],
           codec: [
             "COMFY_DYNAMICCOMBO_V3",
-            { options: [{ key: "auto", inputs: {} }, { key: "h264", inputs: {} }] },
+            {
+              options: [
+                { key: "auto", inputs: {} },
+                {
+                  key: "h264",
+                  inputs: {
+                    required: {
+                      encoding: [
+                        "COMFY_DYNAMICCOMBO_V3",
+                        {
+                          options: [
+                            { key: "auto", inputs: {} },
+                            { key: "re-encode", inputs: { required: { crf: ["FLOAT", { default: 23 }] } } },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
           ],
         },
       },
@@ -117,22 +137,40 @@ function staleLoadImageNodeData() {
   };
 }
 
-function makeComfy({ stale = true } = {}) {
-  function installRebuildAccessor(node, widget) {
+function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
+  const widgetValueStore = new Map();
+  function widgetStoreKey(node, widget) {
+    return `${node.id}:${widget.name}`;
+  }
+
+  function installNativeDynamicCombo(node, widget) {
     let value = widget.value;
     Object.defineProperty(widget, "value", {
       configurable: true,
       get() {
-        return value;
+        return widgetValueStore.get(widget.widgetId)?.value ?? value;
       },
       set(next) {
+        const state = widgetValueStore.get(widget.widgetId);
+        if (state) state.value = next;
         value = next;
         node.dynamicRebuilds.push(widget.name);
-        node.widgets = node.widgets.filter(
-          (candidate) => !candidate.name.startsWith(`${widget.name}.`),
-        );
+        if (dynamicSetterThrows && node.graph && widget.name === "codec") {
+          throw new Error("native codec rebuild failed");
+        }
+        for (let index = node.widgets.length - 1; index >= 0; index--) {
+          const candidate = node.widgets[index];
+          if (candidate !== widget && candidate.name.startsWith(`${widget.name}.`)) {
+            candidate.onRemove?.();
+            node.widgets.splice(index, 1);
+          }
+        }
+        for (let index = node.inputs.length - 1; index >= 0; index--) {
+          if (node.inputs[index].name.startsWith(`${widget.name}.`)) node.inputs.splice(index, 1);
+        }
       },
     });
+    widget.value = value;
   }
 
   const widgets = {
@@ -141,8 +179,6 @@ function makeComfy({ stale = true } = {}) {
     },
     COMBO(node, name, spec) {
       const widget = node.addWidget("combo", name, spec[0][0], null, { values: spec[0] });
-      // The fixture represents the stale SaveVideo format dynamic root reported by #2254.
-      if (node.type === "SaveVideo" && name === "format") installRebuildAccessor(node, widget);
       return { widget };
     },
     COMFY_DYNAMICCOMBO_V3(node, name, spec) {
@@ -153,7 +189,7 @@ function makeComfy({ stale = true } = {}) {
         null,
         {},
       );
-      installRebuildAccessor(node, widget);
+      installNativeDynamicCombo(node, widget);
       return { widget };
     },
   };
@@ -177,7 +213,17 @@ function makeComfy({ stale = true } = {}) {
         outputs: [],
         dynamicRebuilds: [],
         addWidget(kind, name, value, callback, options) {
-          const widget = { type: kind, name, value, callback, options: options ?? {} };
+          const widget = {
+            type: kind,
+            name,
+            value,
+            callback,
+            options: options ?? {},
+            widgetId: null,
+            onRemove() {
+              if (widget.widgetId) widgetValueStore.delete(widget.widgetId);
+            },
+          };
           node.widgets.push(widget);
           return widget;
         },
@@ -189,15 +235,14 @@ function makeComfy({ stale = true } = {}) {
         else node.inputs.push({ name, type: declared });
       }
       if (type === "SaveVideo") {
-        // A stale nested row can survive the constructor's detached initial pass. The
-        // shipped repair must make the native `format` and `codec` setters clean it up
-        // after graph.add registers the node.
-        node.widgets.push({
-          type: "combo",
-          name: "format.codec",
-          value: "auto",
-          options: {},
-        });
+        // Current SaveVideo has ordinary `format` plus DynamicCombo `codec`. This is
+        // the stale row left by the old dynamic-format construction, before the node
+        // is registered and its current codec store exists.
+        const stale = node.addWidget("combo", "format.codec", "auto", null, {});
+        node.inputs.push({ name: "format.codec", type: "COMFY_DYNAMICCOMBO_V3", link: null });
+        stale.onRemove = () => {
+          if (stale.widgetId) widgetValueStore.delete(stale.widgetId);
+        };
       }
       return node;
     },
@@ -228,13 +273,47 @@ function makeComfy({ stale = true } = {}) {
     add(node) {
       node.graph = graph;
       graph._nodes.push(node);
+      for (const widget of node.widgets) {
+        widget.widgetId = widgetStoreKey(node, widget);
+        widgetValueStore.set(widget.widgetId, { value: widget.value });
+      }
+    },
+    remove(node) {
+      for (const widget of node.widgets) widget.onRemove?.();
+      graph._nodes = graph._nodes.filter((candidate) => candidate !== node);
+      node.graph = null;
     },
     beforeChange() {},
     afterChange() {},
     setDirtyCanvas() {},
   };
 
-  return { app, LG, graph, registry };
+  app.graphToPrompt = async () => {
+    const node = graph._nodes.find((candidate) => candidate.type === "SaveVideo");
+    if (!node) return { output: {} };
+    if (node.widgets.some((widget) => widget.name === "format.codec")) {
+      throw new Error("Dynamic widget doesn't exist on node");
+    }
+    const codec = node.widgets.find((widget) => widget.name === "codec");
+    if (!codec || !widgetValueStore.has(codec.widgetId)) {
+      throw new Error("codec widget store state is missing");
+    }
+    return {
+      output: {
+        [node.id]: {
+          class_type: "SaveVideo",
+          inputs: {
+            video: ["source", 0],
+            filename_prefix: node.widgets.find((widget) => widget.name === "filename_prefix")?.value,
+            format: node.widgets.find((widget) => widget.name === "format")?.value,
+            codec: codec.value,
+          },
+        },
+      },
+    };
+  };
+
+  return { app, LG, graph, registry, widgetValueStore };
 }
 
 /** Build the SHIPPED graph_add_node with its collaborators injected. */
@@ -455,7 +534,7 @@ test("#1242: an add with no drift never calls the refresh", async () => {
   assert.equal(res.added.schema_refreshed, undefined, "nothing to disclose when nothing happened");
 });
 
-test("#2254: a freshly added SaveVideo rebuilds stale format and codec dynamic state", async () => {
+test("#2254: a freshly added SaveVideo uses the native codec widget/store and is queueable", async () => {
   const comfy = makeComfy({ stale: false });
   const { graph_add_node } = realGraphAddNode(comfy);
 
@@ -468,6 +547,37 @@ test("#2254: a freshly added SaveVideo rebuilds stale format and codec dynamic s
     ["filename_prefix", "format", "codec"],
     "the stale format.codec row is removed while the current codec root remains",
   );
-  assert.deepEqual(node.dynamicRebuilds, ["format", "codec"]);
+  assert.equal(Object.getOwnPropertyDescriptor(node.widgets[1], "value")?.set, undefined);
+  assert.deepEqual(node.dynamicRebuilds, ["codec", "codec"], "only the native codec root is replayed");
+  assert.equal(
+    node.inputs.some((input) => input.name === "format.codec"),
+    false,
+    "native stale-input cleanup also removes the stale dotted input",
+  );
+  assert.equal(
+    [...comfy.widgetValueStore.keys()].some((key) => key.endsWith(":format.codec")),
+    false,
+    "native stale-widget cleanup also removes the stale store entry",
+  );
+  const prompt = await comfy.app.graphToPrompt();
+  assert.equal(prompt.output[node.id].inputs.format, "auto");
+  assert.equal(prompt.output[node.id].inputs.codec, "auto");
   assert.ok(node.graph, "the replay runs after graph.add registers the node");
+});
+
+test("#2254: a native dynamic setter throw refuses the add and leaves a retryable canvas", async () => {
+  const comfy = makeComfy({ stale: false, dynamicSetterThrows: true });
+  const { graph_add_node } = realGraphAddNode(comfy);
+
+  await assert.rejects(
+    () => graph_add_node({ class_type: "SaveVideo" }),
+    (err) => {
+      assert.match(err.message, /native dynamic-widget reconciliation failed/i);
+      assert.match(err.message, /codec/);
+      assert.match(err.message, /RETRY panel_add_node/i);
+      return true;
+    },
+  );
+  assert.equal(comfy.graph._nodes.length, 0, "a failed reconciliation must not leave a partial node");
+  assert.equal(comfy.widgetValueStore.size, 0, "rollback removes the registered widget-store state");
 });

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -90,6 +90,21 @@ function backendObjectInfo() {
       input: { required: { image: [["a.png", "b.png"], {}] } },
       output: ["IMAGE", "MASK"],
     },
+    SaveVideo: {
+      name: "SaveVideo",
+      input: {
+        required: {
+          video: ["VIDEO"],
+          filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+          format: [["auto", "mp4"], { default: "auto" }],
+          codec: [
+            "COMFY_DYNAMICCOMBO_V3",
+            { options: [{ key: "auto", inputs: {} }, { key: "h264", inputs: {} }] },
+          ],
+        },
+      },
+      output: ["VIDEO"],
+    },
   };
 }
 
@@ -103,9 +118,43 @@ function staleLoadImageNodeData() {
 }
 
 function makeComfy({ stale = true } = {}) {
+  function installRebuildAccessor(node, widget) {
+    let value = widget.value;
+    Object.defineProperty(widget, "value", {
+      configurable: true,
+      get() {
+        return value;
+      },
+      set(next) {
+        value = next;
+        node.dynamicRebuilds.push(widget.name);
+        node.widgets = node.widgets.filter(
+          (candidate) => !candidate.name.startsWith(`${widget.name}.`),
+        );
+      },
+    });
+  }
+
   const widgets = {
+    STRING(node, name, spec) {
+      return { widget: node.addWidget("text", name, spec?.[1]?.default ?? "", null, {}) };
+    },
     COMBO(node, name, spec) {
-      return { widget: node.addWidget("combo", name, spec[0][0], null, { values: spec[0] }) };
+      const widget = node.addWidget("combo", name, spec[0][0], null, { values: spec[0] });
+      // The fixture represents the stale SaveVideo format dynamic root reported by #2254.
+      if (node.type === "SaveVideo" && name === "format") installRebuildAccessor(node, widget);
+      return { widget };
+    },
+    COMFY_DYNAMICCOMBO_V3(node, name, spec) {
+      const widget = node.addWidget(
+        "combo",
+        name,
+        spec?.[1]?.options?.[0]?.key ?? "auto",
+        null,
+        {},
+      );
+      installRebuildAccessor(node, widget);
+      return { widget };
     },
   };
 
@@ -126,6 +175,7 @@ function makeComfy({ stale = true } = {}) {
         widgets: [],
         inputs: [],
         outputs: [],
+        dynamicRebuilds: [],
         addWidget(kind, name, value, callback, options) {
           const widget = { type: kind, name, value, callback, options: options ?? {} };
           node.widgets.push(widget);
@@ -137,6 +187,17 @@ function makeComfy({ stale = true } = {}) {
         if (Array.isArray(declared)) widgets.COMBO(node, name, spec);
         else if (typeof widgets[declared] === "function") widgets[declared](node, name, spec);
         else node.inputs.push({ name, type: declared });
+      }
+      if (type === "SaveVideo") {
+        // A stale nested row can survive the constructor's detached initial pass. The
+        // shipped repair must make the native `format` and `codec` setters clean it up
+        // after graph.add registers the node.
+        node.widgets.push({
+          type: "combo",
+          name: "format.codec",
+          value: "auto",
+          options: {},
+        });
       }
       return node;
     },
@@ -159,11 +220,13 @@ function makeComfy({ stale = true } = {}) {
   // the entry is the stale page-load one or already current is the scenario knob.
   void app.registerNodesFromDefs({
     LoadImage: stale ? staleLoadImageNodeData() : backendObjectInfo().LoadImage,
+    SaveVideo: backendObjectInfo().SaveVideo,
   });
 
   const graph = {
     _nodes: [],
     add(node) {
+      node.graph = graph;
       graph._nodes.push(node);
     },
     beforeChange() {},
@@ -390,4 +453,21 @@ test("#1242: an add with no drift never calls the refresh", async () => {
   assert.equal(res.added.type, "LoadImage");
   assert.equal(refreshCalls.length, 0, "a healthy add must not pay for a whole-schema refresh");
   assert.equal(res.added.schema_refreshed, undefined, "nothing to disclose when nothing happened");
+});
+
+test("#2254: a freshly added SaveVideo rebuilds stale format and codec dynamic state", async () => {
+  const comfy = makeComfy({ stale: false });
+  const { graph_add_node } = realGraphAddNode(comfy);
+
+  const res = await graph_add_node({ class_type: "SaveVideo" });
+  const node = comfy.graph._nodes[0];
+
+  assert.equal(res.added.type, "SaveVideo");
+  assert.deepEqual(
+    node.widgets.map((widget) => widget.name),
+    ["filename_prefix", "format", "codec"],
+    "the stale format.codec row is removed while the current codec root remains",
+  );
+  assert.deepEqual(node.dynamicRebuilds, ["format", "codec"]);
+  assert.ok(node.graph, "the replay runs after graph.add registers the node");
 });

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -139,10 +139,24 @@ function staleLoadImageNodeData() {
 
 function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
   const widgetValueStore = new Map();
-  function widgetStoreKey(node, widget) {
-    return `${node.id}:${widget.name}`;
+  const storeEvents = [];
+  function widgetStoreKey(nodeId, widget) {
+    return `${nodeId}:${widget.name}`;
+  }
+  function registerWidget(widget, nodeId) {
+    const widgetId = widgetStoreKey(nodeId, widget);
+    widgetValueStore.set(widgetId, { value: widget.value });
+    storeEvents.push({ type: "register", widgetId });
+    return widgetId;
+  }
+  function deleteWidget(widgetId) {
+    if (!widgetId) return false;
+    const deleted = widgetValueStore.delete(widgetId);
+    if (deleted) storeEvents.push({ type: "delete", widgetId });
+    return deleted;
   }
 
+  let throwNextNativeSetter = dynamicSetterThrows;
   function installNativeDynamicCombo(node, widget) {
     let value = widget.value;
     Object.defineProperty(widget, "value", {
@@ -155,13 +169,15 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
         if (state) state.value = next;
         value = next;
         node.dynamicRebuilds.push(widget.name);
-        if (dynamicSetterThrows && node.graph && widget.name === "codec") {
+        if (throwNextNativeSetter && node.graph && widget.name === "codec") {
+          throwNextNativeSetter = false;
           throw new Error("native codec rebuild failed");
         }
         for (let index = node.widgets.length - 1; index >= 0; index--) {
           const candidate = node.widgets[index];
           if (candidate !== widget && candidate.name.startsWith(`${widget.name}.`)) {
             candidate.onRemove?.();
+            deleteWidget(candidate.widgetId);
             node.widgets.splice(index, 1);
           }
         }
@@ -213,16 +229,24 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
         outputs: [],
         dynamicRebuilds: [],
         addWidget(kind, name, value, callback, options) {
+          let boundNodeId = null;
           const widget = {
             type: kind,
             name,
             value,
             callback,
             options: options ?? {},
-            widgetId: null,
-            onRemove() {
-              if (widget.widgetId) widgetValueStore.delete(widget.widgetId);
+            onRemove() {},
+          };
+          Object.defineProperty(widget, "widgetId", {
+            configurable: true,
+            get() {
+              return boundNodeId == null ? null : widgetStoreKey(boundNodeId, widget);
             },
+          });
+          widget.setNodeId = (nodeId) => {
+            boundNodeId = nodeId;
+            registerWidget(widget, nodeId);
           };
           node.widgets.push(widget);
           return widget;
@@ -238,11 +262,8 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
         // Current SaveVideo has ordinary `format` plus DynamicCombo `codec`. This is
         // the stale row left by the old dynamic-format construction, before the node
         // is registered and its current codec store exists.
-        const stale = node.addWidget("combo", "format.codec", "auto", null, {});
+        node.addWidget("combo", "format.codec", "auto", null, {});
         node.inputs.push({ name: "format.codec", type: "COMFY_DYNAMICCOMBO_V3", link: null });
-        stale.onRemove = () => {
-          if (stale.widgetId) widgetValueStore.delete(stale.widgetId);
-        };
       }
       return node;
     },
@@ -274,8 +295,7 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
       node.graph = graph;
       graph._nodes.push(node);
       for (const widget of node.widgets) {
-        widget.widgetId = widgetStoreKey(node, widget);
-        widgetValueStore.set(widget.widgetId, { value: widget.value });
+        widget.setNodeId?.(node.id);
       }
     },
     remove(node) {
@@ -313,7 +333,7 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
     };
   };
 
-  return { app, LG, graph, registry, widgetValueStore };
+  return { app, LG, graph, registry, widgetValueStore, storeEvents };
 }
 
 /** Build the SHIPPED graph_add_node with its collaborators injected. */
@@ -559,6 +579,20 @@ test("#2254: a freshly added SaveVideo uses the native codec widget/store and is
     false,
     "native stale-widget cleanup also removes the stale store entry",
   );
+  assert.equal(
+    comfy.storeEvents.some(
+      (event) => event.type === "delete" && event.widgetId.endsWith(":format.codec"),
+    ),
+    true,
+    "native cleanup explicitly deletes the original store key after re-registration",
+  );
+  assert.equal(
+    comfy.storeEvents.some(
+      (event) => event.type === "register" && event.widgetId.endsWith(":codec.__cmcp_stale_0"),
+    ),
+    true,
+    "the renamed widget is re-registered under its current LiteGraph-derived key",
+  );
   const prompt = await comfy.app.graphToPrompt();
   assert.equal(prompt.output[node.id].inputs.format, "auto");
   assert.equal(prompt.output[node.id].inputs.codec, "auto");
@@ -580,4 +614,9 @@ test("#2254: a native dynamic setter throw refuses the add and leaves a retryabl
   );
   assert.equal(comfy.graph._nodes.length, 0, "a failed reconciliation must not leave a partial node");
   assert.equal(comfy.widgetValueStore.size, 0, "rollback removes the registered widget-store state");
+  assert.equal(
+    comfy.storeEvents.some((event) => event.type === "delete" && event.widgetId.endsWith(":format.codec")),
+    true,
+    "rollback cleanup deletes the original stale store key too",
+  );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14773,9 +14773,28 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.add(node);
       // COMFY_DYNAMICCOMBO_V3 first runs its value setter while LG.createNode is still
       // detached from a graph. Replay it after registration so the widget-value store and
-      // dynamic rows match the fresh node. This also lets a stale dotted row such as
-      // `format.codec` be removed by the frontend's own dynamic rebuild.
-      reconcileFreshDynamicWidgets(node, currentDef);
+      // dynamic rows match the fresh node. A schema-verified stale path such as
+      // `format.codec` is routed through the current `codec` root so the frontend's own
+      // widget/store cleanup removes it.
+      const dynamicReconciliation = reconcileFreshDynamicWidgets(node, currentDef);
+      if (dynamicReconciliation.failures.length) {
+        let rollbackError = null;
+        try {
+          safeRemoveNode(graph, node);
+        } catch (error) {
+          rollbackError = error;
+        }
+        const failures = dynamicReconciliation.failures
+          .map(({ name, phase, error }) => `${name} (${phase}: ${error?.message ?? String(error)})`)
+          .join(", ");
+        throw new Error(
+          `Cannot add "${class_type}": native dynamic-widget reconciliation failed for ${failures}. ` +
+            (rollbackError
+              ? `The panel could not roll back the partially added node (${rollbackError?.message ?? String(rollbackError)}); ` +
+                "do not retry until the canvas is refreshed."
+              : "The node was removed and nothing was added; RETRY panel_add_node once the frontend dynamic widget is ready."),
+        );
+      }
     } finally {
       graph.afterChange();
     }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14778,6 +14778,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // widget/store cleanup removes it.
       const dynamicReconciliation = reconcileFreshDynamicWidgets(node, currentDef);
       if (dynamicReconciliation.failures.length) {
+        const storeCleanup = dynamicReconciliation.cleanupStore?.() ?? { cleaned: true };
         let rollbackError = null;
         try {
           safeRemoveNode(graph, node);
@@ -14787,10 +14788,19 @@ const GRAPH_TOOL_EXECUTORS = {
         const failures = dynamicReconciliation.failures
           .map(({ name, phase, error }) => `${name} (${phase}: ${error?.message ?? String(error)})`)
           .join(", ");
+        const storeCleanupError = storeCleanup.cleaned
+          ? null
+          : `widget-store cleanup failed (${storeCleanup.error?.message ?? String(storeCleanup.error)})`;
         throw new Error(
           `Cannot add "${class_type}": native dynamic-widget reconciliation failed for ${failures}. ` +
-            (rollbackError
-              ? `The panel could not roll back the partially added node (${rollbackError?.message ?? String(rollbackError)}); ` +
+            (rollbackError || storeCleanupError
+              ? `${[
+                  rollbackError &&
+                    `The panel could not roll back the partially added node (${rollbackError?.message ?? String(rollbackError)})`,
+                  storeCleanupError,
+                ]
+                  .filter(Boolean)
+                  .join("; ")}; ` +
                 "do not retry until the canvas is refreshed."
               : "The node was removed and nothing was added; RETRY panel_add_node once the frontend dynamic widget is ready."),
         );

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -356,6 +356,7 @@ import {
   releaseReconnectScopePin,
 } from "./lib/reconnect-scope-fence.js";
 import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "./lib/set-widget.js";
+import { reconcileFreshDynamicWidgets } from "./lib/dynamic-widget-reconcile.js";
 import {
   createDeferredWidgetEditQueue,
   deferredWidgetQueueCounts,
@@ -14770,6 +14771,11 @@ const GRAPH_TOOL_EXECUTORS = {
       node.pos = placementFor(graph, pos);
       if (title && typeof title === "string") node.title = title;
       graph.add(node);
+      // COMFY_DYNAMICCOMBO_V3 first runs its value setter while LG.createNode is still
+      // detached from a graph. Replay it after registration so the widget-value store and
+      // dynamic rows match the fresh node. This also lets a stale dotted row such as
+      // `format.codec` be removed by the frontend's own dynamic rebuild.
+      reconcileFreshDynamicWidgets(node, currentDef);
     } finally {
       graph.afterChange();
     }

--- a/web/js/lib/dynamic-widget-reconcile.js
+++ b/web/js/lib/dynamic-widget-reconcile.js
@@ -8,30 +8,49 @@ function hasValueSetter(widget) {
   }
 }
 
+function staleDynamicGroup(name, required, dynamicNames) {
+  if (typeof name !== "string") return null;
+  const parts = name.split(".");
+  if (parts.length < 2) return null;
+
+  // This is the one schema migration that needs cleanup here: an ordinary current
+  // input can retain a dotted child whose path contains a CURRENT dynamic root (the
+  // SaveVideo `format.codec` residue). The current definition proves both sides of
+  // that decision. Do not infer a root from an arbitrary dotted accessor parent.
+  const parent = parts[0];
+  if (!Object.prototype.hasOwnProperty.call(required, parent) || dynamicNames.has(parent)) {
+    return null;
+  }
+  const dynamicPart = parts.slice(1).find((part) => dynamicNames.has(part));
+  return dynamicPart ?? null;
+}
+
 /**
  * Re-run the native value setter for dynamic-combo roots on a newly-created node.
  *
  * COMFY_DYNAMICCOMBO_V3 installs its rebuild logic as an own `value` setter. The
  * constructor runs that setter before `graph.add`, when the widget-value store has no
  * node identity yet. Replaying the same value after registration makes the node's
- * dynamic rows and store state agree. Dotted widget names also identify a stale dynamic
- * root (for example `format.codec`) that is no longer present in the current definition.
+ * dynamic rows and store state agree. A schema-verified legacy dotted path (for
+ * example `format.codec`) is temporarily placed in the current dynamic root's group
+ * so the native setter removes it through the frontend's normal widget/store cleanup.
  *
  * @param {object} node
  * @param {object} currentDef
- * @returns {string[]} names of roots that were replayed
+ * @returns {{replayed: string[], relocated: string[], failures: Array<{name: string, phase: string, error: unknown}>}}
  */
 export function reconcileFreshDynamicWidgets(node, currentDef) {
   const required = currentDef?.input?.required;
   const widgets = Array.isArray(node?.widgets) ? node.widgets.slice() : [];
-  if (!required || typeof required !== "object" || !widgets.length) return [];
+  const empty = { replayed: [], relocated: [], failures: [] };
+  if (!required || typeof required !== "object" || !widgets.length) return empty;
 
   const dynamicNames = new Set(
     Object.entries(required)
       .filter(([, spec]) => Array.isArray(spec) && spec[0] === DYNAMIC_COMBO_V3)
       .map(([name]) => name),
   );
-  if (!dynamicNames.size) return [];
+  if (!dynamicNames.size) return empty;
 
   const byName = new Map(
     widgets
@@ -39,42 +58,64 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
       .map((widget) => [widget.name, widget]),
   );
   const roots = new Set();
+  const relocated = [];
+  const failures = [];
+
+  // A current dynamic root is the only accessor we are authorized to replay. Before
+  // doing so, move a schema-verified legacy child into that root's native group. This
+  // lets the native setter call its own onRemove/widget-store deletion logic; simply
+  // filtering node.widgets would leave a stale store entry behind.
+  let relocationIndex = 0;
+  const relocationByName = new Map();
+  for (const widget of widgets) {
+    const dynamicRoot = staleDynamicGroup(widget?.name, required, dynamicNames);
+    if (!dynamicRoot) continue;
+    const oldName = widget.name;
+    let replacement = relocationByName.get(oldName);
+    if (!replacement) {
+      replacement = `${dynamicRoot}.__cmcp_stale_${relocationIndex++}`;
+      relocationByName.set(oldName, replacement);
+    }
+    try {
+      widget.name = replacement;
+      relocated.push(oldName);
+    } catch (error) {
+      failures.push({ name: oldName, phase: "relocate", error });
+    }
+  }
+  if (Array.isArray(node.inputs)) {
+    for (const input of node.inputs) {
+      const replacement = relocationByName.get(input?.name);
+      if (replacement) input.name = replacement;
+    }
+  }
 
   // Current dynamic declarations must be replayed even when they have no stale rows.
   for (const name of dynamicNames) {
     const widget = byName.get(name);
-    if (widget) roots.add(widget);
-  }
-
-  // A stale dynamic declaration can leave a dotted child behind while its parent is no
-  // longer described by currentDef. Replaying an accessor-bearing parent lets the
-  // frontend's own rebuild remove that child without guessing at its input shape.
-  for (const widget of widgets) {
-    const name = widget?.name;
-    if (typeof name !== "string") continue;
-    const dot = name.indexOf(".");
-    if (dot <= 0) continue;
-    const parent = byName.get(name.slice(0, dot));
-    if (parent && hasValueSetter(parent)) roots.add(parent);
+    if (!widget) {
+      failures.push({ name, phase: "missing-root", error: new Error("dynamic widget root is missing") });
+      continue;
+    }
+    if (!hasValueSetter(widget)) {
+      failures.push({ name, phase: "missing-setter", error: new Error("dynamic widget value setter is missing") });
+      continue;
+    }
+    roots.add(widget);
   }
 
   const replayed = [];
   for (const widget of widgets) {
-    if (
-      !roots.has(widget) ||
-      !node.widgets.includes(widget) ||
-      !hasValueSetter(widget)
-    ) {
+    if (!roots.has(widget) || !node.widgets.includes(widget) || !hasValueSetter(widget)) {
       continue;
     }
     try {
       const value = widget.value;
       widget.value = value;
       replayed.push(widget.name);
-    } catch {
-      // A custom accessor remains responsible for its own failure; do not turn an
-      // otherwise successful node add into a second, unrelated refusal.
+    } catch (error) {
+      failures.push({ name: widget.name, phase: "setter", error });
     }
   }
-  return replayed;
+  return { replayed, relocated, failures };
 }

--- a/web/js/lib/dynamic-widget-reconcile.js
+++ b/web/js/lib/dynamic-widget-reconcile.js
@@ -1,0 +1,80 @@
+const DYNAMIC_COMBO_V3 = "COMFY_DYNAMICCOMBO_V3";
+
+function hasValueSetter(widget) {
+  try {
+    return typeof Object.getOwnPropertyDescriptor(widget, "value")?.set === "function";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Re-run the native value setter for dynamic-combo roots on a newly-created node.
+ *
+ * COMFY_DYNAMICCOMBO_V3 installs its rebuild logic as an own `value` setter. The
+ * constructor runs that setter before `graph.add`, when the widget-value store has no
+ * node identity yet. Replaying the same value after registration makes the node's
+ * dynamic rows and store state agree. Dotted widget names also identify a stale dynamic
+ * root (for example `format.codec`) that is no longer present in the current definition.
+ *
+ * @param {object} node
+ * @param {object} currentDef
+ * @returns {string[]} names of roots that were replayed
+ */
+export function reconcileFreshDynamicWidgets(node, currentDef) {
+  const required = currentDef?.input?.required;
+  const widgets = Array.isArray(node?.widgets) ? node.widgets.slice() : [];
+  if (!required || typeof required !== "object" || !widgets.length) return [];
+
+  const dynamicNames = new Set(
+    Object.entries(required)
+      .filter(([, spec]) => Array.isArray(spec) && spec[0] === DYNAMIC_COMBO_V3)
+      .map(([name]) => name),
+  );
+  if (!dynamicNames.size) return [];
+
+  const byName = new Map(
+    widgets
+      .filter((widget) => typeof widget?.name === "string")
+      .map((widget) => [widget.name, widget]),
+  );
+  const roots = new Set();
+
+  // Current dynamic declarations must be replayed even when they have no stale rows.
+  for (const name of dynamicNames) {
+    const widget = byName.get(name);
+    if (widget) roots.add(widget);
+  }
+
+  // A stale dynamic declaration can leave a dotted child behind while its parent is no
+  // longer described by currentDef. Replaying an accessor-bearing parent lets the
+  // frontend's own rebuild remove that child without guessing at its input shape.
+  for (const widget of widgets) {
+    const name = widget?.name;
+    if (typeof name !== "string") continue;
+    const dot = name.indexOf(".");
+    if (dot <= 0) continue;
+    const parent = byName.get(name.slice(0, dot));
+    if (parent && hasValueSetter(parent)) roots.add(parent);
+  }
+
+  const replayed = [];
+  for (const widget of widgets) {
+    if (
+      !roots.has(widget) ||
+      !node.widgets.includes(widget) ||
+      !hasValueSetter(widget)
+    ) {
+      continue;
+    }
+    try {
+      const value = widget.value;
+      widget.value = value;
+      replayed.push(widget.name);
+    } catch {
+      // A custom accessor remains responsible for its own failure; do not turn an
+      // otherwise successful node add into a second, unrelated refusal.
+    }
+  }
+  return replayed;
+}

--- a/web/js/lib/dynamic-widget-reconcile.js
+++ b/web/js/lib/dynamic-widget-reconcile.js
@@ -8,6 +8,23 @@ function hasValueSetter(widget) {
   }
 }
 
+function readWidgetId(widget) {
+  try {
+    const widgetId = widget?.widgetId;
+    return typeof widgetId === "string" && widgetId ? widgetId : null;
+  } catch {
+    return null;
+  }
+}
+
+function storeCleanupAlias(dynamicRoot, widgetId, index) {
+  return {
+    name: `${dynamicRoot}.__cmcp_store_cleanup_${index}`,
+    widgetId,
+    onRemove() {},
+  };
+}
+
 function staleDynamicGroup(name, required, dynamicNames) {
   if (typeof name !== "string") return null;
   const parts = name.split(".");
@@ -37,12 +54,17 @@ function staleDynamicGroup(name, required, dynamicNames) {
  *
  * @param {object} node
  * @param {object} currentDef
- * @returns {{replayed: string[], relocated: string[], failures: Array<{name: string, phase: string, error: unknown}>}}
+ * @returns {{replayed: string[], relocated: string[], failures: Array<{name: string, phase: string, error: unknown}>, cleanupStore: () => {cleaned: boolean, error?: unknown}}}
  */
 export function reconcileFreshDynamicWidgets(node, currentDef) {
   const required = currentDef?.input?.required;
   const widgets = Array.isArray(node?.widgets) ? node.widgets.slice() : [];
-  const empty = { replayed: [], relocated: [], failures: [] };
+  const empty = {
+    replayed: [],
+    relocated: [],
+    failures: [],
+    cleanupStore: () => ({ cleaned: true }),
+  };
   if (!required || typeof required !== "object" || !widgets.length) return empty;
 
   const dynamicNames = new Set(
@@ -71,6 +93,7 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
     const dynamicRoot = staleDynamicGroup(widget?.name, required, dynamicNames);
     if (!dynamicRoot) continue;
     const oldName = widget.name;
+    const oldWidgetId = readWidgetId(widget);
     let replacement = relocationByName.get(oldName);
     if (!replacement) {
       replacement = `${dynamicRoot}.__cmcp_stale_${relocationIndex++}`;
@@ -78,6 +101,17 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
     }
     try {
       widget.name = replacement;
+      // Current LiteGraph widgets derive widgetId from name. graph.add() already
+      // registered the old `format.codec` key, so renaming alone leaves that key
+      // behind and the native setter would delete only the newly-derived key.
+      // Re-register the renamed widget, then give native cleanup an alias carrying
+      // the original key so both registrations are deleted by deleteWidget().
+      if (oldWidgetId) {
+        node.widgets.push(storeCleanupAlias(dynamicRoot, oldWidgetId, relocationIndex++));
+      }
+      if (typeof widget.setNodeId === "function" && node?.id != null) {
+        widget.setNodeId(node.id);
+      }
       relocated.push(oldName);
     } catch (error) {
       failures.push({ name: oldName, phase: "relocate", error });
@@ -117,5 +151,36 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
       failures.push({ name: widget.name, phase: "setter", error });
     }
   }
-  return { replayed, relocated, failures };
+
+  const cleanupStore = () => {
+    const root = roots.values().next().value;
+    if (!root) {
+      return { cleaned: false, error: new Error("no verified dynamic root can clean widget-store entries") };
+    }
+
+    const widgetIds = new Set();
+    for (const widget of node.widgets ?? []) {
+      const widgetId = readWidgetId(widget);
+      if (widgetId) widgetIds.add(widgetId);
+    }
+    const aliases = [];
+    let aliasIndex = 0;
+    for (const widgetId of widgetIds) {
+      const alias = storeCleanupAlias(root.name, widgetId, `rollback_${aliasIndex++}`);
+      aliases.push(alias);
+      node.widgets.push(alias);
+    }
+    try {
+      const value = root.value;
+      root.value = value;
+      const remaining = aliases.filter((alias) => node.widgets.includes(alias));
+      return remaining.length
+        ? { cleaned: false, error: new Error("native dynamic cleanup left widget-store aliases attached") }
+        : { cleaned: true };
+    } catch (error) {
+      return { cleaned: false, error };
+    }
+  };
+
+  return { replayed, relocated, failures, cleanupStore };
 }


### PR DESCRIPTION
## Summary

- Replays native COMFY_DYNAMICCOMBO_V3 value setters after panel_add_node graph registration.
- Cleans stale dotted dynamic rows such as format.codec while preserving the current codec root/state.
- Adds a production-path SaveVideo regression covering the freshly-added node shape.

## Validation

- Full unit suite: 6,820 tests, 6,819 passed, 1 todo, 0 failed.
- npm.cmd run typecheck: passed.
- All add-node suites: 81 passed.
- check:scope: unavailable because this fresh worktree lacks node_modules/typescript; the gate reports that dependency requirement explicitly.

Related: https://github.com/Artokun/comfyui-mcp/issues/2254

Commit: 4861d810