### PR TITLE
fix(panel): retry stale root identity heal after workflow switch

### DIFF
--- a/browser_tests/unit/stale-root-fence-after-tab-switch.test.mjs
+++ b/browser_tests/unit/stale-root-fence-after-tab-switch.test.mjs
@@ -357,7 +357,7 @@ test("#1477 a genuine tab switch heals the root tag next to the re-hello", () =>
   assert.match(body, /client\?\.rehello\?\.\(\)/, "the session fence still republishes");
   assert.match(
     body,
-    /if \(!renaming\) tryHealStaleRootWorkflowIdentity\(\)/,
+    /if \(!renaming\) \{[\s\S]*?tryHealStaleRootWorkflowIdentity\(\)/,
     "and the root tag is restamped on the same switch, not a later graph command",
   );
   const heal = panelFunctionSource(PANEL_SRC, "tryHealStaleRootWorkflowIdentity", "stampGraphRootWorkflowUuid");
@@ -365,5 +365,29 @@ test("#1477 a genuine tab switch heals the root tag next to the re-hello", () =>
     heal,
     /assertGraphBoundToActiveWorkflow\(graph, rootGraph, graphCommandBindingBar\("graph_outline"\)\)/,
     "the heal is the shipped fence, not a second spelling of the proof",
+  );
+});
+
+test("#1854 a delayed canvas repaint keeps retrying the guarded root heal", () => {
+  const start = PANEL_SRC.indexOf("function onWorkflowMaybeChanged() {");
+  assert.notEqual(start, -1);
+  const body = PANEL_SRC.slice(start, PANEL_SRC.indexOf("\n  function renderHistory()", start));
+  const sameRouteStart = body.indexOf("if (wfid === currentWorkflowId) {");
+  const sameRoute = body.slice(sameRouteStart, body.indexOf("\n    const initial =", sameRouteStart));
+  assert.match(
+    sameRoute,
+    /staleRootHealDeadline > 0[\s\S]*?tryHealStaleRootWorkflowIdentity\(\)/,
+    "a same-route poll must retry a heal that raced the frontend repaint",
+  );
+  assert.match(
+    body,
+    /staleRootHealDeadline = monotonicNow\(\) \+ STALE_ROOT_HEAL_RETRY_WINDOW_MS[\s\S]*?tryHealStaleRootWorkflowIdentity\(\)/,
+    "the retry must be armed only by a genuine non-rename workflow switch",
+  );
+  const heal = panelFunctionSource(PANEL_SRC, "tryHealStaleRootWorkflowIdentity", "stampGraphRootWorkflowUuid");
+  assert.match(
+    heal,
+    /describeLiveCanvasBinding\(activeWorkflowRef\(\)\) !== "foreign"/,
+    "a read-only content bypass must not retire the retry while the root tag stays foreign",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3473,6 +3473,11 @@ let currentWorkflowKey = null;
 // place on rename/Save-As (path and the derived .key getter both change), so the
 // instance is the only stable identity a rename leaves intact.
 let currentWorkflowRef = null;
+// #1854 — a frontend tab switch can publish the new active workflow before its reused
+// root graph has finished repainting. Keep the #1477 root-heal eligible for a short,
+// bounded retry window instead of treating the first same-route poll as settled.
+const STALE_ROOT_HEAL_RETRY_WINDOW_MS = 5_000;
+let staleRootHealDeadline = 0;
 /**
  * Flush the live canvas into a workflow's ChangeTracker, and say what happened (#882).
  *
@@ -9250,8 +9255,13 @@ function tryHealStaleRootWorkflowIdentity() {
   try {
     const { graph, rootGraph } = getGraphCtx();
     assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar("graph_outline"));
+    // A read may pass through #995's content-only bypass while the conflicting tag is
+    // still present. That is useful for inspection but does not prove a mutation-ready
+    // binding, so keep the retry alive until the production guard actually restamps it.
+    return describeLiveCanvasBinding(activeWorkflowRef()) !== "foreign";
   } catch {
     /* best-effort — a canvas that cannot prove ownership stays tagged as it is */
+    return false;
   }
 }
 
@@ -35346,6 +35356,18 @@ function buildPanel() {
       // carried, so the settled case (the overwhelming majority of the 600ms ticks
       // that reach this line) costs one comparison and sends nothing.
       noteWorkflowIdentityDrift();
+      // #1854 — the first #1477 heal can race ComfyUI's async canvas repaint. The route
+      // is already current on the next poll, but the root may still carry the previous
+      // tab's tag. Re-run the SAME guarded heal only for the bounded window armed by a
+      // genuine switch; a foreign canvas remains fail-closed because the guard itself
+      // is unchanged.
+      if (staleRootHealDeadline > 0) {
+        if (monotonicNow() <= staleRootHealDeadline) {
+          if (tryHealStaleRootWorkflowIdentity()) staleRootHealDeadline = 0;
+        } else {
+          staleRootHealDeadline = 0;
+        }
+      }
       return; // case 1: no change
     }
 
@@ -35485,7 +35507,12 @@ function buildPanel() {
         // root tag when content proves the canvas is the new tab's. Together they
         // are the atomic identity update a tab switch was leaving split. A rename
         // is the same instance, so the tag already matches and this is a no-op.
-        if (!renaming) tryHealStaleRootWorkflowIdentity();
+        if (!renaming) {
+          staleRootHealDeadline = monotonicNow() + STALE_ROOT_HEAL_RETRY_WINDOW_MS;
+          if (tryHealStaleRootWorkflowIdentity()) staleRootHealDeadline = 0;
+        } else {
+          staleRootHealDeadline = 0;
+        }
         const name = wf?.filename || wfkey || wfid;
         client?.armContext?.(
           renaming


### PR DESCRIPTION
References artokun/comfyui-mcp#1854

## Summary
- Retry the existing guarded root-identity heal for a bounded 5-second window after a genuine workflow switch.
- Do not clear the retry when the read-only content bypass still reports a foreign root.
- Add regression coverage for the delayed canvas repaint recurrence.

## Validation
- Panel focused: 109 passed.
- Panel full unit suite: 6,837 passed, 0 failed, 1 todo.
- Typecheck and scope checks pass.
- MCP consumer unchanged; its focused tests pass.

Cross-repository fix: the issue is in Panel; no MCP production change is required.