### PR TITLE
fix(panel): recover stale refresh route after reconnect (#1787)

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -100,6 +100,10 @@ export const REFRESH_NODES_EXECUTOR_DEPS = Object.freeze({
   get REFRESH_NODES_RUN_BUDGET_MS() {
     return REFRESH_NODES_RUN_BUDGET_MS;
   },
+  // #1787 — the production executor waits for the active bridge route before
+  // touching the global node-definition refresh. Harnesses inject their own
+  // readiness promise; this default preserves the existing refresh-only cases.
+  awaitActiveRouteRegistration: async () => {},
 });
 
 /** #1413 — the whole-command deadline `graph_set_widget` takes on its first line. */

--- a/browser_tests/unit/bridge-route.test.mjs
+++ b/browser_tests/unit/bridge-route.test.mjs
@@ -442,7 +442,7 @@ test("#640 wiring: every outbound frame site reads bridgeRouteId() and refuses o
   const src = readFileSync(PANEL_JS, "utf8");
   // hello — the registration itself.
   assert.match(src, /tabRouteIdentity\.adopt\(tabSessionId\)/, "the route must be adopted from the COMPLETED lease");
-  assert.match(src, /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) \{/);
+  assert.match(src, /const liveRouteId = bridgeRouteId\(\);\s*\n\s*if \(!liveRouteId\) \{/);
   assert.match(src, /tabId: routeId,/, "the hello payload must carry the established route");
   // sendFrame — every control/agent frame.
   assert.match(src, /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) return false;/);

--- a/browser_tests/unit/reconnect-refresh-route.test.mjs
+++ b/browser_tests/unit/reconnect-refresh-route.test.mjs
@@ -1,0 +1,67 @@
+// #1787 — exercise the shipped panel_refresh_nodes wrapper at the command
+// boundary. A helper-only test would not prove that route readiness is checked
+// before the coalescer is allowed to fetch/register node definitions.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PANEL_SRC, REFRESH_NODES_EXECUTOR_DEPS } from "./_panel-constants.mjs";
+
+const refreshNodesMatch = PANEL_SRC.match(/\n {2}async refresh_nodes\(\) \{[\s\S]*?\n {2}\},/);
+assert.ok(refreshNodesMatch, "could not locate refresh_nodes in panel source");
+
+function buildRefreshNodes(awaitActiveRouteRegistration) {
+  let refreshCalls = 0;
+  const deps = {
+    ...REFRESH_NODES_EXECUTOR_DEPS,
+    awaitActiveRouteRegistration,
+    refreshComfyNodeDefs: async () => {
+      refreshCalls += 1;
+      return { refreshed: true, reason: "refreshed" };
+    },
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${refreshNodesMatch[0]}};
+     return executors.refresh_nodes;`,
+  );
+  return {
+    refresh_nodes: factory(...names.map((name) => deps[name])),
+    get refreshCalls() {
+      return refreshCalls;
+    },
+  };
+}
+
+test("#1787 refresh_nodes waits for the active route before starting the production refresh", async () => {
+  let release;
+  const routeReady = new Promise((resolve) => {
+    release = resolve;
+  });
+  const built = buildRefreshNodes(() => routeReady);
+  const pending = built.refresh_nodes();
+
+  await Promise.resolve();
+  assert.equal(built.refreshCalls, 0, "node definitions must not be fetched while route registration is pending");
+
+  release();
+  const result = await pending;
+  assert.equal(result.refreshed, true);
+  assert.equal(built.refreshCalls, 1, "the refresh starts exactly once after the route becomes ready");
+});
+
+test("#1787 a route-readiness refusal is fail-closed before the refresh consumer runs", async () => {
+  const built = buildRefreshNodes(async () => {
+    throw new Error("route registration not ready");
+  });
+
+  await assert.rejects(built.refresh_nodes(), /route registration not ready/);
+  assert.equal(built.refreshCalls, 0, "a failed handoff must not fetch or register node definitions");
+});
+
+test("#1787 production wiring keeps the readiness gate ahead of refreshComfyNodeDefs", () => {
+  const refreshBody = refreshNodesMatch[0];
+  assert.match(refreshBody, /await awaitActiveRouteRegistration\(\);[\s\S]*refreshComfyNodeDefs/);
+  assert.match(PANEL_SRC, /route_registration_readiness/);
+  assert.match(PANEL_SRC, /routeRegistrationReadinessRefusalError/);
+});

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -119,6 +119,7 @@ assert.ok(refreshNodesMatch, "refresh_nodes not found");
 function buildRefreshNodes({ refreshComfyNodeDefs, commandBudget = COMMAND_BUDGET }) {
   const deps = {
     refreshComfyNodeDefs,
+    awaitActiveRouteRegistration: async () => {},
     REFRESH_JOIN_ABANDONED,
     NODE_DEF_REFRESH_REASONS,
     REFRESH_NODES_COMMAND_BUDGET_MS: commandBudget,

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -198,6 +198,8 @@ function buildRuntimeBridgeClient({ routeRef, failNextSend = false } = {}) {
     {
       WebSocket: RuntimeBridgeSocket,
       DEFAULT_BRIDGE_URL: "ws://bridge.test",
+      RECONNECT_BASE_MS: 1000,
+      RECONNECT_MAX_MS: 15000,
       STORAGE_KEY_BACKEND: "backend",
       window: {
         localStorage: {
@@ -217,7 +219,11 @@ function buildRuntimeBridgeClient({ routeRef, failNextSend = false } = {}) {
       routeIsStale,
       createRehelloGate,
       monotonicNow: () => performance.now(),
-      buildHelloPayload: () => ({ type: "hello", tab_id: routeRef.current, workflow_uuid: "wf-1728" }),
+      buildHelloPayload: ({ tabId } = {}) => ({
+        type: "hello",
+        tab_id: tabId ?? routeRef.current,
+        workflow_uuid: "wf-1728",
+      }),
       sendBridgeHello: async ({ socket, isCurrent, makePayload }) => {
         if (!isCurrent()) return false;
         if (helloState.block) await new Promise((resolve) => (helloState.release = resolve));
@@ -1268,8 +1274,8 @@ test("#1728 production bridge wiring fences same-route re-advertisement before r
   const sendHelloAt = panelSrc.indexOf("  function sendHello() {");
   const sendHelloEnd = panelSrc.indexOf("\n\n  /** Returns a promise", sendHelloAt);
   const sendHello = panelSrc.slice(sendHelloAt, sendHelloEnd);
-  const readyAt = panelSrc.indexOf("    isRouteReady() {");
-  const readyEnd = panelSrc.indexOf("\n    },", readyAt);
+  const readyAt = panelSrc.indexOf("  function routeReady() {");
+  const readyEnd = panelSrc.indexOf("\n\n  return {", readyAt);
   const ready = panelSrc.slice(readyAt, readyEnd);
   const senderAt = panelSrc.indexOf("  const panelRunReceiptSender =");
   const senderEnd = panelSrc.indexOf("\n  const panelRunReceiptTransport", senderAt);
@@ -1281,6 +1287,45 @@ test("#1728 production bridge wiring fences same-route re-advertisement before r
   assert.match(ready, /pendingRouteBindingGeneration !== null/);
   assert.match(sender, /runReceiptOutbox\.enqueue\(rid, promptId, routeId\)/);
   assert.doesNotMatch(sender, /routeId\s*\?\?/);
+});
+
+test("#1787 replacement-socket handoff keeps the stale route reachable until the live route lands", async () => {
+  const routeRef = { current: "panel-route-stale-1787" };
+  const built = buildRuntimeBridgeClient({ routeRef });
+  try {
+    built.client.start();
+    const firstSocket = built.socket();
+    firstSocket.open();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(firstSocket.sent[0]?.tab_id, "panel-route-stale-1787");
+    firstSocket.receive({ type: "models", epoch: "epoch-stale-1787", models: [] });
+    assert.equal(built.client.isRouteReady(), true);
+
+    routeRef.current = "panel-route-live-1787";
+    firstSocket.close();
+    for (let attempts = 0; attempts < 80 && built.socket() === firstSocket; attempts += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    const replacementSocket = built.socket();
+    assert.notEqual(replacementSocket, firstSocket, "the reconnect loop must create a replacement socket");
+    replacementSocket.open();
+    for (let attempts = 0; attempts < 20 && replacementSocket.sent.length < 2; attempts += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    assert.deepEqual(
+      replacementSocket.sent.map((frame) => frame.tab_id),
+      ["panel-route-stale-1787", "panel-route-live-1787"],
+      "the replacement socket first accepts the stale explicit target, then migrates to the live route",
+    );
+    assert.equal(built.client.isRouteReady(), false, "a replacement socket is not ready before its models handshake");
+    const routeReady = built.client.waitForRouteReady({ stepsMs: [0, 50, 100] });
+    replacementSocket.receive({ type: "models", epoch: "epoch-live-1787", models: [] });
+    assert.equal(await routeReady, true, "refresh callers can await the handoff's completed route registration");
+    assert.equal(built.client.isRouteReady(), true, "the current route is ready only after the handoff hello lands");
+  } finally {
+    built.client.stop();
+  }
 });
 
 test("#1728 CALL SITE: a null dispatch route is refused rather than substituted from the remount", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1005,6 +1005,11 @@ let openReceiptSeq = 0;
 // never mistake a property attached by a later command failure for proof that no
 // workflow-targeting work ran.
 const workflowListReadinessRefusals = new WeakSet();
+// #1787 — a refresh command can arrive on the route the bridge still remembers
+// while a replacement socket is handing this tab over to its live route. Keep
+// this refusal authoritative: the command must not refresh node definitions
+// until the active route is registered on the replacement socket.
+const routeRegistrationReadinessRefusals = new WeakSet();
 // #402 / codex P2 — at most ONE outstanding staleness disk-read per workflow path. The
 // read is bounded by a deadline, but a deadline only stops US waiting: one of the two
 // read paths takes no AbortSignal, so without this a server that accepts requests and
@@ -4956,6 +4961,49 @@ function readWorkflowListReadinessRefusal(error) {
     stage: "pre-probe",
     retryable: true,
   };
+}
+
+function routeRegistrationReadinessRefusalError(reason) {
+  const detail =
+    typeof reason === "string" && reason.trim()
+      ? reason.trim()
+      : "the active bridge route is still being registered";
+  const error = new Error(
+    "panel_refresh_nodes did not run because " +
+      detail +
+      ". Nothing was refreshed; retry after the reconnect settles.",
+  );
+  routeRegistrationReadinessRefusals.add(error);
+  return error;
+}
+
+function readRouteRegistrationReadinessRefusal(error) {
+  if (!error || typeof error !== "object" || !routeRegistrationReadinessRefusals.has(error)) return null;
+  return {
+    code: "route-registration-not-ready",
+    ready: false,
+    applied: false,
+    stage: "pre-refresh",
+    retryable: true,
+  };
+}
+
+// #1787 — the bridge may still dispatch a stale explicit tab_id during the
+// replacement-socket handoff. Wait for the live route before starting the
+// global, otherwise-safe refresh; if the bridge is down entirely, preserve the
+// local refresh path and let its existing backend readiness handling decide.
+const ROUTE_REGISTRATION_WAIT_STEPS_MS = Object.freeze([100, 250, 500, 1000, 2000]);
+async function awaitActiveRouteRegistration() {
+  const client = liveBridgeClient;
+  if (!client || client.isConnected?.() !== true) return;
+  if (client.isRouteReady?.() === true) return;
+  const ready =
+    typeof client.waitForRouteReady === "function"
+      ? await client.waitForRouteReady({ stepsMs: ROUTE_REGISTRATION_WAIT_STEPS_MS })
+      : false;
+  if (ready !== true || liveBridgeClient !== client || client.isRouteReady?.() !== true) {
+    throw routeRegistrationReadinessRefusalError();
+  }
 }
 
 // Per-tab agent session id + which thread this tab is showing. sessionStorage
@@ -12553,6 +12601,10 @@ const GRAPH_TOOL_EXECUTORS = {
   // acknowledgement of that work: subscribe to it instead of queueing a second
   // trailing run. When the slot is empty, force:true still starts a fresh refresh.
   async refresh_nodes() {
+    // #1787 — a stale explicit tab_id can still reach this executor during a
+    // replacement-socket handoff. Do not let the global refresh run until the
+    // bridge has registered the current active route.
+    await awaitActiveRouteRegistration();
     const verdict = await refreshComfyNodeDefs(undefined, {
       force: true,
       joinInFlight: true,
@@ -25172,6 +25224,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // the panel has already committed to; see routeIsStale in lib/rehello-gate.js for why
   // that gap exists at all and what leaks through it.
   let lastAdvertisedRouteId = null;
+  // #1787 — when a replacement socket opens after a reconnect, the bridge may
+  // still receive commands addressed to the last route it knew. Preserve that
+  // landed route for one handoff hello; the follow-up hello carries the live
+  // route and creates the bridge's same-socket migration alias.
+  let reconnectRouteHandoff = null;
 
   /** #1095 — is this socket's binding out of date with the committed workflow? */
   function advertisedRouteIsStale() {
@@ -26123,6 +26180,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         } catch (err) {
           const reconnectRefusal = readReconnectRefusal(err);
           const workflowListReadiness = readWorkflowListReadinessRefusal(err);
+          const routeRegistrationReadiness = readRouteRegistrationReadinessRefusal(err);
           reply = {
             rid: msg.rid,
             ok: false,
@@ -26147,6 +26205,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // cannot confuse a workflow-list readiness miss with a graph
             // command blocked by a different fence.
             ...(workflowListReadiness ? { workflow_list_readiness: workflowListReadiness } : {}),
+            // #1787 — this is a read-only, pre-refresh refusal. The route handoff
+            // did not settle, so no node definitions were fetched or registered.
+            ...(routeRegistrationReadiness
+              ? { route_registration_readiness: routeRegistrationReadiness }
+              : {}),
           };
         }
         // Settle the rid ledger BEFORE the dead-socket drop below (#517): even
@@ -26369,6 +26432,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // the active `sock`, don't reject its pending calls, don't scheduleReconnect
       // (that would orphan the new socket and spawn a duplicate). Just let it die.
       if (!isActive()) return;
+      if (typeof lastAdvertisedRouteId === "string" && lastAdvertisedRouteId) {
+        reconnectRouteHandoff = lastAdvertisedRouteId;
+      }
       sock = null;
       handshakeDone = false;
       // #654 — a pending refused-hello retry belongs to the dead socket; the
@@ -26494,6 +26560,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // published only on the landed path below, for the same reason as the uuid: a hello that
     // never reached the orchestrator advertised no route.
     let advertisedRouteId = null;
+    const handoffCandidate = reconnectRouteHandoff;
+    const firstHelloOnSocket = advertisedSock !== target;
+    let usedRouteHandoff = false;
     return sendBridgeHello({
       socket: target,
       isCurrent: () => sock === target && target.readyState === WebSocket.OPEN,
@@ -26505,8 +26574,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // COMPLETED lease (never a value we hope to get) is the same ordering rule
       // as the epoch bump below: nothing is recorded before it is true.
       tabRouteIdentity.adopt(tabSessionId);
-      const routeId = bridgeRouteId();
-      if (!routeId) {
+      const liveRouteId = bridgeRouteId();
+      if (!liveRouteId) {
         // Nothing has been dispatched, so this is a refusal, not a disclosure of
         // something already done — but say so, or the panel just sits on a
         // "connecting" pill it will never leave.
@@ -26518,6 +26587,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // open. Bounded; a landed hello or a fresh socket resets the budget.
         scheduleRouteRefusalRetry();
         return null;
+      }
+      let routeId = liveRouteId;
+      if (
+        firstHelloOnSocket &&
+        typeof handoffCandidate === "string" &&
+        handoffCandidate &&
+        handoffCandidate !== liveRouteId
+      ) {
+        usedRouteHandoff = true;
+        routeId = handoffCandidate;
       }
       // #1095 — recorded only past the refusal, so `advertisedRouteId` is never a route the
       // hello declined to carry. It is published to `lastAdvertisedRouteId` only once the
@@ -26608,6 +26687,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // …and THIS is the binding the orchestrator now holds for this socket. Outbound
           // frames it routes by binding are compared against it (advertisedRouteIsStale).
           lastAdvertisedRouteId = advertisedRouteId;
+          if (reconnectRouteHandoff === handoffCandidate) reconnectRouteHandoff = null;
           // #1095 — release exactly the held frames composed FOR this route, and discard any
           // composed for a workflow the panel has since moved past. Driven from the landed
           // path, so "advertised" means the orchestrator was told, never that we meant to.
@@ -26616,6 +26696,15 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // replenished and any pending retry is moot.
           routeRefusalRetries = 0;
           clearRouteRefusalRetry();
+          if (usedRouteHandoff) {
+            // The old route gets this replacement socket only long enough for the
+            // bridge to accept stale explicit targets. Re-advertise immediately on
+            // the same socket so the live route becomes canonical and isRouteReady stays
+            // false until that second hello has landed.
+            void Promise.resolve().then(() => {
+              if (sock === target && target.readyState === WebSocket.OPEN) void sendHello();
+            });
+          }
         }
         return sent === true;
       })
@@ -26897,6 +26986,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       if (attempt > respawnAfterAttempts() && onBridgeClosed?.() === true) return;
       connect();
     }, delay);
+  }
+
+  function routeReady() {
+    if (!sock || sock.readyState !== WebSocket.OPEN || !handshakeDone) return false;
+    if (pendingRouteBindingGeneration !== null) return false;
+    let routeId = null;
+    try {
+      routeId = bridgeRouteId();
+    } catch {
+      routeId = null;
+    }
+    return !!routeId && !!lastAdvertisedRouteId && routeId === lastAdvertisedRouteId;
   }
 
   return {
@@ -27234,6 +27335,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       rehelloGate.cancel();
       pendingRouteBindingGeneration = null;
       advertisedSock = null;
+      reconnectRouteHandoff = null;
       connect();
     },
     currentUrl() {
@@ -27242,6 +27344,17 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     isConnected() {
       return !!sock && sock.readyState === WebSocket.OPEN;
     },
+    /** #1787 — wait only for the bounded replacement-socket route handoff. */
+    async waitForRouteReady({ stepsMs = [100, 250, 500, 1000, 2000] } = {}) {
+      const isReady = () => routeReady();
+      if (isReady()) return true;
+      const steps = Array.isArray(stepsMs) ? stepsMs : [];
+      for (const delay of steps) {
+        await new Promise((resolve) => setTimeout(resolve, Math.max(0, Number(delay) || 0)));
+        if (isReady()) return true;
+      }
+      return isReady();
+    },
     /**
      * True only when the live socket has completed its handshake and the
      * orchestrator has advertised the current workflow route. Stamped control
@@ -27249,15 +27362,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
      * socket-open plus a readable route is not sufficient.
      */
     isRouteReady() {
-      if (!sock || sock.readyState !== WebSocket.OPEN || !handshakeDone) return false;
-      if (pendingRouteBindingGeneration !== null) return false;
-      let routeId = null;
-      try {
-        routeId = bridgeRouteId();
-      } catch {
-        routeId = null;
-      }
-      return !!routeId && !!lastAdvertisedRouteId && routeId === lastAdvertisedRouteId;
+      return routeReady();
     },
     /** #1095 — diagnostics only. The in-flight count is NOT exported for callers to gate
      *  on: an earlier cut had the workflow poll read it and decide for itself, and that is
@@ -27286,6 +27391,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       rehelloGate.cancel();
       pendingRouteBindingGeneration = null;
       advertisedSock = null;
+      reconnectRouteHandoff = null;
     },
     destroy() {
       closed = true;
@@ -27304,6 +27410,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       rehelloGate.cancel();
       pendingRouteBindingGeneration = null;
       advertisedSock = null;
+      reconnectRouteHandoff = null;
     },
   };
 }


### PR DESCRIPTION
Fixes #1787. Preserves the last landed route for one replacement-socket handoff hello, immediately migrates to the live route, and makes panel_refresh_nodes wait for active route registration before refreshing node definitions. Validation: npm.cmd run test:unit passed with 6830 tests, 1 todo, 0 failures; focused tests 38 passed; npm.cmd run typecheck passed; npm.cmd run check:scope passed; git diff --check passed. Do not merge or release.