### PR TITLE
chore: release v0.15.94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.94] - 2026-08-25
+
+### Fixed
+- fail closed when workflow-open binding settles or reconnect proofs become stale during concurrent tab operations (#887)
+
 ## [0.15.93] - 2026-08-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.93",
+  "version": "0.15.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.93",
+      "version": "0.15.94",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.93",
+  "version": "0.15.94",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {


### PR DESCRIPTION
Release Panel v0.15.94.\n\nIncludes the fail-closed concurrent workflow binding/proof fix for #887.\n\n- [ ] independent release review\n- [ ] hosted CI green\n- [ ] tag and GitHub release after merge