### PR TITLE
fix(panel): label completion duration as workflow time (#1805)

### DIFF
--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -367,6 +367,57 @@ test("#269/#468 presentation: a MIXED run (stills + 2 videos) emits EXACTLY ONE 
   assert.match(frames[0].note, /v2\.mp4/, "note names the second video");
 });
 
+test("#1805: cache-assisted and real completion spans are labelled as workflow time", async () => {
+  const formatDuration = (ms) => `${(ms / 1000).toFixed(1)}s`;
+
+  // A cache-assisted prompt still has a real lifecycle span, but the panel does
+  // not observe ComfyUI's execution_cached events and must not call that span a
+  // render benchmark.
+  const cached = makeHarness();
+  cached.tracker.onExecutionStart("cached-prompt");
+  cached.advance(5800);
+  cached.tracker.onExecuted("cached-prompt", {
+    videos: [{ m: { filename: "cached.mp4", type: "output" }, nodeId: "save" }],
+  });
+  cached.tracker.onExecutionSuccess("cached-prompt");
+  assert.equal(cached.flushes[0].durationMs, 5800, "keep the measured workflow span");
+  const cachedDeps = makeFrameDeps({ formatDuration });
+  const cachedFrame = await composeRunCompletionFrame(cached.flushes[0], cachedDeps.deps);
+  assert.match(cachedFrame.note, /workflow completed in 5\.8s/);
+  assert.doesNotMatch(cachedFrame.note, /rendered in/);
+
+  // The same wording applies when still metadata is unavailable and the
+  // completion falls back to the batch-level duration line.
+  const fallbackDeps = makeFrameDeps({
+    formatDuration,
+    fetchImageBytes: () => new Promise(() => {}),
+    fetchImageDimensions: () => new Promise(() => {}),
+    stillsMetadataTimeoutMs: 1,
+  });
+  const fallbackFrame = await composeRunCompletionFrame(
+    { promptId: "cached-stills", images: [{ filename: "cached.png", type: "output" }], durationMs: 5800 },
+    fallbackDeps.deps,
+  );
+  assert.match(fallbackFrame.note, /workflow completed in 5\.8s/);
+  assert.doesNotMatch(fallbackFrame.note, /rendered in/);
+
+  // A genuine long render keeps its full measured duration; only the misleading
+  // render-time label changes.
+  const rendered = makeHarness();
+  rendered.tracker.onExecutionStart("rendered-prompt");
+  rendered.advance(940000);
+  rendered.tracker.onExecuted("rendered-prompt", {
+    images: [{ filename: "rendered.png", type: "output" }],
+  });
+  rendered.tracker.onExecutionSuccess("rendered-prompt");
+  assert.equal(rendered.flushes[0].durationMs, 940000, "preserve true render duration data");
+  const renderedDeps = makeFrameDeps({ formatDuration });
+  const renderedFrame = await composeRunCompletionFrame(rendered.flushes[0], renderedDeps.deps);
+  assert.match(renderedFrame.note, /workflow completed in 940\.0s/);
+  assert.doesNotMatch(renderedFrame.note, /rendered in/);
+  assert.equal(renderedFrame.metadata[0].durationMs, 940000);
+});
+
 test("presentation: a still-storyboard fallback (no blob) still yields ONE frame with the note", async () => {
   const { deps, frames } = makeFrameDeps({ buildVideoStoryboard: async () => null });
   const frame = await composeRunCompletionFrame(

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -19,6 +19,7 @@ import {
   createRunCompletionTracker,
   NO_PROMPT_KEY,
 } from "../../web/js/lib/run-completion.js";
+import { createRunCompletionFlushHandler } from "../../web/js/lib/run-completion-delivery.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 
 /** Deterministic scheduler: timers are held until tick() fires the due ones. */
@@ -502,24 +503,34 @@ test("#1805 production event wiring: a cached completion reaches the agent frame
   );
 
   let now = 0;
-  const flushes = [];
   const frameDeps = makeFrameDeps({
     formatDuration: (durationMs) => `${(durationMs / 1000).toFixed(1)}s`,
   });
   let resolveFrame;
-  let rejectFrame;
-  const frameReady = new Promise((resolve, reject) => {
+  const frameReady = new Promise((resolve) => {
     resolveFrame = resolve;
-    rejectFrame = reject;
   });
-  const runCompletion = createRunCompletionTracker({
-    onFlush: (payload) => {
-      flushes.push(payload);
-      void composeRunCompletionFrame(payload, frameDeps.deps).then(
-        resolveFrame,
-        rejectFrame,
-      );
+  let runCompletion;
+  let sentFrame = null;
+  let pruneCount = 0;
+  const productionOnFlush = createRunCompletionFlushHandler({
+    ...frameDeps.deps,
+    sendFrame: (frame) => {
+      const ok = frameDeps.deps.sendFrame(frame);
+      if (ok) sentFrame = frame;
+      return ok;
     },
+    markDelivered: (promptId) => runCompletion.markDelivered(promptId),
+    markUndelivered: (promptId) => runCompletion.markUndelivered(promptId),
+    pruneRebootMarker: () => {
+      pruneCount += 1;
+      if (sentFrame) resolveFrame(sentFrame);
+    },
+    isAgentMuted: () => false,
+    now: () => Date.now(),
+  });
+  runCompletion = createRunCompletionTracker({
+    onFlush: productionOnFlush,
     now: () => now,
     setTimer: () => 0,
     clearTimer: () => {},
@@ -573,14 +584,14 @@ test("#1805 production event wiring: a cached completion reaches the agent frame
 
   const frame = await frameReady;
   assert.equal(cachedSignalSeen, true);
-  assert.equal(flushes.length, 1);
-  assert.equal(flushes[0].promptId, promptId);
-  assert.equal(flushes[0].durationMs, 5800);
   assert.equal(frameDeps.frames.length, 1);
   assert.equal(frame.type, "agent_event");
   assert.equal(frame.kind, "executed");
   assert.match(frame.note, /workflow completed in 5\.8s/);
   assert.doesNotMatch(frame.note, /rendered in/);
+  assert.equal(pruneCount, 1);
+  assert.equal(runCompletion.isSettled(promptId), true);
+  assert.equal(runCompletion._delivered.has(promptId), true);
 });
 
 test("presentation: a still-storyboard fallback (no blob) still yields ONE frame with the note", async () => {
@@ -836,19 +847,19 @@ test("#609: ONE decision per frame — parallel segments can never disagree with
 });
 
 // #609 wiring: the behavioral tests above inject `agentReceivesImages` by hand,
-// so they cannot catch the panel's REAL call site dropping the dep (the composer
-// then defaults to always-sighted while the sendFrame gate still strips the
-// pixels — the exact #609 hole). Pin the wiring by source inspection, the
+// so they cannot catch the panel's REAL delivery seam dropping the dep (the
+// composer then defaults to always-sighted while the sendFrame gate still strips
+// the pixels — the exact #609 hole). Pin the wiring by source inspection, the
 // panel's established pattern for the giant module (cf. bridge-disconnect).
-test("#609 wiring: the panel call site feeds the composer the gate's own blind predicate", () => {
+test("#609 wiring: the panel delivery seam feeds the gate's own blind predicate", () => {
   const src = readFileSync(
     fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
     "utf8",
   ).replace(/\r\n/g, "\n");
-  const start = src.indexOf("composeRunCompletionFrame(");
-  assert.notEqual(start, -1, "could not locate the composeRunCompletionFrame call site");
-  const end = src.indexOf(".then((frame)", start);
-  assert.notEqual(end, -1, "could not locate the end of the call site");
+  const start = src.indexOf("createRunCompletionFlushHandler({");
+  assert.notEqual(start, -1, "could not locate the run-completion delivery seam");
+  const end = src.indexOf("\n    }),\n    // #370: deliver a reconcile-discovered terminal ERROR", start);
+  assert.notEqual(end, -1, "could not locate the end of the delivery seam");
   const callSite = src.slice(start, end);
   assert.match(
     callSite,

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -418,6 +418,171 @@ test("#1805: cache-assisted and real completion spans are labelled as workflow t
   assert.equal(renderedFrame.metadata[0].durationMs, 940000);
 });
 
+test("#1805 production event wiring: a cached completion reaches the agent frame as workflow time", async () => {
+  const panelSrc = readFileSync(
+    new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const onExecutedStart = panelSrc.indexOf("  function onExecuted(ev) {");
+  const onExecutedEnd = panelSrc.indexOf("\n  function onExecError(ev)", onExecutedStart);
+  const onExecutionSuccessStart = panelSrc.indexOf(
+    "  function onExecutionSuccess(ev) {",
+  );
+  const onExecutionSuccessEnd = panelSrc.indexOf(
+    "\n  // Primary render-duration start signal",
+    onExecutionSuccessStart,
+  );
+  const onExecutionStart = panelSrc.indexOf(
+    "  function onExecutionStart(ev) {",
+  );
+  const onExecutionStartEnd = panelSrc.indexOf(
+    "\n  // Legacy/secondary run-end",
+    onExecutionStart,
+  );
+  assert.ok(onExecutedStart >= 0 && onExecutedEnd > onExecutedStart);
+  assert.ok(
+    onExecutionSuccessStart >= 0 &&
+      onExecutionSuccessEnd > onExecutionSuccessStart,
+  );
+  assert.ok(onExecutionStart >= 0 && onExecutionStartEnd > onExecutionStart);
+
+  const createProductionHandlers = new Function(
+    "imageViewUrl",
+    "isVideoOutput",
+    "isAudioOutput",
+    "paintVideo",
+    "paintAudio",
+    "paintImage",
+    "stripMisattachedExecutionPreviews",
+    "app",
+    "createStoryboardIdentity",
+    "appendStoryboardCacheBust",
+    `return (runCompletion) => [
+      (${panelSrc.slice(onExecutedStart, onExecutedEnd).trim()}),
+      (${panelSrc.slice(
+        onExecutionSuccessStart,
+        onExecutionSuccessEnd,
+      ).trim()}),
+      (${panelSrc.slice(onExecutionStart, onExecutionStartEnd).trim()}),
+    ];`,
+  )(
+    (media) => `view://${media.filename}`,
+    () => false,
+    () => false,
+    () => {},
+    () => {},
+    () => {},
+    () => {},
+    { graph: {}, nodeOutputs: {}, nodePreviewImages: {} },
+    () => "storyboard",
+    (url) => url,
+  );
+
+  const registrationStart = panelSrc.indexOf(
+    '    api.addEventListener("executed", onExecuted);',
+  );
+  const registrationEnd = panelSrc.indexOf("\n  } catch {", registrationStart);
+  assert.ok(registrationStart >= 0 && registrationEnd > registrationStart);
+  const listenerLines = panelSrc
+    .slice(registrationStart, registrationEnd)
+    .match(/    api\.addEventListener\("[^"]+", \w+\);/g);
+  assert.ok(listenerLines);
+  assert.ok(
+    listenerLines.includes('    api.addEventListener("executed", onExecuted);'),
+  );
+  assert.ok(
+    listenerLines.includes(
+      '    api.addEventListener("execution_success", onExecutionSuccess);',
+    ),
+  );
+  assert.ok(
+    listenerLines.includes(
+      '    api.addEventListener("execution_start", onExecutionStart);',
+    ),
+  );
+
+  let now = 0;
+  const flushes = [];
+  const frameDeps = makeFrameDeps({
+    formatDuration: (durationMs) => `${(durationMs / 1000).toFixed(1)}s`,
+  });
+  let resolveFrame;
+  let rejectFrame;
+  const frameReady = new Promise((resolve, reject) => {
+    resolveFrame = resolve;
+    rejectFrame = reject;
+  });
+  const runCompletion = createRunCompletionTracker({
+    onFlush: (payload) => {
+      flushes.push(payload);
+      void composeRunCompletionFrame(payload, frameDeps.deps).then(
+        resolveFrame,
+        rejectFrame,
+      );
+    },
+    now: () => now,
+    setTimer: () => 0,
+    clearTimer: () => {},
+  });
+  const [onExecuted, onExecutionSuccess, onStart] =
+    createProductionHandlers(runCompletion);
+
+  const api = new EventTarget();
+  let cachedSignalSeen = false;
+  api.addEventListener("execution_cached", () => {
+    cachedSignalSeen = true;
+  });
+  new Function(
+    "api",
+    "onExecuted",
+    "onExecutionSuccess",
+    "onExecutionStart",
+    "onExecuting",
+    "onExecError",
+    "onComfyReconnecting",
+    "onComfyReconnected",
+    listenerLines.join("\n"),
+  )(
+    api,
+    onExecuted,
+    onExecutionSuccess,
+    onStart,
+    () => {},
+    () => {},
+    () => {},
+    () => {},
+  );
+
+  const dispatch = (type, detail) => {
+    const event = new Event(type);
+    Object.defineProperty(event, "detail", { value: detail });
+    api.dispatchEvent(event);
+  };
+  const promptId = "cached-production-path";
+  dispatch("execution_start", { prompt_id: promptId });
+  // The shipped wiring does not consume this provenance-only signal; it is
+  // still delivered on the same API target before the normal completion events.
+  dispatch("execution_cached", { prompt_id: promptId, nodes: ["sampler"] });
+  now = 5800;
+  dispatch("executed", {
+    prompt_id: promptId,
+    node: "save",
+    output: { images: [{ filename: "cached.png", type: "output" }] },
+  });
+  dispatch("execution_success", { prompt_id: promptId });
+
+  const frame = await frameReady;
+  assert.equal(cachedSignalSeen, true);
+  assert.equal(flushes.length, 1);
+  assert.equal(flushes[0].promptId, promptId);
+  assert.equal(flushes[0].durationMs, 5800);
+  assert.equal(frameDeps.frames.length, 1);
+  assert.equal(frame.type, "agent_event");
+  assert.equal(frame.kind, "executed");
+  assert.match(frame.note, /workflow completed in 5\.8s/);
+  assert.doesNotMatch(frame.note, /rendered in/);
+});
+
 test("presentation: a still-storyboard fallback (no blob) still yields ONE frame with the note", async () => {
   const { deps, frames } = makeFrameDeps({ buildVideoStoryboard: async () => null });
   const frame = await composeRunCompletionFrame(

--- a/browser_tests/unit/run-reconcile-stale-age.test.mjs
+++ b/browser_tests/unit/run-reconcile-stale-age.test.mjs
@@ -419,31 +419,27 @@ test("#1199 presentation: ages read at the right magnitude", async () => {
 // 4. Wiring — the seam that made the reported fix inert
 // ─────────────────────────────────────────────────────────────────────────────
 
-test("#1199 wiring: the panel call site forwards finishedAt AND reconciled to the composer", () => {
-  // The tracker has ALWAYS passed a finishedAt; this closure dropped it, so the
-  // composer stamped its own clock. Every behavioural test above hands the
-  // composer a payload by hand and therefore cannot see the real call site
-  // omitting the field — the same source-inspection pattern #609 uses.
+test("#1199 wiring: the panel uses the delivery seam that forwards finishedAt AND reconciled", () => {
+  // The tracker has ALWAYS passed a finishedAt; the old inline callback dropped
+  // it, so the composer stamped its own clock. The production callback now lives
+  // in a focused module seam, so pin both the panel wiring and that seam's payload.
   const src = readFileSync(
     fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
     "utf8",
   ).replace(/\r\n/g, "\n");
+  const deliverySrc = readFileSync(
+    fileURLToPath(new URL("../../web/js/lib/run-completion-delivery.js", import.meta.url)),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
 
-  const flushStart = src.indexOf("onFlush: ({");
-  assert.notEqual(flushStart, -1, "could not locate the tracker's onFlush handler");
-  const composeStart = src.indexOf("composeRunCompletionFrame(", flushStart);
-  assert.notEqual(composeStart, -1, "could not locate the composeRunCompletionFrame call site");
-  const composeEnd = src.indexOf(".then((frame)", composeStart);
-  assert.notEqual(composeEnd, -1, "could not locate the end of the call site");
-
-  // The handler must DESTRUCTURE both fields off the flush payload…
-  const handlerSignature = src.slice(flushStart, composeStart);
-  assert.match(handlerSignature, /\bfinishedAt\b/, "onFlush must destructure finishedAt");
-  assert.match(handlerSignature, /\breconciled\b/, "onFlush must destructure reconciled");
-
-  // …and PASS both into the composer's payload. Destructuring without forwarding
-  // is the exact half-fix that leaves the defect intact.
-  const payload = src.slice(composeStart, composeEnd);
-  assert.match(payload, /\bfinishedAt\b/, "the composer payload must carry finishedAt");
-  assert.match(payload, /\breconciled\b/, "the composer payload must carry reconciled");
+  assert.notEqual(
+    src.indexOf("onFlush: createRunCompletionFlushHandler({"),
+    -1,
+    "the panel must use the production delivery seam",
+  );
+  const composeStart = deliverySrc.indexOf("composeRunCompletionFrame(");
+  assert.notEqual(composeStart, -1, "could not locate the delivery seam's composer call");
+  const payload = deliverySrc.slice(composeStart);
+  assert.match(payload, /\bfinishedAt\b/, "the production composer payload must carry finishedAt");
+  assert.match(payload, /\breconciled\b/, "the production composer payload must carry reconciled");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -698,7 +698,7 @@ import {
   workflowSaveTimeoutObservation,
 } from "./lib/workflow-save-budget.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
-import { classifyCompletionDelivery } from "./lib/completion-delivery-diagnostics.js";
+import { createRunCompletionFlushHandler } from "./lib/run-completion-delivery.js";
 import {
   clearInheritedExecutionPreview,
   clearStoredExecutionOutputs,
@@ -37532,138 +37532,30 @@ function buildPanel() {
     // or a fast re-render it is cannot be proven, and losing a render the user waited
     // for would be worse than an extra message. The console line makes the annotation
     // visible without the agent having to infer it.
-    // #1199 — `finishedAt` and `reconciled` MUST be destructured here. The tracker
-    // has always passed a finish time, and this closure has always dropped it on the
-    // floor, so the composer stamped its own clock — which is why a completion
-    // recovered from /history days later announced itself as having finished in the
-    // second it was delivered. Fixing the tracker alone changes nothing observable;
-    // the value has to be forwarded to reach the agent.
-    onFlush: ({
-      promptId,
-      images: flImages,
-      videos: flVideos,
-      durationMs,
-      noMedia,
-      duplicateOf,
-      looksCached,
-      finishedAt,
-      reconciled,
-    }) => {
-      // #370: track whether the composed completion frame actually reached the
-      // agent. sendFrame returns false when the bridge socket is down — in that
-      // case the completion is LOST, so we re-pend the prompt (markUndelivered) so
-      // the next reconnect recovers it via /history. A confirmed send (or an empty
-      // batch that emits no frame) retires it from pending.
-      let framePushed = false;
-      let sendAttempted = false;
-      const compositionStartedAt = Date.now();
-      // A completed prompt delivers its FULL batch here, exactly once. Compose
-      // ONE consolidated agent_event for the whole run — stills AND every video's
-      // storyboard folded into a single images+note+metadata turn — so a mixed /
-      // multi-video run resumes the agent with EXACTLY ONE completion frame, never
-      // a stills frame plus one frame per video (#269/#468). The composer awaits
-      // ALL storyboards for this prompt before its single send. Fire-and-forget:
-      // it's async (metadata HEADs / frame sampling), but the batch is already
-      // captured — a failure inside must never wedge the lifecycle.
-      composeRunCompletionFrame(
-        // #356 Bug 2 — `noMedia` marks a panel-queued run that finished producing
-        // no image or video. Without it the composer returns null, the call site
-        // below reads that as "empty batch ⇒ already delivered", and the agent that
-        // panel_run told to end its turn and wait is never told anything.
-        {
-          promptId,
-          images: flImages,
-          videos: flVideos,
-          durationMs,
-          noMedia,
-          duplicateOf,
-          looksCached,
-          finishedAt,
-          reconciled,
-        },
-        {
-          sendFrame: (frame) => {
-            sendAttempted = true;
-            const ok = client.sendFrame(frame);
-            if (ok) framePushed = true;
-            return ok;
-          },
-          coerceMessageText,
-          formatDuration,
-          formatClock,
-          imageViewUrl,
-          fetchImageBytes,
-          fetchImageDimensions,
-          humanizeBytes,
-          buildVideoStoryboard,
-          uploadBlobToInput,
-          storyboardFrameCount,
-          paintImage,
-          // The card is already in the log by the time the storyboard resolves,
-          // so the poster it produced is handed back by video URL rather than
-          // passed down at paint time.
-          applyVideoPoster,
-          videoStoryboardEnabled: prefs.videoStoryboard !== false,
-          // #609 — Blind mode strips images at the sendFrame gate below; the
-          // storyboard note must not ask for a visual review of pixels the
-          // agent never received. A function, so the composer makes its single
-          // per-frame decision after the storyboards resolve, near send time.
-          agentReceivesImages: () => !AGENT_BLIND,
-          warn: (...a) => console.warn(...a),
-        },
-      )
-        .then((frame) => {
-          const deliveryStage = classifyCompletionDelivery({
-            sendAttempted,
-            transportAccepted: framePushed,
-            frameEmitted: frame != null,
-            compositionMs: Date.now() - compositionStartedAt,
-          });
-          if (
-            deliveryStage !== "transport-accepted" &&
-            deliveryStage !== "empty-no-frame" &&
-            !AGENT_MUTED
-          ) {
-            console.warn("[cmcp] completion delivery diagnostic", {
-              prompt_id: promptId,
-              stage: deliveryStage,
-            });
-          }
-          // frame===null ⇒ empty batch (nothing to deliver) ⇒ delivered. A frame
-          // that was pushed ⇒ delivered. A frame that FAILED to push ⇒ re-pend —
-          // UNLESS it failed because agents are MUTED, which is intentional,
-          // permanent suppression (sendFrame returns false for both a down socket
-          // AND AGENT_MUTED): a muted completion must NOT be recovered/replayed on
-          // a later unmute+reconnect, so treat it as delivered (codex P1).
-          if (frame == null || framePushed) runCompletion.markDelivered(promptId);
-          else if (AGENT_MUTED) runCompletion.markDelivered(promptId);
-          else runCompletion.markUndelivered(promptId);
-          // #585: this is the moment "the agent was told" becomes true (or is
-          // re-pended). Refresh the persisted reboot marker now so a reload in the
-          // gap before the next watch tick can't re-adopt an already-delivered run
-          // and have /history deliver its completion a second time.
-          pruneRebootMarker();
-        })
-        .catch((err) => {
-          if (!AGENT_MUTED) {
-            console.warn("[cmcp] completion delivery diagnostic", {
-              prompt_id: promptId,
-              stage: classifyCompletionDelivery({
-                sendAttempted,
-                transportAccepted: framePushed,
-                compositionMs: Date.now() - compositionStartedAt,
-              }),
-            });
-          }
-          console.warn("[cmcp] composeRunCompletionFrame failed:", err);
-          // Composition threw before/around the send — treat as undelivered so a
-          // reconnect can recover the outcome from /history rather than lose it
-          // (but respect an intentional mute, as above).
-          if (framePushed || AGENT_MUTED) runCompletion.markDelivered(promptId);
-          else runCompletion.markUndelivered(promptId);
-          pruneRebootMarker(); // #585 — see the .then branch above
-        });
-    },
+    // #1199 — `finishedAt` and `reconciled` are forwarded by the production
+    // delivery seam so recovered completions retain their real finish time.
+    onFlush: createRunCompletionFlushHandler({
+      sendFrame: (frame) => client.sendFrame(frame),
+      markDelivered: (promptId) => runCompletion.markDelivered(promptId),
+      markUndelivered: (promptId) => runCompletion.markUndelivered(promptId),
+      pruneRebootMarker,
+      coerceMessageText,
+      formatDuration,
+      formatClock,
+      imageViewUrl,
+      fetchImageBytes,
+      fetchImageDimensions,
+      humanizeBytes,
+      buildVideoStoryboard,
+      uploadBlobToInput,
+      storyboardFrameCount,
+      paintImage,
+      applyVideoPoster,
+      videoStoryboardEnabled: () => prefs.videoStoryboard !== false,
+      agentReceivesImages: () => !AGENT_BLIND,
+      isAgentMuted: () => AGENT_MUTED,
+      warn: (...a) => console.warn(...a),
+    }),
     // #370: deliver a reconcile-discovered terminal ERROR. Routed through the
     // tracker (not the reconcile summary) so it fires whether the error is found
     // by the reconnect reconcile loop OR by a later /history RETRY — otherwise a

--- a/web/js/lib/run-completion-delivery.js
+++ b/web/js/lib/run-completion-delivery.js
@@ -1,0 +1,171 @@
+// Production delivery boundary for a completed run.
+//
+// The lifecycle tracker owns WHEN a prompt is complete. This seam owns the
+// completion callback that composes the agent-facing frame, records whether
+// the transport accepted it, and updates the tracker's delivery ledger.
+
+import { classifyCompletionDelivery } from "./completion-delivery-diagnostics.js";
+import { composeRunCompletionFrame } from "./run-completion-frame.js";
+
+/**
+ * Build the production completion callback used by createRunCompletionTracker.
+ *
+ * The dependencies are the panel's live helpers/state so this is the same
+ * delivery path as the mounted panel, while the boundary remains directly
+ * invocable by focused tests.
+ */
+export function createRunCompletionFlushHandler({
+  sendFrame,
+  markDelivered,
+  markUndelivered,
+  pruneRebootMarker,
+  coerceMessageText,
+  formatDuration,
+  formatClock,
+  imageViewUrl,
+  fetchImageBytes,
+  fetchImageDimensions,
+  humanizeBytes,
+  buildVideoStoryboard,
+  uploadBlobToInput,
+  storyboardFrameCount,
+  paintImage,
+  applyVideoPoster,
+  videoStoryboardEnabled = true,
+  agentReceivesImages = () => true,
+  isAgentMuted = () => false,
+  warn = (...args) => console.warn(...args),
+  now = () => Date.now(),
+} = {}) {
+  const readVideoStoryboardEnabled =
+    typeof videoStoryboardEnabled === "function"
+      ? videoStoryboardEnabled
+      : () => videoStoryboardEnabled;
+
+  return ({
+    promptId,
+    images: flImages,
+    videos: flVideos,
+    durationMs,
+    noMedia,
+    duplicateOf,
+    looksCached,
+    finishedAt,
+    reconciled,
+  }) => {
+    // #370: track whether the composed completion frame actually reached the
+    // agent. sendFrame returns false when the bridge socket is down — in that
+    // case the completion is LOST, so we re-pend the prompt (markUndelivered) so
+    // the next reconnect recovers it via /history. A confirmed send (or an empty
+    // batch that emits no frame) retires it from pending.
+    let framePushed = false;
+    let sendAttempted = false;
+    const compositionStartedAt = now();
+    // A completed prompt delivers its FULL batch here, exactly once. Compose
+    // ONE consolidated agent_event for the whole run — stills AND every video's
+    // storyboard folded into a single images+note+metadata turn — so a mixed /
+    // multi-video run resumes the agent with EXACTLY ONE completion frame, never
+    // a stills frame plus one frame per video (#269/#468). The composer awaits
+    // ALL storyboards for this prompt before its single send. Fire-and-forget:
+    // it's async (metadata HEADs / frame sampling), but the batch is already
+    // captured — a failure inside must never wedge the lifecycle.
+    composeRunCompletionFrame(
+      // #356 Bug 2 — `noMedia` marks a panel-queued run that finished producing
+      // no image or video. Without it the composer returns null, the call site
+      // below reads that as "empty batch ⇒ already delivered", and the agent that
+      // panel_run told to end your turn and wait is never told anything.
+      {
+        promptId,
+        images: flImages,
+        videos: flVideos,
+        durationMs,
+        noMedia,
+        duplicateOf,
+        looksCached,
+        finishedAt,
+        reconciled,
+      },
+      {
+        sendFrame: (frame) => {
+          sendAttempted = true;
+          const ok = sendFrame(frame);
+          if (ok) framePushed = true;
+          return ok;
+        },
+        coerceMessageText,
+        formatDuration,
+        formatClock,
+        imageViewUrl,
+        fetchImageBytes,
+        fetchImageDimensions,
+        humanizeBytes,
+        buildVideoStoryboard,
+        uploadBlobToInput,
+        storyboardFrameCount,
+        paintImage,
+        // The card is already in the log by the time the storyboard resolves,
+        // so the poster it produced is handed back by video URL rather than
+        // passed down at paint time.
+        applyVideoPoster,
+        videoStoryboardEnabled: readVideoStoryboardEnabled(),
+        // #609 — Blind mode strips images at the sendFrame gate below; the
+        // storyboard note must not ask for a visual review of pixels the
+        // agent never received. A function, so the composer makes its single
+        // per-frame decision after the storyboards resolve, near send time.
+        agentReceivesImages,
+        warn,
+      },
+    )
+      .then((frame) => {
+        const deliveryStage = classifyCompletionDelivery({
+          sendAttempted,
+          transportAccepted: framePushed,
+          frameEmitted: frame != null,
+          compositionMs: now() - compositionStartedAt,
+        });
+        if (
+          deliveryStage !== "transport-accepted" &&
+          deliveryStage !== "empty-no-frame" &&
+          !isAgentMuted()
+        ) {
+          warn("[cmcp] completion delivery diagnostic", {
+            prompt_id: promptId,
+            stage: deliveryStage,
+          });
+        }
+        // frame===null ⇒ empty batch (nothing to deliver) ⇒ delivered. A frame
+        // that was pushed ⇒ delivered. A frame that FAILED to push ⇒ re-pend —
+        // UNLESS it failed because agents are MUTED, which is intentional,
+        // permanent suppression (sendFrame returns false for both a down socket
+        // AND AGENT_MUTED): a muted completion must NOT be recovered/replayed on
+        // a later unmute+reconnect, so treat it as delivered (codex P1).
+        if (frame == null || framePushed) markDelivered(promptId);
+        else if (isAgentMuted()) markDelivered(promptId);
+        else markUndelivered(promptId);
+        // #585: this is the moment "the agent was told" becomes true (or is
+        // re-pended). Refresh the persisted reboot marker now so a reload in the
+        // gap before the next watch tick can't re-adopt an already-delivered run
+        // and have /history deliver its completion a second time.
+        pruneRebootMarker();
+      })
+      .catch((err) => {
+        if (!isAgentMuted()) {
+          warn("[cmcp] completion delivery diagnostic", {
+            prompt_id: promptId,
+            stage: classifyCompletionDelivery({
+              sendAttempted,
+              transportAccepted: framePushed,
+              compositionMs: now() - compositionStartedAt,
+            }),
+          });
+        }
+        warn("[cmcp] composeRunCompletionFrame failed:", err);
+        // Composition threw before/around the send — treat as undelivered so a
+        // reconnect can recover the outcome from /history rather than lose it
+        // (but respect an intentional mute, as above).
+        if (framePushed || isAgentMuted()) markDelivered(promptId);
+        else markUndelivered(promptId);
+        pruneRebootMarker(); // #585 — see the .then branch above
+      });
+  };
+}

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -128,6 +128,10 @@ export async function composeRunCompletionFrame(
   // on the line that names the file.
   const finishedClock =
     reconciled && realFinishedAt ? formatStamp(realFinishedAt) : formatClock(finishedAt);
+  // This is the execution_start → execution_success span for the whole prompt.
+  // ComfyUI may satisfy part of that prompt from its execution cache, and this
+  // panel does not consume execution_cached provenance, so it is workflow time,
+  // not a render benchmark.
   const duration = durationMs != null ? formatDuration(durationMs) : null;
   // Age of the completion at the moment we present it. Known ONLY when the real
   // finish time is — with an unknown finish time the age is unknown too, and is
@@ -498,14 +502,14 @@ async function buildStillsSegment(bufImages, deps) {
           : `output ${meta.index} of ${meta.total} from this run`,
       );
       if (meta.siblings.length) parts.push(`alongside: ${meta.siblings.join(", ")}`);
-      if (meta.duration) parts.push(`rendered in ${meta.duration}`);
+      if (meta.duration) parts.push(`workflow completed in ${meta.duration}`);
       if (meta.finishedClock) parts.push(`finished ${meta.finishedClock}`);
       return `• ${meta.filename} — ${parts.join(" · ")}`;
     });
     note += `\n${lines.join("\n")}`;
   } else if (duration || finishedClock) {
     const bits = [];
-    if (duration) bits.push(`rendered in ${duration}`);
+    if (duration) bits.push(`workflow completed in ${duration}`);
     if (finishedClock) bits.push(`finished ${finishedClock}`);
     if (bits.length) note += `\n• ${bits.join(" · ")}`;
   }
@@ -566,7 +570,7 @@ async function buildVideoSegment(v, deps) {
       parts.push(`${storyboardN}-frame storyboard`);
     }
     if (sizeStr) parts.push(sizeStr);
-    if (duration) parts.push(`rendered in ${duration}`);
+    if (duration) parts.push(`workflow completed in ${duration}`);
     if (finishedClock) parts.push(`finished ${finishedClock}`);
     return parts.length ? `\n• ${fileName} — ${parts.join(" · ")}` : "";
   };


### PR DESCRIPTION
Closes #1805

- Relabel completion lifecycle spans as "workflow completed in" for still, fallback, and video completion notes.
- Preserve measured duration and keep focused helper regressions for cache-assisted-style fast runs, long true renders, and still fallback.
- Extract the shipped completion onFlush delivery closure into a production module seam used unchanged by the panel; the real API event-path regression now invokes it, asserts the agent-facing frame wording, and verifies delivery bookkeeping.

Validation:
- node --test browser_tests/unit/run-completion.test.mjs (37/37)
- node --test browser_tests/unit/run-reconcile-stale-age.test.mjs (15/15)
- npm.cmd run test:unit (6843 tests: 6842 pass, 1 todo, 0 fail)
- npm.cmd run check:scope
- npm.cmd run typecheck
- npm.cmd run i18n:check