### PR TITLE
fix(panel): retain panel_run completion until receipt (#1824)

### DIFF
--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -529,6 +529,64 @@ test("#1824: restart adoption preserves the keyed completion route and session",
   }]);
 });
 
+test("#1824: a timeout-released terminal batch survives teardown and late prompt adoption", async () => {
+  const firstFlushes = [];
+  const first = makeTracker((payload) => firstFlushes.push(payload));
+  const dispatchToken = first.beginPanelRun();
+  first.onExecutionStart("P-timeout");
+  first.onExecuted("P-timeout", {
+    images: [{ filename: "timeout.png", type: "output" }],
+  });
+  first.onExecutionSuccess("P-timeout");
+  first._fireTimers(30000);
+  assert.equal(firstFlushes.length, 1, "the expired production hold emits its fallback frame");
+  assert.equal(firstFlushes[0].awaitingCompletionKey, true);
+  assert.equal(first.hasPending(), true);
+  const terminalState = first.terminalCompletionMetadata();
+  assert.deepEqual(terminalState[0], {
+    promptId: "P-timeout",
+    payload: {
+      promptId: "P-timeout",
+      images: [{ filename: "timeout.png", type: "output" }],
+      videos: [],
+      durationMs: 0,
+      finishedAt: 1_000_000,
+    },
+    unkeyedFlushed: true,
+  });
+  first.dispose();
+
+  const replayed = [];
+  const fresh = makeTracker((payload) => replayed.push(payload));
+  assert.equal(fresh.restoreTerminalCompletion(terminalState[0]), true);
+  await fresh.reconcile({
+    fetchHistory: async () => ({
+      outputs: { 9: { images: [{ filename: "history.png", type: "output" }] } },
+      status: { status_str: "success", completed: true, messages: [] },
+    }),
+    fetchQueued: async () => false,
+    isVideo: () => false,
+  });
+  assert.equal(replayed.length, 0, "history cannot replace the retained unkeyed terminal record");
+  assert.equal(fresh.terminalCompletionMetadata().length, 1);
+  fresh.onQueued("P-timeout", {
+    routeId: "panel-route-1824",
+    sessionId: "session-1824",
+    dispatchToken,
+  });
+  assert.equal(replayed.length, 1, "the delayed prompt binds and replays after restart");
+  assert.equal(replayed[0].promptId, "P-timeout");
+  assert.equal(replayed[0].images[0].filename, "timeout.png");
+  assert.equal(typeof replayed[0].completionKey, "string");
+  assert.equal(fresh.hasPending(), true, "restart adoption still waits for the matching receipt");
+  assert.equal(
+    fresh.acknowledgeDelivery("P-timeout", replayed[0].completionKey),
+    true,
+    "the bound completion can be retired only by its exact receipt",
+  );
+  assert.equal(fresh.hasPending(), false);
+});
+
 // ── the resume must reach the conversation that ASKED for the restart ─────────
 
 test("#585 P1(session): switching conversations between arm and ack must not misdeliver the resume", () => {

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -498,6 +498,37 @@ test("#585 P1(version): a v1 marker still round-trips every field", () => {
   assert.equal(m.sessionId, "s-A");
 });
 
+test("#1824: restart adoption preserves the keyed completion route and session", () => {
+  const completionKey = JSON.stringify(["panel-route-1824", "session-1824", "P", "generation-a"]);
+  const raw = encodeRebootMarker({
+    at: 1000,
+    runs: ["P"],
+    completionMeta: [{
+      promptId: "P",
+      completionKey,
+      routeId: "panel-route-1824",
+      sessionId: "session-1824",
+    }],
+  });
+  const marker = decodeRebootMarker(raw);
+  assert.deepEqual(marker.completionMeta, [{
+    promptId: "P",
+    completionKey,
+    routeId: "panel-route-1824",
+    sessionId: "session-1824",
+  }]);
+
+  const fresh = makeTracker();
+  assert.deepEqual(adoptRebootRuns(marker.runs, fresh, marker.completionMeta), ["P"]);
+  assert.equal(fresh.completionKeyFor("P"), completionKey);
+  assert.deepEqual(fresh.completionMetadata(), [{
+    promptId: "P",
+    completionKey,
+    routeId: "panel-route-1824",
+    sessionId: "session-1824",
+  }]);
+});
+
 // ── the resume must reach the conversation that ASKED for the restart ─────────
 
 test("#585 P1(session): switching conversations between arm and ack must not misdeliver the resume", () => {

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -1094,6 +1094,7 @@ test("#1728 CALL SITE: late capture crosses the bridge, arms the real sweep, and
       intervalMs: 60000,
     });
     let latePromptId;
+    const completionKey = JSON.stringify(["panel-route-1728", "session-1728", "late-reconnect-prompt-1728", "generation-a"]);
     const built = realGraphRun({
       app,
       apiTarget,
@@ -1237,25 +1238,29 @@ test("#1824 CALL SITE: a long panel_run completion stays replayable until the or
 
     const result = await built.graph_run({ to_node_id: 327, rid: "run-rid-1824" });
     assert.equal(result.queued_unknown, true);
-    latePromptId();
-    assert.equal(sweep._hasTimer(), true, "the real panel_run capture arms reconciliation");
-
     // The render lasts 458,180 ms — far beyond the old fixed completion cutoff.
+    // Deliberately deliver the execution lifecycle BEFORE the delayed /prompt
+    // response. The production tracker must retain this media batch and replay
+    // it keyed when the real panel_run receipt finally arrives.
     tracker.onExecutionStart("long-prompt-1824");
     const sentP = waitForSend();
     tracker.onExecuted("long-prompt-1824", {
       images: [{ filename: "long-render.png", type: "output" }],
     });
     tracker.onExecutionSuccess("long-prompt-1824");
+    assert.equal(frames.length, 0, "media-before-prompt is held, not delivered unkeyed");
+    latePromptId();
+    assert.equal(sweep._hasTimer(), true, "the real panel_run capture arms reconciliation");
     await sentP;
     assert.equal(flushes.length, 1);
     assert.equal(frames.length, 1);
     const completionKey = frames[0].completion_key;
-    assert.equal(
-      completionKey,
-      JSON.stringify(["panel-route-1824", 1824, "long-prompt-1824"]),
-      "the frame carries a stable route/session/prompt delivery key",
-    );
+    const completionParts = JSON.parse(completionKey);
+    assert.equal(completionParts[0], "panel-route-1824");
+    assert.equal(completionParts[1], "1824");
+    assert.equal(completionParts[2], "long-prompt-1824");
+    assert.equal(typeof completionParts[3], "string");
+    assert.ok(completionParts[3].length > 0, "the frame carries a per-queue generation nonce");
     assert.equal(tracker.hasPending(), true, "socket acceptance does not retire the completion");
     assert.equal(tracker.isSettled("long-prompt-1824"), false);
     assert.equal(tracker.acknowledgeDelivery("long-prompt-1824", "stale-key"), false);
@@ -1312,6 +1317,7 @@ test("#1728 CALL SITE: a closed-route receipt is retained and flushed once on re
       },
     });
     let latePromptId;
+    const completionKey = JSON.stringify(["panel-route-1728", "session-1728", "late-reconnect-prompt-1728", "generation-a"]);
     const built = realGraphRun({
       app,
       apiTarget,
@@ -1319,7 +1325,7 @@ test("#1728 CALL SITE: a closed-route receipt is retained and flushed once on re
       serializeMs: 400,
       panelRunOwnerRef: { current: { generation: 1 } },
       runReceiptRouteRef: () => "panel-route-1728",
-      runReceiptSender: (rid, promptId, routeId) => outbox.enqueue(rid, promptId, routeId),
+      runReceiptSender: (rid, promptId, routeId, key) => outbox.enqueue(rid, promptId, routeId, key || completionKey),
       dispatch: async (args) => {
         latePromptId = () => args.onPromptId("late-reconnect-prompt-1728");
         return { outcome: "unverified", queueMark: 1, verified: 0, inFlight: 1, error: "stub" };
@@ -1336,7 +1342,12 @@ test("#1728 CALL SITE: a closed-route receipt is retained and flushed once on re
     outbox.notifyRouteReady();
     assert.equal(outbox.pendingSize(), 0, "the reconnect flush retires the receipt only after sendFrame true");
     assert.deepEqual(receiptFrames, [
-      { type: "run_receipt", run_rid: "run-rid-reconnect-1728", prompt_id: "late-reconnect-prompt-1728" },
+      {
+        type: "run_receipt",
+        run_rid: "run-rid-reconnect-1728",
+        prompt_id: "late-reconnect-prompt-1728",
+        completion_key: completionKey,
+      },
     ]);
   } finally {
     stop();
@@ -1431,7 +1442,7 @@ test("#1728 production bridge wiring fences same-route re-advertisement before r
   assert.match(sendHello, /pendingRouteBindingGeneration = bindingGeneration/);
   assert.match(sendHello, /sent === true/);
   assert.match(ready, /pendingRouteBindingGeneration !== null/);
-  assert.match(sender, /runReceiptOutbox\.enqueue\(rid, promptId, routeId\)/);
+  assert.match(sender, /runReceiptOutbox\.enqueue\(rid, promptId, routeId, completionKey\)/);
   assert.doesNotMatch(sender, /routeId\s*\?\?/);
 });
 

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -76,6 +76,7 @@ import {
 } from "../../web/js/lib/queue-prompt-chain.js";
 import { MUTATION_BINDING_BAR } from "../../web/js/lib/graph-binding.js";
 import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+import { createRunCompletionFlushHandler } from "../../web/js/lib/run-completion-delivery.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 import { createRunReconcileSweep } from "../../web/js/lib/run-reconcile-sweep.js";
 import { createRunReceiptOutbox } from "../../web/js/lib/run-receipt-outbox.js";
@@ -1141,6 +1142,151 @@ test("#1728 CALL SITE: late capture crosses the bridge, arms the real sweep, and
     tracker.onExecutionSuccess("late-prompt-1728");
     assert.equal(flushes.length, 1, "duplicate capture/lifecycle signals stay fenced");
     assert.equal(sent.length, 1, "duplicate capture/lifecycle signals do not duplicate the frame");
+  } finally {
+    sweep?.dispose();
+    stop();
+  }
+});
+
+test("#1824 CALL SITE: a long panel_run completion stays replayable until the orchestrator receipt", async () => {
+  const stop = keepAlive();
+  let sweep;
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, queue: "never" });
+    app.graph = { _nodes: [] };
+    const frames = [];
+    const flushes = [];
+    const timers = new Set();
+    let nextTimer = 0;
+    const schedule = (fn, ms) => {
+      const timer = { id: ++nextTimer, fn, ms };
+      timers.add(timer);
+      return timer;
+    };
+    const cancel = (timer) => timers.delete(timer);
+    let resolveSend;
+    const waitForSend = () =>
+      new Promise((resolve) => {
+        resolveSend = resolve;
+      });
+    let tracker;
+    const productionOnFlush = createRunCompletionFlushHandler({
+      sendFrame: (frame) => {
+        frames.push(frame);
+        resolveSend?.(frame);
+        resolveSend = null;
+        return true; // the browser socket accepted it; the orchestrator ack is separate
+      },
+      markDelivered: (promptId) => tracker.markDelivered(promptId),
+      markUndelivered: (promptId) => tracker.markUndelivered(promptId),
+      pruneRebootMarker: () => {},
+      coerceMessageText: (value) => String(value ?? ""),
+      formatDuration: (ms) => `${(ms / 1000).toFixed(1)}s`,
+      formatClock: () => "12:00:00",
+      imageViewUrl: (m) => `view://${m.filename}`,
+      fetchImageBytes: async () => 2048,
+      fetchImageDimensions: async () => ({ w: 512, h: 512 }),
+      humanizeBytes: (n) => `${n} B`,
+      warn: () => {},
+      now: () => Date.now(),
+    });
+    tracker = createRunCompletionTracker({
+      onFlush: (payload) => {
+        flushes.push(payload);
+        productionOnFlush(payload);
+      },
+      now: () => 458180,
+      setTimer: schedule,
+      clearTimer: cancel,
+    });
+    const history = {
+      outputs: { 9: { images: [{ filename: "long-render.png", type: "output" }] } },
+      status: { status_str: "success", completed: true, messages: [] },
+    };
+    sweep = createRunReconcileSweep({
+      hasPending: () => tracker.hasPending(),
+      reconcile: () =>
+        tracker.reconcile({
+          fetchHistory: async () => history,
+          fetchQueued: async () => false,
+          isVideo: () => false,
+        }),
+      setTimer: schedule,
+      clearTimer: cancel,
+      intervalMs: 60000,
+    });
+
+    let latePromptId;
+    const owner = { current: { generation: 1824 } };
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 800,
+      serializeMs: 400,
+      runCompletionRef: tracker,
+      armRunReconcileSweepRef: () => sweep.arm(),
+      panelRunOwnerRef: owner,
+      runReceiptRouteRef: () => "panel-route-1824",
+      runReceiptSender: () => {},
+      dispatch: async (args) => {
+        latePromptId = () => args.onPromptId("long-prompt-1824");
+        return { outcome: "unverified", queueMark: 1, verified: 0, inFlight: 1, error: "stub" };
+      },
+    });
+
+    const result = await built.graph_run({ to_node_id: 327, rid: "run-rid-1824" });
+    assert.equal(result.queued_unknown, true);
+    latePromptId();
+    assert.equal(sweep._hasTimer(), true, "the real panel_run capture arms reconciliation");
+
+    // The render lasts 458,180 ms — far beyond the old fixed completion cutoff.
+    tracker.onExecutionStart("long-prompt-1824");
+    const sentP = waitForSend();
+    tracker.onExecuted("long-prompt-1824", {
+      images: [{ filename: "long-render.png", type: "output" }],
+    });
+    tracker.onExecutionSuccess("long-prompt-1824");
+    await sentP;
+    assert.equal(flushes.length, 1);
+    assert.equal(frames.length, 1);
+    const completionKey = frames[0].completion_key;
+    assert.equal(
+      completionKey,
+      JSON.stringify(["panel-route-1824", 1824, "long-prompt-1824"]),
+      "the frame carries a stable route/session/prompt delivery key",
+    );
+    assert.equal(tracker.hasPending(), true, "socket acceptance does not retire the completion");
+    assert.equal(tracker.isSettled("long-prompt-1824"), false);
+    assert.equal(tracker.acknowledgeDelivery("long-prompt-1824", "stale-key"), false);
+    assert.equal(tracker.hasPending(), true, "a stale receipt cannot retire the run");
+
+    // A safety-sweep/history replay before the receipt must send the same logical
+    // completion, not lose it and not create an unkeyed duplicate.
+    const replayP = waitForSend();
+    await tracker.reconcile({
+      fetchHistory: async () => history,
+      fetchQueued: async () => false,
+      isVideo: () => false,
+    });
+    await replayP;
+    assert.equal(frames.length, 2, "pending history reconciliation replays the completion");
+    assert.equal(frames[1].completion_key, completionKey, "replay uses the same idempotency key");
+    assert.equal(tracker.hasPending(), true, "replay remains pending until the receipt");
+
+    assert.equal(
+      tracker.acknowledgeDelivery("long-prompt-1824", completionKey),
+      true,
+      "the matching orchestrator receipt settles the exact run",
+    );
+    assert.equal(tracker.hasPending(), false);
+    assert.equal(tracker.isSettled("long-prompt-1824"), true);
+
+    const timer = [...timers].find((candidate) => candidate.ms === 60000);
+    assert.ok(timer, "the safety sweep remains armed while the receipt is missing");
+    timers.delete(timer);
+    await timer.fn();
+    assert.equal(sweep._hasTimer(), false, "the sweep self-disarms after the receipt drains the ledger");
   } finally {
     sweep?.dispose();
     stop();

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -1243,18 +1243,35 @@ test("#1824 CALL SITE: a long panel_run completion stays replayable until the or
     // response. The production tracker must retain this media batch and replay
     // it keyed when the real panel_run receipt finally arrives.
     tracker.onExecutionStart("long-prompt-1824");
-    const sentP = waitForSend();
     tracker.onExecuted("long-prompt-1824", {
       images: [{ filename: "long-render.png", type: "output" }],
     });
-    tracker.onExecutionSuccess("long-prompt-1824");
     assert.equal(frames.length, 0, "media-before-prompt is held, not delivered unkeyed");
+
+    // The production hold really expires while this render is still active.
+    // The eventual execution_success must still retain the media as a
+    // recoverable terminal record rather than taking the ordinary unkeyed path.
+    const timeout = [...timers].find((candidate) => candidate.ms === 30000);
+    assert.ok(timeout, "the production panel_run hold has a 30-second timeout");
+    timers.delete(timeout);
+    const unkeyedP = waitForSend();
+    await timeout.fn();
+    assert.equal(frames.length, 0, "the hold timeout does not flush an active render");
+    tracker.onExecutionSuccess("long-prompt-1824");
+    await unkeyedP;
+    assert.equal(frames.length, 1, "the expired hold emits its best-effort unkeyed frame");
+    assert.equal(frames[0].completion_key, undefined, "the timeout frame has no prompt key yet");
+    assert.equal(flushes[0].awaitingCompletionKey, true);
+    assert.equal(tracker.hasPending(), true, "the timeout frame remains in the recovery ledger");
+    assert.equal(tracker.isSettled("long-prompt-1824"), false);
+
+    const sentP = waitForSend();
     latePromptId();
     assert.equal(sweep._hasTimer(), true, "the real panel_run capture arms reconciliation");
     await sentP;
-    assert.equal(flushes.length, 1);
-    assert.equal(frames.length, 1);
-    const completionKey = frames[0].completion_key;
+    assert.equal(flushes.length, 2, "the delayed prompt binds and replays the held terminal media");
+    assert.equal(frames.length, 2);
+    const completionKey = frames[1].completion_key;
     const completionParts = JSON.parse(completionKey);
     assert.equal(completionParts[0], "panel-route-1824");
     assert.equal(completionParts[1], "1824");
@@ -1275,8 +1292,8 @@ test("#1824 CALL SITE: a long panel_run completion stays replayable until the or
       isVideo: () => false,
     });
     await replayP;
-    assert.equal(frames.length, 2, "pending history reconciliation replays the completion");
-    assert.equal(frames[1].completion_key, completionKey, "replay uses the same idempotency key");
+    assert.equal(frames.length, 3, "pending history reconciliation replays the completion");
+    assert.equal(frames[2].completion_key, completionKey, "replay uses the same idempotency key");
     assert.equal(tracker.hasPending(), true, "replay remains pending until the receipt");
 
     assert.equal(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5056,6 +5056,9 @@ const REBOOT_KEY = "comfyui-mcp.panel.rebootResume";
 // frontend reload. The reboot marker carries the same metadata for a ComfyUI
 // restart; this smaller ledger covers an ordinary panel remount as well.
 const RUN_COMPLETION_META_KEY = "comfyui-mcp.panel.runCompletionMeta.v1";
+// Unkeyed terminal media released after the bounded panel_run hold. This is a
+// separate ledger because the prompt-scoped completion key may arrive later.
+const RUN_COMPLETION_TERMINAL_KEY = "comfyui-mcp.panel.runCompletionTerminal.v1";
 // Set while a soft reload (orchestrator respawn, no ComfyUI restart) is in
 // flight. Value is the trigger origin ("agent" | "user") so that after the
 // fresh orchestrator reconnects we resume the session and — only for an
@@ -5351,6 +5354,54 @@ function restoreRunCompletionMetadata(tracker) {
     }
   }
   return entries.length;
+}
+
+function readRunCompletionTerminals() {
+  const raw = ssGet(RUN_COMPLETION_TERMINAL_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (entry) =>
+          entry &&
+          typeof entry.promptId === "string" &&
+          entry.promptId.trim() &&
+          entry.payload &&
+          typeof entry.payload === "object" &&
+          (Array.isArray(entry.payload.images) || Array.isArray(entry.payload.videos)),
+      )
+      .slice(0, 64);
+  } catch {
+    return [];
+  }
+}
+
+function persistRunCompletionTerminals(entries) {
+  const safe = Array.isArray(entries) ? entries.slice(0, 64) : [];
+  if (!safe.length) {
+    ssSet(RUN_COMPLETION_TERMINAL_KEY, null);
+    return;
+  }
+  try {
+    ssSet(RUN_COMPLETION_TERMINAL_KEY, JSON.stringify(safe));
+  } catch {
+    // Storage is best-effort; the in-memory tracker remains authoritative.
+  }
+}
+
+function restoreRunCompletionTerminals(tracker) {
+  if (!tracker || typeof tracker.restoreTerminalCompletion !== "function") return 0;
+  let restored = 0;
+  for (const entry of readRunCompletionTerminals()) {
+    try {
+      if (tracker.restoreTerminalCompletion(entry)) restored += 1;
+    } catch {
+      // A malformed persisted row must not prevent the panel from mounting.
+    }
+  }
+  return restored;
 }
 
 // Sticky auto-connect: once the user has connected, the panel auto-reconnects
@@ -37931,6 +37982,7 @@ function buildPanel() {
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
     onCompletionStateChange: (entries) => persistRunCompletionMetadata(entries),
+    onTerminalCompletionStateChange: (entries) => persistRunCompletionTerminals(entries),
     // comfyui-mcp#1739 — a run re-pended by markUndelivered (the completion frame's
     // sendFrame failed: bridge/socket churn, e.g. around a workflow-tab switch
     // re-hello) re-enters a ledger that may have NO sweeper left: flush() retired
@@ -38163,7 +38215,12 @@ function buildPanel() {
   // Remount/reload adoption restores the exact key and route/session metadata
   // before the first reconcile probe, so a retained completion can be replayed
   // as the same panel_run receipt rather than downgraded to a fresh run.
-  if (restoreRunCompletionMetadata(runCompletion) > 0) armRunReconcileSweep();
+  if (
+    restoreRunCompletionMetadata(runCompletion) > 0 ||
+    restoreRunCompletionTerminals(runCompletion) > 0
+  ) {
+    armRunReconcileSweep();
+  }
 
   // ── #585: correlated restart-resume ───────────────────────────────────────
   // After a ComfyUI restart the panel nudges the agent to continue. If a render
@@ -42577,6 +42634,7 @@ function buildPanel() {
       // refs if they still point at THIS instance — a newer mount may already own them.
       runReconcileSweep.dispose();
       persistRunCompletionMetadata(runCompletion.completionMetadata?.() ?? []);
+      persistRunCompletionTerminals(runCompletion.terminalCompletionMetadata?.() ?? []);
       runCompletion.dispose?.();
       if (panelRunOwnerRef.current === mountOwner) {
         panelRunOwnerRef.current = null;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18189,7 +18189,10 @@ const GRAPH_TOOL_EXECUTORS = {
         armRunReconcileSweepRef === dispatchArmRunReconcileSweep;
       if (ownsDispatch) {
         try {
-          dispatchRunCompletion?.onQueued(id);
+          dispatchRunCompletion?.onQueued(id, {
+            routeId: dispatchReceiptRoute,
+            sessionId: dispatchOwner?.generation ?? null,
+          });
         } catch {}
         try {
           dispatchArmRunReconcileSweep?.();
@@ -37550,6 +37553,20 @@ function buildPanel() {
         // receipt) is still proof the resume was taken — stronger proof, in fact.
         onRebootResumeReceipt(ack.mid);
         markRead(ack.mid);
+        return;
+      }
+      // #1824 — a successful WebSocket write only proves the browser handed the
+      // frame to the socket. Retire a panel_run completion only after the
+      // orchestrator accepts the same route-scoped completion key; until then
+      // the tracker keeps /history reconciliation armed and replays idempotently.
+      if (
+        ack?.kind === "completion" &&
+        typeof ack.prompt_id === "string" &&
+        typeof ack.completion_key === "string"
+      ) {
+        if (runCompletionRef?.acknowledgeDelivery(ack.prompt_id, ack.completion_key)) {
+          pruneRebootMarker();
+        }
         return;
       }
       // Effort change while the agent was mid-turn: it can't change a running

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5052,6 +5052,10 @@ const CURRENT_THREAD_KEY = "comfyui-mcp.panel.currentThreadId";
 // nudges it to continue — making install→restart→continue autonomous. Survives
 // a page reload (sessionStorage) in case the restart reloads the frontend.
 const REBOOT_KEY = "comfyui-mcp.panel.rebootResume";
+// Keyed panel-run completion identities survive a component teardown and a
+// frontend reload. The reboot marker carries the same metadata for a ComfyUI
+// restart; this smaller ledger covers an ordinary panel remount as well.
+const RUN_COMPLETION_META_KEY = "comfyui-mcp.panel.runCompletionMeta.v1";
 // Set while a soft reload (orchestrator respawn, no ComfyUI restart) is in
 // flight. Value is the trigger origin ("agent" | "user") so that after the
 // fresh orchestrator reconnects we resume the session and — only for an
@@ -5293,6 +5297,60 @@ function ssSet(key, val) {
   } catch {
     // sessionStorage unavailable — resume/restore degrade to off.
   }
+}
+
+function readRunCompletionMetadata() {
+  const raw = ssGet(RUN_COMPLETION_META_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (entry) =>
+          entry &&
+          typeof entry.promptId === "string" &&
+          entry.promptId.trim() &&
+          typeof entry.completionKey === "string" &&
+          entry.completionKey.trim() &&
+          entry.completionKey.length <= 512,
+      )
+      .slice(0, 256)
+      .map((entry) => ({
+        promptId: entry.promptId.trim(),
+        completionKey: entry.completionKey.trim(),
+        routeId: entry.routeId == null ? null : String(entry.routeId),
+        sessionId: entry.sessionId == null ? null : String(entry.sessionId),
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function persistRunCompletionMetadata(entries) {
+  const safe = Array.isArray(entries) ? entries.slice(0, 256) : [];
+  if (!safe.length) {
+    ssSet(RUN_COMPLETION_META_KEY, null);
+    return;
+  }
+  try {
+    ssSet(RUN_COMPLETION_META_KEY, JSON.stringify(safe));
+  } catch {
+    // Storage is best-effort; the in-memory tracker remains authoritative.
+  }
+}
+
+function restoreRunCompletionMetadata(tracker) {
+  if (!tracker || typeof tracker.onQueued !== "function") return 0;
+  const entries = readRunCompletionMetadata();
+  for (const entry of entries) {
+    try {
+      tracker.onQueued(entry.promptId, entry);
+    } catch {
+      // A malformed persisted row must not prevent the panel from mounting.
+    }
+  }
+  return entries.length;
 }
 
 // Sticky auto-connect: once the user has connected, the panel auto-reconnects
@@ -17901,6 +17959,10 @@ const GRAPH_TOOL_EXECUTORS = {
     const dispatchOwner = panelRunOwnerRef.current;
     const dispatchRunCompletion = runCompletionRef;
     const dispatchArmRunReconcileSweep = armRunReconcileSweepRef;
+    // Mark the dispatch before queuePrompt can produce a fast execution_success.
+    // The tracker holds that completion until the delayed /prompt response gives
+    // it a prompt-scoped key, then replays the exact batch keyed.
+    const dispatchPanelRunToken = dispatchRunCompletion?.beginPanelRun?.() ?? null;
     const { app, graph, rootGraph } = getGraphCtx();
     // /run invokes this executor directly rather than through bridge dispatch.
     // Queueing a stale root would render the wrong workflow even though no graph
@@ -18192,6 +18254,7 @@ const GRAPH_TOOL_EXECUTORS = {
           dispatchRunCompletion?.onQueued(id, {
             routeId: dispatchReceiptRoute,
             sessionId: dispatchOwner?.generation ?? null,
+            dispatchToken: dispatchPanelRunToken,
           });
         } catch {}
         try {
@@ -18203,7 +18266,12 @@ const GRAPH_TOOL_EXECUTORS = {
       // event channel; this is metadata only, never an agent_event completion.
       if (receiptRid && sendReceipt) {
         try {
-          sendReceipt(receiptRid, id, dispatchReceiptRoute);
+          sendReceipt(
+            receiptRid,
+            id,
+            dispatchReceiptRoute,
+            dispatchRunCompletion?.completionKeyFor?.(id) ?? null,
+          );
         } catch {}
       }
     };
@@ -37262,6 +37330,7 @@ function buildPanel() {
         const armedMarker = encodeRebootMarker({
           at: Date.now(),
           runs: armedRuns,
+          completionMeta: runCompletionRef?.completionMetadata?.() ?? [],
           // WHICH conversation asked for the restart. The wait set above is global;
           // the delivery target is not. Recorded here because this is the only
           // moment we know it — by the time the ready ack lands the user may have
@@ -37739,8 +37808,8 @@ function buildPanel() {
       return null;
     }
   };
-  const panelRunReceiptSender = (rid, promptId, routeId) =>
-    runReceiptOutbox.enqueue(rid, promptId, routeId);
+  const panelRunReceiptSender = (rid, promptId, routeId, completionKey) =>
+    runReceiptOutbox.enqueue(rid, promptId, routeId, completionKey);
   const panelRunReceiptTransport = {
     routeId: panelRunReceiptRouteRef,
     ready: () => client.isRouteReady?.() === true,
@@ -37861,6 +37930,7 @@ function buildPanel() {
   // This closure owns ONLY presentation: it receives the full, correctly-scoped
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
+    onCompletionStateChange: (entries) => persistRunCompletionMetadata(entries),
     // comfyui-mcp#1739 — a run re-pended by markUndelivered (the completion frame's
     // sendFrame failed: bridge/socket churn, e.g. around a workflow-tab switch
     // re-hello) re-enters a ledger that may have NO sweeper left: flush() retired
@@ -38090,6 +38160,10 @@ function buildPanel() {
   });
   const armRunReconcileSweep = () => runReconcileSweep.arm();
   armRunReconcileSweepRef = armRunReconcileSweep;
+  // Remount/reload adoption restores the exact key and route/session metadata
+  // before the first reconcile probe, so a retained completion can be replayed
+  // as the same panel_run receipt rather than downgraded to a fresh run.
+  if (restoreRunCompletionMetadata(runCompletion) > 0) armRunReconcileSweep();
 
   // ── #585: correlated restart-resume ───────────────────────────────────────
   // After a ComfyUI restart the panel nudges the agent to continue. If a render
@@ -38274,9 +38348,10 @@ function buildPanel() {
   function adoptRebootRunsHere() {
     const tracker = runCompletionRef;
     if (!tracker) return;
-    const runs = readRebootMarker()?.runs ?? [];
+    const marker = readRebootMarker();
+    const runs = marker?.runs ?? [];
     if (!runs.length) return;
-    adoptRebootRuns(runs, tracker);
+    adoptRebootRuns(runs, tracker, marker?.completionMeta ?? []);
     // Only start probing once the bridge is up. Reconcile's give-up path fires a
     // one-time "safe to requeue" frame and then EVICTS the run — firing that at a
     // disconnected agent burns the run's only outcome on a dropped frame. That
@@ -42501,6 +42576,8 @@ function buildPanel() {
       // reconcile await (codex P1 unmount-resurrection leak). Only null the shared
       // refs if they still point at THIS instance — a newer mount may already own them.
       runReconcileSweep.dispose();
+      persistRunCompletionMetadata(runCompletion.completionMetadata?.() ?? []);
+      runCompletion.dispose?.();
       if (panelRunOwnerRef.current === mountOwner) {
         panelRunOwnerRef.current = null;
         runReceiptOutbox.setTransport(null);

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -71,6 +71,26 @@ function normalizeRunIds(runs) {
   return out;
 }
 
+/** Keep the keyed completion identity beside its reboot-owned prompt id. */
+function normalizeCompletionMeta(entries) {
+  const out = [];
+  const seen = new Set();
+  for (const raw of Array.isArray(entries) ? entries : []) {
+    const promptId = typeof raw?.promptId === "string" ? raw.promptId.trim() : "";
+    const completionKey = typeof raw?.completionKey === "string" ? raw.completionKey.trim() : "";
+    if (!promptId || !completionKey || completionKey.length > 512 || seen.has(promptId)) continue;
+    seen.add(promptId);
+    out.push({
+      promptId,
+      completionKey,
+      routeId: raw?.routeId == null ? null : String(raw.routeId),
+      sessionId: raw?.sessionId == null ? null : String(raw.sessionId),
+    });
+    if (out.length >= 256) break;
+  }
+  return out;
+}
+
 /**
  * Serialize the reboot marker for sessionStorage.
  *
@@ -88,6 +108,7 @@ export function encodeRebootMarker({
   sessionId = null,
   attempts = 0,
   totalAttempts,
+  completionMeta = [],
 } = {}) {
   const ids = normalizeRunIds(runs);
   const armed = Number.isFinite(armedRunCount) ? Math.max(0, Math.trunc(armedRunCount)) : ids.length;
@@ -124,6 +145,7 @@ export function encodeRebootMarker({
     // restart while stranding the one that did.
     tid: threadId == null ? null : String(threadId),
     sid: sessionId == null ? null : String(sessionId),
+    cm: normalizeCompletionMeta(completionMeta),
   };
   if (t != null) out.t = t;
   if (ts != null) out.ts = ts;
@@ -156,6 +178,7 @@ export function decodeRebootMarker(raw) {
     // claiming "none were made" would suppress the duplicate warning on a guess.
     attempts: null,
     totalAttempts: null,
+    completionMeta: [],
   };
   if (text[0] !== "{") return empty; // legacy "1"
   let parsed = null;
@@ -192,6 +215,7 @@ export function decodeRebootMarker(raw) {
       : Number.isFinite(parsed.t)
         ? Math.max(0, Math.trunc(parsed.t)) // older marker: the episode count is all we have
         : null,
+    completionMeta: normalizeCompletionMeta(parsed.cm),
   };
 }
 
@@ -389,14 +413,22 @@ function pickUnconfirmed(runs, isDeliveryUnconfirmed) {
  * @param {{isKnown?:(id:string)=>boolean, onQueued?:(id:string)=>void}} tracker
  * @returns {string[]} the ids newly adopted (empty ⇒ nothing to reconcile)
  */
-export function adoptRebootRuns(runs, tracker) {
+export function adoptRebootRuns(runs, tracker, completionMeta = []) {
   const adopted = [];
   const ids = normalizeRunIds(runs);
   if (!ids.length || !tracker || typeof tracker.onQueued !== "function") return adopted;
+  const metaByPrompt = new Map(
+    normalizeCompletionMeta(completionMeta).map((entry) => [entry.promptId, entry]),
+  );
   for (const id of ids) {
     try {
       if (typeof tracker.isKnown === "function" && tracker.isKnown(id)) continue;
-      tracker.onQueued(id);
+      const meta = metaByPrompt.get(id);
+      tracker.onQueued(id, meta ? {
+        routeId: meta.routeId,
+        sessionId: meta.sessionId,
+        completionKey: meta.completionKey,
+      } : undefined);
       adopted.push(id);
     } catch {
       /* a malformed id must never wedge the resume flow */
@@ -415,6 +447,7 @@ function markerFields(marker) {
     sessionId: marker.sessionId,
     attempts: marker.attempts,
     totalAttempts: marker.totalAttempts,
+    completionMeta: marker.completionMeta,
   };
 }
 

--- a/web/js/lib/run-completion-delivery.js
+++ b/web/js/lib/run-completion-delivery.js
@@ -47,6 +47,7 @@ export function createRunCompletionFlushHandler({
     images: flImages,
     videos: flVideos,
     completionKey,
+    awaitingCompletionKey,
     durationMs,
     noMedia,
     duplicateOf,
@@ -60,6 +61,9 @@ export function createRunCompletionFlushHandler({
     // orchestrator's matching receipt arrives. Legacy/canvas completions without
     // a key retain the existing transport-confirmation behavior.
     const awaitsReceipt = typeof completionKey === "string" && completionKey.length > 0;
+    // A timeout fallback may be sent before delayed /prompt identity arrives.
+    // It remains recoverable until the tracker can replay it with a key.
+    const awaitsCompletionKey = awaitingCompletionKey === true;
     let framePushed = false;
     let sendAttempted = false;
     const compositionStartedAt = now();
@@ -145,15 +149,19 @@ export function createRunCompletionFlushHandler({
         // permanent suppression (sendFrame returns false for both a down socket
         // AND AGENT_MUTED): a muted completion must NOT be recovered/replayed on
         // a later unmute+reconnect, so treat it as delivered (codex P1).
-        if (frame == null || (framePushed && !awaitsReceipt)) markDelivered(promptId);
-        else if (framePushed && awaitsReceipt) {
-          // The receipt, not the browser write, retires this panel_run.
+        if (frame == null && !awaitsCompletionKey) markDelivered(promptId);
+        else if (framePushed && !awaitsReceipt && !awaitsCompletionKey) markDelivered(promptId);
+        else if (framePushed && (awaitsReceipt || awaitsCompletionKey)) {
+          // A receipt retires keyed delivery; a delayed prompt identity retires
+          // the recoverable unkeyed fallback by replaying it keyed.
         } else if (isAgentMuted()) markDelivered(promptId);
         else markUndelivered(promptId);
         // #585: for legacy/unkeyed frames this is the moment "the agent was
         // told" becomes true (or is re-pended). Keyed panel_run frames update
         // the marker from the orchestrator acknowledgement callback instead.
-        if (frame == null || !awaitsReceipt || isAgentMuted()) pruneRebootMarker();
+        if ((frame == null && !awaitsCompletionKey) || (!awaitsReceipt && !awaitsCompletionKey) || isAgentMuted()) {
+          pruneRebootMarker();
+        }
       })
       .catch((err) => {
         if (!isAgentMuted()) {
@@ -170,9 +178,13 @@ export function createRunCompletionFlushHandler({
         // Composition threw before/around the send — treat as undelivered so a
         // reconnect can recover the outcome from /history rather than lose it
         // (but respect an intentional mute, as above).
-        if ((framePushed && !awaitsReceipt) || isAgentMuted()) markDelivered(promptId);
-        else if (!(framePushed && awaitsReceipt)) markUndelivered(promptId);
-        if (!awaitsReceipt || isAgentMuted()) pruneRebootMarker(); // #585 — see the .then branch above
+        if ((framePushed && !awaitsReceipt && !awaitsCompletionKey) || isAgentMuted()) markDelivered(promptId);
+        else if (framePushed && (awaitsReceipt || awaitsCompletionKey)) {
+          // The already-pushed frame remains recoverable until its key/receipt.
+        } else markUndelivered(promptId);
+        if ((!awaitsReceipt && !awaitsCompletionKey) || isAgentMuted()) {
+          pruneRebootMarker(); // #585 — see the .then branch above
+        }
       });
   };
 }

--- a/web/js/lib/run-completion-delivery.js
+++ b/web/js/lib/run-completion-delivery.js
@@ -46,6 +46,7 @@ export function createRunCompletionFlushHandler({
     promptId,
     images: flImages,
     videos: flVideos,
+    completionKey,
     durationMs,
     noMedia,
     duplicateOf,
@@ -53,11 +54,12 @@ export function createRunCompletionFlushHandler({
     finishedAt,
     reconciled,
   }) => {
-    // #370: track whether the composed completion frame actually reached the
-    // agent. sendFrame returns false when the bridge socket is down — in that
-    // case the completion is LOST, so we re-pend the prompt (markUndelivered) so
-    // the next reconnect recovers it via /history. A confirmed send (or an empty
-    // batch that emits no frame) retires it from pending.
+    // #370/#1824: track whether the composed completion frame reached the
+    // orchestrator. A route-scoped completion key means sendFrame returning true
+    // only proves the browser write; the tracker remains pending until the
+    // orchestrator's matching receipt arrives. Legacy/canvas completions without
+    // a key retain the existing transport-confirmation behavior.
+    const awaitsReceipt = typeof completionKey === "string" && completionKey.length > 0;
     let framePushed = false;
     let sendAttempted = false;
     const compositionStartedAt = now();
@@ -88,7 +90,9 @@ export function createRunCompletionFlushHandler({
       {
         sendFrame: (frame) => {
           sendAttempted = true;
-          const ok = sendFrame(frame);
+          const ok = sendFrame(
+            awaitsReceipt ? { ...frame, completion_key: completionKey } : frame,
+          );
           if (ok) framePushed = true;
           return ok;
         },
@@ -133,20 +137,23 @@ export function createRunCompletionFlushHandler({
             stage: deliveryStage,
           });
         }
-        // frame===null ⇒ empty batch (nothing to deliver) ⇒ delivered. A frame
-        // that was pushed ⇒ delivered. A frame that FAILED to push ⇒ re-pend —
+        // frame===null ⇒ empty batch (nothing to deliver) ⇒ delivered. A keyed
+        // frame that was pushed stays pending until acknowledgeDelivery(). An
+        // unkeyed frame that was pushed retains the legacy behavior. A frame
+        // that FAILED to push ⇒ re-pend —
         // UNLESS it failed because agents are MUTED, which is intentional,
         // permanent suppression (sendFrame returns false for both a down socket
         // AND AGENT_MUTED): a muted completion must NOT be recovered/replayed on
         // a later unmute+reconnect, so treat it as delivered (codex P1).
-        if (frame == null || framePushed) markDelivered(promptId);
-        else if (isAgentMuted()) markDelivered(promptId);
+        if (frame == null || (framePushed && !awaitsReceipt)) markDelivered(promptId);
+        else if (framePushed && awaitsReceipt) {
+          // The receipt, not the browser write, retires this panel_run.
+        } else if (isAgentMuted()) markDelivered(promptId);
         else markUndelivered(promptId);
-        // #585: this is the moment "the agent was told" becomes true (or is
-        // re-pended). Refresh the persisted reboot marker now so a reload in the
-        // gap before the next watch tick can't re-adopt an already-delivered run
-        // and have /history deliver its completion a second time.
-        pruneRebootMarker();
+        // #585: for legacy/unkeyed frames this is the moment "the agent was
+        // told" becomes true (or is re-pended). Keyed panel_run frames update
+        // the marker from the orchestrator acknowledgement callback instead.
+        if (frame == null || !awaitsReceipt || isAgentMuted()) pruneRebootMarker();
       })
       .catch((err) => {
         if (!isAgentMuted()) {
@@ -163,9 +170,9 @@ export function createRunCompletionFlushHandler({
         // Composition threw before/around the send — treat as undelivered so a
         // reconnect can recover the outcome from /history rather than lose it
         // (but respect an intentional mute, as above).
-        if (framePushed || isAgentMuted()) markDelivered(promptId);
-        else markUndelivered(promptId);
-        pruneRebootMarker(); // #585 — see the .then branch above
+        if ((framePushed && !awaitsReceipt) || isAgentMuted()) markDelivered(promptId);
+        else if (!(framePushed && awaitsReceipt)) markUndelivered(promptId);
+        if (!awaitsReceipt || isAgentMuted()) pruneRebootMarker(); // #585 — see the .then branch above
       });
   };
 }

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -80,6 +80,9 @@ export function createRunCompletionKey(routeId, sessionId, promptId, nonce = nul
  * @param {(promptId:(string|null)) => void} [opts.onRepend]  Called after
  *   markUndelivered() re-pends a run, so the wiring can re-arm recovery
  *   (the safety sweep) for the ledger the run just re-entered (#1739).
+ * @param {(entries:Array<object>) => void} [opts.onTerminalCompletionStateChange]
+ *   Called when a completion released without its prompt-scoped key changes
+ *   state, so teardown/reload can preserve the exact media batch.
  * @param {(fn:Function, ms:number) => any} [opts.setTimer]
  * @param {(t:any) => void} [opts.clearTimer]
  * @param {number} [opts.debounceMs]       Orphan-flush / re-arm interval (default 1500).
@@ -91,6 +94,7 @@ export function createRunCompletionTracker({
   onReconcileInterrupted,
   onReconcileGiveUp,
   onCompletionStateChange,
+  onTerminalCompletionStateChange,
   // comfyui-mcp#1739 — called AFTER markUndelivered() has re-pended a run. The
   // pending ledger is recovery-driven (reconnect edges + the safety sweep, which
   // SELF-DISARMS the moment it observes an empty ledger), and flush() retires a
@@ -181,7 +185,16 @@ export function createRunCompletionTracker({
   // onQueued can attach that key; otherwise the ordinary unkeyed path marks it
   // delivered and the later prompt receipt has nothing to replay.
   const terminalNoKeyCompletion = new Map(); // key -> payload
+  // The timeout fallback may already have emitted an unkeyed frame, but it must
+  // remain recoverable until the delayed /prompt identity binds it.
+  const terminalNoKeyFlushed = new Set(); // keys whose unkeyed fallback was sent
   const panelRunDispatches = new Map(); // token -> timer
+  // Lifecycle prompt ids observed while a panel_run hold is active remain
+  // associated with that dispatch after the 30-second timer expires. Without
+  // this handoff fence, a long render finishing after the timer bypasses
+  // terminalNoKeyCompletion entirely and is marked delivered unkeyed.
+  const panelRunCompletionKeys = new Set();
+  let panelRunLateCapture = false;
   // A panel_run completion is not retired when the browser socket accepts the
   // frame. Keep the stable route+prompt key with the run so /history retries
   // carry the same idempotency key until the orchestrator acknowledges it.
@@ -371,12 +384,34 @@ export function createRunCompletionTracker({
     );
   }
 
-  function releaseUnkeyedCompletion(k, payload) {
-    terminalNoKeyCompletion.delete(k);
+  function releaseUnkeyedCompletion(k, payload, { retire = false } = {}) {
+    if (terminalNoKeyFlushed.has(k)) {
+      if (retire) {
+        terminalNoKeyCompletion.delete(k);
+        terminalNoKeyFlushed.delete(k);
+        markDelivered(k);
+        notifyTerminalCompletionStateChange();
+      }
+      return;
+    }
+    if (k !== NO_PROMPT_KEY && !pending.has(k)) {
+      pending.set(k, { promptId: k, at: now() });
+    }
+    terminalNoKeyFlushed.add(k);
     markTerminal(k);
     markDispatched(k);
-    markDelivered(k);
-    onFlush({ ...payload, key: k, promptId: payload.promptId ?? promptIdOf(k) });
+    onFlush({
+      ...payload,
+      key: k,
+      promptId: payload.promptId ?? promptIdOf(k),
+      awaitingCompletionKey: true,
+    });
+    if (retire) {
+      terminalNoKeyCompletion.delete(k);
+      terminalNoKeyFlushed.delete(k);
+      markDelivered(k);
+    }
+    notifyTerminalCompletionStateChange();
   }
 
   function releaseHeldUnkeyedCompletions() {
@@ -386,14 +421,47 @@ export function createRunCompletionTracker({
     }
   }
 
+  function notePanelRunLifecycle(k) {
+    if (k === NO_PROMPT_KEY) return;
+    if (panelRunDispatches.size || panelRunLateCapture) {
+      panelRunCompletionKeys.add(k);
+      if (!panelRunDispatches.size) panelRunLateCapture = false;
+    }
+  }
+
   function completionMetadataSnapshot() {
     return [...completionMeta.entries()].map(([promptId, value]) => ({ promptId, ...value }));
+  }
+
+  function terminalCompletionMetadataSnapshot() {
+    return [...terminalNoKeyCompletion.entries()].map(([promptId, payload]) => ({
+      promptId,
+      payload: {
+        promptId,
+        images: Array.isArray(payload?.images) ? [...payload.images] : [],
+        videos: Array.isArray(payload?.videos) ? [...payload.videos] : [],
+        durationMs: Number.isFinite(payload?.durationMs) ? payload.durationMs : null,
+        finishedAt: Number.isFinite(payload?.finishedAt) ? payload.finishedAt : null,
+        ...(typeof payload?.duplicateOf === "string" ? { duplicateOf: payload.duplicateOf } : {}),
+        ...(typeof payload?.looksCached === "boolean" ? { looksCached: payload.looksCached } : {}),
+      },
+      unkeyedFlushed: terminalNoKeyFlushed.has(promptId),
+    }));
   }
 
   function notifyCompletionStateChange() {
     if (typeof onCompletionStateChange !== "function") return;
     try {
       onCompletionStateChange(completionMetadataSnapshot());
+    } catch {
+      /* persistence is best-effort and must never affect delivery */
+    }
+  }
+
+  function notifyTerminalCompletionStateChange() {
+    if (typeof onTerminalCompletionStateChange !== "function") return;
+    try {
+      onTerminalCompletionStateChange(terminalCompletionMetadataSnapshot());
     } catch {
       /* persistence is best-effort and must never affect delivery */
     }
@@ -518,13 +586,21 @@ export function createRunCompletionTracker({
         ? { duplicateOf: verdict.duplicateOf, looksCached: !!verdict.looksCached }
         : {}),
     };
-    if (!completionKey && panelRunDispatches.size && k !== NO_PROMPT_KEY) {
+    if (
+      !completionKey &&
+      (panelRunDispatches.size || panelRunCompletionKeys.has(k)) &&
+      k !== NO_PROMPT_KEY
+    ) {
       // Do not retire this as an ordinary canvas completion while a panel_run
       // dispatch is waiting for its delayed prompt receipt. The bounded dispatch
       // hold lets onQueued re-key the exact media batch; its timer is the explicit
       // compatibility fence for a legacy/aborted queue response.
       terminalNoKeyCompletion.set(k, payload);
       markTerminal(k);
+      notifyTerminalCompletionStateChange();
+      // Once the bounded hold has expired, release the unkeyed best-effort
+      // frame immediately but retain the terminal record for keyed replay.
+      if (!panelRunDispatches.size) releaseUnkeyedCompletion(k, payload);
       return;
     }
     markTerminal(k);
@@ -569,6 +645,13 @@ export function createRunCompletionTracker({
   async function reconcileKey(promptId, fetchHistory, fetchQueued, isVideo) {
     const k = key(promptId);
     if (delivered.has(k) || !pending.has(k)) return null;
+    // A timeout-released panel_run already owns the exact media batch, but its
+    // delayed /prompt identity has not supplied the completion key yet. Do not
+    // replace that recoverable record with an unkeyed /history delivery: the
+    // later onQueued callback must still be able to bind and replay it.
+    if (terminalNoKeyCompletion.has(k) && !completionKeys.has(k)) {
+      return { promptId, status: "success", delivered: false };
+    }
     // #1619 — a live executed batch is stronger than a remote history probe:
     // it is the exact output for this prompt, already observed on the panel's
     // authenticated websocket. Retain the temp PreviewImage descriptor when a
@@ -773,6 +856,10 @@ export function createRunCompletionTracker({
     panelQueued.delete(k); // #356 Bug 2 — evicted with it
     liveReplays.delete(k);
     completionKeys.delete(k);
+    panelRunCompletionKeys.delete(k);
+    terminalNoKeyCompletion.delete(k);
+    terminalNoKeyFlushed.delete(k);
+    notifyTerminalCompletionStateChange();
     markTerminal(promptId); // fence any stray late execution_start; ages out (not pinned)
     if (typeof onReconcileGiveUp === "function") {
       try {
@@ -843,6 +930,7 @@ export function createRunCompletionTracker({
       // being RE-PENDED for retry (markUndelivered clears `delivered` but not
       // `terminal`). NO_PROMPT_KEY is never in `terminal`, so id-less runs proceed.
       if (terminal.has(k)) return;
+      notePanelRunLifecycle(k);
       // Runs are sequential: a new run beginning means EVERY prior run has ended
       // (even one whose end signal we missed). Flush every existing buffer under
       // ITS OWN key/timing first, so an older buffer — including a legacy
@@ -885,6 +973,7 @@ export function createRunCompletionTracker({
       markStart(id, { observed: false });
       trackPending(id);
       const k = key(id);
+      notePanelRunLifecycle(k);
       const buf = ensureBuffer(k);
       if (images.length) buf.images.push(...images);
       if (videos.length) buf.videos.push(...videos);
@@ -904,6 +993,7 @@ export function createRunCompletionTracker({
     startObserved.delete(k);
         return;
       }
+      notePanelRunLifecycle(k);
       // #356 Bug 2 — a run that produced NO image and NO video buffers nothing
       // (onExecuted discards a media-less `executed`), so flush() returns at its
       // `!buf` guard and the agent is never told the run finished. For a canvas run
@@ -986,7 +1076,13 @@ export function createRunCompletionTracker({
       // If already terminal (reconcile surfaced this run's outcome), don't re-mark
       // (which would clear a re-pend). The caller uses wasTerminal() BEFORE calling
       // this to suppress a duplicate run_error frame (codex P1).
-      if (!terminal.has(k)) markDelivered(k);
+      if (!terminal.has(k)) {
+        panelRunCompletionKeys.delete(k);
+        terminalNoKeyCompletion.delete(k);
+        terminalNoKeyFlushed.delete(k);
+        notifyTerminalCompletionStateChange();
+        markDelivered(k);
+      }
     },
 
     /**
@@ -1064,6 +1160,9 @@ export function createRunCompletionTracker({
       const lateMedia = id != null ? terminalNoKeyCompletion.get(k) : null;
       if (lateMedia) {
         terminalNoKeyCompletion.delete(k);
+        terminalNoKeyFlushed.delete(k);
+        panelRunCompletionKeys.delete(k);
+        notifyTerminalCompletionStateChange();
         delivered.delete(k);
         if (completionKeys.has(k)) {
           if (!pending.has(k)) pending.set(k, { promptId: k, at: now() });
@@ -1072,7 +1171,7 @@ export function createRunCompletionTracker({
           markDispatched(k);
           onFlush({ ...lateMedia, key: k, completionKey: completionKeys.get(k) });
         } else {
-          releaseUnkeyedCompletion(k, lateMedia);
+          releaseUnkeyedCompletion(k, lateMedia, { retire: true });
         }
       }
       // #1728 P2 — execution_success can win the race with the delayed /prompt
@@ -1083,6 +1182,7 @@ export function createRunCompletionTracker({
       const lateSuccess = id != null ? terminalNoMediaSuccess.get(k) : null;
       if (lateSuccess) {
         terminalNoMediaSuccess.delete(k);
+        panelRunCompletionKeys.delete(k);
         delivered.delete(k);
         if (completionKeys.has(k)) {
           if (!pending.has(k)) pending.set(k, { promptId: k, at: now() });
@@ -1121,7 +1221,11 @@ export function createRunCompletionTracker({
       liveReplays.delete(key(id));
       completionKeys.delete(key(id));
       completionMeta.delete(key(id));
+      terminalNoKeyCompletion.delete(key(id));
+      terminalNoKeyFlushed.delete(key(id));
+      panelRunCompletionKeys.delete(key(id));
       notifyCompletionStateChange();
+      notifyTerminalCompletionStateChange();
       markDelivered(id);
     },
 
@@ -1138,7 +1242,11 @@ export function createRunCompletionTracker({
       liveReplays.delete(k);
       completionKeys.delete(k);
       completionMeta.delete(k);
+      terminalNoKeyCompletion.delete(k);
+      terminalNoKeyFlushed.delete(k);
+      panelRunCompletionKeys.delete(k);
       notifyCompletionStateChange();
+      notifyTerminalCompletionStateChange();
       markDelivered(k);
       return true;
     },
@@ -1175,6 +1283,7 @@ export function createRunCompletionTracker({
       const token = `panel-run-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
       const timer = setTimer(() => {
         panelRunDispatches.delete(token);
+        if (!panelRunDispatches.size) panelRunLateCapture = true;
         releaseHeldUnkeyedCompletions();
       }, 30_000);
       panelRunDispatches.set(token, timer);
@@ -1200,11 +1309,48 @@ export function createRunCompletionTracker({
       return completionMetadataSnapshot();
     },
 
+    /** Persistable terminal media held for a delayed prompt-scoped key. */
+    terminalCompletionMetadata() {
+      return terminalCompletionMetadataSnapshot();
+    },
+
+    /** Restore one held terminal record after teardown/reload. */
+    restoreTerminalCompletion(entry) {
+      const k = key(entry?.promptId);
+      const payload = entry?.payload;
+      if (
+        k === NO_PROMPT_KEY ||
+        !payload ||
+        typeof payload !== "object" ||
+        (!Array.isArray(payload.images) && !Array.isArray(payload.videos)) ||
+        (!payload.images?.length && !payload.videos?.length)
+      ) {
+        return false;
+      }
+      terminalNoKeyCompletion.set(k, {
+        key: k,
+        promptId: k,
+        images: Array.isArray(payload.images) ? [...payload.images] : [],
+        videos: Array.isArray(payload.videos) ? [...payload.videos] : [],
+        durationMs: Number.isFinite(payload.durationMs) ? payload.durationMs : null,
+        finishedAt: Number.isFinite(payload.finishedAt) ? payload.finishedAt : null,
+        ...(typeof payload.duplicateOf === "string" ? { duplicateOf: payload.duplicateOf } : {}),
+        ...(typeof payload.looksCached === "boolean" ? { looksCached: payload.looksCached } : {}),
+      });
+      if (entry.unkeyedFlushed === true) terminalNoKeyFlushed.add(k);
+      else terminalNoKeyFlushed.delete(k);
+      panelRunCompletionKeys.add(k);
+      if (!pending.has(k)) pending.set(k, { promptId: k, at: now() });
+      markTerminal(k);
+      return true;
+    },
+
     dispose() {
       for (const timer of panelRunDispatches.values()) {
         try { clearTimer(timer); } catch {}
       }
       panelRunDispatches.clear();
+      panelRunLateCapture = false;
     },
 
     /**
@@ -1363,5 +1509,7 @@ export function createRunCompletionTracker({
     _awaitingDelivery: awaitingDelivery,
     _unconfirmedDelivery: unconfirmedDelivery,
     _terminalNoKeyCompletion: terminalNoKeyCompletion,
+    _terminalNoKeyFlushed: terminalNoKeyFlushed,
+    _panelRunCompletionKeys: panelRunCompletionKeys,
   };
 }

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -51,6 +51,22 @@ import { parseHistoryEntry } from "./history-reconcile.js";
 export const NO_PROMPT_KEY = "__no_prompt__";
 
 /**
+ * Mint a per-queue completion identity. The route/session are diagnostic
+ * ownership metadata; the nonce is the generation fence that keeps a reused
+ * prompt id from looking like the previous run.
+ */
+export function createRunCompletionKey(routeId, sessionId, promptId, nonce = null) {
+  const route = typeof routeId === "string" ? routeId.trim() : "";
+  const prompt = promptId == null ? "" : String(promptId).trim();
+  if (!route || !prompt) return null;
+  const salt =
+    typeof nonce === "string" && nonce.trim()
+      ? nonce.trim()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  return JSON.stringify([route, sessionId == null ? null : String(sessionId), prompt, salt]);
+}
+
+/**
  * @param {object} opts
  * @param {(payload:{key:string, promptId:(string|null), images:any[], videos:any[], durationMs:number|null, finishedAt:(number|null), completionKey?:string, reconciled?:boolean, replayed?:boolean}) => void} opts.onFlush
  *   `finishedAt` is epoch ms. On the LIVE paths it is the flush clock; on the
@@ -74,6 +90,7 @@ export function createRunCompletionTracker({
   onReconcileError,
   onReconcileInterrupted,
   onReconcileGiveUp,
+  onCompletionStateChange,
   // comfyui-mcp#1739 — called AFTER markUndelivered() has re-pended a run. The
   // pending ledger is recovery-driven (reconnect edges + the safety sweep, which
   // SELF-DISARMS the moment it observes an empty ledger), and flush() retires a
@@ -159,10 +176,17 @@ export function createRunCompletionTracker({
   // this run as panel-queued. Keep only the media-less success that still needs
   // the panel_run promise applied; onQueued consumes it exactly once.
   const terminalNoMediaSuccess = new Map(); // key -> { promptId, durationMs, finishedAt, at }
+  // A panel_run completion can finish before the delayed /prompt response gives
+  // us the id's route-scoped delivery key. Hold the complete payload until
+  // onQueued can attach that key; otherwise the ordinary unkeyed path marks it
+  // delivered and the later prompt receipt has nothing to replay.
+  const terminalNoKeyCompletion = new Map(); // key -> payload
+  const panelRunDispatches = new Map(); // token -> timer
   // A panel_run completion is not retired when the browser socket accepts the
   // frame. Keep the stable route+prompt key with the run so /history retries
   // carry the same idempotency key until the orchestrator acknowledges it.
   const completionKeys = new Map(); // key -> route-scoped completion key
+  const completionMeta = new Map(); // key -> { completionKey, routeId, sessionId }
   // Far beyond any realistic WS-replay-after-reconnect delay, so pruning an entry
   // older than this can never re-open the double-delivery window it guards.
   const deliveredTtlMs = 10 * 60 * 1000;
@@ -347,6 +371,34 @@ export function createRunCompletionTracker({
     );
   }
 
+  function releaseUnkeyedCompletion(k, payload) {
+    terminalNoKeyCompletion.delete(k);
+    markTerminal(k);
+    markDispatched(k);
+    markDelivered(k);
+    onFlush({ ...payload, key: k, promptId: payload.promptId ?? promptIdOf(k) });
+  }
+
+  function releaseHeldUnkeyedCompletions() {
+    if (panelRunDispatches.size) return;
+    for (const [k, payload] of [...terminalNoKeyCompletion]) {
+      releaseUnkeyedCompletion(k, payload);
+    }
+  }
+
+  function completionMetadataSnapshot() {
+    return [...completionMeta.entries()].map(([promptId, value]) => ({ promptId, ...value }));
+  }
+
+  function notifyCompletionStateChange() {
+    if (typeof onCompletionStateChange !== "function") return;
+    try {
+      onCompletionStateChange(completionMetadataSnapshot());
+    } catch {
+      /* persistence is best-effort and must never affect delivery */
+    }
+  }
+
   function clearReconcileRetry(k) {
     const t = retryTimers.get(k);
     if (t != null) clearTimer(t);
@@ -451,9 +503,6 @@ export function createRunCompletionTracker({
     // completion. Keep panel_run in pending until the matching completion ack;
     // the stable key makes every /history replay idempotent downstream.
     const completionKey = completionKeys.get(k);
-    markTerminal(k);
-    markDispatched(k);
-    if (!completionKey) markDelivered(k);
     const payload = {
       key: k,
       promptId: promptIdOf(k),
@@ -469,6 +518,18 @@ export function createRunCompletionTracker({
         ? { duplicateOf: verdict.duplicateOf, looksCached: !!verdict.looksCached }
         : {}),
     };
+    if (!completionKey && panelRunDispatches.size && k !== NO_PROMPT_KEY) {
+      // Do not retire this as an ordinary canvas completion while a panel_run
+      // dispatch is waiting for its delayed prompt receipt. The bounded dispatch
+      // hold lets onQueued re-key the exact media batch; its timer is the explicit
+      // compatibility fence for a legacy/aborted queue response.
+      terminalNoKeyCompletion.set(k, payload);
+      markTerminal(k);
+      return;
+    }
+    markTerminal(k);
+    markDispatched(k);
+    if (!completionKey) markDelivered(k);
     if (
       k !== NO_PROMPT_KEY &&
       payload.images.some((image) => image?.type === "temp")
@@ -864,6 +925,15 @@ export function createRunCompletionTracker({
       const mediaLess = !hasMedia && panelQueued.has(k);
       const mediaLessStart = mediaLess ? starts.get(k) : null;
       flush(k);
+      // `flush` deliberately held this media batch because the panel_run
+      // dispatch had not received its delayed prompt id yet. It is not an
+      // ordinary unkeyed canvas completion and must not be marked delivered
+      // before onQueued can replay it with the stable key.
+      if (terminalNoKeyCompletion.has(k)) {
+        starts.delete(k);
+        startObserved.delete(k);
+        return;
+      }
       if (mediaLess) {
         // Keep the panel_run in the recovery ledger until the orchestrator
         // acknowledges this exact completion. The terminal fence still blocks
@@ -968,16 +1038,41 @@ export function createRunCompletionTracker({
      * execution_start/executing/executed ever reaches us — is still reconcilable
      * against /history because we recorded its prompt_id at queue time.
      */
-    onQueued(id, { routeId, sessionId = null } = {}) {
+    onQueued(id, { routeId, sessionId = null, completionKey, dispatchToken = null } = {}) {
       const k = key(id);
       trackPending(id);
       // #356 Bug 2 — records that THIS run carried panel_run's wait-for-it promise.
       if (id != null) {
         panelQueued.add(k);
-        if (routeId != null && String(routeId).trim()) {
-          // JSON avoids delimiter collisions while keeping this deterministic
-          // across retries and safe to compare as an opaque wire value.
-          completionKeys.set(k, JSON.stringify([String(routeId), sessionId, k]));
+        const suppliedKey = typeof completionKey === "string" && completionKey.trim() ? completionKey.trim() : null;
+        const existingKey = completionKeys.get(k);
+        const nextKey = suppliedKey || existingKey || createRunCompletionKey(routeId, sessionId, k);
+        if (nextKey) {
+          completionKeys.set(k, nextKey);
+          completionMeta.set(k, {
+            completionKey: nextKey,
+            routeId: routeId == null ? null : String(routeId),
+            sessionId: sessionId == null ? null : String(sessionId),
+          });
+          notifyCompletionStateChange();
+        }
+      }
+      if (dispatchToken && panelRunDispatches.has(dispatchToken)) {
+        // Keep the dispatch hold until its bounded timer expires. A batch may
+        // produce more than one prompt id, and a later id can still be waiting.
+      }
+      const lateMedia = id != null ? terminalNoKeyCompletion.get(k) : null;
+      if (lateMedia) {
+        terminalNoKeyCompletion.delete(k);
+        delivered.delete(k);
+        if (completionKeys.has(k)) {
+          if (!pending.has(k)) pending.set(k, { promptId: k, at: now() });
+          markTerminal(k);
+          clearReconcileRetry(k);
+          markDispatched(k);
+          onFlush({ ...lateMedia, key: k, completionKey: completionKeys.get(k) });
+        } else {
+          releaseUnkeyedCompletion(k, lateMedia);
         }
       }
       // #1728 P2 — execution_success can win the race with the delayed /prompt
@@ -1025,6 +1120,8 @@ export function createRunCompletionTracker({
       panelQueued.delete(key(id));
       liveReplays.delete(key(id));
       completionKeys.delete(key(id));
+      completionMeta.delete(key(id));
+      notifyCompletionStateChange();
       markDelivered(id);
     },
 
@@ -1040,6 +1137,8 @@ export function createRunCompletionTracker({
       panelQueued.delete(k);
       liveReplays.delete(k);
       completionKeys.delete(k);
+      completionMeta.delete(k);
+      notifyCompletionStateChange();
       markDelivered(k);
       return true;
     },
@@ -1064,10 +1163,48 @@ export function createRunCompletionTracker({
       // 120s backstop can't be what decides isSettled() for it (#585).
       clearAwaitingDelivery(k);
       if (!pending.has(k)) pending.set(k, { promptId: k, at: now() }); // normalized string id
+      notifyCompletionStateChange();
       // comfyui-mcp#1739 — the re-pend is only half the recovery: the ledger the
       // run just re-entered may have NO sweeper left (the safety sweep disarmed
       // during the optimistic-retire window), so notify the wiring to re-arm it.
       if (typeof onRepend === "function") onRepend(promptIdOf(k));
+    },
+
+    /** Mark a panel_run dispatch as active before queuePrompt starts. */
+    beginPanelRun() {
+      const token = `panel-run-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+      const timer = setTimer(() => {
+        panelRunDispatches.delete(token);
+        releaseHeldUnkeyedCompletions();
+      }, 30_000);
+      panelRunDispatches.set(token, timer);
+      return token;
+    },
+
+    /** End a known dispatch without disturbing prompt ids already registered. */
+    endPanelRun(token) {
+      if (!token || !panelRunDispatches.has(token)) return;
+      const timer = panelRunDispatches.get(token);
+      if (timer != null) clearTimer(timer);
+      panelRunDispatches.delete(token);
+      releaseHeldUnkeyedCompletions();
+    },
+
+    /** Stable key used by the matching run_receipt control frame. */
+    completionKeyFor(id) {
+      return completionKeys.get(key(id)) ?? null;
+    },
+
+    /** Persistable route/session/key metadata for pending panel-run ids. */
+    completionMetadata() {
+      return completionMetadataSnapshot();
+    },
+
+    dispose() {
+      for (const timer of panelRunDispatches.values()) {
+        try { clearTimer(timer); } catch {}
+      }
+      panelRunDispatches.clear();
     },
 
     /**
@@ -1225,5 +1362,6 @@ export function createRunCompletionTracker({
     _terminal: terminal,
     _awaitingDelivery: awaitingDelivery,
     _unconfirmedDelivery: unconfirmedDelivery,
+    _terminalNoKeyCompletion: terminalNoKeyCompletion,
   };
 }

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -52,7 +52,7 @@ export const NO_PROMPT_KEY = "__no_prompt__";
 
 /**
  * @param {object} opts
- * @param {(payload:{key:string, promptId:(string|null), images:any[], videos:any[], durationMs:number|null, finishedAt:(number|null), reconciled?:boolean, replayed?:boolean}) => void} opts.onFlush
+ * @param {(payload:{key:string, promptId:(string|null), images:any[], videos:any[], durationMs:number|null, finishedAt:(number|null), completionKey?:string, reconciled?:boolean, replayed?:boolean}) => void} opts.onFlush
  *   `finishedAt` is epoch ms. On the LIVE paths it is the flush clock; on the
  *   RECONCILED path (`reconciled:true`) it is the run's real execution_success
  *   time recovered from /history, or **null** when that entry records none —
@@ -159,6 +159,10 @@ export function createRunCompletionTracker({
   // this run as panel-queued. Keep only the media-less success that still needs
   // the panel_run promise applied; onQueued consumes it exactly once.
   const terminalNoMediaSuccess = new Map(); // key -> { promptId, durationMs, finishedAt, at }
+  // A panel_run completion is not retired when the browser socket accepts the
+  // frame. Keep the stable route+prompt key with the run so /history retries
+  // carry the same idempotency key until the orchestrator acknowledges it.
+  const completionKeys = new Map(); // key -> route-scoped completion key
   // Far beyond any realistic WS-replay-after-reconnect delay, so pruning an entry
   // older than this can never re-open the double-delivery window it guards.
   const deliveredTtlMs = 10 * 60 * 1000;
@@ -172,15 +176,14 @@ export function createRunCompletionTracker({
   const retryCounts = new Map(); // key -> attempts already made
 
   // Pending is a RECOVERY LEDGER, not a debounce cache: it holds exactly the runs
-  // whose completion has NOT been confirmed delivered. Every entry is removed the
-  // instant its run reaches a confirmed terminal outcome — execution_success/error
-  // with a delivered frame, or a /history reconcile — so the map is self-limiting
-  // to the (normally ≤1–2) currently-undelivered runs. It is deliberately NOT
-  // size-capped: evicting an entry would permanently forfeit the ONLY record that
-  // lets a bridge-down completion be recovered on reconnect, defeating #370 for
-  // that prompt (codex P1). Entries are tiny ({promptId, at}); a large batch simply
-  // registers each of its accepted prompt_ids and drains them as they finish —
-  // ledger depth mirrors the actual ComfyUI queue depth, which the server bounds.
+  // whose completion has NOT been confirmed delivered. Ordinary canvas frames can
+  // retire it after transport confirmation; a keyed panel_run stays here until
+  // the orchestrator receipt, so a long render or lost ack remains recoverable.
+  // It is deliberately NOT size-capped: evicting an entry would permanently
+  // forfeit the ONLY record that lets a completion be recovered on reconnect,
+  // defeating #370 for that prompt (codex P1). Entries are tiny ({promptId, at});
+  // a large batch simply registers each accepted prompt_id and drains them as they
+  // finish — ledger depth mirrors the actual ComfyUI queue depth.
   function trackPending(id) {
     if (id == null) return; // no prompt_id ⇒ not reconcilable against /history
     const k = key(id);
@@ -444,16 +447,13 @@ export function createRunCompletionTracker({
     // A panel-queued delivery still records its signature, so a canvas re-queue of
     // the SAME output afterwards is recognised rather than getting one free pass.
     if (panelQueued.has(k)) deduper.record({ signature, promptId: promptIdOf(k) });
-    // Optimistically mark delivered so a reconnect-triggered reconcile racing
-    // this flush can't double-deliver the same prompt. If the caller reports the
-    // send FAILED (bridge down), it calls markUndelivered() to re-pend it (#370).
-    markDelivered(k);
-    // …but that optimism is NOT proof the agent was told: the caller composes and
-    // sends asynchronously. Hold the run as "delivery in flight" until the caller
-    // confirms via markDelivered()/markUndelivered(), so isSettled() can't report
-    // it settled mid-window (#585). Set synchronously, before onFlush, so no
-    // observer can sample the gap.
+    // A successful browser write is not proof the orchestrator received the
+    // completion. Keep panel_run in pending until the matching completion ack;
+    // the stable key makes every /history replay idempotent downstream.
+    const completionKey = completionKeys.get(k);
+    markTerminal(k);
     markDispatched(k);
+    if (!completionKey) markDelivered(k);
     const payload = {
       key: k,
       promptId: promptIdOf(k),
@@ -461,6 +461,7 @@ export function createRunCompletionTracker({
       videos: buf.videos,
       durationMs,
       finishedAt: now(),
+      ...(completionKey ? { completionKey } : {}),
       // #986 — the agent is TOLD this output was already announced, never denied it.
       // Which of a replay or a fast re-render it is cannot be proven, so the panel
       // reports what it observed and lets the reader decide.
@@ -513,7 +514,8 @@ export function createRunCompletionTracker({
     // bridge send failed, and replay it without requiring /history to succeed.
     const liveReplay = liveReplays.get(k);
     if (liveReplay) {
-      markDelivered(k);
+      if (completionKeys.has(k)) markTerminal(k);
+      else markDelivered(k);
       markDispatched(k);
       onFlush({ ...liveReplay, replayed: true });
       return { promptId, status: "success", delivered: true };
@@ -567,8 +569,8 @@ export function createRunCompletionTracker({
     }
 
     // ── Terminal. Retire ALL live state for this key so a stale partial buffer (from
-    // pre-drop `executed` events) can't double-deliver later, and mark it delivered
-    // BEFORE onFlush so a concurrent reconcile can't race it.
+    // pre-drop `executed` events) can't double-deliver later. The terminal fence is
+    // marked before onFlush; keyed panel_run delivery remains pending until its ack.
     const buf = buffers.get(k);
     if (buf?.timer) clearTimer(buf.timer);
     buffers.delete(k);
@@ -581,7 +583,17 @@ export function createRunCompletionTracker({
     // media-less recovery below would never fire — the mistake this line exists to
     // prevent, and the one the reconcile test caught.
     const wasPanelQueued = panelQueued.has(k);
-    markDelivered(k); // also clears any scheduled retry for this key
+    const completionKey = completionKeys.get(k);
+    const holdsForCompletionAck =
+      wasPanelQueued && parsed.status === "success" && completionKey != null;
+    if (holdsForCompletionAck) {
+      // The terminal fence is needed to suppress late ComfyUI lifecycle events,
+      // but the recovery ledger must remain until the orchestrator receipt.
+      markTerminal(k);
+      clearReconcileRetry(k);
+    } else {
+      markDelivered(k); // also clears any scheduled retry for this key
+    }
     if (parsed.status === "error") {
       // Deliver the terminal error through the SAME hook whether we're in the
       // reconcile loop OR a scheduled retry — otherwise a transient /history miss
@@ -656,6 +668,7 @@ export function createRunCompletionTracker({
         images: parsed.images,
         videos: parsed.videos,
         durationMs,
+        ...(completionKey ? { completionKey } : {}),
         // Epoch ms of the REAL finish, or null when history records none (#1199).
         finishedAt: historyFinishedAt,
         reconciled: true,
@@ -698,6 +711,7 @@ export function createRunCompletionTracker({
     pending.delete(k); // EVICT — bounds the ledger
     panelQueued.delete(k); // #356 Bug 2 — evicted with it
     liveReplays.delete(k);
+    completionKeys.delete(k);
     markTerminal(promptId); // fence any stray late execution_start; ages out (not pinned)
     if (typeof onReconcileGiveUp === "function") {
       try {
@@ -840,8 +854,9 @@ export function createRunCompletionTracker({
       // ones (onQueued populates it), so a user's own UI run stays silent and no new
       // wakeups are introduced.
       //
-      // Both reads happen BEFORE flush(): a flush that delivers calls markDelivered
-      // (removing the key from `pending`) and retires the duration start.
+      // Both reads happen BEFORE flush(): a flush that delivers an ordinary canvas
+      // completion calls markDelivered (removing the key from `pending`) and retires
+      // the duration start. A keyed panel_run remains pending until its receipt.
       // Snapshot this before flush(): flush() consumes the media buffers, so
       // checking hasBufferedMedia(k) afterwards would misclassify a media run
       // as a late media-less success.
@@ -850,16 +865,18 @@ export function createRunCompletionTracker({
       const mediaLessStart = mediaLess ? starts.get(k) : null;
       flush(k);
       if (mediaLess) {
-        // Same ordering as flush(): retire from pending first so a reconnect
-        // reconcile racing this cannot deliver the same run twice, then hold it as
-        // delivery-in-flight until the caller confirms (#585).
-        markDelivered(k);
+        // Keep the panel_run in the recovery ledger until the orchestrator
+        // acknowledges this exact completion. The terminal fence still blocks
+        // late lifecycle events while /history reconciliation remains active.
+        markTerminal(k);
+        clearReconcileRetry(k);
         markDispatched(k);
         onFlush({
           key: k,
           promptId: promptIdOf(k),
           images: [],
           videos: [],
+          ...(completionKeys.get(k) ? { completionKey: completionKeys.get(k) } : {}),
           durationMs: mediaLessStart != null ? now() - mediaLessStart : null,
           finishedAt: now(),
           noMedia: true,
@@ -880,10 +897,10 @@ export function createRunCompletionTracker({
       // Retire start for runs that buffered nothing (flush early-returns then).
       starts.delete(k);
     startObserved.delete(k);
-      // A terminal success we OBSERVED live needs no /history reconcile — clear it
-      // from pending. (If the completion frame is later reported undelivered, the
-      // caller's markUndelivered re-pends it, so a bridge-down drop still recovers.)
-      markDelivered(k);
+      // A panel_run remains owed until the orchestrator explicitly acknowledges
+      // the completion frame. Ordinary canvas runs retain the legacy transport
+      // confirmation behavior.
+      if (!completionKeys.has(k)) markDelivered(k);
     },
 
     /** ComfyUI `execution_error` — drop this prompt's buffer, deliver no batch. */
@@ -951,11 +968,18 @@ export function createRunCompletionTracker({
      * execution_start/executing/executed ever reaches us — is still reconcilable
      * against /history because we recorded its prompt_id at queue time.
      */
-    onQueued(id) {
+    onQueued(id, { routeId, sessionId = null } = {}) {
       const k = key(id);
       trackPending(id);
       // #356 Bug 2 — records that THIS run carried panel_run's wait-for-it promise.
-      if (id != null) panelQueued.add(k);
+      if (id != null) {
+        panelQueued.add(k);
+        if (routeId != null && String(routeId).trim()) {
+          // JSON avoids delimiter collisions while keeping this deterministic
+          // across retries and safe to compare as an opaque wire value.
+          completionKeys.set(k, JSON.stringify([String(routeId), sessionId, k]));
+        }
+      }
       // #1728 P2 — execution_success can win the race with the delayed /prompt
       // response. The terminal fence correctly blocks re-pending, but before this
       // handoff the media-less decision had already observed panelQueued=false.
@@ -964,12 +988,21 @@ export function createRunCompletionTracker({
       const lateSuccess = id != null ? terminalNoMediaSuccess.get(k) : null;
       if (lateSuccess) {
         terminalNoMediaSuccess.delete(k);
+        delivered.delete(k);
+        if (completionKeys.has(k)) {
+          if (!pending.has(k)) pending.set(k, { promptId: k, at: now() });
+          markTerminal(k);
+          clearReconcileRetry(k);
+        } else {
+          markDelivered(k);
+        }
         markDispatched(k);
         onFlush({
           key: k,
           promptId: lateSuccess.promptId,
           images: [],
           videos: [],
+          ...(completionKeys.get(k) ? { completionKey: completionKeys.get(k) } : {}),
           durationMs: lateSuccess.durationMs,
           finishedAt: lateSuccess.finishedAt,
           noMedia: true,
@@ -978,9 +1011,9 @@ export function createRunCompletionTracker({
     },
 
     /**
-     * Caller reports the completion frame for `id` was CONFIRMED delivered to the
-     * agent (sendFrame succeeded / batch was empty). Retires it from pending and
-     * drops any retained live replay.
+     * Caller reports the completion frame for `id` was confirmed delivered to the
+     * agent (legacy transport confirmation, an empty batch, or the keyed
+     * orchestrator receipt). Retires it from pending and drops any retained replay.
      */
     markDelivered(id) {
       // The CALLER confirming delivery is the only proof the agent was told, so
@@ -991,7 +1024,24 @@ export function createRunCompletionTracker({
       // retired safely, for the same reason: before this, a re-pend is still possible.
       panelQueued.delete(key(id));
       liveReplays.delete(key(id));
+      completionKeys.delete(key(id));
       markDelivered(id);
+    },
+
+    /**
+     * The orchestrator accepted this exact completion frame. A prompt id alone
+     * is insufficient: a stale receipt must not retire a newer route's run.
+     */
+    acknowledgeDelivery(id, completionKey) {
+      if (id == null || typeof completionKey !== "string") return false;
+      const k = key(id);
+      if (completionKeys.get(k) !== completionKey) return false;
+      clearAwaitingDelivery(k);
+      panelQueued.delete(k);
+      liveReplays.delete(k);
+      completionKeys.delete(k);
+      markDelivered(k);
+      return true;
     },
 
     /**
@@ -1022,12 +1072,12 @@ export function createRunCompletionTracker({
 
     /**
      * True when NO completion frame is still owed to the agent for `id` — the run
-     * is neither pending recovery NOR mid-delivery. This is the honest answer to
-     * "has the agent been told?", as opposed to `hasPending()`/`_pending`, which
-     * go false the instant flush() optimistically retires a run, before the
-     * caller's async compose+send has resolved. #585 gates the post-restart resume
-     * nudge on this so the nudge can never overtake the completion it is waiting
-     * for. An id the tracker has never heard of is settled (nothing is owed).
+     * is neither pending recovery NOR mid-delivery. For legacy canvas runs,
+     * `hasPending()` can go false when flush() optimistically retires the run,
+     * before async compose+send resolves; keyed panel_run completions remain in
+     * pending until the orchestrator receipt. #585 gates the post-restart resume
+     * nudge on this so it can never overtake the completion it is waiting for.
+     * An id the tracker has never heard of is settled (nothing is owed).
      */
     isSettled(id) {
       const k = key(id);

--- a/web/js/lib/run-receipt-outbox.js
+++ b/web/js/lib/run-receipt-outbox.js
@@ -90,6 +90,7 @@ export function createRunReceiptOutbox({
           type: "run_receipt",
           run_rid: entry.runRid,
           prompt_id: entry.promptId,
+          ...(entry.completionKey ? { completion_key: entry.completionKey } : {}),
         }) === true;
       } catch {
         sent = false;
@@ -104,7 +105,7 @@ export function createRunReceiptOutbox({
   }
 
   return {
-    enqueue(runRid, promptId, routeId) {
+    enqueue(runRid, promptId, routeId, completionKey = null) {
       const rid = text(runRid);
       const pid = text(promptId);
       const route = text(routeId);
@@ -115,7 +116,15 @@ export function createRunReceiptOutbox({
           const oldest = pending.keys().next();
           if (!oldest.done) pending.delete(oldest.value);
         }
-        pending.set(key, { routeId: route, runRid: rid, promptId: pid, createdAt: now() });
+        pending.set(key, {
+          routeId: route,
+          runRid: rid,
+          promptId: pid,
+          ...(typeof completionKey === "string" && completionKey.trim()
+            ? { completionKey: completionKey.trim() }
+            : {}),
+          createdAt: now(),
+        });
       }
       flush();
       return !pending.has(key);


### PR DESCRIPTION
Fixes #1824\n\nA successful browser WebSocket write is not proof that the orchestrator received a panel_run completion. Keep keyed panel_run completions in the recovery ledger until the matching route/session/prompt receipt arrives, and replay /history outcomes with the same idempotency key. Reject stale receipts.\n\nIncludes a production graph_run lifecycle regression covering a 458180 ms render, accepted socket write, history replay, and matching receipt settlement.\n\nRequired companion protocol change: Artokun/comfyui-mcp#2322.\n\nTests: npm run test:unit (6890 tests: 6889 pass, 1 todo); npm run typecheck; npm run check:scope.