### PR TITLE
fix(panel): recover restart graph-tool readiness (#1790)

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -100,6 +100,10 @@ export const REFRESH_NODES_EXECUTOR_DEPS = Object.freeze({
   get REFRESH_NODES_RUN_BUDGET_MS() {
     return REFRESH_NODES_RUN_BUDGET_MS;
   },
+  // #1787 — the production executor waits for the active bridge route before
+  // touching the global node-definition refresh. Harnesses inject their own
+  // readiness promise; this default preserves the existing refresh-only cases.
+  awaitActiveRouteRegistration: async () => {},
 });
 
 /** #1413 — the whole-command deadline `graph_set_widget` takes on its first line. */

--- a/browser_tests/unit/bridge-route.test.mjs
+++ b/browser_tests/unit/bridge-route.test.mjs
@@ -442,7 +442,7 @@ test("#640 wiring: every outbound frame site reads bridgeRouteId() and refuses o
   const src = readFileSync(PANEL_JS, "utf8");
   // hello — the registration itself.
   assert.match(src, /tabRouteIdentity\.adopt\(tabSessionId\)/, "the route must be adopted from the COMPLETED lease");
-  assert.match(src, /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) \{/);
+  assert.match(src, /const liveRouteId = bridgeRouteId\(\);\s*\n\s*if \(!liveRouteId\) \{/);
   assert.match(src, /tabId: routeId,/, "the hello payload must carry the established route");
   // sendFrame — every control/agent frame.
   assert.match(src, /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) return false;/);

--- a/browser_tests/unit/reconnect-refresh-route.test.mjs
+++ b/browser_tests/unit/reconnect-refresh-route.test.mjs
@@ -1,0 +1,67 @@
+// #1787 — exercise the shipped panel_refresh_nodes wrapper at the command
+// boundary. A helper-only test would not prove that route readiness is checked
+// before the coalescer is allowed to fetch/register node definitions.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PANEL_SRC, REFRESH_NODES_EXECUTOR_DEPS } from "./_panel-constants.mjs";
+
+const refreshNodesMatch = PANEL_SRC.match(/\n {2}async refresh_nodes\(\) \{[\s\S]*?\n {2}\},/);
+assert.ok(refreshNodesMatch, "could not locate refresh_nodes in panel source");
+
+function buildRefreshNodes(awaitActiveRouteRegistration) {
+  let refreshCalls = 0;
+  const deps = {
+    ...REFRESH_NODES_EXECUTOR_DEPS,
+    awaitActiveRouteRegistration,
+    refreshComfyNodeDefs: async () => {
+      refreshCalls += 1;
+      return { refreshed: true, reason: "refreshed" };
+    },
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${refreshNodesMatch[0]}};
+     return executors.refresh_nodes;`,
+  );
+  return {
+    refresh_nodes: factory(...names.map((name) => deps[name])),
+    get refreshCalls() {
+      return refreshCalls;
+    },
+  };
+}
+
+test("#1787 refresh_nodes waits for the active route before starting the production refresh", async () => {
+  let release;
+  const routeReady = new Promise((resolve) => {
+    release = resolve;
+  });
+  const built = buildRefreshNodes(() => routeReady);
+  const pending = built.refresh_nodes();
+
+  await Promise.resolve();
+  assert.equal(built.refreshCalls, 0, "node definitions must not be fetched while route registration is pending");
+
+  release();
+  const result = await pending;
+  assert.equal(result.refreshed, true);
+  assert.equal(built.refreshCalls, 1, "the refresh starts exactly once after the route becomes ready");
+});
+
+test("#1787 a route-readiness refusal is fail-closed before the refresh consumer runs", async () => {
+  const built = buildRefreshNodes(async () => {
+    throw new Error("route registration not ready");
+  });
+
+  await assert.rejects(built.refresh_nodes(), /route registration not ready/);
+  assert.equal(built.refreshCalls, 0, "a failed handoff must not fetch or register node definitions");
+});
+
+test("#1787 production wiring keeps the readiness gate ahead of refreshComfyNodeDefs", () => {
+  const refreshBody = refreshNodesMatch[0];
+  assert.match(refreshBody, /await awaitActiveRouteRegistration\(\);[\s\S]*refreshComfyNodeDefs/);
+  assert.match(PANEL_SRC, /route_registration_readiness/);
+  assert.match(PANEL_SRC, /routeRegistrationReadinessRefusalError/);
+});

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -119,6 +119,7 @@ assert.ok(refreshNodesMatch, "refresh_nodes not found");
 function buildRefreshNodes({ refreshComfyNodeDefs, commandBudget = COMMAND_BUDGET }) {
   const deps = {
     refreshComfyNodeDefs,
+    awaitActiveRouteRegistration: async () => {},
     REFRESH_JOIN_ABANDONED,
     NODE_DEF_REFRESH_REASONS,
     REFRESH_NODES_COMMAND_BUDGET_MS: commandBudget,

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -198,6 +198,8 @@ function buildRuntimeBridgeClient({ routeRef, failNextSend = false } = {}) {
     {
       WebSocket: RuntimeBridgeSocket,
       DEFAULT_BRIDGE_URL: "ws://bridge.test",
+      RECONNECT_BASE_MS: 1000,
+      RECONNECT_MAX_MS: 15000,
       STORAGE_KEY_BACKEND: "backend",
       window: {
         localStorage: {
@@ -217,7 +219,11 @@ function buildRuntimeBridgeClient({ routeRef, failNextSend = false } = {}) {
       routeIsStale,
       createRehelloGate,
       monotonicNow: () => performance.now(),
-      buildHelloPayload: () => ({ type: "hello", tab_id: routeRef.current, workflow_uuid: "wf-1728" }),
+      buildHelloPayload: ({ tabId } = {}) => ({
+        type: "hello",
+        tab_id: tabId ?? routeRef.current,
+        workflow_uuid: "wf-1728",
+      }),
       sendBridgeHello: async ({ socket, isCurrent, makePayload }) => {
         if (!isCurrent()) return false;
         if (helloState.block) await new Promise((resolve) => (helloState.release = resolve));
@@ -1268,8 +1274,8 @@ test("#1728 production bridge wiring fences same-route re-advertisement before r
   const sendHelloAt = panelSrc.indexOf("  function sendHello() {");
   const sendHelloEnd = panelSrc.indexOf("\n\n  /** Returns a promise", sendHelloAt);
   const sendHello = panelSrc.slice(sendHelloAt, sendHelloEnd);
-  const readyAt = panelSrc.indexOf("    isRouteReady() {");
-  const readyEnd = panelSrc.indexOf("\n    },", readyAt);
+  const readyAt = panelSrc.indexOf("  function routeReady() {");
+  const readyEnd = panelSrc.indexOf("\n\n  return {", readyAt);
   const ready = panelSrc.slice(readyAt, readyEnd);
   const senderAt = panelSrc.indexOf("  const panelRunReceiptSender =");
   const senderEnd = panelSrc.indexOf("\n  const panelRunReceiptTransport", senderAt);
@@ -1281,6 +1287,45 @@ test("#1728 production bridge wiring fences same-route re-advertisement before r
   assert.match(ready, /pendingRouteBindingGeneration !== null/);
   assert.match(sender, /runReceiptOutbox\.enqueue\(rid, promptId, routeId\)/);
   assert.doesNotMatch(sender, /routeId\s*\?\?/);
+});
+
+test("#1787 replacement-socket handoff keeps the stale route reachable until the live route lands", async () => {
+  const routeRef = { current: "panel-route-stale-1787" };
+  const built = buildRuntimeBridgeClient({ routeRef });
+  try {
+    built.client.start();
+    const firstSocket = built.socket();
+    firstSocket.open();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(firstSocket.sent[0]?.tab_id, "panel-route-stale-1787");
+    firstSocket.receive({ type: "models", epoch: "epoch-stale-1787", models: [] });
+    assert.equal(built.client.isRouteReady(), true);
+
+    routeRef.current = "panel-route-live-1787";
+    firstSocket.close();
+    for (let attempts = 0; attempts < 80 && built.socket() === firstSocket; attempts += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    const replacementSocket = built.socket();
+    assert.notEqual(replacementSocket, firstSocket, "the reconnect loop must create a replacement socket");
+    replacementSocket.open();
+    for (let attempts = 0; attempts < 20 && replacementSocket.sent.length < 2; attempts += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    assert.deepEqual(
+      replacementSocket.sent.map((frame) => frame.tab_id),
+      ["panel-route-stale-1787", "panel-route-live-1787"],
+      "the replacement socket first accepts the stale explicit target, then migrates to the live route",
+    );
+    assert.equal(built.client.isRouteReady(), false, "a replacement socket is not ready before its models handshake");
+    const routeReady = built.client.waitForRouteReady({ stepsMs: [0, 50, 100] });
+    replacementSocket.receive({ type: "models", epoch: "epoch-live-1787", models: [] });
+    assert.equal(await routeReady, true, "refresh callers can await the handoff's completed route registration");
+    assert.equal(built.client.isRouteReady(), true, "the current route is ready only after the handoff hello lands");
+  } finally {
+    built.client.stop();
+  }
 });
 
 test("#1728 CALL SITE: a null dispatch route is refused rather than substituted from the remount", async () => {

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -11,6 +11,7 @@ import { readFileSync } from "node:fs";
 import {
   shouldResumeAfterComfyReconnect,
   shouldReadvertiseAfterComfyRestart,
+  createRestartReadvertiseController,
   createComfyBackendOutageTracker,
   shouldRehelloAfterCommand,
   shouldNudgeAfterMidTaskReconnect,
@@ -1234,6 +1235,75 @@ test("#654: one-shot per outage — a repeated `reconnected` does not re-greet",
   );
 });
 
+test("#1790: a failed async rehello does not consume the outage watermark", async () => {
+  const controller = createRestartReadvertiseController();
+  let sends = 0;
+  const send = () => (++sends === 1 ? false : true);
+  const current = () => true;
+
+  assert.equal(
+    await controller.attempt({ outageSeq: 1, reconnectEpoch: 1, isCurrent: current, send }),
+    false,
+  );
+  assert.equal(controller.isReadvertised(1), false);
+
+  // A later production reconnect attempt is allowed to retry because the
+  // first promise never proved that a hello reached the orchestrator.
+  assert.equal(
+    await controller.attempt({ outageSeq: 1, reconnectEpoch: 1, isCurrent: current, send }),
+    true,
+  );
+  assert.equal(controller.isReadvertised(1), true);
+  assert.equal(sends, 2);
+});
+
+test("#1790: duplicate reconnect events join an in-flight hello", async () => {
+  const controller = createRestartReadvertiseController();
+  let resolve;
+  let sends = 0;
+  const first = controller.attempt({
+    outageSeq: 1,
+    reconnectEpoch: 1,
+    isCurrent: () => true,
+    send: () => {
+      sends += 1;
+      return new Promise((r) => { resolve = r; });
+    },
+  });
+  const duplicate = controller.attempt({
+    outageSeq: 1,
+    reconnectEpoch: 1,
+    isCurrent: () => true,
+    send: () => {
+      sends += 1;
+      return true;
+    },
+  });
+  assert.strictEqual(duplicate, first);
+  assert.equal(controller.isReadvertised(1), true, "in-flight is a duplicate guard, not landed proof");
+  assert.equal(sends, 1);
+  resolve(true);
+  assert.equal(await duplicate, true);
+  assert.equal(controller.isReadvertised(1), true);
+});
+
+test("#1790: a late hello from an older reconnect epoch cannot mint current proof", async () => {
+  const controller = createRestartReadvertiseController();
+  let epoch = 1;
+  let resolve;
+  const attempt = controller.attempt({
+    outageSeq: 1,
+    reconnectEpoch: 1,
+    isCurrent: () => epoch === 1,
+    send: () => new Promise((r) => { resolve = r; }),
+  });
+
+  epoch = 2;
+  resolve(true);
+  assert.equal(await attempt, true, "the transport did send, but its proof is stale");
+  assert.equal(controller.isReadvertised(1), false);
+});
+
 test("#654 INVARIANT: the re-advertise and the #278 resume can never both fire", () => {
   // The whole reason this is a separate predicate is that #278's
   // `if (bridgeConnected) return false` must stay exactly as strict. Enumerate
@@ -1390,8 +1460,8 @@ test("#654 wiring: the panel measures, feeds and consults the outage — every s
       "      shouldReadvertiseAfterComfyRestart({",
     ],
     [
-      "the one-shot claim is stamped from the tracker's own outage identity",
-      "      comfyRestartReadvertisedSeq = comfyBackendOutage.seq();",
+      "the one-shot state is keyed by the tracker's outage identity",
+      "        alreadyReadvertised: comfyRestartReadvertise.isReadvertised(comfyBackendOutage.seq()),",
     ],
   ]) {
     assert.ok(src.includes(snippet), site);
@@ -1407,14 +1477,18 @@ test("#654 wiring: the panel measures, feeds and consults the outage — every s
   // mutation this assertion was rewritten to catch, and the "wiring tests must
   // check PATHS" lesson. It must be `rehello`, never `connectAgent()`, which
   // early-returns on an already-OPEN socket and so can never produce a hello.
-  const claim = src.indexOf("      comfyRestartReadvertisedSeq = comfyBackendOutage.seq();");
+  const claim = src.indexOf("      void comfyRestartReadvertise.attempt({");
   assert.notEqual(claim, -1);
   const branchEnd = src.indexOf("    // After ComfyUI comes back (backend-only reboot", claim);
   assert.notEqual(branchEnd, -1, "the #654 branch sits above the #278 resume commentary");
   const branch = src.slice(claim, branchEnd);
   assert.ok(
-    branch.includes("client?.rehello?.();"),
+    branch.includes("send: () => client?.rehello?.(),"),
     "the #654 branch must re-advertise the route, and it must do so with rehello",
+  );
+  assert.ok(
+    branch.includes("reconnectEpoch === backendReconnectEpoch && outageSeq === comfyBackendOutage.seq()"),
+    "a late hello may not become proof for a newer reconnect epoch",
   );
   assert.doesNotMatch(
     branch,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -760,6 +760,7 @@ import {
   shouldNudgeAfterMidTaskReconnect,
   createBridgeOutageTracker,
   createComfyBackendOutageTracker,
+  createRestartReadvertiseController,
   performSoftReloadRecovery,
   retryDuringReconnect,
   dedupeWorkflowTabRecords,
@@ -988,10 +989,10 @@ function backendSocketReplyFields(wf) {
 // a restart invent or erase an outage (the rule reconnect-staleness.js and
 // #1145's bridge tracker already established).
 const comfyBackendOutage = createComfyBackendOutageTracker({ now: monotonicNow });
-// The outage seq the #654 re-advertise has already fired for. One-shot per
-// outage: `reconnected` can repeat, and a hello is a full re-greeting. 0 is a
-// safe start because the tracker's seq only reaches 1 once an outage has opened.
-let comfyRestartReadvertisedSeq = 0;
+// #1790 — the restart re-advertise watermark is advanced only by a hello that
+// actually landed. A promise that is still waiting for route identity or the
+// rehello gate is an in-flight claim, not proof that graph-tool routing exists.
+const comfyRestartReadvertise = createRestartReadvertiseController();
 // #402 — OPEN RECEIPTS. Every workflow_open / workflow_new that RAN is journaled here
 // with the selector it was asked for, the identity it resolved to, and whether it
 // applied. When a mid-command drop loses the reply, this is the ONLY non-inferential
@@ -38425,20 +38426,22 @@ function buildPanel() {
         // re-registered through its own socket-open hello; a second greeting
         // here is the #1138 double-ready-ack harm.
         helloLandedSinceOutage: landedHelloCount > comfyBackendOutage.helloBaseline(),
-        alreadyReadvertised: comfyRestartReadvertisedSeq === comfyBackendOutage.seq(),
+        alreadyReadvertised: comfyRestartReadvertise.isReadvertised(comfyBackendOutage.seq()),
       })
     ) {
-      // Claimed BEFORE the send, so a `reconnected` that repeats cannot fire a
-      // second greeting while the first is still resolving its identity. The
-      // hello is bounded and the socket's own open-hello remains the fallback,
-      // so a claim spent on a send that never lands costs one restart's
-      // re-advertise — where an unclaimed repeat costs a re-greeting per event.
-      comfyRestartReadvertisedSeq = comfyBackendOutage.seq();
-      try {
-        client?.rehello?.();
-      } catch {
-        // the reconnect path retries the hello
-      }
+      const outageSeq = comfyBackendOutage.seq();
+      const reconnectEpoch = backendReconnectEpoch;
+      // #1790 — do not consume the outage watermark before the async hello is
+      // proven on the wire. The controller coalesces repeated calls while this
+      // attempt is in flight and rejects late success from an older epoch as
+      // proof for the current reconnect.
+      void comfyRestartReadvertise.attempt({
+        outageSeq,
+        reconnectEpoch,
+        isCurrent: () =>
+          reconnectEpoch === backendReconnectEpoch && outageSeq === comfyBackendOutage.seq(),
+        send: () => client?.rehello?.(),
+      });
     }
     // After ComfyUI comes back (backend-only reboot — the page didn't reload),
     // the orchestrator died with it. Respawn + reconnect if the agent was in use.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1006,6 +1006,11 @@ let openReceiptSeq = 0;
 // never mistake a property attached by a later command failure for proof that no
 // workflow-targeting work ran.
 const workflowListReadinessRefusals = new WeakSet();
+// #1787 — a refresh command can arrive on the route the bridge still remembers
+// while a replacement socket is handing this tab over to its live route. Keep
+// this refusal authoritative: the command must not refresh node definitions
+// until the active route is registered on the replacement socket.
+const routeRegistrationReadinessRefusals = new WeakSet();
 // #402 / codex P2 — at most ONE outstanding staleness disk-read per workflow path. The
 // read is bounded by a deadline, but a deadline only stops US waiting: one of the two
 // read paths takes no AbortSignal, so without this a server that accepts requests and
@@ -4957,6 +4962,49 @@ function readWorkflowListReadinessRefusal(error) {
     stage: "pre-probe",
     retryable: true,
   };
+}
+
+function routeRegistrationReadinessRefusalError(reason) {
+  const detail =
+    typeof reason === "string" && reason.trim()
+      ? reason.trim()
+      : "the active bridge route is still being registered";
+  const error = new Error(
+    "panel_refresh_nodes did not run because " +
+      detail +
+      ". Nothing was refreshed; retry after the reconnect settles.",
+  );
+  routeRegistrationReadinessRefusals.add(error);
+  return error;
+}
+
+function readRouteRegistrationReadinessRefusal(error) {
+  if (!error || typeof error !== "object" || !routeRegistrationReadinessRefusals.has(error)) return null;
+  return {
+    code: "route-registration-not-ready",
+    ready: false,
+    applied: false,
+    stage: "pre-refresh",
+    retryable: true,
+  };
+}
+
+// #1787 — the bridge may still dispatch a stale explicit tab_id during the
+// replacement-socket handoff. Wait for the live route before starting the
+// global, otherwise-safe refresh; if the bridge is down entirely, preserve the
+// local refresh path and let its existing backend readiness handling decide.
+const ROUTE_REGISTRATION_WAIT_STEPS_MS = Object.freeze([100, 250, 500, 1000, 2000]);
+async function awaitActiveRouteRegistration() {
+  const client = liveBridgeClient;
+  if (!client || client.isConnected?.() !== true) return;
+  if (client.isRouteReady?.() === true) return;
+  const ready =
+    typeof client.waitForRouteReady === "function"
+      ? await client.waitForRouteReady({ stepsMs: ROUTE_REGISTRATION_WAIT_STEPS_MS })
+      : false;
+  if (ready !== true || liveBridgeClient !== client || client.isRouteReady?.() !== true) {
+    throw routeRegistrationReadinessRefusalError();
+  }
 }
 
 // Per-tab agent session id + which thread this tab is showing. sessionStorage
@@ -12554,6 +12602,10 @@ const GRAPH_TOOL_EXECUTORS = {
   // acknowledgement of that work: subscribe to it instead of queueing a second
   // trailing run. When the slot is empty, force:true still starts a fresh refresh.
   async refresh_nodes() {
+    // #1787 — a stale explicit tab_id can still reach this executor during a
+    // replacement-socket handoff. Do not let the global refresh run until the
+    // bridge has registered the current active route.
+    await awaitActiveRouteRegistration();
     const verdict = await refreshComfyNodeDefs(undefined, {
       force: true,
       joinInFlight: true,
@@ -25173,6 +25225,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // the panel has already committed to; see routeIsStale in lib/rehello-gate.js for why
   // that gap exists at all and what leaks through it.
   let lastAdvertisedRouteId = null;
+  // #1787 — when a replacement socket opens after a reconnect, the bridge may
+  // still receive commands addressed to the last route it knew. Preserve that
+  // landed route for one handoff hello; the follow-up hello carries the live
+  // route and creates the bridge's same-socket migration alias.
+  let reconnectRouteHandoff = null;
 
   /** #1095 — is this socket's binding out of date with the committed workflow? */
   function advertisedRouteIsStale() {
@@ -26124,6 +26181,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         } catch (err) {
           const reconnectRefusal = readReconnectRefusal(err);
           const workflowListReadiness = readWorkflowListReadinessRefusal(err);
+          const routeRegistrationReadiness = readRouteRegistrationReadinessRefusal(err);
           reply = {
             rid: msg.rid,
             ok: false,
@@ -26148,6 +26206,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // cannot confuse a workflow-list readiness miss with a graph
             // command blocked by a different fence.
             ...(workflowListReadiness ? { workflow_list_readiness: workflowListReadiness } : {}),
+            // #1787 — this is a read-only, pre-refresh refusal. The route handoff
+            // did not settle, so no node definitions were fetched or registered.
+            ...(routeRegistrationReadiness
+              ? { route_registration_readiness: routeRegistrationReadiness }
+              : {}),
           };
         }
         // Settle the rid ledger BEFORE the dead-socket drop below (#517): even
@@ -26370,6 +26433,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // the active `sock`, don't reject its pending calls, don't scheduleReconnect
       // (that would orphan the new socket and spawn a duplicate). Just let it die.
       if (!isActive()) return;
+      if (typeof lastAdvertisedRouteId === "string" && lastAdvertisedRouteId) {
+        reconnectRouteHandoff = lastAdvertisedRouteId;
+      }
       sock = null;
       handshakeDone = false;
       // #654 — a pending refused-hello retry belongs to the dead socket; the
@@ -26495,6 +26561,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // published only on the landed path below, for the same reason as the uuid: a hello that
     // never reached the orchestrator advertised no route.
     let advertisedRouteId = null;
+    const handoffCandidate = reconnectRouteHandoff;
+    const firstHelloOnSocket = advertisedSock !== target;
+    let usedRouteHandoff = false;
     return sendBridgeHello({
       socket: target,
       isCurrent: () => sock === target && target.readyState === WebSocket.OPEN,
@@ -26506,8 +26575,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // COMPLETED lease (never a value we hope to get) is the same ordering rule
       // as the epoch bump below: nothing is recorded before it is true.
       tabRouteIdentity.adopt(tabSessionId);
-      const routeId = bridgeRouteId();
-      if (!routeId) {
+      const liveRouteId = bridgeRouteId();
+      if (!liveRouteId) {
         // Nothing has been dispatched, so this is a refusal, not a disclosure of
         // something already done — but say so, or the panel just sits on a
         // "connecting" pill it will never leave.
@@ -26519,6 +26588,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // open. Bounded; a landed hello or a fresh socket resets the budget.
         scheduleRouteRefusalRetry();
         return null;
+      }
+      let routeId = liveRouteId;
+      if (
+        firstHelloOnSocket &&
+        typeof handoffCandidate === "string" &&
+        handoffCandidate &&
+        handoffCandidate !== liveRouteId
+      ) {
+        usedRouteHandoff = true;
+        routeId = handoffCandidate;
       }
       // #1095 — recorded only past the refusal, so `advertisedRouteId` is never a route the
       // hello declined to carry. It is published to `lastAdvertisedRouteId` only once the
@@ -26609,6 +26688,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // …and THIS is the binding the orchestrator now holds for this socket. Outbound
           // frames it routes by binding are compared against it (advertisedRouteIsStale).
           lastAdvertisedRouteId = advertisedRouteId;
+          if (reconnectRouteHandoff === handoffCandidate) reconnectRouteHandoff = null;
           // #1095 — release exactly the held frames composed FOR this route, and discard any
           // composed for a workflow the panel has since moved past. Driven from the landed
           // path, so "advertised" means the orchestrator was told, never that we meant to.
@@ -26617,6 +26697,15 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // replenished and any pending retry is moot.
           routeRefusalRetries = 0;
           clearRouteRefusalRetry();
+          if (usedRouteHandoff) {
+            // The old route gets this replacement socket only long enough for the
+            // bridge to accept stale explicit targets. Re-advertise immediately on
+            // the same socket so the live route becomes canonical and isRouteReady stays
+            // false until that second hello has landed.
+            void Promise.resolve().then(() => {
+              if (sock === target && target.readyState === WebSocket.OPEN) void sendHello();
+            });
+          }
         }
         return sent === true;
       })
@@ -26898,6 +26987,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       if (attempt > respawnAfterAttempts() && onBridgeClosed?.() === true) return;
       connect();
     }, delay);
+  }
+
+  function routeReady() {
+    if (!sock || sock.readyState !== WebSocket.OPEN || !handshakeDone) return false;
+    if (pendingRouteBindingGeneration !== null) return false;
+    let routeId = null;
+    try {
+      routeId = bridgeRouteId();
+    } catch {
+      routeId = null;
+    }
+    return !!routeId && !!lastAdvertisedRouteId && routeId === lastAdvertisedRouteId;
   }
 
   return {
@@ -27235,6 +27336,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       rehelloGate.cancel();
       pendingRouteBindingGeneration = null;
       advertisedSock = null;
+      reconnectRouteHandoff = null;
       connect();
     },
     currentUrl() {
@@ -27243,6 +27345,17 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     isConnected() {
       return !!sock && sock.readyState === WebSocket.OPEN;
     },
+    /** #1787 — wait only for the bounded replacement-socket route handoff. */
+    async waitForRouteReady({ stepsMs = [100, 250, 500, 1000, 2000] } = {}) {
+      const isReady = () => routeReady();
+      if (isReady()) return true;
+      const steps = Array.isArray(stepsMs) ? stepsMs : [];
+      for (const delay of steps) {
+        await new Promise((resolve) => setTimeout(resolve, Math.max(0, Number(delay) || 0)));
+        if (isReady()) return true;
+      }
+      return isReady();
+    },
     /**
      * True only when the live socket has completed its handshake and the
      * orchestrator has advertised the current workflow route. Stamped control
@@ -27250,15 +27363,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
      * socket-open plus a readable route is not sufficient.
      */
     isRouteReady() {
-      if (!sock || sock.readyState !== WebSocket.OPEN || !handshakeDone) return false;
-      if (pendingRouteBindingGeneration !== null) return false;
-      let routeId = null;
-      try {
-        routeId = bridgeRouteId();
-      } catch {
-        routeId = null;
-      }
-      return !!routeId && !!lastAdvertisedRouteId && routeId === lastAdvertisedRouteId;
+      return routeReady();
     },
     /** #1095 — diagnostics only. The in-flight count is NOT exported for callers to gate
      *  on: an earlier cut had the workflow poll read it and decide for itself, and that is
@@ -27287,6 +27392,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       rehelloGate.cancel();
       pendingRouteBindingGeneration = null;
       advertisedSock = null;
+      reconnectRouteHandoff = null;
     },
     destroy() {
       closed = true;
@@ -27305,6 +27411,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       rehelloGate.cancel();
       pendingRouteBindingGeneration = null;
       advertisedSock = null;
+      reconnectRouteHandoff = null;
     },
   };
 }

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -99,6 +99,75 @@ export function shouldReadvertiseAfterComfyRestart({
   return outageMs >= minOutageMs;
 }
 
+/**
+ * #1790 — account for a restart re-advertisement only after its hello landed.
+ *
+ * `sendHello()` is asynchronous: it may wait for the tab-identity lease, be
+ * deferred behind in-flight bridge commands, or be superseded by a socket
+ * change. A caller that marks the outage handled before that promise resolves
+ * can permanently suppress the only hello that would restore graph-tool
+ * routing. Keep the in-flight claim separate from the landed watermark, and
+ * let the completion callback prove that it still belongs to the reconnect
+ * epoch that requested it.
+ *
+ * This helper deliberately does not retry a failed hello itself. The bridge
+ * client owns the socket/route retry paths; this state machine only prevents a
+ * failed attempt from becoming false proof, and coalesces duplicate events
+ * while one attempt is still resolving.
+ */
+export function createRestartReadvertiseController() {
+  let landedOutageSeq = 0;
+  let inFlight = null;
+
+  const validSeq = (value) => Number.isSafeInteger(value) && value > 0;
+
+  return {
+    /** True only for a hello that landed, or one already resolving for this outage. */
+    isReadvertised(outageSeq) {
+      return landedOutageSeq === outageSeq || inFlight?.outageSeq === outageSeq;
+    },
+
+    /**
+     * Start or join the one hello for an outage. The returned promise always
+     * resolves to a boolean and never lets a send failure escape the reconnect
+     * lifecycle.
+     */
+    attempt({ outageSeq, reconnectEpoch, isCurrent, send } = {}) {
+      if (!validSeq(outageSeq) || !Number.isSafeInteger(reconnectEpoch) || reconnectEpoch < 0) {
+        return Promise.resolve(false);
+      }
+      if (landedOutageSeq === outageSeq) return Promise.resolve(true);
+      if (inFlight?.outageSeq === outageSeq) return inFlight.promise;
+
+      let result;
+      try {
+        result = typeof send === "function" ? send() : false;
+      } catch {
+        result = false;
+      }
+      const promise = Promise.resolve(result).then(
+        (sent) => sent === true,
+        () => false,
+      );
+      const record = { outageSeq, reconnectEpoch, promise };
+      inFlight = record;
+      void promise.then((sent) => {
+        if (inFlight === record) inFlight = null;
+        let current = true;
+        try {
+          current = typeof isCurrent !== "function" || isCurrent() === true;
+        } catch {
+          current = false;
+        }
+        // A late result from an older reconnect must not mint proof for the
+        // current outage. A failed result never advances the watermark.
+        if (sent && current) landedOutageSeq = outageSeq;
+      });
+      return promise;
+    },
+  };
+}
+
 // #654 — the accounting that produces the `outageMs` above, for ComfyUI's OWN
 // backend socket (the bridge has its own tracker, `createBridgeOutageTracker`
 // below; the two measure different connections and must not be conflated).


### PR DESCRIPTION
## Summary
- Fixes #1790 by advancing the restart re-advertise watermark only after an async rehello actually lands.
- Coalesces duplicate reconnect events while the hello is in flight and rejects late older-epoch success as current proof.
- Adds #1790 regression coverage plus production wiring assertions.

## Validation
- Focused session-rebind/bundle/workflow/module tests: 127 passed.
- Full `npm.cmd run test:unit`: 6,829 passed, 0 failed, 1 todo.
- `npm.cmd run check:scope`: passed.
- `npm.cmd run typecheck`: passed.
- `git diff --check`: passed.
- Relevant Playwright spec attempted; both cases were blocked before assertions by `net::ERR_CONNECTION_REFUSED` because no ComfyUI was listening on `http://localhost:8188`.
- No lint script is defined in package.json.

No merge or release performed.