### PR TITLE
chore(release): 0.15.91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.91] - 2026-08-25
+
+### Fixed
+- label cache-assisted completion durations as workflow time, not render time (#1805)
+
 ## [0.15.90] - 2026-08-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.90",
+  "version": "0.15.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.90",
+      "version": "0.15.91",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.90",
+  "version": "0.15.91",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
Release v0.15.91\n\nIncludes merged PR #1808 for issue #1805: label cache-assisted completion duration as workflow time, not render time.