### PR TITLE
fix: relay fixed ComfyUI diagnostic reads through panel

### DIFF
--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -71,7 +71,8 @@ async function rejection(promise, code) {
 }
 
 test("#2283: the three allowed operations use only their fixed same-origin routes", async () => {
-  const calls = [];
+  const apiCalls = [];
+  const rawCalls = [];
   const bodies = {
     history: '{"prompt-1":{"status":{"status_str":"success"}}}',
     system_stats: '{"system":{"os":"windows"},"devices":[]}',
@@ -83,11 +84,15 @@ test("#2283: the three allowed operations use only their fixed same-origin route
       {
         expectedOrigin: "https://panel.test",
         api: {
-          apiURL: (path) => `/comfy${path}`,
+          apiURL: (path) => `https://panel.test/comfy${path}`,
           fetchApi: async (path, init) => {
-            calls.push({ path, init });
+            apiCalls.push({ path, init });
             return response({ body: bodies[operation] });
           },
+        },
+        fetchImpl: async (url, init) => {
+          rawCalls.push({ url, init });
+          return response({ body: bodies[operation], url });
         },
       },
     );
@@ -100,14 +105,47 @@ test("#2283: the three allowed operations use only their fixed same-origin route
     });
   }
 
-  assert.deepEqual(calls.map(({ path }) => path), ["/history", "/system_stats", "/internal/logs"]);
-  for (const { init } of calls) {
+  assert.deepEqual(apiCalls.map(({ path }) => path), ["/history", "/system_stats"]);
+  assert.deepEqual(rawCalls.map(({ url }) => url), ["https://panel.test/comfy/internal/logs"]);
+  for (const { init } of [...apiCalls, ...rawCalls]) {
     assert.equal(init.method, "GET");
     assert.equal(init.cache, "no-store");
     assert.equal(init.credentials, "include");
     assert.equal(init.redirect, "manual");
     assert.ok(init.signal instanceof AbortSignal);
   }
+});
+
+test("#2283: logs raw transport retains origin, redirect, and body-size fences", async () => {
+  const options = {
+    expectedOrigin: "https://panel.test",
+    api: {
+      apiURL: (path) => `https://panel.test/comfy${path}`,
+      fetchApi: async () => { throw new Error("logs must not use fetchApi"); },
+    },
+  };
+
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "logs" },
+      { ...options, fetchImpl: async (url) => response({ url: "https://evil.test/internal/logs" }) },
+    ),
+    "invalid_origin",
+  );
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "logs" },
+      { ...options, fetchImpl: async (url) => response({ status: 302, url, stream: false }) },
+    ),
+    "redirect_error",
+  );
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "logs" },
+      { ...options, maxBytes: 4, fetchImpl: async (url) => response({ body: "12345", url }) },
+    ),
+    "too_large",
+  );
 });
 
 test("#2283: arbitrary paths, URLs, origins, targets, and operation names are refused before fetch", async () => {

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -71,6 +71,8 @@ async function rejection(promise, code) {
 }
 
 test("#2283: the three allowed operations use only their fixed same-origin routes", async () => {
+  const apiURLCalls = [];
+  const fileURLCalls = [];
   const apiCalls = [];
   const rawCalls = [];
   const bodies = {
@@ -84,7 +86,14 @@ test("#2283: the three allowed operations use only their fixed same-origin route
       {
         expectedOrigin: "https://panel.test",
         api: {
-          apiURL: (path) => `https://panel.test/comfy${path}`,
+          apiURL: (path) => {
+            apiURLCalls.push(path);
+            return `https://panel.test/comfy/api${path}`;
+          },
+          fileURL: (path) => {
+            fileURLCalls.push(path);
+            return `https://panel.test/comfy${path}`;
+          },
           fetchApi: async (path, init) => {
             apiCalls.push({ path, init });
             return response({ body: bodies[operation] });
@@ -105,8 +114,10 @@ test("#2283: the three allowed operations use only their fixed same-origin route
     });
   }
 
+  assert.deepEqual(apiURLCalls, ["/history", "/system_stats"]);
+  assert.deepEqual(fileURLCalls, ["/internal/logs/raw"]);
   assert.deepEqual(apiCalls.map(({ path }) => path), ["/history", "/system_stats"]);
-  assert.deepEqual(rawCalls.map(({ url }) => url), ["https://panel.test/comfy/internal/logs"]);
+  assert.deepEqual(rawCalls.map(({ url }) => url), ["https://panel.test/comfy/internal/logs/raw"]);
   for (const { init } of [...apiCalls, ...rawCalls]) {
     assert.equal(init.method, "GET");
     assert.equal(init.cache, "no-store");
@@ -120,7 +131,8 @@ test("#2283: logs raw transport retains origin, redirect, and body-size fences",
   const options = {
     expectedOrigin: "https://panel.test",
     api: {
-      apiURL: (path) => `https://panel.test/comfy${path}`,
+      apiURL: () => { throw new Error("logs must not use apiURL"); },
+      fileURL: (path) => `https://panel.test/comfy${path}`,
       fetchApi: async () => { throw new Error("logs must not use fetchApi"); },
     },
   };
@@ -200,7 +212,10 @@ test("#2283: the resolved and final response origins stay fenced", async () => {
 test("#2283: redirects and oversized bodies are refused", async () => {
   const options = {
     expectedOrigin: "https://panel.test",
-    api: { apiURL: (path) => path },
+    api: {
+      apiURL: (path) => path,
+      fileURL: (path) => `https://panel.test${path}`,
+    },
   };
   await rejection(
     fetchComfyUIReadForMcp(

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -1,0 +1,194 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  fetchComfyUIReadForMcp,
+  validateFetchComfyUIReadArgs,
+} from "../../web/js/lib/fetch-comfyui-read.js";
+import {
+  commandIsCanvasIndependent,
+  commandIsCanvasTargetless,
+} from "../../web/js/lib/workflow-chat-identity.js";
+
+function response({
+  status = 200,
+  body = "{}",
+  contentType = "application/json",
+  contentLength,
+  url,
+  type,
+  redirected = false,
+  stream = true,
+} = {}) {
+  const bytes = new TextEncoder().encode(body);
+  let offset = 0;
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    ...(url === undefined ? {} : { url }),
+    ...(type === undefined ? {} : { type }),
+    redirected,
+    headers: {
+      get(name) {
+        const key = name.toLowerCase();
+        if (key === "content-type") return contentType;
+        if (key === "content-length") return contentLength == null ? null : String(contentLength);
+        return null;
+      },
+    },
+    ...(stream
+      ? {
+          body: {
+            getReader() {
+              return {
+                async read() {
+                  if (offset >= bytes.byteLength) return { done: true, value: undefined };
+                  const chunk = bytes.subarray(offset, offset + 3);
+                  offset += chunk.byteLength;
+                  return { done: false, value: chunk };
+                },
+                cancel() {},
+                releaseLock() {},
+              };
+            },
+          },
+        }
+      : {
+          body: null,
+          async text() {
+            return body;
+          },
+        }),
+  };
+}
+
+async function rejection(promise, code) {
+  await assert.rejects(promise, (error) => {
+    assert.equal(error.code, code, error.message);
+    return true;
+  });
+}
+
+test("#2283: the three allowed operations use only their fixed same-origin routes", async () => {
+  const calls = [];
+  const bodies = {
+    history: '{"prompt-1":{"status":{"status_str":"success"}}}',
+    system_stats: '{"system":{"os":"windows"},"devices":[]}',
+    logs: "ERROR: render failed\n",
+  };
+  for (const operation of Object.keys(bodies)) {
+    const result = await fetchComfyUIReadForMcp(
+      { operation, workflow_uuid: "stamped-by-bridge", workflow_path: "ignored-by-targetless-read" },
+      {
+        expectedOrigin: "https://panel.test",
+        api: {
+          apiURL: (path) => `/comfy${path}`,
+          fetchApi: async (path, init) => {
+            calls.push({ path, init });
+            return response({ body: bodies[operation] });
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(result, {
+      operation,
+      body: bodies[operation],
+      contentType: "application/json",
+      bytes: new TextEncoder().encode(bodies[operation]).byteLength,
+    });
+  }
+
+  assert.deepEqual(calls.map(({ path }) => path), ["/history", "/system_stats", "/internal/logs"]);
+  for (const { init } of calls) {
+    assert.equal(init.method, "GET");
+    assert.equal(init.cache, "no-store");
+    assert.equal(init.credentials, "include");
+    assert.equal(init.redirect, "manual");
+    assert.ok(init.signal instanceof AbortSignal);
+  }
+});
+
+test("#2283: arbitrary paths, URLs, origins, targets, and operation names are refused before fetch", async () => {
+  const invalid = [
+    {},
+    { operation: "object_info" },
+    { operation: "history", path: "/admin" },
+    { operation: "history", url: "https://evil.test" },
+    { operation: "history", origin: "https://evil.test" },
+    { operation: "history", target: "other-tab" },
+    { operation: "history", method: "POST" },
+  ];
+  for (const args of invalid) {
+    assert.throws(() => validateFetchComfyUIReadArgs(args), { code: "invalid_input" }, JSON.stringify(args));
+    await rejection(
+      fetchComfyUIReadForMcp(args, {
+        expectedOrigin: "https://panel.test",
+        api: { apiURL: (path) => path },
+        fetchImpl: async () => { throw new Error("must not fetch"); },
+      }),
+      "invalid_input",
+    );
+  }
+});
+
+test("#2283: the resolved and final response origins stay fenced", async () => {
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "history" },
+      {
+        expectedOrigin: "https://panel.test",
+        api: { apiURL: () => "https://evil.test/history" },
+        fetchImpl: async () => { throw new Error("must not fetch"); },
+      },
+    ),
+    "invalid_origin",
+  );
+
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "system_stats" },
+      {
+        expectedOrigin: "https://panel.test",
+        api: { apiURL: (path) => path },
+        fetchImpl: async (url) => response({ url: "https://evil.test/system_stats" }),
+      },
+    ),
+    "invalid_origin",
+  );
+});
+
+test("#2283: redirects and oversized bodies are refused", async () => {
+  const options = {
+    expectedOrigin: "https://panel.test",
+    api: { apiURL: (path) => path },
+  };
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "logs" },
+      { ...options, fetchImpl: async () => response({ status: 302, url: "https://panel.test/login", stream: false }) },
+    ),
+    "redirect_error",
+  );
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "history" },
+      { ...options, maxBytes: 4, fetchImpl: async () => response({ body: "12345" }) },
+    ),
+    "too_large",
+  );
+});
+
+test("#2283: the command remains on the authenticated rid executor/reply path", () => {
+  const source = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(source, /fetch_comfyui_read\(args = \{\}\)/);
+  assert.match(source, /return fetchComfyUIReadForMcp\(args, \{ api \}\)/);
+  assert.match(source, /"ui_render", "ui_update", "fetch_image", "fetch_comfyui_read"/);
+  assert.match(source, /const isCommandFrame = msg && typeof msg\.rid === "string" && typeof msg\.cmd === "string"/);
+  assert.match(source, /const executor = GRAPH_TOOL_EXECUTORS\[msg\.cmd\]/);
+  assert.match(source, /reply = \{ rid: msg\.rid, ok: true, result \}/);
+  assert.match(source, /deliverReply\(reply, msg\.cmd, superseded, inFlightMark\)/);
+  assert.equal(commandIsCanvasIndependent("fetch_comfyui_read"), true);
+  assert.equal(commandIsCanvasTargetless("fetch_comfyui_read"), true);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -293,6 +293,7 @@ import { recordSkillFromGraph, persistRecordedSkill } from "./lib/record-skill.j
 // 1.7MB panel IIFE.
 import { makeCommandBudget } from "./lib/command-budget.js";
 import { fetchImageForMcp } from "./lib/fetch-image.js";
+import { fetchComfyUIReadForMcp } from "./lib/fetch-comfyui-read.js";
 // #1184 — the ORDER a backend switch commits in. A module because the defect is an
 // ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
 import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
@@ -12585,6 +12586,12 @@ const GRAPH_TOOL_EXECUTORS = {
   // fetches same-origin /view bytes, and never paints into the panel chat.
   fetch_image(args = {}) {
     return fetchImageForMcp(args, { api });
+  },
+  // Read-only MCP fallback for the connected ComfyUI's fixed diagnostics routes.
+  // The operation-to-path mapping and same-origin/credential checks live in the
+  // helper; no caller-supplied URL, path, target, or origin reaches fetch().
+  fetch_comfyui_read(args = {}) {
+    return fetchComfyUIReadForMcp(args, { api });
   },
   // #608: force a fresh /object_info re-register + combo refresh so an asset that
   // appeared server-side AFTER page-load — an upload_image action:"stage" input, a freshly
@@ -26370,7 +26377,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // commands get the normal activity card.
         const SILENT_CMDS = new Set([
           "ask_user", "request_secret", "set_todo", "show_media", "open_civitai",
-          "ui_render", "ui_update", "fetch_image",
+          "ui_render", "ui_update", "fetch_image", "fetch_comfyui_read",
           "civitai_results", "civitai_highlight", "civitai_clear_highlight",
           "civitai_switch_tab", "civitai_search", "civitai_open_lightbox",
           "open_training", "training_get_state", "training_set_field",

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -254,7 +254,11 @@ export async function fetchComfyUIReadForMcp(
   try {
     let response;
     try {
-      if (typeof api?.fetchApi === "function") {
+      // ComfyUI's internal logs route is not under the API wrapper's /api
+      // namespace. Keep history/system_stats on fetchApi (which preserves the
+      // frontend's base-path behavior), but send logs through the already
+      // origin-validated absolute URL.
+      if (operation !== "logs" && typeof api?.fetchApi === "function") {
         response = await Promise.race([api.fetchApi(path, request), timeout.timeoutPromise]);
       } else {
         if (typeof fetchImpl !== "function") {

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -1,0 +1,297 @@
+// Fixed-operation ComfyUI read relay for MCP.
+//
+// This module deliberately accepts an operation name, never a path, URL, origin,
+// or target. The panel API helper keeps the request on the connected ComfyUI
+// origin and carries the browser's normal credentials.
+
+export const FETCH_COMFYUI_READ_TIMEOUT_MS = 8000;
+export const MAX_FETCH_COMFYUI_READ_BYTES = 16 * 1024 * 1024;
+
+const READ_OPERATIONS = new Map([
+  ["history", "/history"],
+  ["system_stats", "/system_stats"],
+  ["logs", "/internal/logs"],
+]);
+
+// These are bridge transport/routing fields, not read arguments. The
+// dispatcher may stamp them onto every command frame before it reaches us.
+const COMMAND_FRAME_FIELDS = new Set([
+  "cmd",
+  "rid",
+  "retry_of",
+  "timeout_ms",
+  "epoch",
+  "workflow_uuid",
+  "workflow_path",
+]);
+
+function readError(code, message, extra = {}) {
+  const error = new Error(message);
+  error.code = code;
+  Object.assign(error, extra);
+  return error;
+}
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function invalidInput(message) {
+  return readError(
+    "invalid_input",
+    `fetch_comfyui_read rejected the operation: ${message}`,
+  );
+}
+
+/** Validate and normalize the public `{operation}` shape. */
+export function validateFetchComfyUIReadArgs(args) {
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    throw invalidInput("expected an object");
+  }
+  for (const key of Object.keys(args)) {
+    if (key !== "operation" && !COMMAND_FRAME_FIELDS.has(key)) {
+      throw invalidInput(`unexpected field "${key}"`);
+    }
+  }
+  if (!hasOwn(args, "operation")) {
+    throw invalidInput("operation is required");
+  }
+  if (typeof args.operation !== "string" || !READ_OPERATIONS.has(args.operation)) {
+    throw invalidInput("operation must be one of history, system_stats, logs");
+  }
+  return { operation: args.operation, path: READ_OPERATIONS.get(args.operation) };
+}
+
+function pageOrigin() {
+  const origin = globalThis.location?.origin;
+  return typeof origin === "string" && origin && origin !== "null" ? origin : null;
+}
+
+function resolveSameOriginUrl(api, path, expectedOrigin = pageOrigin()) {
+  if (typeof api?.apiURL !== "function") {
+    throw readError("api_unavailable", "fetch_comfyui_read requires the panel API URL helper");
+  }
+  let rawUrl;
+  try {
+    rawUrl = api.apiURL(path);
+  } catch (error) {
+    throw readError(
+      "api_unavailable",
+      `fetch_comfyui_read could not resolve ${path}: ${error?.message ?? error}`,
+    );
+  }
+  if (typeof rawUrl !== "string" || rawUrl === "") {
+    throw readError("api_unavailable", "fetch_comfyui_read could not resolve the fixed read URL");
+  }
+  try {
+    const parsed = new URL(rawUrl, expectedOrigin || "http://comfyui-panel.invalid");
+    if (expectedOrigin && parsed.origin !== expectedOrigin) {
+      throw readError("invalid_origin", "fetch_comfyui_read resolved a non-same-origin URL");
+    }
+    if (!expectedOrigin && parsed.origin !== "http://comfyui-panel.invalid") {
+      throw readError("invalid_origin", "fetch_comfyui_read cannot verify an absolute URL origin");
+    }
+  } catch (error) {
+    if (error?.code) throw error;
+    throw readError("invalid_origin", "fetch_comfyui_read resolved an invalid URL");
+  }
+  return rawUrl;
+}
+
+function responseHeader(response, name) {
+  try {
+    return typeof response?.headers?.get === "function" ? response.headers.get(name) : null;
+  } catch {
+    return null;
+  }
+}
+
+function validateResponseOrigin(response, expectedOrigin) {
+  const rawUrl = response?.url;
+  if (rawUrl == null || rawUrl === "") return;
+  if (typeof rawUrl !== "string") {
+    throw readError("invalid_origin", "fetch_comfyui_read received a response with an invalid URL");
+  }
+  try {
+    const parsed = new URL(rawUrl, expectedOrigin || "http://comfyui-panel.invalid");
+    if (
+      (!expectedOrigin && parsed.origin !== "http://comfyui-panel.invalid") ||
+      (expectedOrigin && parsed.origin !== expectedOrigin)
+    ) {
+      throw readError("invalid_origin", "fetch_comfyui_read received a non-same-origin response URL");
+    }
+  } catch (error) {
+    if (error?.code) throw error;
+    throw readError("invalid_origin", "fetch_comfyui_read received an invalid response URL");
+  }
+}
+
+function rejectRedirectResponse(response) {
+  const status = Number(response?.status);
+  if (
+    response?.type === "opaqueredirect" ||
+    response?.redirected === true ||
+    (Number.isFinite(status) && status >= 300 && status < 400)
+  ) {
+    throw readError(
+      "redirect_error",
+      `fetch_comfyui_read rejected a redirect response${Number.isFinite(status) ? ` (HTTP ${status})` : ""}`,
+      { status: Number.isFinite(status) ? status : null },
+    );
+  }
+}
+
+function declaredLength(response) {
+  const raw = responseHeader(response, "content-length");
+  if (!raw || !/^\d+$/.test(raw.trim())) return null;
+  const length = Number(raw);
+  return Number.isSafeInteger(length) ? length : null;
+}
+
+function timeoutState(timeoutMs) {
+  const controller = new AbortController();
+  const timeoutError = readError("timeout", `fetch_comfyui_read timed out after ${timeoutMs}ms`);
+  let rejectTimeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    rejectTimeout = reject;
+  });
+  const timer = setTimeout(() => {
+    controller.abort();
+    rejectTimeout(timeoutError);
+  }, timeoutMs);
+  return {
+    controller,
+    timeoutPromise,
+    timeoutError,
+    dispose: () => clearTimeout(timer),
+  };
+}
+
+async function readResponseText(response, maxBytes, timeoutPromise) {
+  const length = declaredLength(response);
+  if (length !== null && length > maxBytes) {
+    throw readError(
+      "too_large",
+      `fetch_comfyui_read response exceeds the ${maxBytes}-byte limit`,
+      { bytes: length },
+    );
+  }
+
+  if (typeof response?.body?.getReader === "function") {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const parts = [];
+    let total = 0;
+    try {
+      while (true) {
+        const part = await Promise.race([reader.read(), timeoutPromise]);
+        if (part.done) break;
+        const chunk = part.value instanceof Uint8Array ? part.value : new Uint8Array(part.value);
+        total += chunk.byteLength;
+        if (total > maxBytes) {
+          try { void reader.cancel(); } catch { /* best effort */ }
+          throw readError(
+            "too_large",
+            `fetch_comfyui_read response exceeds the ${maxBytes}-byte limit`,
+            { bytes: total },
+          );
+        }
+        parts.push(decoder.decode(chunk, { stream: true }));
+      }
+      parts.push(decoder.decode());
+    } finally {
+      try { reader.releaseLock?.(); } catch { /* best effort */ }
+    }
+    return { text: parts.join(""), bytes: total };
+  }
+
+  if (typeof response?.text !== "function") {
+    throw readError("read_error", "fetch_comfyui_read response has no readable body");
+  }
+  if (length === null) {
+    throw readError("read_error", "fetch_comfyui_read response has no bounded body length");
+  }
+  const text = await Promise.race([response.text(), timeoutPromise]);
+  const bytes = new TextEncoder().encode(text).byteLength;
+  if (bytes > maxBytes) {
+    throw readError(
+      "too_large",
+      `fetch_comfyui_read response exceeds the ${maxBytes}-byte limit`,
+      { bytes },
+    );
+  }
+  return { text, bytes };
+}
+
+/** Fetch one fixed ComfyUI read for the MCP fallback path. */
+export async function fetchComfyUIReadForMcp(
+  args,
+  {
+    api,
+    fetchImpl = globalThis.fetch,
+    timeoutMs = FETCH_COMFYUI_READ_TIMEOUT_MS,
+    maxBytes = MAX_FETCH_COMFYUI_READ_BYTES,
+    expectedOrigin,
+  } = {},
+) {
+  if (!(timeoutMs > 0) || !Number.isFinite(timeoutMs)) {
+    throw readError("invalid_config", "fetch_comfyui_read timeout must be positive");
+  }
+  if (!(maxBytes > 0) || !Number.isFinite(maxBytes)) {
+    throw readError("invalid_config", "fetch_comfyui_read byte limit must be positive");
+  }
+  const { operation, path } = validateFetchComfyUIReadArgs(args);
+  const origin = expectedOrigin ?? pageOrigin();
+  const url = resolveSameOriginUrl(api, path, origin);
+  const timeout = timeoutState(timeoutMs);
+  const request = {
+    method: "GET",
+    cache: "no-store",
+    credentials: "include",
+    redirect: "manual",
+    signal: timeout.controller.signal,
+  };
+  try {
+    let response;
+    try {
+      if (typeof api?.fetchApi === "function") {
+        response = await Promise.race([api.fetchApi(path, request), timeout.timeoutPromise]);
+      } else {
+        if (typeof fetchImpl !== "function") {
+          throw readError("api_unavailable", "fetch_comfyui_read has no fetch transport");
+        }
+        response = await Promise.race([fetchImpl(url, request), timeout.timeoutPromise]);
+      }
+    } catch (error) {
+      if (error === timeout.timeoutError || timeout.controller.signal.aborted) throw timeout.timeoutError;
+      if (error?.code) throw error;
+      throw readError("network_error", `fetch_comfyui_read could not reach ${path}: ${error?.message ?? error}`);
+    }
+
+    validateResponseOrigin(response, origin);
+    rejectRedirectResponse(response);
+    const status = Number(response?.status);
+    const ok = response?.ok === true || (Number.isFinite(status) && status >= 200 && status < 300);
+    if (!ok) {
+      throw readError(
+        "http_error",
+        `fetch_comfyui_read ${path} returned HTTP ${Number.isFinite(status) ? status : "unknown"}`,
+        { status: Number.isFinite(status) ? status : null },
+      );
+    }
+    const body = await readResponseText(response, maxBytes, timeout.timeoutPromise);
+    return {
+      operation,
+      body: body.text,
+      contentType: responseHeader(response, "content-type"),
+      bytes: body.bytes,
+    };
+  } catch (error) {
+    if (error === timeout.timeoutError || timeout.controller.signal.aborted) throw timeout.timeoutError;
+    throw error?.code
+      ? error
+      : readError("read_error", `fetch_comfyui_read failed: ${error?.message ?? error}`);
+  } finally {
+    timeout.dispose();
+  }
+}

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -12,6 +12,7 @@ const READ_OPERATIONS = new Map([
   ["system_stats", "/system_stats"],
   ["logs", "/internal/logs"],
 ]);
+const LOGS_TRANSPORT_PATH = "/internal/logs/raw";
 
 // These are bridge transport/routing fields, not read arguments. The
 // dispatcher may stamp them onto every command frame before it reaches us.
@@ -68,16 +69,23 @@ function pageOrigin() {
 }
 
 function resolveSameOriginUrl(api, path, expectedOrigin = pageOrigin()) {
-  if (typeof api?.apiURL !== "function") {
-    throw readError("api_unavailable", "fetch_comfyui_read requires the panel API URL helper");
+  const useFileUrl = path === "/internal/logs";
+  const resolverName = useFileUrl ? "fileURL" : "apiURL";
+  const resolver = api?.[resolverName];
+  if (typeof resolver !== "function") {
+    throw readError(
+      "api_unavailable",
+      `fetch_comfyui_read requires the panel ${resolverName} helper`,
+    );
   }
+  const transportPath = useFileUrl ? LOGS_TRANSPORT_PATH : path;
   let rawUrl;
   try {
-    rawUrl = api.apiURL(path);
+    rawUrl = resolver(transportPath);
   } catch (error) {
     throw readError(
       "api_unavailable",
-      `fetch_comfyui_read could not resolve ${path}: ${error?.message ?? error}`,
+      `fetch_comfyui_read could not resolve ${transportPath}: ${error?.message ?? error}`,
     );
   }
   if (typeof rawUrl !== "string" || rawUrl === "") {

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -397,6 +397,7 @@ const CANVAS_INDEPENDENT_COMMANDS = new Set([
   'graph_update_node',
   'graph_get_virtual_types',
   'fetch_image',
+  'fetch_comfyui_read',
   'comfy_reboot',
   'free_vram',
 ]);


### PR DESCRIPTION
Panel companion for artokun/comfyui-mcp#2283.\n\nAdds the authenticated fixed-operation bridge command fetch_comfyui_read for history, system_stats, and logs only, with same-origin credentials, manual redirects, bounded timeout/body, and fail-closed validation. No arbitrary URL/path proxying.\n\nMCP consumer PR: artokun/comfyui-mcp#2287