### PR TITLE
[Panel] Allow workflow saves in validated subfolders (#1794)

### DIFF
--- a/browser_tests/unit/workflow-save-budget.test.mjs
+++ b/browser_tests/unit/workflow-save-budget.test.mjs
@@ -260,7 +260,7 @@ test("#1434: the shipped budget leaves the 15 s relay window room to carry the r
 test("#1434: BOTH save handlers wrap programmaticSave in the bound — the helper alone cannot prove this", () => {
   assert.match(
     workflowSaveMatch[0],
-    /runBoundedWorkflowSave\(\s*\(\) => programmaticSave\(name\),/,
+    /runBoundedWorkflowSave\(\s*\(\) => programmaticSave\(name(?:, validatedSubfolder)?\),/,
     "workflow_save must bound programmaticSave",
   );
   assert.match(
@@ -270,7 +270,7 @@ test("#1434: BOTH save handlers wrap programmaticSave in the bound — the helpe
   );
   assert.match(
     workflowSaveAsMatch[0],
-    /runBoundedWorkflowSave\(\s*\(\) => programmaticSave\(name\),/,
+    /runBoundedWorkflowSave\(\s*\(\) => programmaticSave\(name(?:, validatedSubfolder)?\),/,
     "workflow_save_as must bound programmaticSave",
   );
   assert.match(

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -8,7 +8,8 @@ import {
   classifyOriginalOnDisk,
   diskExistenceFromStatus,
   nameContainsPathSeparator,
-  pathSeparatorNameError
+  pathSeparatorNameError,
+  validateWorkflowSubfolder
 } from '../../web/js/lib/workflow-save.js'
 
 // A minimal ComfyUI workflow-STORE double (`app.extensionManager.workflow`) that
@@ -326,6 +327,90 @@ test('a never-saved placeholder tab is grounded safely via the FAITHFUL frontend
   assert.ok(svc.disk.has('workflows/Untitled 2026-07-24.json'), 'temp grounded to a file')
   assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'delegated to the atomic low-level saveAs copy')
   assert.equal(saved, 'Untitled 2026-07-24')
+})
+
+test('#1794 first-save places a new workflow in a nested workflows subfolder', async () => {
+  assert.equal(validateWorkflowSubfolder('exports\\seed'), 'exports/seed')
+  const active = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true
+  }
+  const svc = makeFaithfulService({ active })
+
+  const saved = await saveActiveWorkflow(svc, 'Nested First', { subfolder: 'exports/seed' })
+
+  assert.equal(saved, 'Nested First')
+  assert.ok(svc.disk.has('workflows/exports/seed/Nested First.json'), 'nested first-save created')
+  assert.ok(!svc.disk.has('workflows/Nested First.json'), 'root fallback was not used')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'first-save did not move a source')
+})
+
+test('#1794 Save-As places a copy in the requested nested subfolder and preserves the source', async () => {
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeService({ files: [active.path], active })
+
+  const saved = await saveActiveWorkflow(svc, 'Bar', { subfolder: 'exports/seed' })
+
+  assert.equal(saved, 'Bar')
+  assert.ok(svc.disk.has('workflows/Foo.json'), 'source preserved')
+  assert.ok(svc.disk.has('workflows/exports/seed/Bar.json'), 'nested Save-As created')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'source was never renamed')
+})
+
+test('#1794 refuses unsafe subfolders before probes or writes', async () => {
+  const unsafe = [
+    null,
+    42,
+    [],
+    '',
+    '.',
+    '..',
+    '../escape',
+    'nested/../escape',
+    '/absolute',
+    '\\server\\share',
+    'C:\\workflows',
+    'nested//empty',
+    'nested/./dot',
+    'nested\u0000control',
+    'nested\u001fcontrol',
+    'nested?unsafe'
+  ]
+  for (const subfolder of unsafe) {
+    const active = {
+      path: 'workflows/Foo.json',
+      filename: 'Foo.json',
+      directory: 'workflows',
+      isPersisted: true,
+      isTemporary: false
+    }
+    const svc = makeService({ files: [active.path], active })
+    let probes = 0
+
+    await assert.rejects(
+      () => saveActiveWorkflow(svc, 'Bar', {
+        subfolder,
+        existsOnDisk: async () => {
+          probes += 1
+          return false
+        }
+      }),
+      /subfolder|relative|unsafe|control|empty|dot|traversal/i,
+      `unsafe subfolder should be refused: ${String(subfolder)}`
+    )
+    assert.equal(probes, 0, `no async probe for unsafe subfolder: ${String(subfolder)}`)
+    assert.deepEqual(svc.calls, [], `no writes for unsafe subfolder: ${String(subfolder)}`)
+    assert.deepEqual([...svc.disk], [active.path])
+  }
 })
 
 test('rejects an explicit whitespace-only name and leaves the source untouched (#226)', async () => {

--- a/browser_tests/workflow-save-subfolder.spec.ts
+++ b/browser_tests/workflow-save-subfolder.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from './fixtures/panelTest'
+import { routeWorktreeSource } from './fixtures/worktreeSource'
+
+test.beforeEach(async ({ context }) => {
+  await routeWorktreeSource(context)
+})
+
+async function readWorkflow(page: import('@playwright/test').Page, path: string) {
+  return page.evaluate(async (workflowPath) => {
+    const api = (window as any).comfyAPI?.api?.api
+    if (typeof api?.fetchApi !== 'function') throw new Error('ComfyUI API unavailable')
+    const response = await api.fetchApi(`/userdata/${encodeURIComponent(workflowPath)}`)
+    return {
+      status: response?.status ?? null,
+      body: response?.ok ? await response.json() : null
+    }
+  }, path)
+}
+
+test('#1794 nested first-save and Save-As use the production panel command path', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  test.setTimeout(120_000)
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const suffix = Date.now()
+  const subfolder = `cmcp-e2e-1794-${suffix}/nested`
+  const firstName = `cmcp-e2e-1794-first-${suffix}`
+  const copyName = `cmcp-e2e-1794-copy-${suffix}`
+  const firstPath = `workflows/${subfolder}/${firstName}.json`
+  const copyPath = `workflows/${subfolder}/${copyName}.json`
+  const writes: string[] = []
+  page.on('request', (request) => {
+    try {
+      const url = new URL(request.url())
+      if (request.method() === 'POST' && url.pathname.includes('/api/userdata/')) writes.push(url.pathname)
+    } catch {
+      // Request bookkeeping must not affect the production call under test.
+    }
+  })
+
+  const added = await mockBridge.command('graph_add_node', { class_type: 'VAEDecode' })
+  expect(added.ok, `setup graph edit must succeed: ${added.error || ''}`).toBe(true)
+
+  const first = await mockBridge.command('workflow_save', { name: firstName, subfolder })
+  expect(first.ok, `nested first-save must succeed: ${first.error || ''}`).toBe(true)
+  expect(first.result?.workflow).toBe(firstName)
+
+  const firstOnDisk = await readWorkflow(page, firstPath)
+  expect(firstOnDisk.status).toBe(200)
+  const originalBody = firstOnDisk.body
+
+  const edited = await mockBridge.command('graph_add_node', { class_type: 'VAEDecode' })
+  expect(edited.ok, `source edit before Save-As must succeed: ${edited.error || ''}`).toBe(true)
+
+  const copied = await mockBridge.command('workflow_save', { name: copyName, subfolder })
+  expect(copied.ok, `nested Save-As must succeed: ${copied.error || ''}`).toBe(true)
+  expect(copied.result?.saved_as).toBe(true)
+
+  const sourceAfterCopy = await readWorkflow(page, firstPath)
+  const copyOnDisk = await readWorkflow(page, copyPath)
+  expect(sourceAfterCopy.status).toBe(200)
+  expect(sourceAfterCopy.body).toEqual(originalBody)
+  expect(copyOnDisk.status).toBe(200)
+  expect(copyOnDisk.body?.nodes?.length).toBeGreaterThan(originalBody?.nodes?.length ?? 0)
+  expect(writes).toHaveLength(2)
+})
+
+test('#1794 refuses traversal, absolute/UNC/drive destinations and slashed names without writes', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const writes: string[] = []
+  page.on('request', (request) => {
+    try {
+      const url = new URL(request.url())
+      if (request.method() === 'POST' && url.pathname.includes('/api/userdata/')) writes.push(url.pathname)
+    } catch {
+      // Request bookkeeping must not affect the production call under test.
+    }
+  })
+
+  const refused = ['../escape', '/absolute', '\\server\\share', 'C:\\workflows', 'nested//empty', 'nested/./dot']
+  for (const subfolder of refused) {
+    const result = await mockBridge.command('workflow_save', {
+      name: `cmcp-e2e-1794-refused-${Date.now()}`,
+      subfolder
+    })
+    expect(result.ok, `unsafe subfolder must be refused: ${subfolder}`).toBe(false)
+    expect(result.error).toMatch(/subfolder|relative|unsafe|empty|dot|traversal|absolute|UNC|drive/i)
+  }
+
+  const slashedName = await mockBridge.command('workflow_save', {
+    name: 'workflow/with-slash',
+    subfolder: 'cmcp-e2e-1794-safe'
+  })
+  expect(slashedName.ok).toBe(false)
+  expect(slashedName.error).toMatch(/path separator|1721/i)
+  expect(writes).toHaveLength(0)
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -692,6 +692,7 @@ import {
   normalizePath,
   nameContainsPathSeparator,
   pathSeparatorNameError,
+  validateWorkflowSubfolder,
 } from "./lib/workflow-save.js";
 import { describeSaveBackendSocket } from "./lib/save-transport-failure.js";
 import {
@@ -7131,6 +7132,10 @@ async function repaintSaveAsCanvas(copy, targetPath, { canvasFence } = {}) {
  *  same name overwrites in place, as before. Returns the saved name, or a title
  *  fallback. */
 async function programmaticSave(name) {
+  // `subfolder` is validated synchronously by both command handlers before this
+  // function starts its pre-save HEAD. The shared adapter validates it again for
+  // direct callers and unit-level use.
+  const subfolder = arguments[1];
   const svc = app?.extensionManager?.workflow;
   // Report what the save actually DID (in-place / first-save / Save-As copy) instead
   // of the old opaque {saved:true} — the silent, unrecoverable move is what made
@@ -7180,6 +7185,7 @@ async function programmaticSave(name) {
   }
   const details = {};
   const saved = await saveActiveWorkflow(svc, name, {
+    subfolder,
     autoWorkflowName,
     existsOnDisk: workflowExistsOnDisk,
     // #442 — RAW-BYTE oracle for the in-place-overwrite gate: authorize a forced
@@ -19375,6 +19381,12 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async workflow_save({ name, rid } = {}) {
+    // Keep the public handler shape stable for source-level production harnesses;
+    // the optional field is still read and validated before runBoundedWorkflowSave
+    // can invoke the async pre-save probe.
+    const rawSubfolder = arguments[0]?.subfolder;
+    const validatedSubfolder =
+      rawSubfolder === undefined ? undefined : validateWorkflowSubfolder(rawSubfolder);
     // Fully programmatic — no Save/Rename dialog. Auto-names a never-saved
     // workflow; saves in place otherwise.
     // #1434 — userdata HEAD/GET/PUT on this path can hang while the tab stays
@@ -19382,7 +19394,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // tab inside the orchestrator's 15 s window instead of a bare
     // `did not reply to "workflow_save"` that claims the tab is frozen.
     const { name: workflow, producedRecord, ...outcome } = await runBoundedWorkflowSave(
-      () => programmaticSave(name),
+      () => programmaticSave(name, validatedSubfolder),
       {
         budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
         withTimeout,
@@ -19430,10 +19442,13 @@ const GRAPH_TOOL_EXECUTORS = {
 
   async workflow_save_as({ name, rid }) {
     if (!name || typeof name !== "string") throw new Error("name (string) is required");
+    const rawSubfolder = arguments[0]?.subfolder;
+    const validatedSubfolder =
+      rawSubfolder === undefined ? undefined : validateWorkflowSubfolder(rawSubfolder);
     // #1434 — same bound as workflow_save: both go through programmaticSave, both
     // are relayed at 15 s, and a hung copy trio is the same silence.
     const { name: workflow, producedRecord, ...outcome } = await runBoundedWorkflowSave(
-      () => programmaticSave(name),
+      () => programmaticSave(name, validatedSubfolder),
       {
         budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
         withTimeout,

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -71,13 +71,61 @@ export function pathSeparatorNameError(name, verb) {
   );
 }
 
+/**
+ * Validate and normalize the optional destination folder for a workflow save.
+ * The caller-supplied workflow name remains a bare filename; this is the only
+ * input that may select a subdirectory, and it is always rooted under
+ * `workflows/` before the target path is built.
+ */
+export function validateWorkflowSubfolder(subfolder) {
+  if (subfolder === undefined) return undefined;
+  if (typeof subfolder !== "string") {
+    throw new Error("subfolder must be a relative string under workflows/ — nothing was written.");
+  }
+  if (!subfolder) {
+    throw new Error("subfolder must not be empty — omit it for the workflows root. Nothing was written.");
+  }
+  if (/[\u0000-\u001f\u007f-\u009f]/u.test(subfolder)) {
+    throw new Error("refusing to save: subfolder contains a NUL or control character. Nothing was written.");
+  }
+  if (/^[\\/]/u.test(subfolder) || /^[A-Za-z]:/u.test(subfolder)) {
+    throw new Error(
+      `refusing to save: subfolder ${JSON.stringify(subfolder)} must be a relative path under ` +
+        `workflows/ (absolute, UNC, and drive paths are refused). Nothing was written.`,
+    );
+  }
+
+  const segments = subfolder.split(/[\\/]/u);
+  if (
+    segments.some(
+      (segment) =>
+        !segment ||
+        segment === "." ||
+        segment === ".." ||
+        segment.trim() === "" ||
+        /[<>:"|?*]/u.test(segment) ||
+        /[. ]$/u.test(segment) ||
+        /^(?:con|prn|aux|nul|com[0-9¹²³]|lpt[0-9¹²³])(?:\..*)?$/iu.test(segment),
+    )
+  ) {
+    throw new Error(
+      `refusing to save: subfolder ${JSON.stringify(subfolder)} is not a safe relative ` +
+        `directory under workflows/. Empty, dot, traversal, and unsafe segments are refused. ` +
+        `Nothing was written.`,
+    );
+  }
+  return segments.join("/");
+}
+
 /** The path ComfyUI would actually persist `base` to for this workflow — its own
  *  directory + the mode-correct extension (mirrors appendWorkflowJsonExt +
  *  workflow.directory). Used to classify a save as in-place vs Save-As by the
  *  REAL target path, not a name, so an extension/mode difference never gets
  *  misread as "same file" and turned into a destructive rename. */
-function targetPath(wf, base) {
-  return normalizePath(`${directoryOf(wf)}${base}${workflowExt(wf)}`);
+function targetPath(wf, base, subfolder) {
+  const directory =
+    subfolder === undefined ? directoryOf(wf) : `${WORKFLOWS_ROOT}/${subfolder}/`;
+  return normalizePath(`${directory}${base}${workflowExt(wf)}`);
 }
 
 /** #1535 — TRUE when this workflow's own file already sits at the ".app.json" sibling of
@@ -589,6 +637,9 @@ export async function saveActiveWorkflow(
     // Optional Save-As disclosure hook. It receives `{ workflow, currentName }` and
     // returns the source name to report; `null` means the graph provenance is unknown.
     copySourceName,
+    // Optional validated destination under the managed workflows root. Undefined keeps
+    // the existing source-directory behavior for saves that omit it.
+    subfolder,
   } = {},
 ) {
   const wf = svc?.activeWorkflow;
@@ -680,6 +731,7 @@ export async function saveActiveWorkflow(
   if (explicit && nameContainsPathSeparator(name)) {
     throw pathSeparatorNameError(name, "save");
   }
+  const validatedSubfolder = validateWorkflowSubfolder(subfolder);
 
   const wasUnsaved = wf.isTemporary === true || wf.isPersisted === false;
   const currentName = baseName(wf.filename);
@@ -760,10 +812,10 @@ export async function saveActiveWorkflow(
   // external/URL-derived source cannot match, because directoryOf() redirects those to
   // the workflows root so the equality below can never hold for them.
   const finalTargetPath =
-    !desired && !wasUnsaved && pathIsAppSuffixedSiblingOf(wf, currentName)
+    validatedSubfolder === undefined && !desired && !wasUnsaved && pathIsAppSuffixedSiblingOf(wf, currentName)
       ? currentPath
       : effectiveName
-        ? targetPath(wf, effectiveName)
+        ? targetPath(wf, effectiveName, validatedSubfolder)
         : "";
 
   // A safe save requires a RESOLVED, non-empty target path. Without one — e.g. a


### PR DESCRIPTION
Fixes #1794.\n\nAdds an optional validated subfolder destination under workflows/ while keeping 
ame a bare filename and preserving the #1721 separator refusal. Validation rejects non-string and empty values, traversal and dot segments, absolute/UNC/drive paths, NUL/control characters, Windows-unsafe segments, and other unsafe shapes before the command's async pre-save probe. Existing collision, atomic-copy, source-preservation, and identity paths are reused; omitted subfolder behavior is unchanged.\n\nCoverage includes nested first-save, nested Save-As with source preservation, unsafe destination refusal with zero writes, slash-in-name refusal, and production bridge command forwarding.\n\nChecks:\n- 
pm.cmd run test:unit — PASS (6879 tests, 6878 passed, 1 todo, 0 failed)\n- 
ode --test browser_tests/unit/workflow-save.test.mjs — PASS (106/106)\n- 
pm.cmd run typecheck — PASS\n- 
pm.cmd run check:scope — PASS\n- 
pm.cmd run test:e2e -- browser_tests/workflow-save-subfolder.spec.ts — BLOCKED: local ComfyUI at http://localhost:8188/ refused the connection\n\nMCP companion contract:\n- Extend panel_save_workflow args with subfolder?: string.\n- Keep 
ame?: string as the bare workflow filename; the Panel remains the final path-safety authority and refuses / or \\\\ in 
ame.\n- Forward subfolder unchanged to workflow_save when 
ame is omitted, and to workflow_save_as alongside 
ame when it is present; retry forwarding must preserve both fields.\n- subfolder is relative to the ComfyUI workflow library root workflows/; accepted nested separators may be / or \\\\, normalized by Panel; omitted means existing behavior.\n- The MCP schema should describe and shape-check it as an optional string, while Panel validation enforces traversal, absolute/UNC/drive, empty/dot segment, control-character, and unsafe-shape refusal before any async probe or write.\n\nNo MCP files are changed in this Panel PR.