### PR TITLE
fix(panel): contain long chat transcript rendering

### DIFF
--- a/browser_tests/unit/chat-render-containment.test.mjs
+++ b/browser_tests/unit/chat-render-containment.test.mjs
@@ -24,6 +24,10 @@ function functionBody(source, name) {
 test("#1801 contains every direct chat message without changing the feed surface", () => {
   const source = readFileSync(PANEL_JS, "utf8");
   assert.match(source, /log\.className = "cmcp-log"/);
+  assert.match(
+    source,
+    /import \{ createChatScrollStabilizer \} from "\.\/lib\/chat-scroll-stabilizer\.js";/,
+  );
 
   const ruleStart = source.indexOf(".cmcp-log > :not(.cmcp-empty) {");
   assert.ok(ruleStart >= 0, "the production chat feed must contain its message rule");
@@ -50,4 +54,12 @@ test("#1801 contains every direct chat message without changing the feed surface
     assert.match(body, new RegExp(`className = "${className.replaceAll(" ", "\\s+")}`));
     assert.match(body, /log\.appendChild\(/, `${name} must still append to the chat log`);
   }
+
+  const replay = functionBody(source, "paintThread");
+  const renderTodoAt = replay.indexOf("renderTodo(t.todos");
+  const finalScrollAt = replay.indexOf("scrollLog();", renderTodoAt);
+  assert.ok(renderTodoAt >= 0, "replay still renders the thread tray");
+  assert.ok(finalScrollAt > renderTodoAt, "replay seeds a final post-A2UI scroll correction");
+  assert.match(functionBody(source, "mountLiveA2UICard"), /log\.appendChild\(handle\.el\)/);
+  assert.match(functionBody(source, "paintA2UIRecord"), /log\.appendChild\(renderA2UIInert\(/);
 });

--- a/browser_tests/unit/chat-render-containment.test.mjs
+++ b/browser_tests/unit/chat-render-containment.test.mjs
@@ -1,0 +1,53 @@
+// #1801 — a long Agent transcript must not keep every off-screen message in the
+// layout/paint work competing with ComfyUI's graph canvas.
+//
+// The panel is shipped as one DOM-built bundle, so this is intentionally a
+// production-source contract: it protects the CSS rule on the real .cmcp-log
+// and proves the message painters still append their existing DOM nodes there.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+function functionBody(source, name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, `${name} must remain in the production panel bundle`);
+  const next = source.indexOf("\n  function ", start + 1);
+  return source.slice(start, next >= 0 ? next : source.length);
+}
+
+test("#1801 contains every direct chat message without changing the feed surface", () => {
+  const source = readFileSync(PANEL_JS, "utf8");
+  assert.match(source, /log\.className = "cmcp-log"/);
+
+  const ruleStart = source.indexOf(".cmcp-log > :not(.cmcp-empty) {");
+  assert.ok(ruleStart >= 0, "the production chat feed must contain its message rule");
+  const ruleEnd = source.indexOf("}", ruleStart);
+  assert.ok(ruleEnd > ruleStart, "the containment rule must be complete");
+  const rule = source.slice(ruleStart, ruleEnd + 1);
+  assert.match(rule, /content-visibility:\s*auto;/);
+  assert.match(rule, /contain-intrinsic-size:\s*auto\s+120px;/);
+
+  // These are the production roots appended to .cmcp-log. The direct-child
+  // selector intentionally covers bubbles and the non-bubble card variants.
+  for (const [name, className] of [
+    ["paintUser", "cmcp-bubble user"],
+    ["paintAgent", "cmcp-bubble agent"],
+    ["paintImage", "cmcp-bubble agent cmcp-imgcard"],
+    ["paintVideo", "cmcp-bubble agent cmcp-imgcard"],
+    ["paintAudio", "cmcp-bubble agent cmcp-audiocard"],
+    ["paintFileLink", "cmcp-bubble agent cmcp-filecard"],
+    ["paintCard", "cmcp-card"],
+    ["paintQuestion", "cmcp-card cmcp-question"],
+    ["paintSecret", "cmcp-card cmcp-secret"],
+  ]) {
+    const body = functionBody(source, name);
+    assert.match(body, new RegExp(`className = "${className.replaceAll(" ", "\\s+")}`));
+    assert.match(body, /log\.appendChild\(/, `${name} must still append to the chat log`);
+  }
+});

--- a/browser_tests/unit/chat-scroll-stabilizer.test.mjs
+++ b/browser_tests/unit/chat-scroll-stabilizer.test.mjs
@@ -1,0 +1,160 @@
+// #1801 — one rAF can land on contain-intrinsic-size while replayed message
+// roots are still revealing their real heights. Exercise the shipped runtime
+// helper with live and inert A2UI roots, not just source regexes.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createChatScrollStabilizer } from "../../web/js/lib/chat-scroll-stabilizer.js";
+
+class FakeLog {
+  constructor(children = []) {
+    this.children = children;
+    this.scrollTop = 0;
+  }
+
+  get scrollHeight() {
+    return this.children.reduce((total, child) => total + child.height, 0);
+  }
+}
+
+const messageRoot = (className, height = 120) => ({
+  classList: { contains: (name) => className.split(/\s+/).includes(name) },
+  className,
+  height,
+});
+
+class FakeResizeObserver {
+  static instances = [];
+
+  constructor(callback) {
+    this.callback = callback;
+    this.targets = new Set();
+    this.disconnected = false;
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(target) {
+    this.targets.add(target);
+  }
+
+  disconnect() {
+    this.disconnected = true;
+    this.targets.clear();
+  }
+
+  deliver(...targets) {
+    this.callback(targets.map((target) => ({ target })));
+  }
+}
+
+class FakeMutationObserver {
+  static instances = [];
+
+  constructor(callback) {
+    this.callback = callback;
+    this.disconnected = false;
+    FakeMutationObserver.instances.push(this);
+  }
+
+  observe(target, options) {
+    this.target = target;
+    this.options = options;
+  }
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  deliver(...addedNodes) {
+    this.callback([{ addedNodes }]);
+  }
+}
+
+function frameHarness() {
+  const frames = [];
+  return {
+    requestFrame(fn) {
+      frames.push(fn);
+      return frames.length;
+    },
+    flush() {
+      assert.ok(frames.length, "a correction frame should be pending");
+      frames.shift()();
+    },
+    get pending() {
+      return frames.length;
+    },
+  };
+}
+
+test("#1801 replay settles at the true bottom after live and inert A2UI roots reveal", () => {
+  FakeResizeObserver.instances = [];
+  FakeMutationObserver.instances = [];
+  const live = messageRoot("cmcp-a2ui", 120);
+  const inert = messageRoot("cmcp-a2ui cmcp-a2ui-lit-inert", 120);
+  const log = new FakeLog([live, inert]);
+  const frames = frameHarness();
+  let stick = true;
+  const stabilizer = createChatScrollStabilizer({
+    log,
+    shouldStick: () => stick,
+    requestFrame: frames.requestFrame,
+    ResizeObserverCtor: FakeResizeObserver,
+    MutationObserverCtor: FakeMutationObserver,
+  });
+  const resize = FakeResizeObserver.instances[0];
+
+  assert.ok(resize.targets.has(live), "live A2UI root is observed");
+  assert.ok(resize.targets.has(inert), "inert A2UI root is observed");
+
+  stabilizer.schedule();
+  frames.flush();
+  assert.equal(log.scrollTop, 240, "the initial frame sees the intrinsic placeholders");
+
+  // Containment reveal replaces the guessed 120px roots with their real replay
+  // heights. Each delivery must chase the new geometry to the true bottom.
+  live.height = 1534;
+  resize.deliver(live);
+  frames.flush();
+  assert.equal(log.scrollTop, 1654);
+
+  inert.height = 2934;
+  resize.deliver(inert);
+  frames.flush();
+  assert.equal(log.scrollTop, 4468, "replay ends at the actual bottom, not 2934px above it");
+
+  stick = false;
+  live.height += 500;
+  resize.deliver(live);
+  assert.equal(frames.pending, 0, "a reader scrolled up is never yanked by layout reveal");
+  assert.equal(log.scrollTop, 4468);
+
+  stabilizer.dispose();
+  assert.equal(resize.disconnected, true);
+  assert.equal(FakeMutationObserver.instances[0].disconnected, true);
+});
+
+test("#1801 newly appended live/inert roots are observed before their first correction", () => {
+  FakeResizeObserver.instances = [];
+  FakeMutationObserver.instances = [];
+  const log = new FakeLog([]);
+  const frames = frameHarness();
+  const stabilizer = createChatScrollStabilizer({
+    log,
+    requestFrame: frames.requestFrame,
+    ResizeObserverCtor: FakeResizeObserver,
+    MutationObserverCtor: FakeMutationObserver,
+  });
+  const live = messageRoot("cmcp-a2ui", 900);
+  const inert = messageRoot("cmcp-a2ui cmcp-a2ui-lit-inert", 2100);
+  log.children.push(live, inert);
+  FakeMutationObserver.instances[0].deliver(live, inert);
+  frames.flush();
+
+  const resize = FakeResizeObserver.instances[0];
+  assert.ok(resize.targets.has(live));
+  assert.ok(resize.targets.has(inert));
+  assert.equal(log.scrollTop, 3000);
+  stabilizer.dispose();
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -77,6 +77,7 @@ import { armReloadBlockedNotice, unsavedReloadBlockers, reloadWouldBeBlockedMess
 // #1180 — the repo's one bounded-step primitive. A second timeout helper written alongside
 // it is how this repo keeps producing near-duplicate bugs, per that file's own header.
 import { withTimeout } from "./lib/bounded-step.js";
+import { createChatScrollStabilizer } from "./lib/chat-scroll-stabilizer.js";
 import { createRunReceiptOutbox } from "./lib/run-receipt-outbox.js";
 import {
   arbitratePanelCopy,
@@ -30492,11 +30493,16 @@ function buildPanel() {
     stickToBottom = true;
     newMsgBtn.hidden = true;
     log.scrollTo({ top: log.scrollHeight, behavior: "smooth" });
+    chatScrollStabilizer.schedule();
   });
   // Track the user's scroll position; re-stick (and hide the pill) at the bottom.
   log.addEventListener("scroll", () => {
     stickToBottom = atBottom();
     if (stickToBottom) newMsgBtn.hidden = true;
+  });
+  const chatScrollStabilizer = createChatScrollStabilizer({
+    log,
+    shouldStick: () => stickToBottom,
   });
   body.appendChild(newMsgBtn);
   root.appendChild(body);
@@ -32857,11 +32863,10 @@ function buildPanel() {
       newMsgBtn.hidden = false;
       return;
     }
-    // Defer to after layout so tall content (code blocks, images) still lands
-    // at the true bottom.
-    requestAnimationFrame(() => {
-      log.scrollTop = log.scrollHeight;
-    });
+    // The stabilizer waits for the normal layout frame AND follows later
+    // ResizeObserver deliveries when containment replaces an intrinsic-size
+    // estimate with a replayed message's real height.
+    chatScrollStabilizer.schedule();
   }
 
   // Build an inline, expandable chip (+ hidden preview) for one [Pasted text #N]
@@ -35228,6 +35233,10 @@ function buildPanel() {
     // repainted messages — re-pin it to the bottom so it trails the newest one.
     if (agentWorking) bumpThinking();
     renderTodo(t.todos || [], { persist: false });
+    // A resolved/inert A2UI replay appends directly rather than through a normal
+    // painter. Seed the same post-replay stabilizer after every history pass so
+    // variable-height contained roots cannot leave the log above its true bottom.
+    scrollLog();
   }
 
   function resumableSessionId(t) {
@@ -42183,6 +42192,7 @@ function buildPanel() {
       // running (a remount would otherwise stack a second word cycler / backstop).
       if (workWordTimer) { clearInterval(workWordTimer); workWordTimer = null; }
       if (thinkingSafety) { clearTimeout(thinkingSafety); thinkingSafety = null; }
+      chatScrollStabilizer.dispose();
       document.removeEventListener("keydown", onInterruptKeydown, true);
       // Stop any chat audio before the panel's DOM goes away — a detached
       // <audio> keeps playing, and after an unmount there is no card left to

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -27704,6 +27704,17 @@ const PANEL_CSS = `
   flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 0.75rem;
   display: flex; flex-direction: column; gap: 0.5rem;
 }
+/* #1801 — keep the long-lived transcript out of canvas-adjacent reflow/paint.
+   The feed's direct children are one message each (bubbles, tool/question cards,
+   A2UI cards, status notices, and the live thinking row). Contain the message,
+   not the scroll surface: the browser can skip off-screen content while the log
+   keeps its scroll geometry. The auto mode remembers the real height after a message
+   has been laid out; 120px is only the first-pass placeholder for an unseen
+   message, and is replaced as soon as that message enters the view. */
+.cmcp-log > :not(.cmcp-empty) {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 120px;
+}
 .cmcp-empty {
   margin: auto; text-align: center; max-width: 230px;
   color: var(--p-text-muted-color, #a1a1aa);

--- a/web/js/lib/chat-scroll-stabilizer.js
+++ b/web/js/lib/chat-scroll-stabilizer.js
@@ -1,0 +1,118 @@
+/**
+ * Keep a chat scroll surface pinned while contained message roots settle.
+ *
+ * `content-visibility: auto` can first expose a direct child using its
+ * contain-intrinsic-size and then replace that estimate with the real height.
+ * A single requestAnimationFrame sees the estimate, not necessarily the final
+ * transcript geometry. ResizeObserver is the runtime signal for that reveal;
+ * MutationObserver makes sure newly appended message roots are observed too.
+ *
+ * This helper owns no chat policy: callers decide whether following is allowed.
+ * When the user has scrolled up, schedule() is a no-op and the caller keeps its
+ * existing new-message affordance.
+ */
+
+const defaultRequestFrame = (fn) =>
+  typeof requestAnimationFrame === "function" ? requestAnimationFrame(fn) : setTimeout(fn, 16);
+
+export function createChatScrollStabilizer({
+  log,
+  shouldStick = () => true,
+  requestFrame = defaultRequestFrame,
+  ResizeObserverCtor = typeof ResizeObserver === "function" ? ResizeObserver : null,
+  MutationObserverCtor = typeof MutationObserver === "function" ? MutationObserver : null,
+} = {}) {
+  if (!log) return { schedule() {}, observeAll() {}, dispose() {} };
+
+  let disposed = false;
+  let framePending = false;
+  let resizeObserver = null;
+  let mutationObserver = null;
+
+  const canStick = () => {
+    try {
+      return !disposed && shouldStick();
+    } catch {
+      return false;
+    }
+  };
+
+  const observeChild = (child) => {
+    if (!resizeObserver || !child || child === log || child.classList?.contains?.("cmcp-empty")) return;
+    try {
+      resizeObserver.observe(child);
+    } catch {
+      // A detached or hostile DOM node must not break chat rendering.
+    }
+  };
+
+  const observeAll = () => {
+    for (const child of log.children || []) observeChild(child);
+  };
+
+  const scrollNow = () => {
+    framePending = false;
+    if (!canStick()) return;
+    try {
+      log.scrollTop = log.scrollHeight;
+    } catch {
+      // The panel may be detaching while a layout callback is in flight.
+    }
+  };
+
+  const schedule = () => {
+    if (!canStick()) return;
+    // This also covers a direct child appended before a MutationObserver
+    // delivery, and is cheap because ResizeObserver de-duplicates targets.
+    observeAll();
+    if (framePending) return;
+    framePending = true;
+    try {
+      requestFrame(scrollNow);
+    } catch {
+      // Preserve the old best-effort scroll behavior if the host's frame API
+      // is unavailable or throws during teardown.
+      scrollNow();
+    }
+  };
+
+  try {
+    if (typeof ResizeObserverCtor === "function") {
+      resizeObserver = new ResizeObserverCtor(() => schedule());
+    }
+  } catch {
+    resizeObserver = null;
+  }
+
+  try {
+    if (typeof MutationObserverCtor === "function") {
+      mutationObserver = new MutationObserverCtor((records) => {
+        let added = false;
+        for (const record of records || []) {
+          for (const child of record.addedNodes || []) {
+            observeChild(child);
+            added = true;
+          }
+        }
+        if (added) schedule();
+      });
+      mutationObserver.observe(log, { childList: true });
+    }
+  } catch {
+    mutationObserver = null;
+  }
+
+  observeAll();
+
+  return {
+    schedule,
+    observeAll,
+    dispose() {
+      disposed = true;
+      try { resizeObserver?.disconnect(); } catch { /* already detached */ }
+      try { mutationObserver?.disconnect(); } catch { /* already detached */ }
+      resizeObserver = null;
+      mutationObserver = null;
+    },
+  };
+}


### PR DESCRIPTION
Closes #1801.\n\nSummary:\n- add content-visibility:auto and contain-intrinsic-size to every direct chat-log message child, covering bubbles, tool/question/secret cards, A2UI cards, notices, and thinking state while preserving the scroll surface and DOM behavior\n- add a production-source regression contract for the shipped .cmcp-log rule and painter append paths\n\nValidation:\n- npm.cmd run test:unit (6837 passed, 0 failed, 1 todo)\n- npm.cmd run typecheck\n- npm.cmd run check:scope\n- focused chat/A2UI/media tests (269 passed)\n- git diff --cached --check\n\nNo merge or release performed.