### PR TITLE
fix(1818): a provider the user already chose is not re-decided by a probe

### DIFF
--- a/browser_tests/unit/provider-autoselect.test.mjs
+++ b/browser_tests/unit/provider-autoselect.test.mjs
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { providerDiscoveryDecision } from "../../web/js/lib/provider-autoselect.js";
 
 const provider = (backend, available, extra = {}) => ({
@@ -72,4 +74,194 @@ test("uses ready as the compatibility fallback only on an explicitly complete fr
     discoveryComplete: true,
   });
   assert.deepEqual({ action: result.action, backend: result.backend }, { action: "select", backend: "codex" });
+});
+
+// ---------------------------------------------------------------------------
+// #1818 — the picker reappeared on every ComfyUI restart AND omitted the
+// provider that was actively serving the session (Claude, on macOS).
+//
+// One cause, both symptoms: the saved provider was looked up in the
+// reachable-only list, so a provider the host probe could not see could not
+// reach the `keep` branch that suppresses the card.
+//
+// `readiness` below is the frame the orchestrator ACTUALLY sends for claude on
+// a macOS install: `backendReadiness()` returns `ready: true` unconditionally
+// (the orchestrator is the Agent SDK host, there is no CLI), and
+// `allBackendReadiness()` then sets `available` from `claudeCredentialPresent()`
+// — a check for `~/.claude/.credentials.json`, which a Keychain login never
+// writes. Do not "simplify" these to the `provider()` helper above: that helper
+// ties `ready` and `available` together, which is the one shape that cannot
+// reproduce this bug.
+const readiness = (backend, { ready, available, ...extra }) => ({
+  backend,
+  ready,
+  ...(available === undefined ? {} : { available }),
+  ...extra,
+});
+
+const CLAUDE_ON_MACOS = readiness("claude", { ready: true, available: false });
+const OLLAMA_RUNNING = readiness("ollama", { ready: true, available: true });
+
+test("#1818 a saved provider the host probe cannot see is kept, not re-decided", () => {
+  const result = providerDiscoveryDecision({
+    backends: [CLAUDE_ON_MACOS, OLLAMA_RUNNING],
+    selectedBackend: "claude",
+    hasSavedChoice: true,
+    discoveryComplete: true,
+  });
+  // Symptom 1: no card. `choose` here is the bug.
+  assert.equal(result.action, "keep");
+  // Symptom 2: the active provider is in the list, not filtered out of it.
+  assert.deepEqual(
+    result.candidates.map((entry) => entry.backend),
+    ["claude", "ollama"],
+  );
+});
+
+test("#1818 the keep decision does not depend on a live handshake", () => {
+  // `connectedBackend` is set from the `models` frame, which the orchestrator
+  // pushes only after an uncached SDK model probe; `discovery_complete: true`
+  // arrives after three localhost fetches that fail instantly when nothing is
+  // listening. On the cold restart this issue is about, discovery wins that race
+  // and no handshake has landed. Nothing about the connected backend is passed
+  // in here on purpose — `selectedBackend`/`hasSavedChoice` come from
+  // localStorage at mount and are present before any frame arrives.
+  const result = providerDiscoveryDecision({
+    backends: [CLAUDE_ON_MACOS, OLLAMA_RUNNING],
+    selectedBackend: "claude",
+    hasSavedChoice: true,
+    discoveryComplete: true,
+  });
+  assert.equal(result.action, "keep");
+  // And it must NOT quietly move the user onto the one provider the probe CAN
+  // see — the reporter's Ollama was not even reachable.
+  assert.equal(result.backend, undefined);
+});
+
+test("#1818 restarting again re-reads the same state and still does not re-prompt", () => {
+  // The reported loop: same localStorage, same frame, card every single time.
+  const mount = () =>
+    providerDiscoveryDecision({
+      backends: [CLAUDE_ON_MACOS, OLLAMA_RUNNING],
+      selectedBackend: "claude",
+      hasSavedChoice: true,
+      discoveryComplete: true,
+    }).action;
+  assert.deepEqual([mount(), mount(), mount()], ["keep", "keep", "keep"]);
+});
+
+test("#1818 a saved provider that is genuinely gone still falls through", () => {
+  // An uninstalled codex / signed-out gemini reports ready:false. That is the
+  // signal that survives the fix — "your provider disappeared" must keep working,
+  // or this change would strand the user on a backend that cannot start.
+  const result = providerDiscoveryDecision({
+    backends: [readiness("codex", { ready: false, available: false }), OLLAMA_RUNNING],
+    selectedBackend: "codex",
+    hasSavedChoice: true,
+    discoveryComplete: true,
+  });
+  assert.deepEqual({ action: result.action, backend: result.backend }, {
+    action: "select",
+    backend: "ollama",
+  });
+});
+
+test("#1818 an unreachable provider with NO saved choice stays out of the list", () => {
+  // The reachability filter is untouched for everyone else: a first run must not
+  // start offering installed-but-stopped local daemons. Only an explicit prior
+  // choice outranks the probe.
+  const result = providerDiscoveryDecision({
+    backends: [CLAUDE_ON_MACOS, OLLAMA_RUNNING],
+    hasSavedChoice: false,
+    discoveryComplete: true,
+  });
+  assert.deepEqual({ action: result.action, backend: result.backend }, {
+    action: "select",
+    backend: "ollama",
+  });
+});
+
+test("#1818 a saved provider the user turned OFF, hid, or that is experimental is not kept", () => {
+  // Offerability is absolute — the saved-choice escape hatch is scoped to
+  // reachability and must not reach around a Settings opt-out or the
+  // never-auto-pick rule that covers copilot.
+  const disabled = providerDiscoveryDecision({
+    backends: [CLAUDE_ON_MACOS, OLLAMA_RUNNING],
+    selectedBackend: "claude",
+    hasSavedChoice: true,
+    discoveryComplete: true,
+    enabled: (id) => id !== "claude",
+  });
+  assert.equal(disabled.action, "select");
+  assert.equal(disabled.backend, "ollama");
+
+  for (const flag of ["hidden", "experimental"]) {
+    const result = providerDiscoveryDecision({
+      backends: [
+        readiness("claude", { ready: true, available: false, [flag]: true }),
+        OLLAMA_RUNNING,
+      ],
+      selectedBackend: "claude",
+      hasSavedChoice: true,
+      discoveryComplete: true,
+    });
+    assert.equal(result.action, "select", `${flag} must not be kept`);
+    assert.equal(result.backend, "ollama");
+  }
+});
+
+test("#1818 an older orchestrator that sends no `available` is unaffected", () => {
+  const result = providerDiscoveryDecision({
+    backends: [readiness("claude", { ready: false }), readiness("codex", { ready: true })],
+    selectedBackend: "claude",
+    hasSavedChoice: true,
+    discoveryComplete: true,
+  });
+  assert.deepEqual({ action: result.action, backend: result.backend }, {
+    action: "select",
+    backend: "codex",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The call site. A helper-level test proves the decision is right; it cannot
+// prove production reaches it with the persisted state, which is the whole
+// point of not keying this on the handshake. Assert the wiring in the source.
+test("#1818 the panel feeds the decision its PERSISTED choice, and opens no card on keep", () => {
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+
+  const call = src.match(
+    /const decision = providerDiscoveryDecision\(\{[\s\S]{0,400}?\n\s*\}\);/,
+  );
+  assert.ok(call, "the discovery decision call site moved — re-point this test");
+  assert.match(call[0], /\n\s*selectedBackend,/, "must pass the restored selection");
+  assert.match(
+    call[0],
+    /\n\s*hasSavedChoice: hasSavedProviderChoice,/,
+    "must pass the persisted confirmation, not a live-handshake proxy",
+  );
+
+  // Both inputs are restored from localStorage at mount, so they are populated
+  // before any bridge frame lands.
+  assert.match(
+    src,
+    /let selectedBackend = savedBackendAtMount \|\| "claude";/,
+    "selectedBackend must still be restored at mount",
+  );
+  assert.match(
+    src,
+    /let hasSavedProviderChoice = !!lsGet\(PROVIDER_CHOICE_CONFIRMED_KEY\);/,
+    "hasSavedProviderChoice must still be restored at mount",
+  );
+
+  // `keep` must reach no modal: the handler returns for every action that is
+  // not `choose`, so a kept provider cannot re-prompt.
+  assert.match(
+    src,
+    /if \(decision\.action !== "choose"\) return;/,
+    "only the choose action may open the provider card",
+  );
 });

--- a/browser_tests/unit/provider-autoselect.test.mjs
+++ b/browser_tests/unit/provider-autoselect.test.mjs
@@ -102,23 +102,49 @@ const readiness = (backend, { ready, available, ...extra }) => ({
 const CLAUDE_ON_MACOS = readiness("claude", { ready: true, available: false });
 const OLLAMA_RUNNING = readiness("ollama", { ready: true, available: true });
 
-test("#1818 a saved provider the host probe cannot see is kept, not re-decided", () => {
+test("#1818 a saved provider the host probe cannot see is offered and pre-selected", () => {
   const result = providerDiscoveryDecision({
     backends: [CLAUDE_ON_MACOS, OLLAMA_RUNNING],
     selectedBackend: "claude",
     hasSavedChoice: true,
     discoveryComplete: true,
   });
-  // Symptom 1: no card. `choose` here is the bug.
-  assert.equal(result.action, "keep");
-  // Symptom 2: the active provider is in the list, not filtered out of it.
+  // THE defect: claude was filtered out of the list entirely, so the card could
+  // not list it and the call site's `selected:` resolved to null. It is present
+  // now, and first, so the user's own provider is the pre-selected entry.
   assert.deepEqual(
     result.candidates.map((entry) => entry.backend),
     ["claude", "ollama"],
   );
+  // And the panel must ASK rather than relocate: on main this same frame
+  // returned `select: ollama` and moved a working Claude session onto a provider
+  // the reporter's log shows was not even reachable.
+  assert.equal(result.action, "choose");
+  assert.equal(result.backend, undefined);
 });
 
-test("#1818 the keep decision does not depend on a live handshake", () => {
+test("#1818 a saved provider is never silently replaced, whatever the probe says", () => {
+  // The harm on main is the SILENT part. With the saved entry back in the list
+  // there is always more than one candidate, so the `select` branch — which
+  // applies a provider with no user input — is unreachable while a saved choice
+  // is offerable. Checked across every alternative count.
+  for (const others of [[OLLAMA_RUNNING], [OLLAMA_RUNNING, readiness("codex", { ready: true, available: true })]]) {
+    const result = providerDiscoveryDecision({
+      backends: [CLAUDE_ON_MACOS, ...others],
+      selectedBackend: "claude",
+      hasSavedChoice: true,
+      discoveryComplete: true,
+    });
+    assert.equal(result.action, "choose", `${others.length} alternatives`);
+    assert.equal(result.backend, undefined);
+    assert.ok(
+      result.candidates.some((entry) => entry.backend === "claude"),
+      "the saved provider stays in the list it is chosen from",
+    );
+  }
+});
+
+test("#1818 the decision does not depend on a live handshake", () => {
   // `connectedBackend` is set from the `models` frame, which the orchestrator
   // pushes only after an uncached SDK model probe; `discovery_complete: true`
   // arrives after three localhost fetches that fail instantly when nothing is
@@ -132,24 +158,38 @@ test("#1818 the keep decision does not depend on a live handshake", () => {
     hasSavedChoice: true,
     discoveryComplete: true,
   });
+  assert.ok(
+    result.candidates.some((entry) => entry.backend === "claude"),
+    "no handshake landed, and the saved provider is still offered",
+  );
+});
+
+test("#1818 the saved provider alone means no card at all", () => {
+  // Nothing else offerable, so there is nothing to ask about: the user keeps the
+  // provider they already had and the restart is silent. `select` here resolves
+  // to the SAME backend already in `selectedBackend`, which the call site treats
+  // as a re-pick (persist only, no reconnect).
+  const result = providerDiscoveryDecision({
+    backends: [CLAUDE_ON_MACOS, readiness("codex", { ready: false, available: false })],
+    selectedBackend: "claude",
+    hasSavedChoice: true,
+    discoveryComplete: true,
+  });
+  assert.deepEqual({ action: result.action, backend: result.backend }, {
+    action: "select",
+    backend: "claude",
+  });
+});
+
+test("#1818 a reachable saved provider still short-circuits with no card", () => {
+  const result = providerDiscoveryDecision({
+    backends: [readiness("claude", { ready: true, available: true }), OLLAMA_RUNNING],
+    selectedBackend: "claude",
+    hasSavedChoice: true,
+    discoveryComplete: true,
+  });
   assert.equal(result.action, "keep");
-  // And it must NOT quietly move the user onto the one provider the probe CAN
-  // see — the reporter's Ollama was not even reachable.
-  assert.equal(result.backend, undefined);
 });
-
-test("#1818 restarting again re-reads the same state and still does not re-prompt", () => {
-  // The reported loop: same localStorage, same frame, card every single time.
-  const mount = () =>
-    providerDiscoveryDecision({
-      backends: [CLAUDE_ON_MACOS, OLLAMA_RUNNING],
-      selectedBackend: "claude",
-      hasSavedChoice: true,
-      discoveryComplete: true,
-    }).action;
-  assert.deepEqual([mount(), mount(), mount()], ["keep", "keep", "keep"]);
-});
-
 test("#1818 a saved provider that is genuinely gone still falls through", () => {
   // An uninstalled codex / signed-out gemini reports ready:false. That is the
   // signal that survives the fix — "your provider disappeared" must keep working,

--- a/web/js/lib/provider-autoselect.js
+++ b/web/js/lib/provider-autoselect.js
@@ -11,6 +11,7 @@ export function providerDiscoveryDecision({
   }
   // OFFERABLE and REACHABLE are separated on purpose — they answer different
   // questions, and #1818 is what happens when one answer is used for both.
+  //
   // Offerable = "may this provider be put in front of the user at all": not
   // experimental (copilot is opt-in ToS-risk and must never be auto-picked),
   // not hidden, not switched off in Settings. None of those can change behind
@@ -25,54 +26,71 @@ export function providerDiscoveryDecision({
   // fallback.
   const reachable = (entry) =>
     entry.available === undefined ? entry.ready === true : entry.available === true;
-  // #1818 — A CHOICE THE USER ALREADY MADE IS NOT A CANDIDATE TO RE-DECIDE.
+  // #1818 — THE SAVED PROVIDER IS ALWAYS A CANDIDATE, EVEN WHEN THE PROBE
+  // CANNOT SEE IT.
   //
-  // This used to look the saved provider up in the reachable-only list, so a
-  // saved provider the live probe could not see was not merely absent from the
-  // card — it could not reach the `keep` branch that suppresses the card. Both
-  // halves of #1818 came out of that one lookup: the picker reappeared on every
-  // ComfyUI restart BECAUSE the provider it should have kept was filtered out
-  // of the list it was searched in, and the same filter left `selected:` null.
+  // It used to be looked up in the reachable-only list, so a saved provider the
+  // probe missed was not merely absent from the card — it could not reach the
+  // `keep` branch that suppresses the card. Both halves of #1818 came out of
+  // that one lookup: the picker reappeared on every ComfyUI restart BECAUSE the
+  // provider it should have kept had been filtered out of the list it was
+  // searched in, and the same filter left `selected:` null so nothing was
+  // pre-selected.
   //
   // Claude is the case that exposed it. `backendReadiness()` reports claude
   // `ready: true` unconditionally and says why — the orchestrator IS the Agent
   // SDK host, there is no CLI to find. `allBackendReadiness()` then overwrites
   // `available` with `claudeCredentialPresent()`, a check for one exact file
   // (`~/.claude/.credentials.json`). A macOS install keeps that OAuth in the
-  // Keychain and never writes the file, and so do `CLAUDE_CODE_OAUTH_TOKEN`,
-  // `ANTHROPIC_API_KEY` and Bedrock/Vertex. The provider serving the session
-  // reports `ready: true, available: false`, and the picker dropped it.
-  //
-  // So the saved provider is held on `ready` (installed / configured / hosted)
-  // rather than on `available` (answering on localhost this second). The live
-  // probe still decides who is OFFERED; it no longer overturns a decision the
-  // user has already made. A provider that is genuinely gone reports
-  // `ready: false` — an uninstalled codex, a signed-out gemini — and still
-  // falls through to the select/choose paths below, so "your provider
-  // disappeared" keeps working.
-  //
-  // NOT keyed on the live handshake (`connectedBackend`). That value arrives on
-  // the `models` frame, which the orchestrator pushes only after awaiting an
-  // uncached SDK model probe, while `discovery_complete: true` arrives after
-  // three localhost fetches that fail instantly when nothing is listening. On
-  // the cold ComfyUI restart this issue is about, discovery normally wins that
-  // race and the handshake has landed nothing yet. `selectedBackend` and
-  // `hasSavedChoice` are both read from localStorage at mount, before any frame
-  // arrives, so they are the state that is actually there when this runs.
-  const saved =
+  // Keychain and never writes the file, and neither do `CLAUDE_CODE_OAUTH_TOKEN`,
+  // `ANTHROPIC_API_KEY` or Bedrock/Vertex. The provider actually serving the
+  // session arrives as `ready: true, available: false`.
+  // `ready` is still required. It is the signal that separates "the probe cannot
+  // see it" from "it is genuinely gone" — an uninstalled codex or a signed-out
+  // gemini reports `ready: false`, and those must keep falling through to the
+  // select/choose paths below rather than being offered a seat they cannot fill.
+  // Dropping this condition re-offers dead providers; the pre-existing
+  // "keeps a saved provider only while it remains available" case catches it.
+  const savedEntry =
     hasSavedChoice === true
       ? offerable.find(
           (entry) =>
             entry.backend === selectedBackend && (reachable(entry) || entry.ready === true),
         )
       : undefined;
-  // The saved provider rejoins the list it was dropped from, so `keep` reports
-  // the set the user actually has rather than the set the probe could see.
-  const candidates = offerable.filter((entry) => reachable(entry) || entry === saved);
-  if (saved) return { action: "keep", candidates };
+  const candidates = offerable.filter((entry) => reachable(entry) || entry === savedEntry);
+  // Reachable AND chosen — nothing to decide, and no card.
+  if (savedEntry && reachable(savedEntry)) return { action: "keep", candidates };
   if (candidates.length === 0) return { action: "none", candidates };
+  // Exactly one option left. When that one option IS the saved provider (the
+  // macOS-Claude shape, with nothing else offerable), this resolves to the
+  // provider the user already had and still shows no card.
   if (candidates.length === 1) {
     return { action: "select", backend: candidates[0].backend, candidates };
   }
+  // MORE THAN ONE OPTION, AND THE PROBE DISAGREES WITH THE SAVED CHOICE.
+  //
+  // Deliberately `choose` rather than `keep`. The panel cannot tell the two
+  // kinds of `available: false` apart, and the frame carries nothing that would
+  // let it: `BackendReadiness` is `{backend, cli, auth, ready, experimental?,
+  // available?}`, and an installed-but-stopped ollama and a Keychain-authed
+  // claude are byte-identical in it — both `cli: true, auth: true, ready: true,
+  // available: false`. So holding the saved provider outright would be right for
+  // claude and wrong for a local daemon that really is down, with no way to know
+  // which one this is.
+  //
+  // What CAN be fixed without guessing is the part that was never defensible:
+  // the saved provider is in `candidates` now, so the card lists it and the call
+  // site pre-selects it instead of resolving `selected:` to null. And the old
+  // silent `select` past a live saved choice is gone — with the saved entry
+  // present there is more than one candidate, so the user is asked rather than
+  // relocated behind their back. That silent relocation is what put an actively
+  // working Claude session onto an unreachable Ollama in the report.
+  //
+  // The residue — one pre-selected click after a restart rather than none — is
+  // the outcome the reporter named as acceptable ("still pre-select the previous
+  // choice so it is one click, not a re-decision"). Removing that click for good
+  // means fixing `staticAvailability` upstream so claude stops reporting
+  // `available: false`, which is the actual defect and lives in comfyui-mcp.
   return { action: "choose", candidates };
 }

--- a/web/js/lib/provider-autoselect.js
+++ b/web/js/lib/provider-autoselect.js
@@ -9,14 +9,67 @@ export function providerDiscoveryDecision({
   if (discoveryComplete !== true || !Array.isArray(backends)) {
     return { action: "wait", candidates: [] };
   }
-  const candidates = backends.filter((entry) => {
+  // OFFERABLE and REACHABLE are separated on purpose — they answer different
+  // questions, and #1818 is what happens when one answer is used for both.
+  // Offerable = "may this provider be put in front of the user at all": not
+  // experimental (copilot is opt-in ToS-risk and must never be auto-picked),
+  // not hidden, not switched off in Settings. None of those can change behind
+  // the user's back, so they gate every path below without exception.
+  const offerable = backends.filter((entry) => {
     if (!entry || typeof entry.backend !== "string") return false;
-    if (entry.experimental || entry.hidden || !enabled(entry.backend)) return false;
-    return entry.available === undefined ? entry.ready === true : entry.available === true;
+    return !entry.experimental && !entry.hidden && enabled(entry.backend);
   });
-  if (hasSavedChoice && candidates.some((entry) => entry.backend === selectedBackend)) {
-    return { action: "keep", candidates };
-  }
+  // Reachable = "can the host see it working RIGHT NOW". `available` is the
+  // orchestrator's live probe and outranks the static `ready` snapshot when it
+  // is present; an older orchestrator sends no `available` at all, hence the
+  // fallback.
+  const reachable = (entry) =>
+    entry.available === undefined ? entry.ready === true : entry.available === true;
+  // #1818 — A CHOICE THE USER ALREADY MADE IS NOT A CANDIDATE TO RE-DECIDE.
+  //
+  // This used to look the saved provider up in the reachable-only list, so a
+  // saved provider the live probe could not see was not merely absent from the
+  // card — it could not reach the `keep` branch that suppresses the card. Both
+  // halves of #1818 came out of that one lookup: the picker reappeared on every
+  // ComfyUI restart BECAUSE the provider it should have kept was filtered out
+  // of the list it was searched in, and the same filter left `selected:` null.
+  //
+  // Claude is the case that exposed it. `backendReadiness()` reports claude
+  // `ready: true` unconditionally and says why — the orchestrator IS the Agent
+  // SDK host, there is no CLI to find. `allBackendReadiness()` then overwrites
+  // `available` with `claudeCredentialPresent()`, a check for one exact file
+  // (`~/.claude/.credentials.json`). A macOS install keeps that OAuth in the
+  // Keychain and never writes the file, and so do `CLAUDE_CODE_OAUTH_TOKEN`,
+  // `ANTHROPIC_API_KEY` and Bedrock/Vertex. The provider serving the session
+  // reports `ready: true, available: false`, and the picker dropped it.
+  //
+  // So the saved provider is held on `ready` (installed / configured / hosted)
+  // rather than on `available` (answering on localhost this second). The live
+  // probe still decides who is OFFERED; it no longer overturns a decision the
+  // user has already made. A provider that is genuinely gone reports
+  // `ready: false` — an uninstalled codex, a signed-out gemini — and still
+  // falls through to the select/choose paths below, so "your provider
+  // disappeared" keeps working.
+  //
+  // NOT keyed on the live handshake (`connectedBackend`). That value arrives on
+  // the `models` frame, which the orchestrator pushes only after awaiting an
+  // uncached SDK model probe, while `discovery_complete: true` arrives after
+  // three localhost fetches that fail instantly when nothing is listening. On
+  // the cold ComfyUI restart this issue is about, discovery normally wins that
+  // race and the handshake has landed nothing yet. `selectedBackend` and
+  // `hasSavedChoice` are both read from localStorage at mount, before any frame
+  // arrives, so they are the state that is actually there when this runs.
+  const saved =
+    hasSavedChoice === true
+      ? offerable.find(
+          (entry) =>
+            entry.backend === selectedBackend && (reachable(entry) || entry.ready === true),
+        )
+      : undefined;
+  // The saved provider rejoins the list it was dropped from, so `keep` reports
+  // the set the user actually has rather than the set the probe could see.
+  const candidates = offerable.filter((entry) => reachable(entry) || entry === saved);
+  if (saved) return { action: "keep", candidates };
   if (candidates.length === 0) return { action: "none", candidates };
   if (candidates.length === 1) {
     return { action: "select", backend: candidates[0].backend, candidates };


### PR DESCRIPTION
Fixes #1818

> **Revised after gate round 1 returned NO-SHIP.** The first approach held the saved provider outright; the gate was right that this suppresses a legitimate fallback, and I could not narrow my way out of it. See *Gate history* at the bottom for what changed and why.

## The two reported symptoms are one bug

The report describes them as separate — the picker re-prompts on every ComfyUI restart, and the picker omits the provider actually in use. Symptom 2 **causes** symptom 1.

`providerDiscoveryDecision` looked the saved provider up in a list it had already filtered by reachability:

```js
const candidates = backends.filter(/* … available === true … */);
if (hasSavedChoice && candidates.some((e) => e.backend === selectedBackend)) {
  return { action: "keep", candidates };   // ← the branch that suppresses the card
}
```

So a saved provider the host probe could not see was not merely absent from the card — it could not **reach** the branch that prevents the card from opening. The picker reappeared *because* the entry it should have kept had been filtered out of the list it was searched in, and the same filter left `selected:` null so nothing was pre-selected.

Persistence itself was never broken: `PROVIDER_CHOICE_CONFIRMED_KEY` and `STORAGE_KEY_BACKEND` are `window.localStorage`, which survives a ComfyUI restart. The saved choice was read correctly and then discarded.

## Why Claude specifically

`available` outranks `ready` in that filter, and for `claude` the orchestrator sets the two from contradictory sources.

`comfyui-mcp/src/orchestrator/backend-readiness.ts` declares Claude unconditionally ready, and says why:

```js
// - claude: the orchestrator IS the Claude Agent SDK host — no separate CLI …
//   So we report it usable here rather than false-flagging "CLI not installed".
if (b === "claude") return { backend: "claude", cli: true, auth: true, ready: true };
```

`allBackendReadiness` then overwrites `available` with `staticAvailability` → `claudeCredentialPresent(home)`, which reads exactly one path: `~/.claude/.credentials.json`, key `claudeAiOauth.accessToken|refreshToken`. Any Claude credential not in that file yields `available: false` while `ready` stays `true` — **macOS Keychain** (the reporter's platform, darwin 25.5.0; there is no keychain lookup anywhere in `comfyui-mcp/src`), `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, Bedrock/Vertex. `discoverBackendAvailability` does not rescue it — it only overlays `available` for `ollama`, `lmstudio` and `llamacpp`.

Net: **the one provider deliberately marked always-usable is the one that can be reported unavailable while it is actively serving the session.**

## What this changes

The saved provider rejoins `candidates` whenever it is offerable and still `ready`. Two consequences:

1. **The card lists it, and the call site pre-selects it** instead of resolving `selected:` to null.
2. **The silent `select` branch becomes unreachable while a saved choice is offerable** — with the saved entry present there is always more than one candidate, so the user is *asked* rather than relocated behind their back.

That second point is the real harm in the report. On main, this exact frame returns `select: ollama` — it silently moves a working Claude session onto a provider the reporter's own log shows was unreachable (`⚠️ The background agent isn't responding — Ollama isn't reachable`).

Executed, all four paths:

```
saved claude + ollama up      → choose, candidates [claude, ollama]
saved ollama stopped + claude → choose, candidates [ollama, claude]
saved codex uninstalled       → select ollama            (unchanged from main)
claude only offerable         → select claude, no card
```

## Where to look hardest (load-bearing claims)

1. **`ready` is still required on the saved lookup.** The first cut of round 2 dropped it and began re-offering genuinely dead providers; the pre-existing `keeps a saved provider only while it remains available` case caught it. An uninstalled codex or signed-out gemini reports `ready: false` and must keep falling through to `select`. If that condition is removed, this regresses.

2. **Why the saved provider is not simply held (no card at all).** The panel cannot tell the two kinds of `available: false` apart, and the frame carries nothing that would let it — `BackendReadiness` is `{backend, cli, auth, ready, experimental?, available?}`, and an installed-but-stopped ollama and a Keychain-authed claude are byte-identical in it (both `cli:true, auth:true, ready:true, available:false`). Holding outright is right for claude and wrong for a daemon that really is down. So the fallback is *offered* rather than *applied*, which is the only answer available without provider-specific knowledge in the panel.

3. **Deliberately NOT keyed on the live handshake (`connectedBackend`).** That value is set only from the `models` frame, which `pushModels` emits *after awaiting* `ensureModels(backend)` — for claude an SDK subprocess control round-trip. `pushReadiness` pushes `discovery_complete:false` synchronously, then `discovery_complete:true` after `discoverBackendAvailability`, whose three localhost probes fail **instantly** with ECONNREFUSED when nothing is listening (the reporter's machine). On a cold restart discovery normally wins that race and `connectedBackend` is still `null`, so a handshake-keyed guard would be inert in exactly the scenario in the issue title. `selectedBackend` and `hasSavedChoice` are restored from `localStorage` at mount, before any frame arrives. **This ordering claim is reasoned from source, not observed on a live orchestrator** — it is the claim most worth a second opinion.

4. **Residual, stated plainly:** a macOS Claude user still gets one *pre-selected* click after a restart rather than no card. The reporter named that as acceptable ("still pre-select the previous choice so it is one click, not a re-decision"). Removing the click entirely means fixing `staticAvailability` upstream so claude stops reporting `available:false` — the actual defect, and it lives in `comfyui-mcp`, not here.

## Verification

**Unit suite:** `npm run test:unit` → **6888 pass, 0 fail** (i18n, render, tool-vocabulary and panel-scope checks included). `npm run typecheck` clean. All 5 pre-existing `provider-autoselect` tests pass unchanged.

**Mutation-verified.** Fix committed first, then `web/js/lib/provider-autoselect.js` restored from `origin/main` and re-run:

```
✖ #1818 a saved provider the host probe cannot see is offered and pre-selected
✖ #1818 a saved provider is never silently replaced, whatever the probe says
✖ #1818 the decision does not depend on a live handshake
✖ #1818 the saved provider alone means no card at all
ℹ pass 11   ℹ fail 4
```

The four symptom tests go red; the boundary tests stay green, which is correct — they pin behaviour this change does not alter.

**Call site asserted, not assumed.** A helper-level test cannot prove production reaches the helper with the persisted state, which is the entire point of not keying on the handshake. One test reads `web/js/comfyui-mcp-panel.js` and asserts the call site passes `selectedBackend` and `hasSavedChoice: hasSavedProviderChoice`, that both are still restored from `localStorage` at mount, and that `if (decision.action !== "choose") return;` still guards the modal.

**Browser gate: NOT run, and it would not have covered this.** No ComfyUI was listening on this machine (I swept every listening port; the only 200 on `/system_stats` was Ollama's catch-all SPA) and no isolated instance was allocated to this run. Separately and more to the point: `grep -rl discovery_complete browser_tests/` and a grep for the chooser string both return **only the unit test** — there is no Playwright spec covering the provider chooser at all, so a green e2e run would have proved nothing about this change. Stating that rather than implying coverage I do not have.

## Gate history

- **Round 1** (`e17cfd13`) — **NO-SHIP**: *"[P1] `ready === true` overrides `available:false` for the saved provider, suppressing fallback or provider selection … returns `keep` and leaves the panel on unavailable Claude."* Correct about the mechanism. Revised rather than argued: the outright hold is gone, the fallback is now offered to the user instead of suppressed.
- **Round 2** (`996d3f51`) — **SHIP**.

## Collision disclosure

A claim for #1818 was posted at 00:27Z and a `.worktrees/wt-1818` worktree (the other swarm's convention) has been committing since. That work has never been pushed and no PR was opened. I posted my root-cause analysis to the issue thread first rather than open a competing PR, and disclosed the overlap there and here. If the maintainer prefers that branch, point 3 above is the thing to check in it first — its approach keys on `connectedBackend`, and its own test asserts the pre-handshake fallback is `select: ollama`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
