### PR TITLE
chore(release): 0.15.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.87] - 2026-08-25
+
+### Fixed
+- rebuild fresh SaveVideo dynamic widgets and clear stale widget state (#2254)
+
 ## [0.15.86] - 2026-08-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.86",
+  "version": "0.15.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.86",
+      "version": "0.15.87",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.86",
+  "version": "0.15.87",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
Release the SaveVideo dynamic-widget reconciliation fix from #2254. Metadata-only release.