### PR TITLE
fix(panel): rebind after closing refused active workflow

### DIFF
--- a/browser_tests/refused-unsaved-workflow-close.spec.ts
+++ b/browser_tests/refused-unsaved-workflow-close.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * #1795 — a refused save followed by a forced close of an unsaved ACTIVE tab
+ * must select a surviving tab and leave graph tools usable.
+ *
+ * This drives the real panel_close_workflow executor against ComfyUI. The
+ * slash-containing save is expected to refuse; the first close is expected to
+ * preserve that refusal; only force:true may discard the tab. The final list
+ * and graph read prove the production close/rebind path did not leave a stale
+ * active workflow or root binding behind.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+test('closing a refused unsaved workflow rebinds the active canvas', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  await claimFreshCanvas(page, mockBridge)
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    ;(app?.canvas?.graph ?? app?.graph).add(LG.createNode('EmptyLatentImage'))
+  })
+  await settleCanvas(page)
+
+  const before = await mockBridge.command('workflow_list', {})
+  expect(before.ok, `workflow_list setup failed: ${JSON.stringify(before)}`).toBe(true)
+  const unsavedRoute = String(before.result?.active?.routing_key || '')
+  expect(unsavedRoute, 'the new active workflow must have a per-instance route').toMatch(/^tmp:/)
+
+  // The slash is rejected before the save transport runs, so this remains an
+  // unsaved workflow and there is no file for cleanup to remove.
+  const refusedSave = await mockBridge.command('workflow_save', { name: '1795/refused' })
+  expect(refusedSave.ok).toBe(false)
+  expect(refusedSave.error || '').toMatch(/separator|slash|path/i)
+
+  const refusedClose = await mockBridge.command('workflow_close', {
+    path: unsavedRoute
+  })
+  expect(refusedClose.ok).toBe(false)
+  expect(refusedClose.error || '').toMatch(/unsaved|save it first|force:true/i)
+
+  const stillOpen = await mockBridge.command('workflow_list', {})
+  expect(stillOpen.ok).toBe(true)
+  expect(stillOpen.result?.active?.routing_key).toBe(unsavedRoute)
+  expect((stillOpen.result?.open || []).some((row: any) => row?.routing_key === unsavedRoute)).toBe(true)
+
+  const closed = await mockBridge.command('workflow_close', {
+    path: unsavedRoute,
+    force: true
+  })
+  expect(closed.ok, `forced close failed: ${JSON.stringify(closed)}`).toBe(true)
+  expect(closed.result?.closed?.routing_key).toBe(unsavedRoute)
+  expect(closed.result?.active?.routing_key).toBeTruthy()
+  expect(closed.result?.active?.routing_key).not.toBe(unsavedRoute)
+  expect(closed.result?.workflow_uuid).toBeTruthy()
+  expect(closed.result?.graph_binding).toBe('bound')
+
+  const after = await mockBridge.command('workflow_list', {})
+  expect(after.ok).toBe(true)
+  expect(after.result?.active?.routing_key).toBe(closed.result?.active?.routing_key)
+  expect(after.result?.active?.workflow_uuid).toBe(closed.result?.workflow_uuid)
+  expect((after.result?.open || []).some((row: any) => row?.routing_key === unsavedRoute)).toBe(false)
+
+  const outline = await mockBridge.command('graph_outline', {})
+  expect(outline.ok, `graph_outline after close failed: ${JSON.stringify(outline)}`).toBe(true)
+  expect(JSON.stringify(outline)).not.toContain('root-workflow-uuid-mismatch')
+})

