### PR TITLE
fix(panel): preserve live turn across workflow tabs (#1810)

### DIFF
--- a/browser_tests/fixtures/MockBridge.ts
+++ b/browser_tests/fixtures/MockBridge.ts
@@ -39,7 +39,7 @@ export interface MockBridgeOptions {
   port?: number
   /** Model catalog sent on the handshake. */
   models?: MockModel[]
-  /** Backend id reported on the handshake ("claude" | "codex"). */
+  /** Backend id reported on the handshake (for example "claude", "codex", or "grok"). */
   backend?: string
   /** Slash-command catalog sent on the handshake. */
   commands?: unknown[]

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -2763,5 +2763,17 @@ test('mcp#884 the workflow-keyed session bind is unreachable while the chat is p
     'the panel-owned branch RETURNS — this is the only thing keeping the workflow-scoped tail dead'
   )
   const tail = body.slice(guardAt + guardEnd)
-  assert.match(tail, /ssSet\(SESSION_KEY, existing\?\.sessionId/, 'the workflow-keyed bind lives in the dead tail')
+  assert.match(
+    tail,
+    /completeDedicatedWorkflowSessionSwap\(\)/,
+    'the panel-owned branch returns before the deferred dedicated switch call',
+  )
+  const helperAt = PANEL_SRC.indexOf('function completeDedicatedWorkflowSessionSwap(')
+  assert.ok(helperAt > -1, 'the dedicated session bind helper exists')
+  const helper = PANEL_SRC.slice(helperAt, PANEL_SRC.indexOf('\n  }\n', helperAt) + 5)
+  assert.match(
+    helper,
+    /ssSet\(SESSION_KEY, existing\?\.sessionId/,
+    'the workflow-keyed bind remains inside the dedicated helper',
+  )
 })

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -2657,13 +2657,9 @@ test('#1171 a capped open reports failure exactly past the local shadow boundary
 // ---------------------------------------------------------------------------
 // mcp#884 — THE INVARIANT, pinned as a gate rather than left to inspection.
 //
-// "Sessions are ORCHESTRATOR-scoped, never workflow-scoped or tab-scoped" is a
-// project invariant, and this branch is what makes the panel honour it. The
-// retired workflow/ask machinery is still PRESENT in the panel source as
-// deliberately unreachable defence-in-depth (see historyScopeFollowsPanel()),
-// which is a reasonable choice and also a standing hazard: the whole of it wakes
-// up again the moment chatScopeMode() stops being a constant. Reading the source
-// once proved it is unreachable today; these assertions are what keep it so.
+// User-selectable workflow/ask scope is retired, but Grok's real provider state
+// intentionally reaches the existing dedicated branch. These assertions keep
+// that decision independent from persisted scope settings.
 // ---------------------------------------------------------------------------
 
 const PANEL_SRC = readFileSync(
@@ -2680,13 +2676,13 @@ function topLevelFunction(name) {
   return PANEL_SRC.slice(start, end)
 }
 
-test('mcp#884 chatScopeMode is a CONSTANT — no setting can reintroduce workflow scope', () => {
+test('mcp#884 chatScopeMode follows the real provider, never a stored scope setting', () => {
   const body = topLevelFunction('chatScopeMode')
-  // Exactly one return, and it is the literal. A `getSetting(...)` read here is
-  // the single edit that would revive every workflow-scoped path below it.
-  const returns = [...body.matchAll(/return\s+([^;]*);/g)].map((m) => m[1].trim())
-  assert.deepEqual(returns, ['"panel"'], 'chatScopeMode() returns the literal "panel" and nothing else')
+  assert.match(body, /backend\s*===\s*['"]grok['"]/, 'Grok must reach the dedicated provider branch')
   assert.ok(!/getSetting|localStorage|sessionStorage/.test(body), 'it reads no stored value')
+  const chatScopeMode = new Function(`${body}\n}\nreturn chatScopeMode;`)()
+  assert.equal(chatScopeMode('grok'), 'workflow')
+  assert.equal(chatScopeMode('claude'), 'panel')
 })
 
 test('mcp#884 no chat-scope setting is registered any more', () => {

--- a/browser_tests/unit/chat-scope-retired.test.mjs
+++ b/browser_tests/unit/chat-scope-retired.test.mjs
@@ -1,9 +1,6 @@
-// mcp#884/#897: the conversation is ALWAYS panel-owned. The orchestrator keys and
-// persists ONE agent session per backend across every panel, tab and workflow, so a
-// per-workflow chat is a bug, not a mode — a user left in `workflow` or `ask` scope
-// gets several panel transcripts all mapping onto the single session the
-// orchestrator actually runs, and the transcripts silently diverge from the agent's
-// real context.
+// mcp#884/#897: user-selectable scope settings are retired. Panel-owned scope is
+// still the default, while the real Grok provider/session state selects the
+// production per-workflow branch.
 //
 // WHY THIS FILE EXISTS. The retirement was previously pinned only by Playwright
 // specs, which are NOT in CI (they need a live ComfyUI on :8188). A mutation test
@@ -33,7 +30,7 @@ const SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8"
  *  is evaluated — a truncated slice would otherwise be a syntax error or, worse, a
  *  half-function that happens to parse. */
 function loadChatScopeMode(getSetting) {
-  const start = SRC.indexOf("function chatScopeMode() {");
+  const start = SRC.indexOf("function chatScopeMode(backend) {");
   assert.notEqual(start, -1, "chatScopeMode() must exist in the panel source");
   const end = SRC.indexOf("\n}\n", start);
   assert.notEqual(end, -1, "chatScopeMode() must be closed at a column-0 brace");
@@ -64,7 +61,7 @@ const STORED_VALUES = [
   ["workflow"],
 ];
 
-test("chatScopeMode() is panel-owned for EVERY stored value a retired scope could have left", () => {
+test("chatScopeMode() ignores EVERY stored value a retired scope could have left", () => {
   for (const stored of STORED_VALUES) {
     const reads = [];
     const chatScopeMode = loadChatScopeMode((id) => {
@@ -77,6 +74,15 @@ test("chatScopeMode() is panel-owned for EVERY stored value a retired scope coul
       `a stored scope of ${JSON.stringify(stored) ?? String(stored)} must be ignored, not honored`,
     );
   }
+});
+
+test("chatScopeMode() reaches the dedicated branch from the real provider state", () => {
+  const chatScopeMode = loadChatScopeMode(() => {
+    throw new Error("provider scope must not read a retired setting");
+  });
+  assert.equal(chatScopeMode("grok"), "workflow");
+  assert.equal(chatScopeMode("claude"), "panel");
+  assert.equal(chatScopeMode("codex"), "panel");
 });
 
 test("chatScopeMode() does not consult the settings store at all", () => {

--- a/browser_tests/unit/interactive-card-fence.test.mjs
+++ b/browser_tests/unit/interactive-card-fence.test.mjs
@@ -575,6 +575,7 @@ function buildLifecycle() {
     let localEndAt = 0;
     let pendingSecretRequest = null;
     let lastAgentGraph = null, lastAgentGraphKey = null, lastAgentGraphEpoch = null, sessionEpoch = 0;
+    const completeDedicatedWorkflowSessionSwap = () => {};
     const Date = { now };
     ${endTurnLocallyMatch[0]}
     ${fenceMatch[0]}

--- a/browser_tests/unit/interactive-card-fence.test.mjs
+++ b/browser_tests/unit/interactive-card-fence.test.mjs
@@ -576,6 +576,7 @@ function buildLifecycle() {
     let pendingSecretRequest = null;
     let lastAgentGraph = null, lastAgentGraphKey = null, lastAgentGraphEpoch = null, sessionEpoch = 0;
     const completeDedicatedWorkflowSessionSwap = () => {};
+    const settlePendingDedicatedWorkflowSwapAfterCancellation = () => {};
     const Date = { now };
     ${endTurnLocallyMatch[0]}
     ${fenceMatch[0]}

--- a/browser_tests/unit/reboot-target-identity.test.mjs
+++ b/browser_tests/unit/reboot-target-identity.test.mjs
@@ -110,7 +110,7 @@ test("resolving the target cannot throw — one branch runs inside a catch", () 
     PANEL.indexOf("function externalOrchestratorMode() {"),
   );
   assert.ok(setting.includes('typeof v === "string" ? v.trim() : ""'), "a non-string setting must not blow up");
-  const get = PANEL.slice(PANEL.indexOf("\nfunction getSetting(id) {"), PANEL.indexOf("function chatScopeMode() {"));
+  const get = PANEL.slice(PANEL.indexOf("\nfunction getSetting(id) {"), PANEL.indexOf("function chatScopeMode(backend) {"));
   assert.ok(get.includes("} catch {"), "the settings read must be guarded");
 });
 

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -210,6 +210,22 @@ test("#1095: several deferred re-advertises coalesce into ONE hello, all told th
   assert.deepEqual(await Promise.all([a, b, c]), [true, true, true]);
 });
 
+test("#1810: a deferred hello carries its deliberate swap context to the real advertiser", async () => {
+  const contexts = [];
+  const { gate } = harness({
+    advertise: (context) => {
+      contexts.push(context);
+      return Promise.resolve(true);
+    },
+  });
+  const mark = gate.began("graph_set_widget");
+  const landed = gate.request({ dedicatedWorkflowSwap: "swap-1" });
+  gate.request({ dedicatedWorkflowSwap: "swap-2" });
+  gate.ended(mark);
+  assert.equal(await landed, true);
+  assert.deepEqual(contexts, [{ dedicatedWorkflowSwap: "swap-1" }]);
+});
+
 test("#1095: a DOUBLE release of one mark cannot discount another command", () => {
   // deliverReply releases the mark, and a double-delivery (a retry, a future refactor) must
   // not free work that is still running. A counter could not tell the two apart; an id can.

--- a/browser_tests/unit/workflow-turn-abort.test.mjs
+++ b/browser_tests/unit/workflow-turn-abort.test.mjs
@@ -1,0 +1,247 @@
+// Regression coverage for #1810. These tests execute the shipped panel callbacks
+// extracted from web/js/comfyui-mcp-panel.js. A parallel helper-only model would miss
+// the production ordering that swaps SESSION_KEY/re-hello while a turn is live.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { createComfyBackendOutageTracker } from "../../web/js/lib/session-rebind.js";
+
+const PANEL_PATH = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const PANEL = readFileSync(PANEL_PATH, "utf8").replace(/\r\n/g, "\n");
+
+function methodSource(signature) {
+  const start = PANEL.indexOf(signature);
+  assert.notEqual(start, -1, `missing production callback ${signature}`);
+  const bodyStart = PANEL.indexOf(") {", start);
+  assert.notEqual(bodyStart, -1, `missing body for production callback ${signature}`);
+  const open = bodyStart + 1;
+  let depth = 0;
+  for (let i = open; i < PANEL.length; i += 1) {
+    if (PANEL[i] === "{") depth += 1;
+    if (PANEL[i] === "}" && --depth === 0) return PANEL.slice(start, i + 1);
+  }
+  assert.fail(`unbalanced production callback ${signature}`);
+}
+
+const WORKFLOW_CHANGED = methodSource("function onWorkflowMaybeChanged() {");
+const COMPLETE_DEDICATED_SWAP = methodSource("function completeDedicatedWorkflowSessionSwap(");
+const ON_ACK = methodSource("onAck(ack) {");
+
+function buildWorkflowChanged({ working, followsPanel = false } = {}) {
+  const deferred = [];
+  const wf = { key: "new-workflow.json", filename: "new-workflow.json" };
+  const onWorkflowMaybeChanged = new Function(
+    "activeWorkflowRef",
+    "workflowTabId",
+    "currentWorkflowId",
+    "historyScopeFollowsPanel",
+    "agentWorking",
+    "deferDedicatedWorkflowSwitch",
+    `${WORKFLOW_CHANGED}\nreturn onWorkflowMaybeChanged;`,
+  )(
+    () => wf,
+    () => "wf:new-workflow.json",
+    "wf:old-workflow.json",
+    () => followsPanel,
+    working,
+    (...args) => deferred.push(args),
+  );
+  return { onWorkflowMaybeChanged, deferred, wf };
+}
+
+test("#1810 production workflow poll defers a dedicated session swap during the calling turn", () => {
+  const { onWorkflowMaybeChanged, deferred, wf } = buildWorkflowChanged({ working: true });
+
+  onWorkflowMaybeChanged();
+
+  assert.deepEqual(deferred, [[wf, "wf:new-workflow.json", "new-workflow.json"]]);
+  // The real branch returns before the legacy SESSION_KEY/re-hello/session-load
+  // block. The injected defer callback is the only operation it is allowed to make.
+});
+
+function buildDedicatedSwap({ pending = true, working = false, existing = true } = {}) {
+  const events = [];
+  const state = { pending, ackPending: true, thread: existing ? { id: "new-chat", sessionId: "session-new" } : null };
+  const complete = new Function(
+    "historyScopeFollowsPanel",
+    "agentWorking",
+    "pendingDedicatedWorkflowSwap",
+    "dedicatedWorkflowSwapAckPending",
+    "workflowStorageKey",
+    "threadForWorkflow",
+    "ssSet",
+    "SESSION_KEY",
+    "rehelloForWorkflow",
+    "loadThread",
+    "thread",
+    "CURRENT_THREAD_KEY",
+    "resetFeed",
+    "client",
+    "getWorkflowTitle",
+    "appendSystem",
+    "tr",
+    "refreshContextRingForScope",
+    `${COMPLETE_DEDICATED_SWAP}\nreturn { completeDedicatedWorkflowSessionSwap, state: () => ({ pendingDedicatedWorkflowSwap, dedicatedWorkflowSwapAckPending, thread }) };`,
+  )(
+    () => false,
+    working,
+    state.pending,
+    state.ackPending,
+    () => "new-workflow.json",
+    () => state.thread,
+    (key, value) => events.push(["storage", key, value]),
+    "comfyui-mcp.panel.sessionId",
+    (sessionId) => events.push(["rehello", sessionId]),
+    (threadValue) => events.push(["load", threadValue.id]),
+    state.thread,
+    "comfyui-mcp.panel.currentThreadId",
+    () => events.push(["reset"]),
+    { armContext: () => events.push(["context"]) },
+    () => "new-workflow.json",
+    (text) => events.push(["system", text]),
+    (_key, fallback) => fallback,
+    () => events.push(["refresh"]),
+  );
+  return { complete, events };
+}
+
+test("#1810 terminal production swap binds the dedicated session only after the turn ends", () => {
+  const { complete, events } = buildDedicatedSwap();
+
+  assert.equal(complete.completeDedicatedWorkflowSessionSwap({ announce: true }), true);
+  assert.deepEqual(complete.state(), { pendingDedicatedWorkflowSwap: false, dedicatedWorkflowSwapAckPending: false, thread: { id: "new-chat", sessionId: "session-new" } });
+  assert.deepEqual(events, [
+    ["storage", "comfyui-mcp.panel.sessionId", "session-new"],
+    ["rehello", "session-new"],
+    ["load", "new-chat"],
+    ["system", "Switched workflow tab — this chat is dedicated to the new workflow after the previous turn finished."],
+    ["refresh"],
+  ]);
+});
+
+test("#1810 does not complete the dedicated swap while the turn is still working", () => {
+  const { complete, events } = buildDedicatedSwap({ working: true });
+
+  assert.equal(complete.completeDedicatedWorkflowSessionSwap(), false);
+  assert.deepEqual(events, []);
+});
+
+function buildAck({ outageMs = 0, rebootPending = false } = {}) {
+  const mids = new Map([
+    ["mid", "1"],
+    ["reboot", rebootPending ? "1" : null],
+    ["soft", null],
+    ["pending-reset", null],
+  ]);
+  const sent = [];
+  let swapAckPending = true;
+  let rebootHandlerCalls = 0;
+  const onAck = new Function(
+    "cmcpOauthOnAck",
+    "onRebootResumeReceipt",
+    "markReceived",
+    "markRead",
+    "ack",
+    "readyAckCanPromoteBackend",
+    "connectedBackend",
+    "piBackendsReadinessReceived",
+    "backendReady",
+    "readinessFromOrchestrator",
+    "anyReady",
+    "onboard",
+    "renderBackendChips",
+    "knownBackends",
+    "PENDING_SESSION_RESET_KEY",
+    "ssGet",
+    "ssSet",
+    "historyMeta",
+    "currentHistoryScopeKey",
+    "resolvePanelPointer",
+    "client",
+    "REBOOT_KEY",
+    "handleRebootResumeAck",
+    "SOFT_RELOAD_KEY",
+    "MID_TASK_KEY",
+    "appendSystem",
+    "tr",
+    "dedicatedWorkflowSwapAckPending",
+    "bridgeOutage",
+    "shouldNudgeAfterMidTaskReconnect",
+    "showThinking",
+    "pinTurnOwnerAtDispatch",
+    `const callbacks = { ${ON_ACK} };\nreturn callbacks.onAck;`,
+  )(
+    () => {},
+    () => {},
+    () => {},
+    () => {},
+    undefined,
+    () => false,
+    null,
+    false,
+    {},
+    false,
+    false,
+    {},
+    () => {},
+    [],
+    "pending-reset",
+    (key) => mids.get(key) ?? null,
+    (key, value) => mids.set(key, value),
+    {},
+    () => "workflow:new",
+    () => ({ activeId: null, cleared: false }),
+    { sendFrame: (frame) => sent.push(["frame", frame]), sendUserMessage: (message) => { sent.push(["user", message]); return true; } },
+    "reboot",
+    () => { rebootHandlerCalls += 1; return true; },
+    "soft",
+    "mid",
+    () => {},
+    (_key, fallback) => fallback,
+    swapAckPending,
+    { outageMs: () => outageMs },
+    ({ outageMs: measured }) => measured >= 6000,
+    () => {},
+    () => {},
+  );
+  return { onAck, sent, mids, get swapAckPending() { return swapAckPending; }, rebootHandlerCalls: () => rebootHandlerCalls };
+}
+
+test("#1810 ready from the deliberate session rebind does not inject a false resume turn", () => {
+  const ack = buildAck();
+  ack.onAck({ kind: "ready" });
+  assert.deepEqual(ack.sent, []);
+  assert.equal(ack.mids.get("mid"), "1", "the live turn marker remains armed until turn:done");
+});
+
+test("#1810 real bridge outage still reaches the existing mid-turn recovery nudge", () => {
+  const ack = buildAck({ outageMs: 7000 });
+  ack.onAck({ kind: "ready" });
+  assert.equal(ack.sent.length, 1, "the existing recovery user message is preserved");
+  assert.equal(ack.sent[0][0], "user");
+  assert.match(ack.sent[0][1], /agent connection dropped mid-task/);
+  assert.doesNotMatch(ack.sent[0][1], /ComfyUI was restarted/);
+});
+
+test("#1810 explicit REBOOT_KEY recovery remains authoritative over the swap guard", () => {
+  const ack = buildAck({ rebootPending: true });
+  ack.onAck({ kind: "ready" });
+  assert.equal(ack.rebootHandlerCalls(), 1);
+  assert.deepEqual(ack.sent, []);
+});
+
+test("#1810 real ComfyUI saw_down/up evidence remains distinct from a live rebind", () => {
+  let now = 1000;
+  const outage = createComfyBackendOutageTracker({ now: () => now });
+  outage.noteDown(4);
+  now = 8000;
+  outage.noteUp();
+  assert.equal(outage.outageMs(), 7000);
+  assert.equal(outage.helloBaseline(), 4);
+
+  const benign = createComfyBackendOutageTracker({ now: () => now });
+  benign.noteUp();
+  assert.equal(benign.outageMs(), 0, "an up event without saw_down is not a restart cycle");
+});

--- a/browser_tests/unit/workflow-turn-abort.test.mjs
+++ b/browser_tests/unit/workflow-turn-abort.test.mjs
@@ -27,9 +27,26 @@ function methodSource(signature) {
 
 const WORKFLOW_CHANGED = methodSource("function onWorkflowMaybeChanged() {");
 const COMPLETE_DEDICATED_SWAP = methodSource("function completeDedicatedWorkflowSessionSwap(");
+const SETTLE_CANCELLED_SWAP = methodSource("function settlePendingDedicatedWorkflowSwapAfterCancellation() {");
+const NOTE_DEDICATED_HELLO = methodSource("function noteDedicatedWorkflowHello(context) {");
 const ON_ACK = methodSource("onAck(ack) {");
+const END_TURN_LOCALLY = methodSource("function endTurnLocally() {");
+const THINKING_SAFETY = methodSource("function onThinkingSafety() {");
 
-function buildWorkflowChanged({ working, followsPanel = false } = {}) {
+const CHAT_SCOPE_MODE = methodSource("function chatScopeMode(backend) {");
+const HISTORY_SCOPE = methodSource("function historyScopeFollowsPanel() {");
+
+function productionHistoryScopeFor(backend) {
+  const chatScopeMode = new Function(`${CHAT_SCOPE_MODE}\nreturn chatScopeMode;`)();
+  return new Function(
+    "chatScopeMode",
+    "connectedBackend",
+    "selectedBackend",
+    `${HISTORY_SCOPE}\nreturn historyScopeFollowsPanel;`,
+  )(chatScopeMode, backend, backend);
+}
+
+function buildWorkflowChanged({ working, backend = "grok" } = {}) {
   const deferred = [];
   const wf = { key: "new-workflow.json", filename: "new-workflow.json" };
   const onWorkflowMaybeChanged = new Function(
@@ -44,7 +61,7 @@ function buildWorkflowChanged({ working, followsPanel = false } = {}) {
     () => wf,
     () => "wf:new-workflow.json",
     "wf:old-workflow.json",
-    () => followsPanel,
+    productionHistoryScopeFor(backend),
     working,
     (...args) => deferred.push(args),
   );
@@ -52,7 +69,9 @@ function buildWorkflowChanged({ working, followsPanel = false } = {}) {
 }
 
 test("#1810 production workflow poll defers a dedicated session swap during the calling turn", () => {
-  const { onWorkflowMaybeChanged, deferred, wf } = buildWorkflowChanged({ working: true });
+  assert.equal(productionHistoryScopeFor("grok")(), false);
+  assert.equal(productionHistoryScopeFor("claude")(), true);
+  const { onWorkflowMaybeChanged, deferred, wf } = buildWorkflowChanged({ working: true, backend: "grok" });
 
   onWorkflowMaybeChanged();
 
@@ -61,9 +80,13 @@ test("#1810 production workflow poll defers a dedicated session swap during the 
   // block. The injected defer callback is the only operation it is allowed to make.
 });
 
+test("#1810 production scope state keeps non-Grok providers panel-owned", () => {
+  assert.equal(productionHistoryScopeFor("claude")(), true);
+});
+
 function buildDedicatedSwap({ pending = true, working = false, existing = true } = {}) {
   const events = [];
-  const state = { pending, ackPending: true, thread: existing ? { id: "new-chat", sessionId: "session-new" } : null };
+  const state = { pending, ackPending: { token: "swap-1", landed: true }, thread: existing ? { id: "new-chat", sessionId: "session-new" } : null };
   const complete = new Function(
     "historyScopeFollowsPanel",
     "agentWorking",
@@ -83,7 +106,7 @@ function buildDedicatedSwap({ pending = true, working = false, existing = true }
     "appendSystem",
     "tr",
     "refreshContextRingForScope",
-    `${COMPLETE_DEDICATED_SWAP}\nreturn { completeDedicatedWorkflowSessionSwap, state: () => ({ pendingDedicatedWorkflowSwap, dedicatedWorkflowSwapAckPending, thread }) };`,
+    `${COMPLETE_DEDICATED_SWAP}\n${SETTLE_CANCELLED_SWAP}\nreturn { completeDedicatedWorkflowSessionSwap, settlePendingDedicatedWorkflowSwapAfterCancellation, state: () => ({ pendingDedicatedWorkflowSwap, dedicatedWorkflowSwapAckPending, thread }) };`,
   )(
     () => false,
     working,
@@ -104,14 +127,14 @@ function buildDedicatedSwap({ pending = true, working = false, existing = true }
     (_key, fallback) => fallback,
     () => events.push(["refresh"]),
   );
-  return { complete, events };
+  return { complete: complete.completeDedicatedWorkflowSessionSwap, settle: complete.settlePendingDedicatedWorkflowSwapAfterCancellation, state: complete.state, events };
 }
 
 test("#1810 terminal production swap binds the dedicated session only after the turn ends", () => {
-  const { complete, events } = buildDedicatedSwap();
+  const { complete, state, events } = buildDedicatedSwap();
 
-  assert.equal(complete.completeDedicatedWorkflowSessionSwap({ announce: true }), true);
-  assert.deepEqual(complete.state(), { pendingDedicatedWorkflowSwap: false, dedicatedWorkflowSwapAckPending: false, thread: { id: "new-chat", sessionId: "session-new" } });
+  assert.equal(complete({ announce: true }), true);
+  assert.deepEqual(state(), { pendingDedicatedWorkflowSwap: false, dedicatedWorkflowSwapAckPending: null, thread: { id: "new-chat", sessionId: "session-new" } });
   assert.deepEqual(events, [
     ["storage", "comfyui-mcp.panel.sessionId", "session-new"],
     ["rehello", "session-new"],
@@ -124,11 +147,29 @@ test("#1810 terminal production swap binds the dedicated session only after the 
 test("#1810 does not complete the dedicated swap while the turn is still working", () => {
   const { complete, events } = buildDedicatedSwap({ working: true });
 
-  assert.equal(complete.completeDedicatedWorkflowSessionSwap(), false);
+  assert.equal(complete(), false);
   assert.deepEqual(events, []);
 });
 
-function buildAck({ outageMs = 0, rebootPending = false } = {}) {
+function buildHelloCorrelation() {
+  const pending = { token: "swap-1", landed: false };
+  return new Function(
+    "dedicatedWorkflowSwapAckPending",
+    `${NOTE_DEDICATED_HELLO}\nreturn { noteDedicatedWorkflowHello, state: () => dedicatedWorkflowSwapAckPending };`,
+  )(pending);
+}
+
+test("#1810 only the deliberate hello can arm the dedicated ready-ack guard", () => {
+  const hello = buildHelloCorrelation();
+  hello.noteDedicatedWorkflowHello({ dedicatedWorkflowSwap: "other-swap" });
+  assert.equal(hello.state(), null, "an unrelated hello invalidates the pending correlation");
+
+  const deliberate = buildHelloCorrelation();
+  deliberate.noteDedicatedWorkflowHello({ dedicatedWorkflowSwap: "swap-1" });
+  assert.deepEqual(deliberate.state(), { token: "swap-1", landed: true });
+});
+
+function buildAck({ outageMs = 0, rebootPending = false, swapLanded = true } = {}) {
   const mids = new Map([
     ["mid", "1"],
     ["reboot", rebootPending ? "1" : null],
@@ -136,7 +177,7 @@ function buildAck({ outageMs = 0, rebootPending = false } = {}) {
     ["pending-reset", null],
   ]);
   const sent = [];
-  let swapAckPending = true;
+  let swapAckPending = { token: "swap-1", landed: swapLanded };
   let rebootHandlerCalls = 0;
   const onAck = new Function(
     "cmcpOauthOnAck",
@@ -225,6 +266,13 @@ test("#1810 real bridge outage still reaches the existing mid-turn recovery nudg
   assert.doesNotMatch(ack.sent[0][1], /ComfyUI was restarted/);
 });
 
+test("#1810 an unlanded deliberate hello cannot suppress real outage recovery", () => {
+  const ack = buildAck({ outageMs: 7000, swapLanded: false });
+  ack.onAck({ kind: "ready" });
+  assert.equal(ack.sent.length, 1);
+  assert.equal(ack.sent[0][0], "user");
+});
+
 test("#1810 explicit REBOOT_KEY recovery remains authoritative over the swap guard", () => {
   const ack = buildAck({ rebootPending: true });
   ack.onAck({ kind: "ready" });
@@ -244,4 +292,105 @@ test("#1810 real ComfyUI saw_down/up evidence remains distinct from a live rebin
   const benign = createComfyBackendOutageTracker({ now: () => now });
   benign.noteUp();
   assert.equal(benign.outageMs(), 0, "an up event without saw_down is not a restart cycle");
+});
+
+function buildCancellationSettlement() {
+  const built = buildDedicatedSwap({ existing: false });
+  return {
+    settle: built.settle,
+    state: () => {
+      const current = built.state();
+      return {
+        pendingDedicatedWorkflowSwap: current.pendingDedicatedWorkflowSwap,
+        dedicatedWorkflowSwapAckPending: current.dedicatedWorkflowSwapAckPending,
+      };
+    },
+  };
+}
+
+function buildEndTurnForCancellation(settle) {
+  const events = [];
+  const endTurnLocally = new Function(
+    "agentWorking",
+    "localEndAt",
+    "Date",
+    "ssSet",
+    "MID_TASK_KEY",
+    "settlePendingDedicatedWorkflowSwapAfterCancellation",
+    "hideThinking",
+    `${END_TURN_LOCALLY}\nreturn endTurnLocally;`,
+  )(
+    true,
+    null,
+    { now: () => 1234 },
+    (key, value) => events.push(["storage", key, value]),
+    "mid",
+    () => {
+      events.push(["settle"]);
+      settle();
+    },
+    () => events.push(["hide"]),
+  );
+  return { endTurnLocally, events };
+}
+
+for (const input of ["Escape", "Ctrl+C"]) {
+  test(`#1810 ${input} cancellation settles the pending dedicated swap`, () => {
+    const settlement = buildCancellationSettlement();
+    const { endTurnLocally, events } = buildEndTurnForCancellation(settlement.settle);
+    endTurnLocally();
+    assert.deepEqual(events, [["storage", "mid", null], ["settle"], ["hide"]]);
+    assert.deepEqual(settlement.state(), { pendingDedicatedWorkflowSwap: false, dedicatedWorkflowSwapAckPending: null });
+  });
+}
+
+test("#1810 safety-timeout cancellation settles the pending dedicated swap", () => {
+  const settlement = buildCancellationSettlement();
+  const events = [];
+  const onThinkingSafety = new Function(
+    "thinkingSafety",
+    "Date",
+    "lastActivityAt",
+    "MAX_SILENT_TURN_MS",
+    "agentWorking",
+    "thinkingEl",
+    "showThinking",
+    "THINKING_SAFETY_MS",
+    "setTimeout",
+    "ssSet",
+    "MID_TASK_KEY",
+    "settlePendingDedicatedWorkflowSwapAfterCancellation",
+    "hideThinking",
+    `${THINKING_SAFETY}\nreturn onThinkingSafety;`,
+  )(
+    "timer",
+    { now: () => 10_000 },
+    0,
+    100,
+    true,
+    {},
+    () => {},
+    120_000,
+    () => "timer",
+    (key, value) => events.push(["storage", key, value]),
+    "mid",
+    () => {
+      events.push(["settle"]);
+      settlement.settle();
+    },
+    () => events.push(["hide"]),
+  );
+  onThinkingSafety();
+  assert.deepEqual(events, [["storage", "mid", null], ["settle"], ["hide"]]);
+  assert.deepEqual(settlement.state(), { pendingDedicatedWorkflowSwap: false, dedicatedWorkflowSwapAckPending: null });
+});
+
+test("#1810 production interrupt wiring routes Esc and Ctrl+C through endTurnLocally", () => {
+  const start = PANEL.indexOf("function onInterruptKeydown(ev) {");
+  const end = PANEL.indexOf("\n  }\n  document.addEventListener(\"keydown\", onInterruptKeydown", start);
+  assert.ok(start >= 0 && end > start);
+  const body = PANEL.slice(start, end);
+  assert.match(body, /const isCopy = .*ev\.key === \"c\"/s);
+  assert.match(body, /const isEsc = ev\.key === \"Escape\"/);
+  assert.match(body, /endTurnLocally\(\);/);
 });

--- a/browser_tests/unit/workflow-turn-abort.test.mjs
+++ b/browser_tests/unit/workflow-turn-abort.test.mjs
@@ -6,7 +6,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { createComfyBackendOutageTracker } from "../../web/js/lib/session-rebind.js";
+import {
+  createBridgeOutageTracker,
+  createComfyBackendOutageTracker,
+} from "../../web/js/lib/session-rebind.js";
 
 const PANEL_PATH = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const PANEL = readFileSync(PANEL_PATH, "utf8").replace(/\r\n/g, "\n");
@@ -151,8 +154,7 @@ test("#1810 does not complete the dedicated swap while the turn is still working
   assert.deepEqual(events, []);
 });
 
-function buildHelloCorrelation() {
-  const pending = { token: "swap-1", landed: false };
+function buildHelloCorrelation(pending = { token: "swap-1", landed: false }) {
   return new Function(
     "dedicatedWorkflowSwapAckPending",
     `${NOTE_DEDICATED_HELLO}\nreturn { noteDedicatedWorkflowHello, state: () => dedicatedWorkflowSwapAckPending };`,
@@ -167,9 +169,17 @@ test("#1810 only the deliberate hello can arm the dedicated ready-ack guard", ()
   const deliberate = buildHelloCorrelation();
   deliberate.noteDedicatedWorkflowHello({ dedicatedWorkflowSwap: "swap-1" });
   assert.deepEqual(deliberate.state(), { token: "swap-1", landed: true });
+
+  const afterReady = buildHelloCorrelation({ token: "swap-1", landed: true, ready: true });
+  afterReady.noteDedicatedWorkflowHello();
+  assert.deepEqual(
+    afterReady.state(),
+    { token: "swap-1", landed: true, ready: true },
+    "an unrelated re-hello after the tagged ready must not consume the recovery guard",
+  );
 });
 
-function buildAck({ outageMs = 0, rebootPending = false, swapLanded = true } = {}) {
+function buildAck({ outageMs = 0, rebootPending = false, swapLanded = true, swapPending = true } = {}) {
   const mids = new Map([
     ["mid", "1"],
     ["reboot", rebootPending ? "1" : null],
@@ -177,7 +187,18 @@ function buildAck({ outageMs = 0, rebootPending = false, swapLanded = true } = {
     ["pending-reset", null],
   ]);
   const sent = [];
-  let swapAckPending = { token: "swap-1", landed: swapLanded };
+  const clock = { value: 1000 };
+  const bridgeOutage = createBridgeOutageTracker({ now: () => clock.value });
+  const startBridgeOutage = (durationMs) => {
+    bridgeOutage.noteBridgeClosed();
+    clock.value = 1000 + durationMs;
+  };
+  const finishBridgeReconnect = () => bridgeOutage.noteHandshake();
+  if (outageMs > 0) {
+    startBridgeOutage(outageMs);
+    finishBridgeReconnect();
+  }
+  let swapAckPending = swapPending ? { token: "swap-1", landed: swapLanded } : null;
   let rebootHandlerCalls = 0;
   const onAck = new Function(
     "cmcpOauthOnAck",
@@ -242,12 +263,20 @@ function buildAck({ outageMs = 0, rebootPending = false, swapLanded = true } = {
     () => {},
     (_key, fallback) => fallback,
     swapAckPending,
-    { outageMs: () => outageMs },
+    bridgeOutage,
     ({ outageMs: measured }) => measured >= 6000,
     () => {},
     () => {},
   );
-  return { onAck, sent, mids, get swapAckPending() { return swapAckPending; }, rebootHandlerCalls: () => rebootHandlerCalls };
+  return {
+    onAck,
+    sent,
+    mids,
+    startBridgeOutage,
+    finishBridgeReconnect,
+    get swapAckPending() { return swapAckPending; },
+    rebootHandlerCalls: () => rebootHandlerCalls,
+  };
 }
 
 test("#1810 ready from the deliberate session rebind does not inject a false resume turn", () => {
@@ -255,6 +284,35 @@ test("#1810 ready from the deliberate session rebind does not inject a false res
   ack.onAck({ kind: "ready" });
   assert.deepEqual(ack.sent, []);
   assert.equal(ack.mids.get("mid"), "1", "the live turn marker remains armed until turn:done");
+});
+
+test("#1810 tagged ready then unrelated ready preserves recovery until a real outage reconnect", () => {
+  const ack = buildAck();
+
+  // The first ready is the deliberately tagged dedicated-session rebind.
+  ack.onAck({ kind: "ready" });
+  // A later live-socket re-hello (the free_vram/self-heal shape) is unrelated.
+  ack.onAck({ kind: "ready" });
+  assert.deepEqual(ack.sent, []);
+  assert.equal(ack.mids.get("mid"), "1", "an unrelated healthy ready cannot consume MID_TASK_KEY");
+  assert.deepEqual(ack.swapAckPending, { token: "swap-1", landed: true, ready: true });
+
+  // Only the ready that closes a measured outage may enter the existing recovery path.
+  ack.startBridgeOutage(7000);
+  ack.finishBridgeReconnect();
+  ack.onAck({ kind: "ready" });
+  assert.equal(ack.mids.get("mid"), null);
+  assert.equal(ack.sent.length, 1);
+  assert.equal(ack.sent[0][0], "user");
+  assert.match(ack.sent[0][1], /agent connection dropped mid-task/);
+  assert.doesNotMatch(ack.sent[0][1], /ComfyUI was restarted/);
+});
+
+test("#1810 a normal uncorrelated live re-hello preserves an in-flight recovery marker", () => {
+  const ack = buildAck({ swapPending: false });
+  ack.onAck({ kind: "ready" });
+  assert.deepEqual(ack.sent, [], "a normal re-hello must not inject a resume turn");
+  assert.equal(ack.mids.get("mid"), "1", "the marker remains for a later real outage");
 });
 
 test("#1810 real bridge outage still reaches the existing mid-turn recovery nudge", () => {

--- a/browser_tests/workflow-turn-abort.spec.ts
+++ b/browser_tests/workflow-turn-abort.spec.ts
@@ -3,38 +3,47 @@
 // shipped panel path does not create a session rebind or a synthetic resume turn while
 // the calling agent turn is still working.
 import { test, expect } from './fixtures/panelTest'
+import { MockBridge } from './fixtures/MockBridge'
 
 test('panel_new_workflow during an in-flight turn keeps the calling chat and emits no false resume', async ({
   panel,
-  mockBridge,
   page
 }) => {
-  await panel.goto()
-  await panel.setBridgeUrl(mockBridge.url)
-  await panel.openSidebar()
-  await panel.connect()
-
-  const frames: Record<string, unknown>[] = []
-  const off = mockBridge.onFrame((frame) => frames.push(frame))
+  // The dedicated branch is provider-owned in production: use a real Grok
+  // handshake so this browser test cannot pass with a forced followsPanel=false
+  // test seam or the default panel-owned Claude state.
+  const grokBridge = await new MockBridge({ backend: 'grok' }).start()
   try {
-    mockBridge.startTurn()
-    await expect(page.locator('.cmcp-root .cmcp-thinking')).toBeVisible()
+    await panel.goto()
+    await panel.setBridgeUrl(grokBridge.url)
+    await panel.openSidebar()
+    await panel.connect()
 
-    const before = frames.length
-    const created = await mockBridge.command('workflow_new')
-    expect(created.ok).toBe(true)
+    const frames: Record<string, unknown>[] = []
+    const off = grokBridge.onFrame((frame) => frames.push(frame))
+    try {
+      grokBridge.startTurn()
+      await expect(page.locator('.cmcp-root .cmcp-thinking')).toBeVisible()
 
-    // The production workflow poll is 600ms. MockBridge answers the re-hello with
-    // ready while the original turn is still live, which is the false-nudge seam.
-    await page.waitForTimeout(900)
-    const duringSwitch = frames.slice(before)
-    expect(duringSwitch.some((frame) => frame.type === 'hello')).toBe(true)
-    expect(duringSwitch.some((frame) => frame.type === 'resume_session' || frame.type === 'new_session')).toBe(false)
-    expect(duringSwitch.some((frame) => frame.type === 'user_message')).toBe(false)
+      const before = frames.length
+      const created = await grokBridge.command('workflow_new')
+      expect(created.ok).toBe(true)
 
-    mockBridge.turnDone()
-    await expect(page.locator('.cmcp-root .cmcp-thinking')).toBeHidden()
+      // The production workflow poll is 600ms. MockBridge answers the re-hello with
+      // ready while the original turn is still live, which is the false-nudge seam.
+      await page.waitForTimeout(900)
+      const duringSwitch = frames.slice(before)
+      expect(duringSwitch.some((frame) => frame.type === 'hello')).toBe(true)
+      expect(duringSwitch.some((frame) => frame.type === 'resume_session' || frame.type === 'new_session')).toBe(false)
+      expect(duringSwitch.some((frame) => frame.type === 'user_message')).toBe(false)
+
+      grokBridge.turnDone()
+      await expect(page.locator('.cmcp-root .cmcp-thinking')).toBeHidden()
+      await expect(page.locator('.cmcp-root')).toContainText('Switched workflow tab', { timeout: 5_000 })
+    } finally {
+      off()
+    }
   } finally {
-    off()
+    await grokBridge.close()
   }
 })

--- a/browser_tests/workflow-turn-abort.spec.ts
+++ b/browser_tests/workflow-turn-abort.spec.ts
@@ -1,0 +1,40 @@
+// #1810 — drive panel_new_workflow through the live panel/MockBridge lifecycle.
+// The unit regression covers the retired dedicated-chat branch; this test proves the
+// shipped panel path does not create a session rebind or a synthetic resume turn while
+// the calling agent turn is still working.
+import { test, expect } from './fixtures/panelTest'
+
+test('panel_new_workflow during an in-flight turn keeps the calling chat and emits no false resume', async ({
+  panel,
+  mockBridge,
+  page
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const frames: Record<string, unknown>[] = []
+  const off = mockBridge.onFrame((frame) => frames.push(frame))
+  try {
+    mockBridge.startTurn()
+    await expect(page.locator('.cmcp-root .cmcp-thinking')).toBeVisible()
+
+    const before = frames.length
+    const created = await mockBridge.command('workflow_new')
+    expect(created.ok).toBe(true)
+
+    // The production workflow poll is 600ms. MockBridge answers the re-hello with
+    // ready while the original turn is still live, which is the false-nudge seam.
+    await page.waitForTimeout(900)
+    const duringSwitch = frames.slice(before)
+    expect(duringSwitch.some((frame) => frame.type === 'hello')).toBe(true)
+    expect(duringSwitch.some((frame) => frame.type === 'resume_session' || frame.type === 'new_session')).toBe(false)
+    expect(duringSwitch.some((frame) => frame.type === 'user_message')).toBe(false)
+
+    mockBridge.turnDone()
+    await expect(page.locator('.cmcp-root .cmcp-thinking')).toBeHidden()
+  } finally {
+    off()
+  }
+})

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -915,6 +915,7 @@
       "workflow_saved": "Saved “{workflow}”",
       "workflow_saved_as": "Saved as “{workflow}”",
       "workflow_snapshot": "Workflow snapshot",
+      "workflow_chat_switch_after_turn": "Switched workflow tab — this chat is dedicated to the new workflow after the previous turn finished.",
       "working": "Working…",
       "your_agent_inline": "your agent",
       "your_agent_is_at_your_canvas": "Your agent is at your canvas"

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5717,16 +5717,12 @@ async function applyPanelLocale(explicit) {
     return null;
   }
 }
-/** Conversation ownership (mcp#884 — owner-stated invariant): the conversation
- *  ALWAYS belongs to the panel. One agent session spans every workflow and every
- *  tab; the orchestrator keys and persists it (in ~/.comfyui-mcp/sessions, since
- *  mcp#897), so a workflow-scoped chat is a bug, never a mode. The old
- *  "workflow"/"ask" scopes are retired — their stored setting values are ignored
- *  (not migrated), and per-workflow threads created under them remain in
- *  history, reachable through the history picker like any archived
- *  conversation. */
-function chatScopeMode() {
-  return "panel";
+/** Conversation ownership (mcp#884): most providers use the panel-owned
+ *  conversation, while Grok retains its production per-workflow chat/session
+ *  behavior. The old user-selectable "workflow"/"ask" settings remain retired;
+ *  provider state, not persisted scope settings, selects the real behavior. */
+function chatScopeMode(backend) {
+  return backend === "grok" ? "workflow" : "panel";
 }
 function setSetting(id, value) {
   try {
@@ -6335,10 +6331,10 @@ function panelSettingsList() {
         panelHooks.applyBackend?.(v, previous);
       },
     },
-    // mcp#884 — the "Chat conversation scope" combo is retired: the conversation
-    // is ALWAYS panel-owned (one session across every workflow and tab, keyed and
-    // persisted by the orchestrator). chatScopeMode() is hard-wired to "panel";
-    // a stored "workflow"/"ask" value from an older build is simply ignored.
+    // mcp#884 — the user-selectable "Chat conversation scope" combo is retired:
+    // provider state owns the behavior. A stored "workflow"/"ask" value from an
+    // older build is simply ignored; Grok's dedicated workflow sessions are not
+    // user-selectable scope settings.
     {
       id: SETTING_AUTOSTART_MCP,
       name: "Autostart MCP",
@@ -25186,7 +25182,7 @@ function noteActiveWorkflowMove() {
   }
 }
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCommandReceived, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCommandReceived, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert, onHelloLanded }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -25332,7 +25328,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // `advertiseHello` is a hoisted declaration below; the arrow defers the read until the
   // gate actually fires, so this cannot capture it before it exists.
   const rehelloGate = createRehelloGate({
-    advertise: () => advertiseHello(),
+    advertise: (context) => advertiseHello(context),
     now: monotonicNow,
   });
   // #1095 — the socket a hello has actually LANDED on. Only a hello that REPLACES an
@@ -26633,15 +26629,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
    *  deferred hello resolves when it eventually goes out (or false if the client was torn
    *  down first), so the #607 budget still counts only what the orchestrator received. */
   function sendHello() {
+    const context = arguments[0];
     // A hello that REPLACES this socket's mapping is the only one that can strand a
     // command. The first hello on a socket creates the mapping — there is nothing to
     // withdraw, and deferring it would leave the tab unregistered while commands pile up
     // against a route that does not exist yet. `advertisedSock` is set only on the success
     // path below, so a hello that never landed does not arm the gate either.
-    if (!sock || sock !== advertisedSock) return advertiseHello();
+    if (!sock || sock !== advertisedSock) return advertiseHello(context);
     const bindingGeneration = ++nextRouteBindingGeneration;
     pendingRouteBindingGeneration = bindingGeneration;
-    const request = rehelloGate.request();
+    const request = context === undefined ? rehelloGate.request() : rehelloGate.request(context);
     // A failed request leaves the old binding fenced. The active close/new-socket
     // path clears it, and the receipt outbox TTL bounds retention if the socket stays
     // open but the replacement hello never lands.
@@ -26664,6 +26661,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
    *  #1095 — call `sendHello()`, not this, unless you can show the send must not wait for
    *  in-flight commands. This is the ungated send the gate drives. */
   function advertiseHello() {
+    const context = arguments[0];
     if (!sock || sock.readyState !== WebSocket.OPEN) return Promise.resolve(false);
     // #291 — a hello BINDS this socket to an agent session, and not always the one
     // it was bound to a moment ago. Besides the socket-open hello, the panel
@@ -26815,6 +26813,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // frames it routes by binding are compared against it (advertisedRouteIsStale).
           lastAdvertisedRouteId = advertisedRouteId;
           if (reconnectRouteHandoff === handoffCandidate) reconnectRouteHandoff = null;
+          try {
+            onHelloLanded?.(context);
+          } catch {
+            // A lifecycle observer must never turn a landed hello into a false failure.
+          }
           // #1095 — release exactly the held frames composed FOR this route, and discard any
           // composed for a workflow the panel has since moved past. Driven from the landed
           // path, so "advertised" means the orchestrator was told, never that we meant to.
@@ -32373,10 +32376,9 @@ function buildPanel() {
   applyWorkflowAliasesFromHistory();
 
   function historyScopeFollowsPanel() {
-    // Constant since mcp#884 (chatScopeMode() is hard-wired to "panel"). Kept as
-    // the named seam the remaining scope guards read, so they stay honest
-    // defense-in-depth instead of silently deleted invariants.
-    return chatScopeMode() === "panel";
+    // Scope follows the real provider/session state. Grok's orchestrator owns
+    // dedicated per-workflow sessions; the other providers remain panel-owned.
+    return chatScopeMode(connectedBackend || selectedBackend) === "panel";
   }
 
   function currentHistoryScopeKey({ embed = false } = {}) {
@@ -35346,13 +35348,28 @@ function buildPanel() {
   // replacement of the calling turn. Keep the current session until the turn
   // is terminal, then perform the normal dedicated-chat swap once.
   let pendingDedicatedWorkflowSwap = false;
-  let dedicatedWorkflowSwapAckPending = false;
+  let dedicatedWorkflowSwapAckPending = null;
+  let dedicatedWorkflowSwapSequence = 0;
+
+  // A ready ack is evidence for this workflow swap only when the hello that
+  // deliberately initiated it actually landed. Any other hello (including a
+  // reconnect or a generic self-heal) invalidates the association instead of
+  // consuming a future real ComfyUI outage recovery.
+  function noteDedicatedWorkflowHello(context) {
+    const pending = dedicatedWorkflowSwapAckPending;
+    if (!pending) return;
+    if (context?.dedicatedWorkflowSwap === pending.token) {
+      pending.landed = true;
+    } else {
+      dedicatedWorkflowSwapAckPending = null;
+    }
+  }
 
   function completeDedicatedWorkflowSessionSwap({ announce = false } = {}) {
     if (!pendingDedicatedWorkflowSwap || historyScopeFollowsPanel() || agentWorking) return false;
 
     pendingDedicatedWorkflowSwap = false;
-    dedicatedWorkflowSwapAckPending = false;
+    dedicatedWorkflowSwapAckPending = null;
     const historyKey = workflowStorageKey();
     const existing = threadForWorkflow(historyKey);
     // Bind THIS workflow's session BEFORE the re-hello. sendHello() reads
@@ -35389,20 +35406,45 @@ function buildPanel() {
     currentWorkflowKey = wfkey;
     currentWorkflowRef = wf;
     pendingDedicatedWorkflowSwap = true;
-    dedicatedWorkflowSwapAckPending = true;
+    const token = `dedicated-workflow-swap-${++dedicatedWorkflowSwapSequence}`;
+    const ackPending = { token, landed: false };
+    dedicatedWorkflowSwapAckPending = ackPending;
     // Re-target this socket, but deliberately keep SESSION_KEY and the current
     // thread. The calling turn therefore remains owned by its original chat.
+    let hello;
     try {
-      client?.rehello?.();
+      hello = client?.rehello?.({ dedicatedWorkflowSwap: token });
     } catch {
       /* reconnect path retries the hello */
     }
+    // A failed, coalesced, or superseded hello must not leave a stale ack guard
+    // armed for a later unrelated ready frame. The landed callback above is the
+    // positive proof; the promise only confirms that the request settled.
+    void Promise.resolve(hello).then((sent) => {
+      if (dedicatedWorkflowSwapAckPending !== ackPending) return;
+      if (sent !== true || !ackPending.landed) dedicatedWorkflowSwapAckPending = null;
+    }, () => {
+      if (dedicatedWorkflowSwapAckPending === ackPending) dedicatedWorkflowSwapAckPending = null;
+    });
     const name = wf?.filename || wfkey || wfid;
     client?.armContext?.(
       `[panel] The user switched the open workflow on the canvas to "${name}" while an agent turn was in flight. ` +
       `Keep using the current conversation until this turn finishes; the dedicated chat swap is deferred.`,
     );
     refreshContextRingForScope();
+  }
+
+  function settlePendingDedicatedWorkflowSwapAfterCancellation() {
+    if (!pendingDedicatedWorkflowSwap && !dedicatedWorkflowSwapAckPending) return false;
+    // If provider scope changed back to panel ownership while cancellation was
+    // in progress, there is no dedicated session to bind. Clear the stale
+    // commitment anyway so a later poll cannot return early on its target.
+    if (historyScopeFollowsPanel()) {
+      pendingDedicatedWorkflowSwap = false;
+      dedicatedWorkflowSwapAckPending = null;
+      return false;
+    }
+    return completeDedicatedWorkflowSessionSwap({ announce: true });
   }
 
   // #1095 — THIS POLL DOES NOT GATE ANYTHING, AND THAT IS THE FIX.
@@ -36170,6 +36212,7 @@ function buildPanel() {
       agentWorking = false;
       ssSet(MID_TASK_KEY, null);
     }
+    settlePendingDedicatedWorkflowSwapAfterCancellation();
     hideThinking();
   }
 
@@ -36256,6 +36299,7 @@ function buildPanel() {
     agentWorking = false;
     localEndAt = Date.now(); // briefly ignore a straggler turn:working from this turn
     ssSet(MID_TASK_KEY, null); // turn stopped — nothing to resume
+    settlePendingDedicatedWorkflowSwapAfterCancellation();
     hideThinking();
   }
 
@@ -37260,6 +37304,7 @@ function buildPanel() {
       // open credentials card to re-poll oauth_status (see cmcpOpenCredentialsFrame).
       cmcpOauthOnBackendsPush?.();
     },
+    onHelloLanded: noteDedicatedWorkflowHello,
     onAck(ack) {
       // In-panel OAuth acks (oauth_begin/oauth_status/oauth_signout) are routed
       // to whichever credentials card is currently open — see
@@ -37369,8 +37414,13 @@ function buildPanel() {
       // not evidence that the calling turn dropped. Consume only that ack when
       // the bridge stayed up; a real bridge outage still reaches the normal
       // recovery path below.
-      if (ack?.kind === "ready" && dedicatedWorkflowSwapAckPending) {
-        dedicatedWorkflowSwapAckPending = false;
+      if (
+        ack?.kind === "ready" &&
+        !ssGet(REBOOT_KEY) &&
+        !ssGet(SOFT_RELOAD_KEY) &&
+        dedicatedWorkflowSwapAckPending?.landed
+      ) {
+        dedicatedWorkflowSwapAckPending = null;
         if (bridgeOutage.outageMs() <= 0) return;
       }
       // Unexpected bounce while mid-task — a DIFFERENT agent restarting ComfyUI

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -35339,6 +35339,72 @@ function buildPanel() {
       /* reconnect path retries the hello */
     }
   }
+
+  // A dedicated workflow switch normally rebinds the socket and loads the
+  // target workflow's session immediately. During an agent turn that ordering
+  // is unsafe: the session rebind is interpreted by the orchestrator as a
+  // replacement of the calling turn. Keep the current session until the turn
+  // is terminal, then perform the normal dedicated-chat swap once.
+  let pendingDedicatedWorkflowSwap = false;
+  let dedicatedWorkflowSwapAckPending = false;
+
+  function completeDedicatedWorkflowSessionSwap({ announce = false } = {}) {
+    if (!pendingDedicatedWorkflowSwap || historyScopeFollowsPanel() || agentWorking) return false;
+
+    pendingDedicatedWorkflowSwap = false;
+    dedicatedWorkflowSwapAckPending = false;
+    const historyKey = workflowStorageKey();
+    const existing = threadForWorkflow(historyKey);
+    // Bind THIS workflow's session BEFORE the re-hello. sendHello() reads
+    // SESSION_KEY at hello time for its spawn-time `resume`.
+    ssSet(SESSION_KEY, existing?.sessionId || null);
+    rehelloForWorkflow(existing?.sessionId || null);
+    if (existing) {
+      loadThread(existing); // resets feed + repaints + resumes
+    } else {
+      thread = null; // fresh empty view; the thread is minted on first message
+      ssSet(CURRENT_THREAD_KEY, null);
+      resetFeed();
+      try {
+        client?.armContext?.(
+          `[Workspace context: this chat is dedicated to the ComfyUI workflow "${getWorkflowTitle()}". ` +
+          `Each workflow has its own separate agent conversation — other workflows are NOT in your context.]`,
+        );
+      } catch { /* armContext unavailable — awareness rides the title instead */ }
+    }
+    if (announce) {
+      appendSystem(
+        tr(
+          "panel.workflow_chat_switch_after_turn",
+          "Switched workflow tab — this chat is dedicated to the new workflow after the previous turn finished.",
+        ),
+      );
+    }
+    refreshContextRingForScope();
+    return true;
+  }
+
+  function deferDedicatedWorkflowSwitch(wf, wfid, wfkey) {
+    currentWorkflowId = wfid;
+    currentWorkflowKey = wfkey;
+    currentWorkflowRef = wf;
+    pendingDedicatedWorkflowSwap = true;
+    dedicatedWorkflowSwapAckPending = true;
+    // Re-target this socket, but deliberately keep SESSION_KEY and the current
+    // thread. The calling turn therefore remains owned by its original chat.
+    try {
+      client?.rehello?.();
+    } catch {
+      /* reconnect path retries the hello */
+    }
+    const name = wf?.filename || wfkey || wfid;
+    client?.armContext?.(
+      `[panel] The user switched the open workflow on the canvas to "${name}" while an agent turn was in flight. ` +
+      `Keep using the current conversation until this turn finishes; the dedicated chat swap is deferred.`,
+    );
+    refreshContextRingForScope();
+  }
+
   // #1095 — THIS POLL DOES NOT GATE ANYTHING, AND THAT IS THE FIX.
   //
   // The first cut deferred the whole function while a command was in flight, so that the
@@ -35393,6 +35459,16 @@ function buildPanel() {
 
     const initial = currentWorkflowId == null;
     const followsPanel = historyScopeFollowsPanel();
+
+    // Legacy dedicated-chat mode must not use its normal session swap while the
+    // calling turn is live. A `resume_session`/hello handover here cancels the
+    // turn that just called panel_new_workflow and leaves MID_TASK_KEY armed for
+    // the new chat's ready ack. Re-target the socket only, then finish the chat
+    // swap from the terminal turn callback.
+    if (!followsPanel && agentWorking) {
+      deferDedicatedWorkflowSwitch(wf, wfid, wfkey);
+      return;
+    }
 
     // PANEL-OWNED SESSION (default): the conversation is the unit of continuity
     // and the workflow is just the canvas target — switching, saving, renaming,
@@ -35599,41 +35675,7 @@ function buildPanel() {
       return;
     }
 
-    currentWorkflowId = wfid;
-    currentWorkflowKey = wfkey;
-    currentWorkflowRef = wf;
-    const existing = threadForWorkflow(historyKey);
-    // Bind THIS workflow's session BEFORE the re-hello. sendHello() reads
-    // SESSION_KEY at hello time for its spawn-time `resume` — re-helloing first
-    // carried the PREVIOUS workflow's session id, so a fresh workspace's agent
-    // spawned as a resume-FORK of the other conversation (verbatim memory bleed
-    // across workspaces). Order is the whole fix.
-    ssSet(SESSION_KEY, existing?.sessionId || null);
-    rehelloForWorkflow(existing?.sessionId || null);
-    if (existing) {
-      loadThread(existing); // resets feed + repaints + resumes
-    } else {
-      thread = null; // fresh empty view; the thread is minted (tagged) on first message
-      ssSet(CURRENT_THREAD_KEY, null);
-      resetFeed();
-      // NOTE: no `new_session` frame here — SESSION_KEY was bound BEFORE the
-      // re-hello, so the hello already spawns a clean agent for this tab. Sending
-      // new_session too caused a rapid double-spawn (double greeting, and two
-      // concurrent Claude session starts that can race token refresh → 401s).
-      // Workspace awareness: ride a one-shot context on the FIRST message so the
-      // fresh agent knows exactly which workflow it serves (and that other
-      // workflows have their own separate conversations).
-      try {
-        client?.armContext?.(
-          `[Workspace context: this chat is dedicated to the ComfyUI workflow "${getWorkflowTitle()}". ` +
-          `Each workflow has its own separate agent conversation — other workflows are NOT in your context.]`,
-        );
-      } catch { /* armContext unavailable — awareness rides the title instead */ }
-    }
-    // #381: a genuine switch changed the conversation scope — repaint the ring
-    // from the newly-active scope's own last-known fill (or blank it) so it never
-    // keeps showing the previous workflow's value.
-    refreshContextRingForScope();
+    completeDedicatedWorkflowSessionSwap();
   }
 
   function renderHistory() {
@@ -36869,6 +36911,7 @@ function buildPanel() {
           // since (sessionEpoch unchanged).
           lastAgentGraphEpoch = sessionEpoch;
         } catch {}
+        completeDedicatedWorkflowSessionSwap({ announce: true });
       }
     },
     onLog(text) {
@@ -37322,6 +37365,14 @@ function buildPanel() {
         }
         return;
       }
+      // A deliberate dedicated-chat rebind also produces a ready ack. It is
+      // not evidence that the calling turn dropped. Consume only that ack when
+      // the bridge stayed up; a real bridge outage still reaches the normal
+      // recovery path below.
+      if (ack?.kind === "ready" && dedicatedWorkflowSwapAckPending) {
+        dedicatedWorkflowSwapAckPending = false;
+        if (bridgeOutage.outageMs() <= 0) return;
+      }
       // Unexpected bounce while mid-task — a DIFFERENT agent restarting ComfyUI
       // (to load nodes), a crash, or an SDK self-heal. The session resumed with
       // full context but has no pending turn, so it would sit idle. Nudge it.
@@ -37369,7 +37420,7 @@ function buildPanel() {
         appendSystem(tr("panel.reconnected_picking_up_where_we_left_off", "Reconnected — picking up where we left off."));
         showThinking();
         if (client.sendUserMessage(
-          "✅ Your connection dropped mid-task (e.g. ComfyUI was restarted, possibly by another agent installing nodes). The session resumed with full context — continue exactly what you were doing before the drop; if you were mid-build or mid-edit, pick it right back up.",
+          "✅ Your agent connection dropped mid-task. The session resumed with full context — continue exactly what you were doing before the drop; if you were mid-build or mid-edit, pick it right back up.",
         )) pinTurnOwnerAtDispatch();
       }
     },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -35352,15 +35352,19 @@ function buildPanel() {
   let dedicatedWorkflowSwapSequence = 0;
 
   // A ready ack is evidence for this workflow swap only when the hello that
-  // deliberately initiated it actually landed. Any other hello (including a
-  // reconnect or a generic self-heal) invalidates the association instead of
-  // consuming a future real ComfyUI outage recovery.
+  // deliberately initiated it actually landed. An unrelated hello before that
+  // ready invalidates the association; after the tagged ready, later healthy
+  // re-hellos stay outside the swap's recovery decision and must not consume a
+  // future real ComfyUI outage recovery.
   function noteDedicatedWorkflowHello(context) {
     const pending = dedicatedWorkflowSwapAckPending;
     if (!pending) return;
     if (context?.dedicatedWorkflowSwap === pending.token) {
       pending.landed = true;
-    } else {
+    } else if (!pending.ready) {
+      // Before the deliberate ready, an unrelated hello means this request
+      // cannot be correlated to the swap. Once the tagged ready was consumed,
+      // retain the recovery guard across later healthy re-hellos instead.
       dedicatedWorkflowSwapAckPending = null;
     }
   }
@@ -37420,13 +37424,30 @@ function buildPanel() {
         !ssGet(SOFT_RELOAD_KEY) &&
         dedicatedWorkflowSwapAckPending?.landed
       ) {
-        dedicatedWorkflowSwapAckPending = null;
+        // Keep the correlation alive after the deliberate ready: a later
+        // untagged ready on the same socket is a normal re-hello (free_vram,
+        // self-heal, or another tab rebinding), not proof that this turn was
+        // recovered. It must not consume MID_TASK_KEY.
+        dedicatedWorkflowSwapAckPending.ready = true;
+      }
+      if (
+        ack?.kind === "ready" &&
+        !ssGet(REBOOT_KEY) &&
+        !ssGet(SOFT_RELOAD_KEY) &&
+        dedicatedWorkflowSwapAckPending?.ready
+      ) {
+        // A measured bridge outage outranks the healthy-socket guard and lets
+        // the normal recovery path clear the marker and nudge the agent.
         if (bridgeOutage.outageMs() <= 0) return;
+        dedicatedWorkflowSwapAckPending = null;
       }
       // Unexpected bounce while mid-task — a DIFFERENT agent restarting ComfyUI
       // (to load nodes), a crash, or an SDK self-heal. The session resumed with
       // full context but has no pending turn, so it would sit idle. Nudge it.
       if (ack?.kind === "ready" && ssGet(MID_TASK_KEY)) {
+        // A healthy ready is only a re-hello. Keep the marker for the actual
+        // turn:done or a later handshake that proves a real outage.
+        if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;
         ssSet(MID_TASK_KEY, null);
         // Only nudge for a REAL restart. A fast reconnect (a panel remount from a
         // sidebar swap, or a brief WS blip) means the orchestrator never died —
@@ -37466,7 +37487,6 @@ function buildPanel() {
         // duration and let it outrank the guard; review showed that nudges a live agent
         // whenever the panel's conclusion is wrong — a socket that went stale under a
         // sleep or a NAT idle-kill is indistinguishable from a death here.
-        if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;
         appendSystem(tr("panel.reconnected_picking_up_where_we_left_off", "Reconnected — picking up where we left off."));
         showThinking();
         if (client.sendUserMessage(

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -146,7 +146,7 @@ export function deferBudgetMs(cmd) {
 
 /**
  * @param {{
- *   advertise: () => any,          the real re-advertise (the panel's hello send)
+ *   advertise: (context?: any) => any, the real re-advertise (the panel's hello send)
  *   now?: () => number,            MONOTONIC clock; defaults to performance.now()
  *   setTimer?: Function,
  *   clearTimer?: Function,
@@ -253,21 +253,22 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
   /** Send now — or JOIN the advertisement already on its way — and hand the SAME outcome to
    *  every coalesced caller. Never rejects: a caller that cannot tell "did not land" from
    *  "threw" would spend a retry budget on neither. */
-  function flush() {
+  function flush(contextOverride) {
     const pending = waiters;
     waiters = null;
     disarmTimer();
+    const context = contextOverride === undefined ? pending?.[0]?.context : contextOverride;
     // Joining is correct rather than merely cheaper: `makePayload` reads the tab identity
     // AFTER the lease resolves, so an advertisement started a microtask ago has not yet
     // decided what it carries and will carry whatever is live when it gets there — which is
     // the identity a later caller is asking it to advertise.
     if (inFlight) {
-      if (pending) for (const resolve of pending) inFlight.then(resolve);
+      if (pending) for (const { resolve } of pending) inFlight.then(resolve);
       return inFlight;
     }
     let result;
     try {
-      result = send();
+      result = send(context);
     } catch {
       result = false;
     }
@@ -281,7 +282,7 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
     void settled.then(() => {
       if (inFlight === settled) inFlight = null;
     });
-    if (pending) for (const resolve of pending) settled.then(resolve);
+    if (pending) for (const { resolve } of pending) settled.then(resolve);
     return settled;
   }
 
@@ -357,15 +358,16 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
    *  a held frame waits for the hello the deferral will produce, and must not be able to
    *  force one (see that method for the whole argument).
    *  @returns {Promise<boolean>} whether the hello reached the wire. */
-  function request() {
-    if (live.size === 0) return flush();
+  function request(context) {
+    if (live.size === 0) return flush(context);
     const left = drainDeadline - clock();
     // Budget already spent (a command that will not report back). Proceed — an unbounded
     // wait here is the wedge described in the header.
-    if (!(left > 0)) return flush();
+    if (!(left > 0)) return flush(context);
     const promise = new Promise((resolve) => {
-      if (waiters) waiters.push(resolve);
-      else waiters = [resolve];
+      const waiter = { resolve, context };
+      if (waiters) waiters.push(waiter);
+      else waiters = [waiter];
     });
     // Arm only for the FIRST waiter; a later join must not restart the clock, or a steady
     // trickle of re-advertise requests would push the deadline forward forever.
@@ -456,7 +458,7 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       // on the REPLACEMENT socket must not join it and conclude the new route is published
       // because the old socket's hello landed.
       inFlight = null;
-      if (pending) for (const resolve of pending) resolve(false);
+      if (pending) for (const { resolve } of pending) resolve(false);
     },
 
     /**


### PR DESCRIPTION
## Summary

- Prevents a dedicated per-workflow chat/session swap from rebinding the calling session while an agent turn is in flight.
- Defers the dedicated chat swap until authoritative `turn:done`, then emits an honest workflow-tab message.
- Suppresses the ready-ack resume path for intentional live session rebinds while preserving real bridge outage and `REBOOT_KEY` restart recovery.
- Keeps generic bridge recovery wording from falsely claiming that ComfyUI restarted.

Fixes #1810

## Tests

- `node --test browser_tests/unit/*.test.mjs` — 6,849 passed, 0 failed, 1 existing todo.
- `npm.cmd run typecheck` — passed.
- `node scripts/i18n-check.mjs && node scripts/i18n-render-check.mjs` — passed.
- `node scripts/check-tool-vocabulary.mjs` — passed.
- `npm.cmd run test:e2e:list -- --grep "panel_new_workflow during an in-flight turn"` — listed 1 test.
- The targeted Playwright run was attempted but could not start because ComfyUI was unavailable at `http://localhost:8188/` (`ERR_CONNECTION_REFUSED`).