### PR TITLE
fix: the provider setup card scrolls instead of clipping its own tail

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -27953,6 +27953,16 @@ const PANEL_CSS = `
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-md, 6px);
   display: flex; flex-direction: column; gap: 0.5rem;
+  /* The card lists EVERY provider (16 of them) plus the trailing "then start the
+     agent" command, so it is far taller than the panel - ~2700px against a ~680px
+     body. As a plain flex item its min-height resolves to auto, so it refuses to
+     shrink: .cmcp-log collapses instead and .cmcp-body{overflow:hidden} simply
+     CLIPS the remainder - no scrollbar, no way to reach it. On a remote/https
+     ComfyUI (a RunPod pod) the clipped tail is the one line that matters, because
+     connectCommand() puts the pod's own URL in that start command and it is the
+     LAST child. min-height:0 lets the card shrink to the space it actually has;
+     overflow-y then scrolls its own content instead of losing it. */
+  min-height: 0; overflow-y: auto; overscroll-behavior: contain;
 }
 /* The base rule sets display, which beats the UA [hidden] rule — so re-assert
    it or "onboard.hidden = true" won't actually hide the card. */


### PR DESCRIPTION
## The report

"I think our runpod template is broken — when I open the panel it shows localhost."

The RunPod template is **not** broken. What is broken is that the one line
which makes a pod work is unreachable.

## What actually happens

The provider onboarding card renders every provider (16 of them) and then, as
its **last** child, the "Then start the agent" block. `connectCommand()`
already does the right thing on an https page — it appends `location.origin`,
so on a pod it emits:

```
npx -y comfyui-mcp@latest connect https://<pod-id>-3000.proxy.runpod.net
```

That command was rendering correctly. It was just invisible.

`.cmcp-onboard` is a plain flex item of `.cmcp-body`. Its `min-height`
resolves to `auto`, so it will not shrink below content height. `.cmcp-log`
(`min-height: 0`) collapsed instead, and `.cmcp-body { overflow: hidden }`
clipped everything past the fold — no scrollbar, no way to scroll, no
affordance that anything was missing.

Measured on a live pod (panel 0.15.85, behind the https RunPod proxy):

| | before | after |
|---|---|---|
| card client height | 2713px (== scrollHeight, no scroll) | 451px, scrollable |
| panel body | 678px, `overflow: hidden` | unchanged |
| `.cmcp-log` | 24px | 145px |
| last child (start command) | clipped, unreachable | reachable |

So ~75% of the card was cut off, including the pod URL.

Two consequences, which together are the whole bug report:

1. The only "localhost" left on screen was the Bridge URL field
   (`ws://127.0.0.1:9199`) — which is **correct by design**: the agent runs on
   the user's own machine and the pod page connects back to it. With the
   command that explains this clipped away, it just reads as broken.
2. The log notice that spells this out ("No agent is listening on the bridge
   … run the agent on YOUR machine … connect https://…") was squeezed into
   24px by the same collapse.

## The fix

```css
min-height: 0; overflow-y: auto; overscroll-behavior: contain;
```

`min-height: 0` lets the card shrink to the space it actually has;
`overflow-y` scrolls its own content rather than losing it.
`overscroll-behavior: contain` keeps the scroll from chaining out to the
graph canvas.

## Verification

- Applied the exact declaration on the live pod and re-measured (table above);
  scrolled the card to the bottom and confirmed the last child lands inside
  the body rect.
- `node --check` on the panel bundle: clean.
- `scripts/check-panel-scope.mjs`: OK — every name resolves.

CSS-only, inside `PANEL_CSS`; no JS identifiers added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXS5Qys1hiK9aDdXJRJ6Y