--- a/browser_tests/unit/workflow-close-rebind.test.mjs
+++ b/browser_tests/unit/workflow-close-rebind.test.mjs
@@ -1,0 +1,59 @@
+// #1795 — closing a refused/unsaved ACTIVE workflow must not leave the shared
+// canvas and route identity pointing at the unloaded tab.
+//
+// This is intentionally a production-path wiring test. The browser regression
+// drives the real executor against ComfyUI; this companion keeps the critical
+// ordering and fail-closed postcondition visible in the unit gate, so a future
+// edit cannot silently move the repair behind the return or weaken its proof.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function handlerBody(src, sig) {
+  const start = src.indexOf(sig);
+  assert.notEqual(start, -1, `${sig} must exist`);
+  const after = start + sig.length;
+  const next = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  return src.slice(start, next ? after + next.index : src.length);
+}
+
+const CLOSE = handlerBody(SRC, "async workflow_close({");
+
+test("#1795: unsaved-workflow refusal remains before any destructive close", () => {
+  const closeAt = CLOSE.indexOf("await s.closeWorkflow(target);");
+  const dirtyRefusalAt = CLOSE.indexOf("if (target.isModified && !force)");
+  const captureRefusalAt = CLOSE.indexOf('if ((verdict === "failed" || verdict === "unverified") && !force)');
+  assert.ok(captureRefusalAt >= 0, "capture uncertainty must still refuse without force");
+  assert.ok(dirtyRefusalAt >= 0, "the ordinary unsaved-change refusal must still exist");
+  assert.ok(closeAt > captureRefusalAt, "capture refusal must precede close");
+  assert.ok(closeAt > dirtyRefusalAt, "unsaved-change refusal must precede close");
+});
+
+test("#1795: an active close snapshots identity and recovers through the production open path", () => {
+  const closeAt = CLOSE.indexOf("await s.closeWorkflow(target);");
+  const snapshotAt = CLOSE.indexOf("const activeBeforeClose = activeWorkflowRef()", 0);
+  const recoveryAt = CLOSE.indexOf("const openAfterClose =", closeAt);
+  const openPathAt = CLOSE.indexOf("GRAPH_TOOL_EXECUTORS.workflow_open({ path: replacementRoutingKey })", recoveryAt);
+  const finalProofAt = CLOSE.indexOf("const activeAfterRebind = activeWorkflowRef();", openPathAt);
+  assert.ok(snapshotAt >= 0 && snapshotAt < closeAt, "active identity must be captured before close");
+  assert.ok(recoveryAt > closeAt, "successor selection must happen after close");
+  assert.ok(openPathAt > recoveryAt, "successor selection must use the production workflow_open path");
+  assert.ok(finalProofAt > openPathAt, "close success must be checked after the rebind completes");
+  assert.match(CLOSE, /!sameWorkflowObject\(workflow, target\)/, "the closed object must never be selected as its own successor");
+  assert.match(CLOSE, /activeIdentity\.routingKey !== replacementRoutingKey/, "the route identity must be checked");
+  assert.match(CLOSE, /activeBinding !== "bound"/, "a stale/unproven graph binding must refuse success");
+});
+
+test("#1795: a post-close recovery failure is not reported as binding success or blindly retryable", () => {
+  assert.match(CLOSE, /The close was applied, but the active\/graph binding is UNVERIFIED/);
+  assert.match(CLOSE, /do NOT retry[\s\S]*workflow_close/);
+  assert.match(CLOSE, /workflow_uuid: activeIdentity\.uuid/);
+  assert.match(CLOSE, /routing_key: activeIdentity\.routingKey/);
+  // The internal rebind must not reuse the close command's rid as an open receipt.
+  assert.match(CLOSE, /GRAPH_TOOL_EXECUTORS\.workflow_open\(\{ path: replacementRoutingKey \}\)/);
+  assert.doesNotMatch(CLOSE, /workflow_open\(\{ path: replacementRoutingKey, rid/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21505,6 +21505,20 @@ const GRAPH_TOOL_EXECUTORS = {
     // Resolve via the shared helper so the #570 fence sees the SAME target this executor will.
     const target = path ? resolveWorkflowSelectorTarget("workflow_close", s, path) : s.activeWorkflow;
     if (!target) throw new Error("no target workflow");
+    // #1795 — closeWorkflow() is a STORE primitive, not the frontend's tab-selection
+    // service. On the active tab it can unload `target` while leaving the same object in
+    // activeWorkflow and the shared LiteGraph canvas still carrying its identity. Capture
+    // the pre-close facts now: after close the target may be unloaded or removed from the
+    // store, so neither its route nor whether this command must repair the active canvas
+    // can be recovered reliably from the post-close state.
+    const closedPath = target.path;
+    const closedRoutingKey = workflowTabId(target);
+    const activeBeforeClose = activeWorkflowRef() || s.activeWorkflow || null;
+    // An unreadable active pointer is not evidence that this was a background close. The
+    // close already has a destructive effect, so recover conservatively rather than
+    // returning a success that may leave the shared canvas bound to the closed tab.
+    const activeCloseNeedsRecovery =
+      !activeBeforeClose || sameWorkflowObject(activeBeforeClose, target);
     // Guard against data loss: don't silently close a workflow with unsaved
     // changes (closeWorkflow bypasses the UI's save prompt). Save first.
     //
@@ -21547,7 +21561,108 @@ const GRAPH_TOOL_EXECUTORS = {
       );
     }
     await s.closeWorkflow(target);
-    return { closed: { path: target.path } };
+
+    // Closing a background tab cannot move the live canvas. Keep that established fast
+    // path, while still returning the unsaved tab's unique route so callers never have to
+    // match the shared "Unsaved Workflow" label.
+    if (!activeCloseNeedsRecovery) {
+      return {
+        closed: {
+          path: closedPath,
+          ...(closedRoutingKey ? { routing_key: closedRoutingKey } : {}),
+        },
+      };
+    }
+
+    // The store may have selected a successor itself, but older/current frontend store
+    // implementations measured for #1575 leave the closed object active. Prefer a
+    // genuinely listed active successor when one exists; otherwise use the first
+    // surviving open tab. Never reopen the closed object, even if the store's list is
+    // momentarily stale while it is unloading.
+    const openAfterClose = Array.isArray(s.openWorkflows)
+      ? s.openWorkflows.filter((workflow) => workflow && !sameWorkflowObject(workflow, target))
+      : null;
+    const activeAfterClose = activeWorkflowRef() || s.activeWorkflow || null;
+    const replacement =
+      openAfterClose?.find((workflow) => sameWorkflowObject(workflow, activeAfterClose)) ||
+      openAfterClose?.[0] ||
+      null;
+    const replacementRoutingKey = replacement ? workflowTabId(replacement) : null;
+    if (!replacement || !replacementRoutingKey) {
+      throw new Error(
+        `workflow_close closed "${closedPath || closedRoutingKey || "the active workflow"}", ` +
+          "but the frontend exposed no surviving open workflow to rebind the active canvas. " +
+          "The close was applied, but the active/graph binding is UNVERIFIED; do NOT retry " +
+          "workflow_close. Call panel_list_workflows and wait for frontend tab selection, " +
+          "then re-open the intended workflow before any graph mutation.",
+      );
+    }
+
+    // Reuse the full production open path: it selects the successor, repaints the shared
+    // canvas from that tab's own live state, proves the root marker/UUID, updates the
+    // reconnect readiness watermark, and reports the final active identity. Do not pass
+    // the close command's rid: the internal recovery is not a caller-issued open and must
+    // never masquerade as the caller's open receipt in workflow_list.
+    let rebound;
+    try {
+      rebound = await GRAPH_TOOL_EXECUTORS.workflow_open({ path: replacementRoutingKey });
+    } catch (error) {
+      throw new Error(
+        `workflow_close closed "${closedPath || closedRoutingKey || "the active workflow"}", ` +
+          "but rebinding the surviving tab was not proven. The close was applied and the " +
+          `active/graph binding is UNVERIFIED: ${coerceMessageText(error)} Do NOT retry ` +
+          "workflow_close; call panel_list_workflows and inspect the active tab before " +
+          "retrying any graph command.",
+      );
+    }
+
+    // The open executor has its own proof, but take one final same-observation check here
+    // before advertising close success. This prevents a late tab move from pairing the
+    // successor's reply with a different active object or a stale graph binding.
+    const activeAfterRebind = activeWorkflowRef();
+    const openAfterRebind = Array.isArray(s.openWorkflows) ? s.openWorkflows : null;
+    const activeIdentity = activeAfterRebind
+      ? establishedWorkflowReplyIdentity(activeAfterRebind)
+      : null;
+    const activeBinding = activeAfterRebind
+      ? describeLiveCanvasBinding(activeAfterRebind)
+      : "unknown";
+    if (
+      !activeAfterRebind ||
+      !sameWorkflowObject(activeAfterRebind, replacement) ||
+      !openAfterRebind?.some((workflow) => sameWorkflowObject(workflow, replacement)) ||
+      !activeIdentity ||
+      activeIdentity.routingKey !== replacementRoutingKey ||
+      activeBinding !== "bound"
+    ) {
+      throw new Error(
+        `workflow_close closed "${closedPath || closedRoutingKey || "the active workflow"}", ` +
+          "but the successor's active/graph binding changed or could not be proven. " +
+          "The close was applied, but this reply is NOT a binding success; do NOT retry " +
+          "workflow_close. Call panel_list_workflows and inspect the active tab before " +
+          "retrying any graph command.",
+      );
+    }
+
+    const reboundActive = {
+      path: workflowDiskIdentityPath(activeAfterRebind),
+      filename: workflowDiskIdentityPath(activeAfterRebind) ? activeAfterRebind.filename : null,
+      routing_key: activeIdentity.routingKey,
+      workflow_uuid: activeIdentity.uuid,
+    };
+    return {
+      closed: {
+        path: closedPath,
+        ...(closedRoutingKey ? { routing_key: closedRoutingKey } : {}),
+      },
+      rebound: reboundActive,
+      active: reboundActive,
+      routing_key: activeIdentity.routingKey,
+      workflow_uuid: activeIdentity.uuid,
+      // These fields are the same live readiness/binding facts the open path just proved;
+      // returning them lets the route consumer re-fence immediately after the close.
+      ...backendSocketReplyFields(activeAfterRebind),
+    };
   },
 
   // --- Subgraphs: select nodes + group into a subgraph ---------------------


### PR DESCRIPTION
Fixes #1795

## Summary
- preserve the existing unsaved/capture refusal before any close
- after closing the active tab, select a surviving tab and reuse the production workflow_open path to repaint and prove active/graph identity
- fail closed with an UNVERIFIED, do-not-retry receipt when no successor binding can be proven
- return successor routing_key, workflow_uuid, and graph readiness for reconnect/route consumers

## Validation
- npm.cmd run test:unit — 6,837 tests, 6,836 passed, 0 failed, 1 todo
- npm.cmd run typecheck — passed
- npm.cmd run check:scope — passed
- node --test browser_tests/unit/workflow-close-rebind.test.mjs — 3/3 passed
- Playwright discovery — new #1795 test listed
- live Playwright run — blocked because localhost:8188 was not listening (ERR_CONNECTION_REFUSED)

No merge or release performed.