### PR TITLE
fix: atomically fence promoted widget receiver scope (#2314)

### DIFF
--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -191,6 +191,28 @@ test("#1681 shipped graph_query keeps default detail at 2048 and raises one expl
   assert.equal(Object.keys(defaultRow).join(","), Object.keys(raisedRow).join(","), "detail row shape is unchanged");
 });
 
+test("#2314 detail rows explicitly classify ordinary and promoted nodes", () => {
+  const ordinary = detailRows(query({ ids: [78], fields: "detail" }))[0];
+  assert.equal(ordinary.is_subgraph, false);
+
+  const promoted = {
+    id: 83,
+    type: "SubgraphNode",
+    title: "Promoted rail",
+    widgets: [{ name: "prompt_alias", value: "old" }],
+    inputs: [],
+    outputs: [],
+    subgraph: { _nodes: [] },
+  };
+  graph._nodes.push(promoted);
+  try {
+    const row = detailRows(query({ ids: [83], fields: "detail" }))[0];
+    assert.equal(row.is_subgraph, true);
+  } finally {
+    graph._nodes.pop();
+  }
+});
+
 test("#1681 shipped graph_query ignores the raised cap for broad and multi-ID detail", () => {
   const broad = query({ fields: "detail", widget_max_chars: 8192 });
   const multi = query({ ids: [78, 79], fields: "detail", widget_max_chars: 8192 });

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -1,8 +1,45 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
+import { findSubgraphOwner } from "../../web/js/lib/subgraph-scope.js";
 
 const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+function extractShippingMethod(signature) {
+  const start = PANEL_SRC.indexOf(signature);
+  assert.ok(start >= 0, `${signature} not found in panel source`);
+  const open = PANEL_SRC.indexOf(") {", start) + 1;
+  let depth = 0;
+  for (let i = open; i < PANEL_SRC.length; i += 1) {
+    const ch = PANEL_SRC[i];
+    if (ch === "/" && PANEL_SRC[i + 1] === "/") {
+      i = PANEL_SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && PANEL_SRC[i + 1] === "*") {
+      i = PANEL_SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < PANEL_SRC.length; i += 1) {
+        if (PANEL_SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (PANEL_SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return PANEL_SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated method: ${signature}`);
+}
 
 test("graph_set_widget enforces expected_node_type at the synchronous write boundary", () => {
   const start = PANEL_SRC.indexOf("async graph_set_widget({");
@@ -156,6 +193,150 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
     () => assertScope(currentCtx(), { scope: "subgraph", owner_node_id: 78 }),
     /graph_identity must be a non-empty string/,
   );
+});
+
+test("#2314 production graph_enter_subgraph -> graph_set_widget fence refuses a parent-rail relink", async () => {
+  const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
+  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production scope helper boundary not found");
+  const promotionStart = PANEL_SRC.indexOf("function resolveSubgraphLink(");
+  const promotionEnd = PANEL_SRC.indexOf("\nfunction findPromotedHostInput", promotionStart);
+  assert.ok(promotionStart >= 0 && promotionEnd > promotionStart, "production promotion resolver boundary not found");
+  const sourceForSubgraphInput = new Function(
+    `${PANEL_SRC.slice(promotionStart, promotionEnd)}; return sourceForSubgraphInput;`,
+  )();
+  const assertScope = new Function(
+    "describeActiveGraph",
+    "findSubgraphOwner",
+    "resolvePromotedInnerTarget",
+    "sourceForSubgraphInput",
+    `${PANEL_SRC.slice(helperStart, helperEnd)}; return assertExpectedPromotedScope;`,
+  );
+
+  const rail = { name: "quality_prompt", value: "old" };
+  const innerWidget = { name: "quality_prompt", value: "old" };
+  const innerInput = { name: "quality_prompt", widget: { name: "quality_prompt" } };
+  const inner = {
+    id: 76,
+    type: "PrimitiveStringMultiline",
+    inputs: [innerInput],
+    widgets: [innerWidget],
+  };
+  const childGraph = {
+    _nodes: [inner],
+    getNodeById: (id) => (String(id) === "76" ? inner : null),
+    getLink: (id) => (id === 1 ? { origin_id: 76, target_id: 76, target_slot: 0 } : null),
+  };
+  const hostInput = {
+    name: "quality_prompt",
+    widget: rail,
+    _widget: rail,
+    widgetId: "root:78:quality_prompt",
+    _subgraphSlot: { name: "quality_prompt", linkIds: [1] },
+  };
+  const owner = { id: 78, widgets: [rail], inputs: [hostInput], subgraph: childGraph };
+  const rootGraph = { _nodes: [owner] };
+  let currentGraph = rootGraph;
+  const canvas = {
+    get graph() {
+      return currentGraph;
+    },
+    openSubgraph: (subgraph) => {
+      currentGraph = subgraph;
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const describeActiveGraph = (graph) =>
+    graph === childGraph
+      ? {
+          scope: "subgraph",
+          owner_node_id: 78,
+          workflow_uuid: "workflow-a",
+          graph_identity: "graph-a",
+        }
+      : { scope: "root", workflow_uuid: "workflow-a", graph_identity: "root-a" };
+  const getGraphCtx = () => ({ app, graph: currentGraph, rootGraph, canvas });
+
+  const enter = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "confirmCanvasNavigation",
+    "describeActiveGraph",
+    "assertGraphBoundToActiveWorkflow",
+    "coerceMessageText",
+    "pinReconnectScope",
+    "releaseReconnectScopePin",
+    `return (${extractShippingMethod("async graph_enter_subgraph({ node_id })").replace(
+      /^async graph_enter_subgraph\(/,
+      "async function graph_enter_subgraph(",
+    )});`,
+  )(
+    getGraphCtx,
+    (_graph, id) => (String(id) === "78" ? owner : null),
+    async ({ readCanvasGraph, assertBound }) => {
+      assert.equal(readCanvasGraph(), childGraph);
+      assertBound();
+      return { landed: true, everLanded: true, bound: true };
+    },
+    describeActiveGraph,
+    () => {},
+    (value) => String(value),
+    () => {},
+    () => {},
+  );
+
+  const enterReply = await enter({ node_id: 78 });
+  assert.equal(enterReply.settled, true, "the production enter path must settle on the child graph");
+
+  const handlerStart = PANEL_SRC.indexOf("async graph_set_widget({");
+  const fenceStart = PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", handlerStart);
+  const fenceTail = PANEL_SRC.slice(fenceStart).match(/\r?\n      \},\r?\n      \/\/ Stale-combo retry/);
+  const fenceEnd = fenceTail?.index == null ? -1 : fenceStart + fenceTail.index;
+  assert.ok(fenceStart >= 0 && fenceEnd > fenceStart, "production graph_set_widget fence not found");
+  const fenceProperty = PANEL_SRC.slice(fenceStart, fenceEnd) + "\n      }";
+  const makeFence = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "assertActiveWorkflowCommandTarget",
+    "assertExpectedPromotedScope",
+    "WORKFLOW_UUID_FIELD",
+    `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay) {
+      const enforceDeferredExpected = defer_replay === true;
+      return ({ ${fenceProperty} }).assertTargetStillCurrent;
+    };`,
+  );
+  const expectedScope = {
+    scope: "subgraph",
+    owner_node_id: 78,
+    workflow_uuid: "workflow-a",
+    graph_identity: "graph-a",
+    promoted_widget: "quality_prompt",
+    parent_rail: {
+      authoritative: true,
+      widget: "quality_prompt",
+      widget_id: "root:78:quality_prompt",
+    },
+  };
+  const fence = makeFence(
+    getGraphCtx,
+    () => inner,
+    () => {},
+    assertScope(describeActiveGraph, findSubgraphOwner, resolvePromotedInnerTarget, sourceForSubgraphInput),
+    "workflow_uuid",
+  )(76, "PrimitiveStringMultiline", "workflow-a", expectedScope, inner, undefined);
+
+  assert.doesNotThrow(() => fence(), "the entered, still-authoritative promotion is writable");
+  let applied = 0;
+  hostInput.link = 99;
+  assert.throws(
+    () => {
+      fence();
+      applied += 1;
+    },
+    /promoted parent rail changed or became unverifiable/,
+  );
+  assert.equal(applied, 0, "the final graph_set_widget mutation must not run after the relink");
 });
 
 test("#2314 same owner id in a different graph is refused at the shipped fence", () => {

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -91,8 +91,8 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
   const rootGraph = { _nodes: [{ id: 78, subgraph: graphA }, { id: 79, subgraph: graphB }] };
   const describe = (graph) =>
     graph === graphA
-      ? { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-a" }
-      : { scope: "subgraph", owner_node_id: 79, workflow_uuid: "workflow-a" };
+      ? { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-a", graph_identity: "graph-a" }
+      : { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-a", graph_identity: "graph-b" };
   const findOwner = (_root, graph) =>
     graph === graphA ? { id: 78 } : graph === graphB ? { id: 79 } : null;
   const assertScope = makeScopeHelpers(describe, findOwner);
@@ -125,7 +125,7 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
     76,
     "OrdinaryNode",
     "workflow-a",
-    { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-a" },
+    { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-a", graph_identity: "graph-a" },
     liveTarget,
     undefined,
   );
@@ -145,7 +145,47 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
   writes += 1;
   assert.equal(writes, 1);
   assert.throws(
-    () => assertScope(currentCtx(), { scope: "subgraph", owner_node_id: "not-an-id" }),
+    () => assertScope(currentCtx(), {
+      scope: "subgraph",
+      owner_node_id: "not-an-id",
+      graph_identity: "graph-a",
+    }),
     /canonical node id/,
   );
+  assert.throws(
+    () => assertScope(currentCtx(), { scope: "subgraph", owner_node_id: 78 }),
+    /graph_identity must be a non-empty string/,
+  );
+});
+
+test("#2314 same owner id in a different graph is refused at the shipped fence", () => {
+  const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
+  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  const helperSource = PANEL_SRC.slice(helperStart, helperEnd);
+  const assertScope = new Function(
+    "describeActiveGraph",
+    "findSubgraphOwner",
+    `${helperSource}; return assertExpectedPromotedScope;`,
+  )(
+    (graph) => ({
+      scope: "subgraph",
+      owner_node_id: 78,
+      workflow_uuid: "workflow-a",
+      graph_identity: graph.name === "A" ? "graph-a" : "graph-b",
+    }),
+    () => ({ id: 78 }),
+  );
+  const graphA = { name: "A" };
+  const graphB = { name: "B" };
+  const current = () => ({ graph: currentGraph, rootGraph: {} });
+  let currentGraph = graphA;
+  const expected = {
+    scope: "subgraph",
+    owner_node_id: 78,
+    workflow_uuid: "workflow-a",
+    graph_identity: "graph-a",
+  };
+  assert.doesNotThrow(() => assertScope(current(), expected));
+  currentGraph = graphB;
+  assert.throws(() => assertScope(current(), expected), /promoted receiver changed before dispatch/);
 });

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -36,7 +36,7 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
   const original = { id: 7, type: "OtherLoraLoader" };
   let liveTarget = original;
   let resolvedId;
-  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, node, defer_replay) {
+  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay) {
       const enforceDeferredExpected = defer_replay === true;
       return ({ ${fenceProperty} }).assertTargetStillCurrent;
     };`;
@@ -46,6 +46,7 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
     "getGraphCtx",
     "resolveNode",
     "assertActiveWorkflowCommandTarget",
+    "assertExpectedPromotedScope",
     "WORKFLOW_UUID_FIELD",
     factorySource,
     );
@@ -59,8 +60,9 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
       return liveTarget;
     },
     () => {},
+    () => {},
     "workflow_uuid",
-  )("7:subgraph", "OtherLoraLoader", undefined, original, undefined);
+  )("7:subgraph", "OtherLoraLoader", undefined, undefined, original, undefined);
 
   fence();
   assert.equal(resolvedId, "7:subgraph");
@@ -70,4 +72,80 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
 
   liveTarget = { id: 7, type: "KSampler" };
   assert.throws(() => fence(), /target changed before dispatch/);
+});
+
+test("#2314 production scope fence refuses receiver navigation after graph_query reply", () => {
+  const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
+  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  assert.ok(helperStart >= 0, "production promoted-scope helper not found");
+  assert.ok(helperEnd > helperStart, "production promoted-scope helper boundary not found");
+  const helperSource = PANEL_SRC.slice(helperStart, helperEnd);
+  const makeScopeHelpers = new Function(
+    "describeActiveGraph",
+    "findSubgraphOwner",
+    `${helperSource}; return assertExpectedPromotedScope;`,
+  );
+
+  const graphA = { name: "A" };
+  const graphB = { name: "B" };
+  const rootGraph = { _nodes: [{ id: 78, subgraph: graphA }, { id: 79, subgraph: graphB }] };
+  const describe = (graph) =>
+    graph === graphA
+      ? { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-a" }
+      : { scope: "subgraph", owner_node_id: 79, workflow_uuid: "workflow-a" };
+  const findOwner = (_root, graph) =>
+    graph === graphA ? { id: 78 } : graph === graphB ? { id: 79 } : null;
+  const assertScope = makeScopeHelpers(describe, findOwner);
+  let currentGraph = graphA;
+  let writes = 0;
+  let liveTarget = { id: 76, type: "OrdinaryNode" };
+  const currentCtx = () => ({ graph: currentGraph, rootGraph });
+  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay) {
+      const enforceDeferredExpected = defer_replay === true;
+      return ({ ${PANEL_SRC.slice(
+        PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", PANEL_SRC.indexOf("async graph_set_widget({")),
+        PANEL_SRC.indexOf("\n      // Stale-combo retry", PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", PANEL_SRC.indexOf("async graph_set_widget({"))),
+      )} }).assertTargetStillCurrent;
+    };`;
+  const makeFence = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "assertActiveWorkflowCommandTarget",
+    "assertExpectedPromotedScope",
+    "WORKFLOW_UUID_FIELD",
+    factorySource,
+  );
+  const fence = makeFence(
+    currentCtx,
+    () => liveTarget,
+    () => {},
+    assertScope,
+    "workflow_uuid",
+  )(
+    76,
+    "OrdinaryNode",
+    "workflow-a",
+    { scope: "subgraph", owner_node_id: 78, workflow_uuid: "workflow-a" },
+    liveTarget,
+    undefined,
+  );
+
+  // The graph_query reply was for owner A. Navigation happens before the
+  // synchronous production callback, so the write must never be entered.
+  currentGraph = graphB;
+  assert.throws(() => {
+    fence();
+    writes += 1;
+  }, /promoted receiver changed before dispatch/);
+  assert.equal(writes, 0);
+
+  // A same-owner write remains valid, while malformed metadata refuses closed.
+  currentGraph = graphA;
+  fence();
+  writes += 1;
+  assert.equal(writes, 1);
+  assert.throws(
+    () => assertScope(currentCtx(), { scope: "subgraph", owner_node_id: "not-an-id" }),
+    /canonical node id/,
+  );
 });

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -189,3 +189,57 @@ test("#2314 same owner id in a different graph is refused at the shipped fence",
   currentGraph = graphB;
   assert.throws(() => assertScope(current(), expected), /promoted receiver changed before dispatch/);
 });
+
+test("#2314 terminal endpoint is part of the shipped receiver fence", () => {
+  const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
+  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production scope helper boundary not found");
+  const assertScope = new Function(
+    "describeActiveGraph",
+    "findSubgraphOwner",
+    `${PANEL_SRC.slice(helperStart, helperEnd)}; return assertExpectedPromotedScope;`,
+  )(
+    () => ({
+      scope: "subgraph",
+      owner_node_id: 78,
+      workflow_uuid: "workflow-a",
+      graph_identity: "graph-a",
+    }),
+    () => ({ id: 78 }),
+  );
+  const current = { graph: {}, rootGraph: {} };
+  const expected = {
+    scope: "subgraph",
+    owner_node_id: 78,
+    workflow_uuid: "workflow-a",
+    graph_identity: "graph-a",
+    terminal: {
+      node_id: 2768,
+      type: "KSampler",
+      widget: "steps",
+      inputs: [{ name: "steps", type: "INT" }],
+      chain_depth: 1,
+    },
+  };
+  const liveTerminal = () => ({
+    node_id: 2768,
+    type: "KSampler",
+    widget: "steps",
+    inputs: [{ name: "steps", type: "INT" }],
+    depth: 1,
+  });
+
+  assert.doesNotThrow(() => assertScope(current, expected, liveTerminal));
+  assert.throws(
+    () => assertScope(current, { ...expected, terminal: { ...expected.terminal, node_id: 99 } }, liveTerminal),
+    /promoted terminal receiver changed or became unverifiable/,
+  );
+  assert.throws(
+    () => assertScope(current, { ...expected, terminal: { ...expected.terminal, chain_depth: 17 } }, liveTerminal),
+    /chain_depth must be a bounded integer/,
+  );
+  assert.throws(
+    () => assertScope(current, expected),
+    /could not verify the terminal promotion endpoint/,
+  );
+});

--- a/browser_tests/unit/graph-view-identity.test.mjs
+++ b/browser_tests/unit/graph-view-identity.test.mjs
@@ -2,7 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-import { withWorkflowUuid } from "../../web/js/lib/graph-view-identity.js";
+import {
+  graphViewIdentityFor,
+  withGraphViewIdentity,
+  withWorkflowUuid,
+} from "../../web/js/lib/graph-view-identity.js";
 
 const PANEL_SRC = fs.readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
 
@@ -41,14 +45,29 @@ test("an explicit live identity wins over a stale root tag", () => {
   assert.deepEqual(withWorkflowUuid({ scope: "root" }, root, null), { scope: "root" });
 });
 
+test("graph read identity is stable per live graph object and differs across graphs", () => {
+  const graphA = {};
+  const graphB = {};
+  const first = graphViewIdentityFor(graphA);
+  assert.match(first, /^graph:/);
+  assert.equal(graphViewIdentityFor(graphA), first);
+  assert.notEqual(graphViewIdentityFor(graphB), first);
+  assert.deepEqual(withGraphViewIdentity({ scope: "subgraph", owner_node_id: 7 }, graphA), {
+    scope: "subgraph",
+    owner_node_id: 7,
+    graph_identity: first,
+  });
+});
+
 test("production graph read callers publish the live viewing identity", () => {
   assert.match(PANEL_SRC, /const workflow = activeWorkflowRef\(\);/);
-  assert.match(PANEL_SRC, /const withLiveIdentity = \(viewing\) => withWorkflowUuid\(viewing, root, workflowUuid\);/);
+  assert.match(PANEL_SRC, /withGraphViewIdentity\(withWorkflowUuid\(viewing, root, workflowUuid\), graph\)/);
 
   const subgraphStart = PANEL_SRC.indexOf("graph_get_subgraph({ node_id }) {");
   const subgraphEnd = PANEL_SRC.indexOf("async graph_add_node", subgraphStart);
   assert.ok(subgraphStart >= 0 && subgraphEnd > subgraphStart);
   assert.match(PANEL_SRC.slice(subgraphStart, subgraphEnd), /viewing: describeActiveGraph\(graph\)/);
+  assert.match(PANEL_SRC.slice(subgraphStart, subgraphEnd), /graph_identity: graphViewIdentityFor\(sub\)/);
 
   const queryStart = PANEL_SRC.indexOf("graph_query({");
   const queryEnd = PANEL_SRC.indexOf("graph_find_nodes({", queryStart);

--- a/browser_tests/unit/outline-mutation-scope-reconnect.test.mjs
+++ b/browser_tests/unit/outline-mutation-scope-reconnect.test.mjs
@@ -24,7 +24,10 @@ import {
 } from "../../web/js/lib/subgraph-scope.js";
 import { describeMissingNode } from "../../web/js/lib/node-scope-locator.js";
 import { canonicalNodeId, resolveLiveNode } from "../../web/js/lib/node-id.js";
-import { withWorkflowUuid } from "../../web/js/lib/graph-view-identity.js";
+import {
+  withGraphViewIdentity,
+  withWorkflowUuid,
+} from "../../web/js/lib/graph-view-identity.js";
 import {
   rememberAutoLayoutScope,
   clearAutoLayoutScope,
@@ -243,10 +246,11 @@ function buildShippedScopeTools(app) {
     "workflowObjectUuid",
     "workflowStableUuid",
     "withWorkflowUuid",
+    "withGraphViewIdentity",
     "findSubgraphOwner",
     "isSubgraphInRoot",
     `${panelFunctionSource(PANEL_SRC, "describeActiveGraph", "captureGraphSnapshot")}\nreturn describeActiveGraph;`,
-  )(app, () => null, () => "", () => "", withWorkflowUuid, findSubgraphOwner, isSubgraphInRoot);
+  )(app, () => null, () => "", () => "", withWorkflowUuid, withGraphViewIdentity, findSubgraphOwner, isSubgraphInRoot);
 
   const resolveNode = new Function(
     "canonicalNodeId",

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -273,6 +273,7 @@ test("#570/#718: hello ALWAYS advertises both workflow-stamp fences so the orche
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp_at_write, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_expected_node_type_at_write, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).publishes_promoted_terminal_witnesses, true);
+  assert.equal(buildHelloPayload({ tabId: "t" }).enforces_promoted_parent_rail_at_write, true);
   assert.equal(
     buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_workflow_stamp,
     true,

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -272,6 +272,7 @@ test("#570/#718: hello ALWAYS advertises both workflow-stamp fences so the orche
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp_at_write, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_expected_node_type_at_write, true);
+  assert.equal(buildHelloPayload({ tabId: "t" }).publishes_promoted_terminal_witnesses, true);
   assert.equal(
     buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_workflow_stamp,
     true,

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -37,6 +37,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { followPromotionToConcrete, MAX_PROMOTION_CHAIN_DEPTH } from "../../web/js/lib/widget-write.js";
 import { refreshComboOptionsFromDefs } from "../../web/js/lib/asset-staleness.js";
 import { commandTargetsActiveWorkflow } from "../../web/js/lib/workflow-chat-identity.js";
 
@@ -1041,6 +1042,33 @@ test("#458 set_widget: NESTED promotion CYCLE ⇒ FAIL CLOSED (terminates, no mu
       }),
     (err) => err instanceof Error && /could not be resolved to a concrete backend node/.test(err.message),
   );
+});
+
+test("#2314 terminal witness walk is depth-bounded and fails closed", () => {
+  const nodes = Array.from({ length: MAX_PROMOTION_CHAIN_DEPTH + 2 }, (_, index) => ({
+    id: 1000 + index,
+    type: `Subgraph${index}`,
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    inputs: [{ name: "steps", _subgraphSlot: { name: "steps" } }],
+  }));
+  for (let index = 0; index < nodes.length - 1; index += 1) {
+    nodes[index].subgraph = {
+      _nodes: [nodes[index + 1]],
+      getNodeById: (id) => (String(id) === String(nodes[index + 1].id) ? nodes[index + 1] : null),
+    };
+  }
+  const resolveSource = (node) => {
+    const index = nodes.indexOf(node);
+    return index >= 0 && index < nodes.length - 1
+      ? { sourceNodeId: String(nodes[index + 1].id), sourceWidgetName: "steps" }
+      : null;
+  };
+  const result = followPromotionToConcrete(
+    { node: nodes[0], widget: nodes[0].widgets[0], input: null, parentWidget: null, parentWidgets: [] },
+    resolveSource,
+  );
+  assert.match(result.error, /maximum depth/);
+  assert.equal(result.node, null);
 });
 
 test("#458 set_widget: NESTED promoted COMBO recovery keys on the CONCRETE type ⇒ just-staged value accepted (not falsely rejected)", async () => {

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -281,6 +281,7 @@ test("WIRING: production alias witness keeps outer, immediate, and terminal name
         label: "outer display",
         widget: projectedWidget,
         _widget: projectedWidget,
+        widgetId: `root:78:${testCase.outer}`,
         _subgraphSlot: { name: "parent_alias", linkIds: [1] },
       }],
       subgraph: {
@@ -294,7 +295,11 @@ test("WIRING: production alias witness keeps outer, immediate, and terminal name
     const witness = entries.find((entry) => entry.widget === testCase.outer);
     assert.deepEqual(witness, {
       widget: testCase.outer,
-      parent_rail: { authoritative: true, widget: testCase.immediate },
+      parent_rail: {
+        authoritative: true,
+        widget: testCase.immediate,
+        widget_id: `root:78:${testCase.outer}`,
+      },
       immediate_node_id: 188,
       immediate_widget: testCase.immediate,
       terminal_node_id: 2768,

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { graphViewIdentityFor } from "../../web/js/lib/graph-view-identity.js";
 import { subgraphValueProvenance } from "../../web/js/lib/subgraph-value-provenance.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
 
@@ -117,6 +118,7 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     "describeActiveGraph",
     "subgraphValueProvenance",
     "redactWidgetValue",
+    "graphViewIdentityFor",
     "MAX_STATE_NODES",
     "fixedCapNote",
     "summarizeNode",
@@ -127,13 +129,18 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     () => ({ graph: "root" }),
     subgraphValueProvenance,
     redactWidgetValue,
+    graphViewIdentityFor,
     50,
     () => "truncation note",
     (node) => ({ id: node.id, mode: node.mode, inputs: node.inputs, outputs: node.outputs }),
   );
 
   const out = getSubgraph({ node_id: 173 });
-  assert.deepEqual(out.subgraph_of, { node_id: 173, title: "Reusable secret node" });
+  assert.deepEqual(out.subgraph_of, {
+    node_id: 173,
+    title: "Reusable secret node",
+    graph_identity: graphViewIdentityFor(parent.subgraph),
+  });
   assert.deepEqual(out.instance_widgets, {
     ordinarySettings: { value: "SECRET" },
     apiKey: { value: REDACTED_WIDGET_VALUE },

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -100,6 +100,60 @@ test("WIRING: production graph_get_subgraph gives MCP a definitive non-promoted 
   );
 });
 
+test("WIRING: production graph_get_subgraph publishes the terminal nested-promotion witness", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const start = src.indexOf("graph_get_subgraph({ node_id }) {");
+  const end = src.indexOf("async graph_add_node(", start);
+  assert.ok(start >= 0 && end > start, "graph_get_subgraph handler must remain extractable");
+  const method = src.slice(start, end).replace(/,\s*$/, "");
+  const terminal = {
+    widget: "quality_prompt",
+    immediate_node_id: 188,
+    immediate_widget: "quality_prompt",
+    terminal_node_id: 2768,
+    terminal_node_type: "AnimaRegionalCanvasInline",
+    terminal_widget: "quality_prompt",
+    terminal_inputs: [],
+    chain_depth: 1,
+  };
+  const parent = {
+    id: 78,
+    title: "Nested container",
+    inputs: [],
+    subgraph: { _nodes: [{ id: 188, type: "SubgraphB", is_subgraph: true }] },
+  };
+  const graph = {};
+  const getSubgraph = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "describeActiveGraph",
+    "subgraphValueProvenance",
+    "redactWidgetValue",
+    "graphViewIdentityFor",
+    "MAX_STATE_NODES",
+    "fixedCapNote",
+    "summarizeNode",
+    "promotedTerminalWitnesses",
+    `return ({${method}}).graph_get_subgraph;`,
+  )(
+    () => ({ graph }),
+    () => parent,
+    () => ({ scope: "root", graph_identity: "root" }),
+    () => ({}),
+    () => ({}),
+    () => "graph:nested",
+    50,
+    () => "truncation note",
+    (node) => ({ id: node.id, type: node.type }),
+    () => [terminal],
+  );
+
+  const out = getSubgraph({ node_id: 78 });
+  assert.deepEqual(out.promoted_terminals, [terminal]);
+  assert.equal(out.nodes[0].id, 188);
+});
+
 test("WIRING: production graph_get_subgraph redacts instance provenance", async () => {
   // Execute the module-private handler's source fragment. A source-only assertion
   // would miss a sanitizer applied to the wrong object, while a helper-only test
@@ -144,6 +198,7 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     "MAX_STATE_NODES",
     "fixedCapNote",
     "summarizeNode",
+    "promotedTerminalWitnesses",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph }),
@@ -155,6 +210,7 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     50,
     () => "truncation note",
     (node) => ({ id: node.id, mode: node.mode, inputs: node.inputs, outputs: node.outputs }),
+    () => [],
   );
 
   const out = getSubgraph({ node_id: 173 });

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -3,6 +3,12 @@ import assert from "node:assert/strict";
 import { graphViewIdentityFor } from "../../web/js/lib/graph-view-identity.js";
 import { subgraphValueProvenance } from "../../web/js/lib/subgraph-value-provenance.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
+import {
+  followPromotionToConcrete,
+  MAX_PROMOTION_CHAIN_DEPTH,
+  promotedInputAliases,
+  resolvePromotedInnerTarget,
+} from "../../web/js/lib/widget-write.js";
 
 /**
  * #636 (minor) — panel_get_subgraph(173) reported inner node 166 value "MiniMax_H3"
@@ -152,6 +158,105 @@ test("WIRING: production graph_get_subgraph publishes the terminal nested-promot
   const out = getSubgraph({ node_id: 78 });
   assert.deepEqual(out.promoted_terminals, [terminal]);
   assert.equal(out.nodes[0].id, 188);
+});
+
+test("WIRING: production alias witness keeps outer, immediate, and terminal names distinct", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const helperStart = src.indexOf("function resolveSubgraphLink(");
+  const helperEnd = src.indexOf("\nfunction findPromotedHostInput", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production promotion helper range must remain extractable");
+  const makeWitnesses = new Function(
+    "resolvePromotedInnerTarget",
+    "followPromotionToConcrete",
+    "MAX_PROMOTION_CHAIN_DEPTH",
+    "promotedInputAliases",
+    `${src.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
+  )(
+    resolvePromotedInnerTarget,
+    followPromotionToConcrete,
+    MAX_PROMOTION_CHAIN_DEPTH,
+    promotedInputAliases,
+  );
+
+  const cases = [
+    {
+      outer: "prompt_alias",
+      immediate: "prompt_b",
+      terminalType: "AnimaRegionalCanvasInline",
+      terminalWidget: "quality_prompt",
+      inputs: [{ name: "quality_prompt", type: "STRING" }],
+    },
+    {
+      outer: "dynamic_alias",
+      immediate: "dynamic_b",
+      terminalType: "NestedConcreteNode",
+      terminalWidget: "model.prompt",
+      inputs: [
+        { name: "model", type: "COMFY_DYNAMICCOMBO_V3" },
+        { name: "model.prompt", type: "STRING" },
+      ],
+    },
+    {
+      outer: "stack_alias",
+      immediate: "stack_b",
+      terminalType: "DaSiWa_LTX2LoraLoader",
+      terminalWidget: "stack_data",
+      inputs: [{ name: "stack_data", type: "STRING" }],
+    },
+  ];
+
+  for (const testCase of cases) {
+    const terminal = {
+      id: 2768,
+      type: testCase.terminalType,
+      inputs: testCase.inputs.map((input, index) => ({
+        ...input,
+        ...(index === testCase.inputs.findIndex((candidate) => candidate.name === testCase.terminalWidget)
+          ? { widget: { name: testCase.terminalWidget } }
+          : {}),
+      })),
+      widgets: [{ name: testCase.terminalWidget, value: "old" }],
+    };
+    const terminalSlot = testCase.inputs.findIndex((candidate) => candidate.name === testCase.terminalWidget);
+    const inner = {
+      id: 188,
+      type: "SubgraphB",
+      inputs: [{ name: testCase.immediate, widget: { name: testCase.immediate }, _subgraphSlot: { name: "inner_alias", linkIds: [2] } }],
+      widgets: [{ name: testCase.immediate, value: "old" }],
+      subgraph: {
+        _nodes: [terminal],
+        getNodeById: (id) => (String(id) === "2768" ? terminal : null),
+        getLink: (id) => (id === 2 ? { origin_id: 2768, target_id: 2768, target_slot: terminalSlot } : null),
+      },
+    };
+    const parent = {
+      id: 78,
+      inputs: [{
+        name: testCase.outer,
+        label: "outer display",
+        _subgraphSlot: { name: "parent_alias", linkIds: [1] },
+      }],
+      subgraph: {
+        _nodes: [inner],
+        getNodeById: (id) => (String(id) === "188" ? inner : null),
+        getLink: (id) => (id === 1 ? { origin_id: 188, target_id: 188, target_slot: 0 } : null),
+      },
+    };
+
+    const entries = makeWitnesses(parent);
+    const witness = entries.find((entry) => entry.widget === testCase.outer);
+    assert.deepEqual(witness, {
+      widget: testCase.outer,
+      immediate_node_id: 188,
+      immediate_widget: testCase.immediate,
+      terminal_node_id: 2768,
+      terminal_node_type: testCase.terminalType,
+      terminal_widget: testCase.terminalWidget,
+      terminal_inputs: testCase.inputs,
+      chain_depth: 1,
+    });
+  }
 });
 
 test("WIRING: production graph_get_subgraph redacts instance provenance", async () => {

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -78,6 +78,28 @@ test("no promotion-to-inner-widget PAIRING is asserted", () => {
 });
 
 // ── WIRING ────────────────────────────────────────────────────────────────
+test("WIRING: production graph_get_subgraph gives MCP a definitive non-promoted error", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const start = src.indexOf("graph_get_subgraph({ node_id }) {");
+  const end = src.indexOf("async graph_add_node(", start);
+  assert.ok(start >= 0 && end > start, "graph_get_subgraph handler must remain extractable");
+  const method = src.slice(start, end).replace(/,\s*$/, "");
+  const getSubgraph = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    `return ({${method}}).graph_get_subgraph;`,
+  )(
+    () => ({ graph: {} }),
+    (_graph, id) => ({ id, type: "OrdinaryNode" }),
+  );
+
+  assert.throws(
+    () => getSubgraph({ node_id: 78 }),
+    /Node 78 \(OrdinaryNode\) is not a subgraph/,
+  );
+});
+
 test("WIRING: production graph_get_subgraph redacts instance provenance", async () => {
   // Execute the module-private handler's source fragment. A source-only assertion
   // would miss a sanitizer applied to the wrong object, while a helper-only test

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -266,11 +266,20 @@ test("WIRING: production alias witness keeps outer, immediate, and terminal name
         getLink: (id) => (id === 2 ? { origin_id: 2768, target_id: 2768, target_slot: terminalSlot } : null),
       },
     };
+    const projectedWidget = {
+      name: testCase.immediate,
+      label: "outer display",
+      _subgraphSlot: { name: "parent_alias" },
+    };
     const parent = {
       id: 78,
+      widgets: [projectedWidget],
+      properties: { proxyWidgets: [[188, testCase.immediate]] },
       inputs: [{
         name: testCase.outer,
         label: "outer display",
+        widget: projectedWidget,
+        _widget: projectedWidget,
         _subgraphSlot: { name: "parent_alias", linkIds: [1] },
       }],
       subgraph: {
@@ -307,6 +316,37 @@ test("WIRING: production alias witness keeps outer, immediate, and terminal name
       /_subgraphSlot missing|unresolved/i,
     );
   }
+});
+
+test("WIRING: production witness refuses to publish [] for an unenumerable proxyWidgets relation", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const helperStart = src.indexOf("function resolveSubgraphLink(");
+  const helperEnd = src.indexOf("\nfunction findPromotedHostInput", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production promotion helper range must remain extractable");
+  const makeWitnesses = new Function(
+    "resolvePromotedInnerTarget",
+    "followPromotionToConcrete",
+    "MAX_PROMOTION_CHAIN_DEPTH",
+    "promotedInputAliases",
+    `${src.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
+  )(
+    resolvePromotedInnerTarget,
+    followPromotionToConcrete,
+    MAX_PROMOTION_CHAIN_DEPTH,
+    promotedInputAliases,
+  );
+
+  const entries = makeWitnesses({
+    id: 78,
+    properties: { proxyWidgets: [[188, "quality_prompt"]] },
+    widgets: [],
+    inputs: [],
+    subgraph: { _nodes: [] },
+  });
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].widget, "quality_prompt");
+  assert.match(entries[0].error, /proxyWidgets|node\.widgets|_subgraphSlot/i);
 });
 
 test("WIRING: production graph_get_subgraph redacts instance provenance", async () => {

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -115,6 +115,7 @@ test("WIRING: production graph_get_subgraph publishes the terminal nested-promot
   const method = src.slice(start, end).replace(/,\s*$/, "");
   const terminal = {
     widget: "quality_prompt",
+    parent_rail: { authoritative: true, widget: "quality_prompt" },
     immediate_node_id: 188,
     immediate_widget: "quality_prompt",
     terminal_node_id: 2768,
@@ -293,6 +294,7 @@ test("WIRING: production alias witness keeps outer, immediate, and terminal name
     const witness = entries.find((entry) => entry.widget === testCase.outer);
     assert.deepEqual(witness, {
       widget: testCase.outer,
+      parent_rail: { authoritative: true, widget: testCase.immediate },
       immediate_node_id: 188,
       immediate_widget: testCase.immediate,
       terminal_node_id: 2768,
@@ -316,6 +318,103 @@ test("WIRING: production alias witness keeps outer, immediate, and terminal name
       /_subgraphSlot missing|unresolved/i,
     );
   }
+});
+
+test("WIRING: production witness refuses an externally-linked parent rail", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const helperStart = src.indexOf("function resolveSubgraphLink(");
+  const helperEnd = src.indexOf("\nfunction findPromotedHostInput", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production promotion helper range must remain extractable");
+  const makeWitnesses = new Function(
+    "resolvePromotedInnerTarget",
+    "followPromotionToConcrete",
+    "MAX_PROMOTION_CHAIN_DEPTH",
+    "promotedInputAliases",
+    `${src.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
+  )(
+    resolvePromotedInnerTarget,
+    followPromotionToConcrete,
+    MAX_PROMOTION_CHAIN_DEPTH,
+    promotedInputAliases,
+  );
+  const rail = { name: "quality_prompt", value: "old" };
+  const inner = {
+    id: 188,
+    type: "PrimitiveStringMultiline",
+    inputs: [{ name: "quality_prompt", widget: { name: "quality_prompt" } }],
+    widgets: [{ name: "quality_prompt", value: "old" }],
+  };
+  const parent = {
+    id: 78,
+    widgets: [rail],
+    inputs: [{
+      name: "quality_prompt",
+      widget: rail,
+      _widget: rail,
+      _subgraphSlot: { name: "quality_prompt", linkIds: [1] },
+    }],
+    subgraph: {
+      _nodes: [inner],
+      getNodeById: (id) => (String(id) === "188" ? inner : null),
+      getLink: () => ({ origin_id: 188, target_id: 188, target_slot: 0 }),
+    },
+  };
+  parent.inputs[0].link = 99;
+
+  const [entry] = makeWitnesses(parent);
+  assert.equal(entry.widget, "quality_prompt");
+  assert.equal(entry.parent_rail, undefined);
+  assert.match(entry.error, /externally linked|not authoritative/i);
+});
+
+test("WIRING: production witness re-evaluates parent authority after a promotion relink", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const helperStart = src.indexOf("function resolveSubgraphLink(");
+  const helperEnd = src.indexOf("\nfunction findPromotedHostInput", helperStart);
+  const makeWitnesses = new Function(
+    "resolvePromotedInnerTarget",
+    "followPromotionToConcrete",
+    "MAX_PROMOTION_CHAIN_DEPTH",
+    "promotedInputAliases",
+    `${src.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
+  )(
+    resolvePromotedInnerTarget,
+    followPromotionToConcrete,
+    MAX_PROMOTION_CHAIN_DEPTH,
+    promotedInputAliases,
+  );
+  const rail = { name: "quality_prompt", value: "old" };
+  const input = {
+    name: "quality_alias",
+    widget: rail,
+    _widget: rail,
+    _subgraphSlot: { name: "quality_alias", linkIds: [1] },
+  };
+  const inner = {
+    id: 188,
+    type: "PrimitiveStringMultiline",
+    inputs: [{ name: "quality_prompt", widget: { name: "quality_prompt" } }],
+    widgets: [{ name: "quality_prompt", value: "old" }],
+  };
+  const parent = {
+    id: 78,
+    widgets: [rail],
+    inputs: [input],
+    subgraph: {
+      _nodes: [inner],
+      getNodeById: (id) => (String(id) === "188" ? inner : null),
+      getLink: () => ({ origin_id: 188, target_id: 188, target_slot: 0 }),
+    },
+  };
+
+  const [before] = makeWitnesses(parent);
+  assert.equal(before.parent_rail.authoritative, true);
+  input.link = 100;
+  const [after] = makeWitnesses(parent);
+  assert.equal(after.parent_rail, undefined);
+  assert.match(after.error, /externally linked|not authoritative/i);
 });
 
 test("WIRING: production witness refuses to publish [] for an unenumerable proxyWidgets relation", async () => {

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -160,6 +160,42 @@ test("WIRING: production graph_get_subgraph publishes the terminal nested-promot
   assert.equal(out.nodes[0].id, 188);
 });
 
+test("WIRING: production graph_get_subgraph publishes an explicit empty witness array", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const start = src.indexOf("graph_get_subgraph({ node_id }) {");
+  const end = src.indexOf("async graph_add_node(", start);
+  assert.ok(start >= 0 && end > start, "graph_get_subgraph handler must remain extractable");
+  const method = src.slice(start, end).replace(/,\s*$/, "");
+  const parent = { id: 78, title: "Ordinary container", inputs: [], subgraph: { _nodes: [] } };
+  const getSubgraph = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "describeActiveGraph",
+    "subgraphValueProvenance",
+    "redactWidgetValue",
+    "graphViewIdentityFor",
+    "MAX_STATE_NODES",
+    "fixedCapNote",
+    "summarizeNode",
+    "promotedTerminalWitnesses",
+    `return ({${method}}).graph_get_subgraph;`,
+  )(
+    () => ({ graph: {} }),
+    () => parent,
+    () => ({ scope: "root", graph_identity: "root" }),
+    () => ({}),
+    () => ({}),
+    () => "graph:ordinary",
+    50,
+    () => "truncation note",
+    (node) => ({ id: node.id, type: node.type }),
+    () => [],
+  );
+
+  assert.deepEqual(getSubgraph({ node_id: 78 }).promoted_terminals, []);
+});
+
 test("WIRING: production alias witness keeps outer, immediate, and terminal names distinct", async () => {
   const { readFile } = await import("node:fs/promises");
   const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
@@ -256,6 +292,20 @@ test("WIRING: production alias witness keeps outer, immediate, and terminal name
       terminal_inputs: testCase.inputs,
       chain_depth: 1,
     });
+    for (const alias of [testCase.outer, "outer display", "parent_alias"]) {
+      const aliasWitness = entries.find((entry) => entry.widget === alias);
+      assert.equal(aliasWitness?.immediate_node_id, 188, `missing witness for ${alias}`);
+      assert.equal(aliasWitness?.immediate_widget, testCase.immediate, `wrong target for ${alias}`);
+    }
+
+    const missingSlotEntries = makeWitnesses({
+      ...parent,
+      inputs: [{ name: testCase.outer, label: "outer display" }],
+    });
+    assert.match(
+      missingSlotEntries.find((entry) => entry.widget === testCase.outer)?.error ?? "",
+      /_subgraphSlot missing|unresolved/i,
+    );
   }
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9653,6 +9653,27 @@ function promotedTerminalWitnesses(subgraphNode) {
       entries.push({ widget, error: resolution.error || "the immediate promotion was unresolved" });
       continue;
     }
+    // A promotion relation is not write authority by itself. The live setter
+    // refuses when the host input is externally linked (or otherwise has no
+    // identity-authenticated local rail), because writing the resolved inner
+    // widget would report success while the queue still reads the enclosing
+    // rail's value. Do not publish a positive witness for that inner target.
+    const parentRail = resolution.target.parentWidget;
+    if (
+      !parentRail ||
+      typeof parentRail.name !== "string" ||
+      parentRail.name.length === 0 ||
+      !Array.isArray(resolution.target.parentWidgets) ||
+      resolution.target.parentWidgets[0] !== parentRail
+    ) {
+      entries.push({
+        widget,
+        immediate_node_id: resolution.target.node?.id,
+        immediate_widget: resolution.target.widget?.name,
+        error: "the promoted parent rail was missing, externally linked, or not authoritative",
+      });
+      continue;
+    }
 
     let terminal;
     try {
@@ -9706,6 +9727,7 @@ function promotedTerminalWitnesses(subgraphNode) {
     }
     entries.push({
       widget,
+      parent_rail: { authoritative: true, widget: parentRail.name },
       immediate_node_id: resolution.target.node.id,
       immediate_widget: resolution.target.widget.name,
       terminal_node_id: terminalNode.id,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9727,7 +9727,13 @@ function promotedTerminalWitnesses(subgraphNode) {
     }
     entries.push({
       widget,
-      parent_rail: { authoritative: true, widget: parentRail.name },
+      parent_rail: {
+        authoritative: true,
+        widget: parentRail.name,
+        ...(typeof resolution.target.input?.widgetId === "string" && resolution.target.input.widgetId.length > 0
+          ? { widget_id: resolution.target.input.widgetId }
+          : {}),
+      },
       immediate_node_id: resolution.target.node.id,
       immediate_widget: resolution.target.widget.name,
       terminal_node_id: terminalNode.id,
@@ -9906,8 +9912,61 @@ function assertExpectedPromotedScope(current, expectedScope, resolveTerminal) {
         `${expected.workflow_uuid ? ` in workflow ${expected.workflow_uuid}` : ""}, ` +
         `found ${liveViewing.scope} owner ${liveOwnerId ?? "unverifiable"}` +
         `${liveViewing.workflow_uuid ? ` in workflow ${liveViewing.workflow_uuid}` : ""}. ` +
-        "Nothing was applied.",
+      "Nothing was applied.",
     );
+  }
+
+  // A scope witness alone only proves that the final node id is in the right
+  // child graph. A promoted inner write also needs the OUTER host input's
+  // authoritative rail: if that input was relinked after MCP's outer proof,
+  // writing the captured inner/shared definition would be a false success.
+  // Re-resolve through the same identity-authenticated path used by the live
+  // setter, synchronously at this mutation boundary. `input.link != null`
+  // therefore yields no parentWidget and fails closed.
+  if (expected.promoted_widget !== undefined || expected.parent_rail !== undefined) {
+    if (typeof expected.promoted_widget !== "string" || expected.promoted_widget.length === 0) {
+      throw new Error("graph_set_widget expected_scope.promoted_widget must be a non-empty string");
+    }
+    const expectedRail = expected.parent_rail;
+    if (!expectedRail || typeof expectedRail !== "object" || Array.isArray(expectedRail)) {
+      throw new Error("graph_set_widget expected_scope.parent_rail must be a structured authority witness");
+    }
+    if (expectedRail.authoritative !== true || typeof expectedRail.widget !== "string" || expectedRail.widget.length === 0) {
+      throw new Error("graph_set_widget expected_scope.parent_rail must prove an authoritative widget");
+    }
+    if (
+      expectedRail.widget_id !== undefined &&
+      (typeof expectedRail.widget_id !== "string" || expectedRail.widget_id.length === 0)
+    ) {
+      throw new Error("graph_set_widget expected_scope.parent_rail.widget_id must be a non-empty string");
+    }
+    const ownerNode = liveOwner?.node;
+    let promoted;
+    try {
+      promoted = ownerNode
+        ? resolvePromotedInnerTarget(ownerNode, expected.promoted_widget, sourceForSubgraphInput)
+        : null;
+    } catch {
+      promoted = null;
+    }
+    const target = promoted?.promoted === true ? promoted.target : null;
+    const parentWidget = target?.parentWidget ?? null;
+    const parentWidgets = target?.parentWidgets;
+    const liveWidgetId = target?.input?.widgetId;
+    if (
+      !target ||
+      !parentWidget ||
+      !Array.isArray(parentWidgets) ||
+      parentWidgets[0] !== parentWidget ||
+      !Array.isArray(ownerNode?.widgets) ||
+      !ownerNode.widgets.includes(parentWidget) ||
+      parentWidget.name !== expectedRail.widget ||
+      (expectedRail.widget_id !== undefined && liveWidgetId !== expectedRail.widget_id)
+    ) {
+      throw new Error(
+        "graph_set_widget promoted parent rail changed or became unverifiable before dispatch. Nothing was applied.",
+      );
+    }
   }
 
   if (expected.terminal !== undefined) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -64,7 +64,11 @@
 // bottom). Deferral approach contributed by @FreesoSaiFared.
 // Used by the unpack preflight's divergence scan. It was called without ever being imported,
 // so that path threw ReferenceError rather than refusing cleanly (#1136 sweep).
-import { resolvePromotedInnerTarget } from "./lib/widget-write.js";
+import {
+  MAX_PROMOTION_CHAIN_DEPTH,
+  followPromotionToConcrete,
+  resolvePromotedInnerTarget,
+} from "./lib/widget-write.js";
 import { describeVoiceError } from "./lib/voice-error.js";
 import { voiceRecognitionLang } from "./lib/voice-language.js";
 import { isEmbeddedDesktopShell, voiceInputSupport } from "./lib/voice-support.js";
@@ -9491,6 +9495,107 @@ function sourceForSubgraphInput(subgraphNode, subgraphInput) {
   return null;
 }
 
+/** Return the addressable aliases for every host promotion on a subgraph node.
+ * Labels are included because panel_set_widget accepts the displayed alias,
+ * while the resolver itself still authenticates the backing relationship. */
+function promotedHostAliases(subgraphNode) {
+  const aliases = new Set();
+  for (const input of subgraphNode?.inputs ?? []) {
+    for (const value of [input?.name, input?.label, input?._subgraphSlot?.name, input?._subgraphSlot?.label]) {
+      if (value != null && String(value).length > 0) aliases.add(String(value));
+    }
+  }
+  return [...aliases];
+}
+
+/** The terminal shape is deliberately small and value-free. It carries the
+ * identity/type/widget needed by the receiver fence and the input declarations
+ * needed by MCP's dynamic-combo guard, without copying arbitrary widget values. */
+function terminalPromotionShape(node) {
+  if (!Array.isArray(node?.inputs)) return null;
+  const inputs = [];
+  for (const input of node.inputs) {
+    if (!input || typeof input.name !== "string" || input.name.length === 0) return null;
+    if (input.type !== undefined && typeof input.type !== "string") return null;
+    inputs.push({ name: input.name, ...(input.type !== undefined ? { type: input.type } : {}) });
+  }
+  return inputs;
+}
+
+/** Resolve each promoted host alias through the same recursive path used by
+ * graph_set_widget. A missing/cyclic/malformed/deep endpoint is returned as an
+ * explicit error entry so MCP cannot mistake an incomplete witness for a safe
+ * one-hop mapping. */
+function promotedTerminalWitnesses(subgraphNode) {
+  const entries = [];
+  for (const widget of promotedHostAliases(subgraphNode)) {
+    let resolution;
+    try {
+      resolution = resolvePromotedInnerTarget(subgraphNode, widget, sourceForSubgraphInput);
+    } catch (error) {
+      entries.push({
+        widget,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    if (!resolution?.promoted) continue;
+    if (!resolution.target) {
+      entries.push({ widget, error: resolution.error || "the immediate promotion was unresolved" });
+      continue;
+    }
+
+    let terminal;
+    try {
+      terminal = followPromotionToConcrete(resolution.target, sourceForSubgraphInput);
+    } catch (error) {
+      terminal = { error: error instanceof Error ? error.message : String(error) };
+    }
+    const terminalNode = terminal?.node;
+    const terminalWidget = terminal?.widget;
+    const terminalShape = terminalPromotionShape(terminalNode);
+    if (
+      !terminalNode ||
+      !terminalWidget ||
+      terminal?.cycle ||
+      terminal?.error ||
+      terminal?.terminalVirtual ||
+      terminalNode.subgraph ||
+      terminal?.depth === undefined ||
+      !Number.isSafeInteger(terminal.depth) ||
+      terminal.depth < 0 ||
+      terminal.depth > MAX_PROMOTION_CHAIN_DEPTH ||
+      (typeof terminalNode.id !== "number" && typeof terminalNode.id !== "string") ||
+      typeof terminalNode.type !== "string" ||
+      terminalNode.type.length === 0 ||
+      typeof terminalWidget.name !== "string" ||
+      terminalWidget.name.length === 0 ||
+      !terminalShape
+    ) {
+      entries.push({
+        widget,
+        immediate_node_id: resolution.target.node?.id,
+        immediate_widget: resolution.target.widget?.name,
+        error:
+          terminal?.error ||
+          (terminal?.cycle ? "the promotion chain is cyclic" : "the terminal promotion endpoint was malformed or unresolved"),
+      });
+      continue;
+    }
+    entries.push({
+      widget,
+      immediate_node_id: resolution.target.node.id,
+      immediate_widget: resolution.target.widget.name,
+      terminal_node_id: terminalNode.id,
+      terminal_node_type: terminalNode.type,
+      terminal_widget: terminalWidget.name,
+      terminal_inputs: terminalShape,
+      chain_depth: terminal.depth,
+    });
+  }
+  return entries;
+}
+
 function findPromotedHostInput(subgraphNode, source) {
   return (subgraphNode.inputs ?? []).find((input) => {
     const subgraphInput = input?._subgraphSlot;
@@ -9616,7 +9721,7 @@ function canonicalExpectedPromotedOwner(value) {
   return Number.isSafeInteger(parsed) ? String(parsed) : null;
 }
 
-function assertExpectedPromotedScope(current, expectedScope) {
+function assertExpectedPromotedScope(current, expectedScope, resolveTerminal) {
   if (expectedScope === undefined) return;
   if (!expectedScope || typeof expectedScope !== "object" || Array.isArray(expectedScope)) {
     throw new Error("graph_set_widget expected_scope must be a structured subgraph witness");
@@ -9659,6 +9764,59 @@ function assertExpectedPromotedScope(current, expectedScope) {
         `${liveViewing.workflow_uuid ? ` in workflow ${liveViewing.workflow_uuid}` : ""}. ` +
         "Nothing was applied.",
     );
+  }
+
+  if (expected.terminal !== undefined) {
+    const terminal = expected.terminal;
+    if (!terminal || typeof terminal !== "object" || Array.isArray(terminal)) {
+      throw new Error("graph_set_widget expected_scope.terminal must be a structured endpoint witness");
+    }
+    const terminalId = canonicalExpectedPromotedOwner(terminal.node_id);
+    if (!terminalId) {
+      throw new Error("graph_set_widget expected_scope.terminal.node_id must be a canonical node id");
+    }
+    if (typeof terminal.type !== "string" || terminal.type.length === 0) {
+      throw new Error("graph_set_widget expected_scope.terminal.type must be a non-empty string");
+    }
+    if (typeof terminal.widget !== "string" || terminal.widget.length === 0) {
+      throw new Error("graph_set_widget expected_scope.terminal.widget must be a non-empty string");
+    }
+    if (!Number.isSafeInteger(terminal.chain_depth) || terminal.chain_depth < 0 || terminal.chain_depth > 16) {
+      throw new Error("graph_set_widget expected_scope.terminal.chain_depth must be a bounded integer");
+    }
+    if (!Array.isArray(terminal.inputs)) {
+      throw new Error("graph_set_widget expected_scope.terminal.inputs must be an array");
+    }
+    for (const input of terminal.inputs) {
+      if (!input || typeof input !== "object" || Array.isArray(input) || typeof input.name !== "string" || input.name.length === 0) {
+        throw new Error("graph_set_widget expected_scope.terminal.inputs must contain named input shapes");
+      }
+      if (input.type !== undefined && typeof input.type !== "string") {
+        throw new Error("graph_set_widget expected_scope.terminal.inputs type must be a string");
+      }
+    }
+    if (typeof resolveTerminal !== "function") {
+      throw new Error("graph_set_widget could not verify the terminal promotion endpoint");
+    }
+    let observed;
+    try {
+      observed = resolveTerminal();
+    } catch {
+      observed = null;
+    }
+    const observedId = canonicalExpectedPromotedOwner(observed?.node_id);
+    if (
+      !observed ||
+      observedId !== terminalId ||
+      observed.type !== terminal.type ||
+      observed.widget !== terminal.widget ||
+      observed.depth !== terminal.chain_depth ||
+      JSON.stringify(observed.inputs) !== JSON.stringify(terminal.inputs)
+    ) {
+      throw new Error(
+        "graph_set_widget promoted terminal receiver changed or became unverifiable before dispatch. Nothing was applied.",
+      );
+    }
   }
 }
 
@@ -14371,6 +14529,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const sub = node.subgraph;
     if (!sub) throw new Error(`Node ${node.id} (${node.type}) is not a subgraph`);
     const inner = [...(sub._nodes ?? sub.nodes ?? [])];
+    const promotedTerminals = promotedTerminalWitnesses(node);
     // #1729 — provenance is a second structured-read path: its raw instance_widgets
     // map must follow the same recursive credential redaction as node summaries.
     const safeProvenance = redactWidgetValue("", subgraphValueProvenance(node));
@@ -14405,6 +14564,7 @@ const GRAPH_TOOL_EXECUTORS = {
           }
         : {}),
       nodes: inner.slice(0, MAX_STATE_NODES).map(summarizeNode),
+      ...(promotedTerminals.length ? { promoted_terminals: promotedTerminals } : {}),
     };
   },
 
@@ -16885,7 +17045,47 @@ const GRAPH_TOOL_EXECUTORS = {
         });
         if (expected_scope === undefined && expected_node_type === undefined && !enforceDeferredExpected) return;
         const current = getGraphCtx();
-        assertExpectedPromotedScope(current, expected_scope);
+        assertExpectedPromotedScope(current, expected_scope, () => {
+          let terminalNode = node;
+          let terminalWidget = node?.widgets?.find((candidate) => candidate?.name === widget) ?? null;
+          let depth = 0;
+          if (node?.subgraph) {
+            const resolved = resolvePromotedInnerTarget(node, widget, sourceForSubgraphInput);
+            if (!resolved?.promoted || !resolved.target) return null;
+            const reached = followPromotionToConcrete(resolved.target, sourceForSubgraphInput);
+            if (
+              !reached?.node ||
+              !reached.widget ||
+              reached.cycle ||
+              reached.error ||
+              reached.terminalVirtual ||
+              reached.node.subgraph
+            ) {
+              return null;
+            }
+            terminalNode = reached.node;
+            terminalWidget = reached.widget;
+            depth = reached.depth;
+          }
+          const inputs = terminalPromotionShape(terminalNode);
+          if (
+            !terminalNode ||
+            !terminalWidget ||
+            !inputs ||
+            (typeof terminalNode.id !== "number" && typeof terminalNode.id !== "string") ||
+            typeof terminalNode.type !== "string" ||
+            typeof terminalWidget.name !== "string"
+          ) {
+            return null;
+          }
+          return {
+            node_id: terminalNode.id,
+            type: terminalNode.type,
+            widget: terminalWidget.name,
+            inputs,
+            depth,
+          };
+        });
         const liveTarget = resolveNode(current.graph, node_id);
         if (
           expected_node_type !== undefined &&

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9496,15 +9496,112 @@ function sourceForSubgraphInput(subgraphNode, subgraphInput) {
   return null;
 }
 
-/** Return the addressable aliases for every host promotion on a subgraph node.
- * Labels are included because panel_set_widget accepts the displayed alias,
- * while the resolver itself still authenticates the backing relationship. */
-function promotedHostAliases(subgraphNode) {
-  const aliases = new Set();
-  for (const input of subgraphNode?.inputs ?? []) {
-    for (const value of promotedInputAliases(input)) aliases.add(value);
+/**
+ * Return the addressable aliases for every host promotion on a subgraph node,
+ * including the legacy `proxyWidgets`/`node.widgets` projection shape. The
+ * witness producer must not reduce a known promotion relation to `[]` merely
+ * because the current frontend did not materialize a connectable input for it.
+ */
+function promotedHostAliasRecords(subgraphNode) {
+  const records = [];
+  const seen = new Set();
+  const inputs = Array.isArray(subgraphNode?.inputs) ? subgraphNode.inputs : [];
+  const projectedWidgets = Array.isArray(subgraphNode?.widgets) ? subgraphNode.widgets : [];
+  const add = (widget, relation, error) => {
+    if (typeof widget !== "string" || widget.length === 0) return;
+    const existingUnbound = records.find(
+      (record) =>
+        record.widget.toLowerCase() === widget.toLowerCase() &&
+        !record.relation &&
+        !record.error,
+    );
+    if (relation && existingUnbound) {
+      existingUnbound.relation = relation;
+      return;
+    }
+    if (!relation && !error && existingUnbound) return;
+    const relationKey = relation
+      ? `${String(relation.nodeId)}:${relation.widgetName.toLowerCase()}`
+      : "unbound";
+    const key = `${widget.toLowerCase()}|${relationKey}|${error ?? ""}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    records.push({ widget, ...(relation ? { relation } : {}), ...(error ? { error } : {}) });
+  };
+
+  // Modern link-backed promotions expose the aliases through host inputs and
+  // their _subgraphSlot. This remains the primary relation-aware path.
+  for (const input of inputs) {
+    for (const value of promotedInputAliases(input)) add(value, null, null);
   }
-  return [...aliases];
+  // Some frontend builds attach _subgraphSlot to a projected widget rather
+  // than the host input. Include those aliases too; resolution below will
+  // still require the live host relation before publishing a success witness.
+  for (const widget of projectedWidgets) {
+    if (widget?._subgraphSlot) {
+      for (const value of promotedInputAliases(widget, widget._subgraphSlot)) add(value, null, null);
+    }
+  }
+
+  const rawProxyWidgets = subgraphNode?.properties?.proxyWidgets;
+  if (rawProxyWidgets === undefined) return records;
+  if (!Array.isArray(rawProxyWidgets)) {
+    add(
+      "<proxyWidgets>",
+      null,
+      "properties.proxyWidgets was present but not an array; promoted relations could not be enumerated",
+    );
+    return records;
+  }
+
+  // `properties.proxyWidgets` is the serialized relation: [inner node id,
+  // inner widget name]. Match it to the live projected widget and/or its
+  // _subgraphSlot, then carry the expected target into witness validation.
+  for (const raw of rawProxyWidgets) {
+    const nodeId = Array.isArray(raw) ? raw[0] : undefined;
+    const widgetName = Array.isArray(raw) ? raw[1] : undefined;
+    if (
+      (typeof nodeId !== "number" && typeof nodeId !== "string") ||
+      (typeof widgetName !== "string" || widgetName.length === 0)
+    ) {
+      add(
+        typeof widgetName === "string" && widgetName.length > 0 ? widgetName : "<proxyWidgets>",
+        null,
+        "properties.proxyWidgets contained a malformed promoted relation",
+      );
+      continue;
+    }
+    const relation = { nodeId, widgetName };
+    const aliases = new Set();
+    for (const widget of projectedWidgets) {
+      const widgetAliases = promotedInputAliases(widget, widget?._subgraphSlot);
+      const linkedInput = inputs.some(
+        (input) => input?._widget === widget || input?.widget === widget,
+      );
+      if (
+        linkedInput ||
+        widgetAliases.some((alias) => alias.toLowerCase() === widgetName.toLowerCase())
+      ) {
+        for (const value of widgetAliases) aliases.add(value);
+      }
+    }
+    for (const input of inputs) {
+      const inputAliases = promotedInputAliases(input);
+      if (inputAliases.some((alias) => alias.toLowerCase() === widgetName.toLowerCase())) {
+        for (const value of inputAliases) aliases.add(value);
+      }
+    }
+    if (aliases.size === 0) {
+      add(
+        widgetName,
+        relation,
+        "properties.proxyWidgets named a promoted relation that had no live node.widgets/_subgraphSlot projection",
+      );
+      continue;
+    }
+    for (const alias of aliases) add(alias, relation, null);
+  }
+  return records;
 }
 
 /** The terminal shape is deliberately small and value-free. It carries the
@@ -9527,7 +9624,12 @@ function terminalPromotionShape(node) {
  * one-hop mapping. */
 function promotedTerminalWitnesses(subgraphNode) {
   const entries = [];
-  for (const widget of promotedHostAliases(subgraphNode)) {
+  for (const record of promotedHostAliasRecords(subgraphNode)) {
+    const widget = record.widget;
+    if (record.error) {
+      entries.push({ widget, error: record.error });
+      continue;
+    }
     let resolution;
     try {
       resolution = resolvePromotedInnerTarget(subgraphNode, widget, sourceForSubgraphInput);
@@ -9538,7 +9640,15 @@ function promotedTerminalWitnesses(subgraphNode) {
       });
       continue;
     }
-    if (!resolution?.promoted) continue;
+    if (!resolution?.promoted) {
+      entries.push({
+        widget,
+        error: record.relation
+          ? "the proxyWidgets relation was not represented by a live _subgraphSlot promotion"
+          : "the promoted alias was not represented by a live host input",
+      });
+      continue;
+    }
     if (!resolution.target) {
       entries.push({ widget, error: resolution.error || "the immediate promotion was unresolved" });
       continue;
@@ -9578,6 +9688,19 @@ function promotedTerminalWitnesses(subgraphNode) {
         error:
           terminal?.error ||
           (terminal?.cycle ? "the promotion chain is cyclic" : "the terminal promotion endpoint was malformed or unresolved"),
+      });
+      continue;
+    }
+    if (
+      record.relation &&
+      (String(resolution.target.node?.id) !== String(record.relation.nodeId) ||
+        resolution.target.widget?.name !== record.relation.widgetName)
+    ) {
+      entries.push({
+        widget,
+        immediate_node_id: resolution.target.node?.id,
+        immediate_widget: resolution.target.widget?.name,
+        error: "the live _subgraphSlot target disagreed with properties.proxyWidgets",
       });
       continue;
     }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -67,6 +67,7 @@
 import {
   MAX_PROMOTION_CHAIN_DEPTH,
   followPromotionToConcrete,
+  promotedInputAliases,
   resolvePromotedInnerTarget,
 } from "./lib/widget-write.js";
 import { describeVoiceError } from "./lib/voice-error.js";
@@ -9501,9 +9502,7 @@ function sourceForSubgraphInput(subgraphNode, subgraphInput) {
 function promotedHostAliases(subgraphNode) {
   const aliases = new Set();
   for (const input of subgraphNode?.inputs ?? []) {
-    for (const value of [input?.name, input?.label, input?._subgraphSlot?.name, input?._subgraphSlot?.label]) {
-      if (value != null && String(value).length > 0) aliases.add(String(value));
-    }
+    for (const value of promotedInputAliases(input)) aliases.add(value);
   }
   return [...aliases];
 }
@@ -14056,7 +14055,13 @@ const GRAPH_TOOL_EXECUTORS = {
         // #609: bound each widget value AND the total widgets size so a
         // ResolutionMaster/LTXDirector/VHS blob (or a many-widget node) can't consume
         // the entire budget in one node's detail — even the protected first line.
-        const summary = capSummaryWidgets(summarizeNode(n), detailWidgetCap, maxChars);
+        const summary = {
+          ...capSummaryWidgets(summarizeNode(n), detailWidgetCap, maxChars),
+          // #2314 — MCP must distinguish a definitive ordinary node from an
+          // older Panel whose detail projection cannot classify promotion.
+          // Positive-only emission made missing capability look like false.
+          is_subgraph: !!n.subgraph,
+        };
         line = JSON.stringify(summary);
         // Final guard: if the fully-capped detail STILL exceeds max_chars (a node with
         // very many/large slots, which capSummaryWidgets doesn't touch), degrade the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -203,7 +203,11 @@ import {
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
 import { fetchSingleNodeInfo } from "./lib/single-node-def.js";
 import { createVerifiedNodeDefCache } from "./lib/verified-node-def-cache.js";
-import { withWorkflowUuid } from "./lib/graph-view-identity.js";
+import {
+  graphViewIdentityFor,
+  withGraphViewIdentity,
+  withWorkflowUuid,
+} from "./lib/graph-view-identity.js";
 import { saveReplyIdentity, shouldEstablishIdentityAfterSave } from "./lib/save-reply-identity.js";
 import { describeOpenActiveBinding } from "./lib/open-active-binding.js";
 import { compareVersions, releasesSince, summarizeReleases, updateAnnouncement } from "./lib/changelog-delta.js";
@@ -9575,7 +9579,8 @@ function describeActiveGraph(graph) {
   } catch {
     workflowUuid = null;
   }
-  const withLiveIdentity = (viewing) => withWorkflowUuid(viewing, root, workflowUuid);
+  const withLiveIdentity = (viewing) =>
+    withGraphViewIdentity(withWorkflowUuid(viewing, root, workflowUuid), graph);
   if (!root || !graph || graph === root) return withLiveIdentity({ scope: "root" });
   const owner = findSubgraphOwner(root, graph);
   if (owner) {
@@ -9630,6 +9635,13 @@ function assertExpectedPromotedScope(current, expectedScope) {
   ) {
     throw new Error("graph_set_widget expected_scope.workflow_uuid must be a non-empty string");
   }
+  if (
+    typeof expected.graph_identity !== "string" ||
+    expected.graph_identity.length === 0 ||
+    expected.graph_identity.length > 256
+  ) {
+    throw new Error("graph_set_widget expected_scope.graph_identity must be a non-empty string");
+  }
 
   const liveViewing = describeActiveGraph(current.graph);
   const liveOwner = findSubgraphOwner(current.rootGraph, current.graph);
@@ -9637,7 +9649,8 @@ function assertExpectedPromotedScope(current, expectedScope) {
   if (
     liveViewing.scope !== "subgraph" ||
     liveOwnerId !== expectedOwner ||
-    (expected.workflow_uuid !== undefined && liveViewing.workflow_uuid !== expected.workflow_uuid)
+    (expected.workflow_uuid !== undefined && liveViewing.workflow_uuid !== expected.workflow_uuid) ||
+    liveViewing.graph_identity !== expected.graph_identity
   ) {
     throw new Error(
       `graph_set_widget promoted receiver changed before dispatch: expected subgraph owner ${expectedOwner}` +
@@ -14363,7 +14376,15 @@ const GRAPH_TOOL_EXECUTORS = {
     const safeProvenance = redactWidgetValue("", subgraphValueProvenance(node));
     return {
       viewing: describeActiveGraph(graph),
-      subgraph_of: { node_id: node.id, title: node.title },
+      // The wrapper id is local to `graph`; the write happens after entering
+      // `sub`, so carry the object-keyed identity of that exact target graph.
+      // A parent/root viewing token alone cannot distinguish two same-id
+      // subgraphs elsewhere in the workflow.
+      subgraph_of: {
+        node_id: node.id,
+        title: node.title,
+        graph_identity: graphViewIdentityFor(sub),
+      },
       // #636 — the inner nodes below are the DEFINITION's; the parent instance's
       // promoted widgets can override them. Carry both, labelled, so a legitimate
       // per-instance override cannot be misread as stale data.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9599,6 +9599,56 @@ function describeActiveGraph(graph) {
   return withLiveIdentity({ scope: "root" });
 }
 
+/** #2314 — validate the promoted receiver at the synchronous mutation boundary.
+ * The MCP-side graph_query is only a classification read; navigation can replace
+ * the viewed graph before the write resumes. The expected scope is therefore an
+ * envelope the panel itself must compare against its current canvas immediately
+ * before runSetWidget reaches applyWidgetWrite. */
+function canonicalExpectedPromotedOwner(value) {
+  if (typeof value === "number") return Number.isSafeInteger(value) ? String(value) : null;
+  if (typeof value !== "string" || !/^-?(?:0|[1-9]\d*)$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? String(parsed) : null;
+}
+
+function assertExpectedPromotedScope(current, expectedScope) {
+  if (expectedScope === undefined) return;
+  if (!expectedScope || typeof expectedScope !== "object" || Array.isArray(expectedScope)) {
+    throw new Error("graph_set_widget expected_scope must be a structured subgraph witness");
+  }
+  const expected = expectedScope;
+  if (expected.scope !== "subgraph") {
+    throw new Error("graph_set_widget expected_scope.scope must be \"subgraph\"");
+  }
+  const expectedOwner = canonicalExpectedPromotedOwner(expected.owner_node_id);
+  if (!expectedOwner) {
+    throw new Error("graph_set_widget expected_scope.owner_node_id must be a canonical node id");
+  }
+  if (
+    expected.workflow_uuid !== undefined &&
+    (typeof expected.workflow_uuid !== "string" || expected.workflow_uuid.length === 0)
+  ) {
+    throw new Error("graph_set_widget expected_scope.workflow_uuid must be a non-empty string");
+  }
+
+  const liveViewing = describeActiveGraph(current.graph);
+  const liveOwner = findSubgraphOwner(current.rootGraph, current.graph);
+  const liveOwnerId = canonicalExpectedPromotedOwner(liveOwner?.id);
+  if (
+    liveViewing.scope !== "subgraph" ||
+    liveOwnerId !== expectedOwner ||
+    (expected.workflow_uuid !== undefined && liveViewing.workflow_uuid !== expected.workflow_uuid)
+  ) {
+    throw new Error(
+      `graph_set_widget promoted receiver changed before dispatch: expected subgraph owner ${expectedOwner}` +
+        `${expected.workflow_uuid ? ` in workflow ${expected.workflow_uuid}` : ""}, ` +
+        `found ${liveViewing.scope} owner ${liveOwnerId ?? "unverifiable"}` +
+        `${liveViewing.workflow_uuid ? ` in workflow ${liveViewing.workflow_uuid}` : ""}. ` +
+        "Nothing was applied.",
+    );
+  }
+}
+
 // ---- per-turn graph snapshots (rollback foundation, #44) -------------------
 // Before each turn that may edit the graph, capture the ROOT workflow JSON so a
 // whole turn's worth of agent edits can be reverted to a known-good point in one
@@ -16119,6 +16169,8 @@ const GRAPH_TOOL_EXECUTORS = {
     // Keep the established handler signature stable for the source-level
     // wiring checks; these fields are an explicit protocol extension, not new
     // positional arguments.
+    const expected_scope =
+      arguments[0] && typeof arguments[0] === "object" ? arguments[0].expected_scope : undefined;
     const { defer_until_idle, expected_value, defer_replay } = arguments[0] ?? {};
     // #1413 — ONE deadline for the whole command, taken BEFORE anything awaits, so the
     // bounded steps inside it compose instead of adding (#1192, #671). The step this
@@ -16180,6 +16232,7 @@ const GRAPH_TOOL_EXECUTORS = {
           workflow_uuid,
           builder_state,
           expected_node_type: node.type,
+          expected_scope,
           expected_value,
           defer_replay: true,
         });
@@ -16221,6 +16274,7 @@ const GRAPH_TOOL_EXECUTORS = {
             workflow_uuid,
             builder_state,
             expected_node_type: deferredNode.type,
+            expected_scope,
             expected_value,
             defer_replay: true,
           }),
@@ -16808,8 +16862,9 @@ const GRAPH_TOOL_EXECUTORS = {
           cmd: "graph_set_widget",
           [WORKFLOW_UUID_FIELD]: workflow_uuid,
         });
-        if (expected_node_type === undefined && !enforceDeferredExpected) return;
+        if (expected_scope === undefined && expected_node_type === undefined && !enforceDeferredExpected) return;
         const current = getGraphCtx();
+        assertExpectedPromotedScope(current, expected_scope);
         const liveTarget = resolveNode(current.graph, node_id);
         if (
           expected_node_type !== undefined &&

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14569,7 +14569,11 @@ const GRAPH_TOOL_EXECUTORS = {
           }
         : {}),
       nodes: inner.slice(0, MAX_STATE_NODES).map(summarizeNode),
-      ...(promotedTerminals.length ? { promoted_terminals: promotedTerminals } : {}),
+      // The hello capability promises a complete alias witness. Publish an
+      // explicit empty array too, so the consumer can distinguish a subgraph
+      // with no promoted aliases from a current/legacy capability-skewed
+      // response that omitted the witness entirely.
+      promoted_terminals: promotedTerminals,
     };
   },
 

--- a/web/js/lib/graph-view-identity.js
+++ b/web/js/lib/graph-view-identity.js
@@ -15,3 +15,38 @@ export function withWorkflowUuid(viewing, rootGraph, workflowUuid) {
     ? { ...viewing, workflow_uuid: uuid }
     : viewing;
 }
+
+// A graph-local node id (including a subgraph wrapper id) is not a graph
+// identity. Keep an opaque, object-keyed token for each live graph object so a
+// read from graph A cannot authorize the same numeric ids after the canvas
+// navigates to graph B. WeakMap lifetime deliberately follows the live graph
+// object: a rebuild/reconnect produces a new token and therefore fails closed.
+const graphViewIdentities = new WeakMap();
+let nextGraphViewIdentity = 0;
+
+function newGraphViewIdentity() {
+  const cryptoObject = globalThis.crypto;
+  if (typeof cryptoObject?.randomUUID === "function") {
+    return `graph:${cryptoObject.randomUUID()}`;
+  }
+  nextGraphViewIdentity += 1;
+  return `graph:local-${nextGraphViewIdentity}`;
+}
+
+/** Return the stable identity for this live graph object, or null when the
+ * caller did not provide an object that can be keyed by identity. */
+export function graphViewIdentityFor(graph) {
+  if (!graph || typeof graph !== "object") return null;
+  let identity = graphViewIdentities.get(graph);
+  if (!identity) {
+    identity = newGraphViewIdentity();
+    graphViewIdentities.set(graph, identity);
+  }
+  return identity;
+}
+
+/** Attach the live graph-object identity to a structured graph read reply. */
+export function withGraphViewIdentity(viewing, graph) {
+  const identity = graphViewIdentityFor(graph);
+  return identity ? { ...viewing, graph_identity: identity } : viewing;
+}

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -804,6 +804,11 @@ export function buildHelloPayload({
     // #2314 P1: the promoted-scope fence also validates the object-keyed live
     // graph identity, not only graph-local owner/workflow fields.
     enforces_expected_scope_graph_identity_at_write: true,
+    // #2314 P1: graph_get_subgraph publishes the complete alias -> immediate
+    // -> terminal promotion witness consumed by the orchestrator. This is a
+    // separate capability from the write-boundary fence so an older bundle is
+    // never mistaken for one that can classify renamed promotion aliases.
+    publishes_promoted_terminal_witnesses: true,
     // Advertise that this build understands `agent_note` — an orchestrator frame that is
     // delivered to the AGENT ONLY and never rendered as a chat bubble.
     //

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -798,6 +798,9 @@ export function buildHelloPayload({
     // synchronous write boundary, so the orchestrator can fence a node
     // replacement between its final identity probe and mutation.
     enforces_expected_node_type_at_write: true,
+    // #2314: graph_set_widget validates an optional promoted subgraph owner and
+    // workflow witness against the LIVE canvas at the same synchronous boundary.
+    enforces_expected_scope_at_write: true,
     // Advertise that this build understands `agent_note` — an orchestrator frame that is
     // delivered to the AGENT ONLY and never rendered as a chat bubble.
     //

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -801,6 +801,9 @@ export function buildHelloPayload({
     // #2314: graph_set_widget validates an optional promoted subgraph owner and
     // workflow witness against the LIVE canvas at the same synchronous boundary.
     enforces_expected_scope_at_write: true,
+    // #2314 P1: the promoted-scope fence also validates the object-keyed live
+    // graph identity, not only graph-local owner/workflow fields.
+    enforces_expected_scope_graph_identity_at_write: true,
     // Advertise that this build understands `agent_note` — an orchestrator frame that is
     // delivered to the AGENT ONLY and never rendered as a chat bubble.
     //

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -809,6 +809,10 @@ export function buildHelloPayload({
     // separate capability from the write-boundary fence so an older bundle is
     // never mistaken for one that can classify renamed promotion aliases.
     publishes_promoted_terminal_witnesses: true,
+    // #2314 final-rail race: graph_set_widget re-resolves the promoted alias
+    // through the live owner/input relationship immediately before mutation,
+    // so an external/relinked host input cannot permit an inner/shared write.
+    enforces_promoted_parent_rail_at_write: true,
     // Advertise that this build understands `agent_note` — an orchestrator frame that is
     // delivered to the AGENT ONLY and never rendered as a chat bubble.
     //

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1396,12 +1396,7 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
   const matches = [];
   for (const input of subgraphNode.inputs ?? []) {
     const subgraphInput = input?._subgraphSlot ?? null;
-    const aliases = [
-      input?.name,
-      input?.label,
-      subgraphInput?.name,
-      subgraphInput?.label,
-    ].map((a) => (a == null ? null : String(a).toLowerCase()));
+    const aliases = promotedInputAliases(input, subgraphInput).map((a) => a.toLowerCase());
     // Labels are used ONLY to DETECT which promotion the caller meant (a caller
     // may address by a renamed promotion's display label). Locating the parent's
     // authoritative rail widget is done LATER by the promotion RELATIONSHIP
@@ -1522,6 +1517,25 @@ export function followPromotionToConcrete(target, resolveSource) {
     depth += 1;
   }
   return { node, widget, depth };
+}
+
+/** Every addressable spelling of a promoted host rail. Frontend versions have
+ * carried the programmatic name/label on the input, its backing subgraph slot,
+ * or the rail widget projection. Keep graph_get_subgraph's witness enumeration
+ * and graph_set_widget's live resolver on this exact shared alias contract. */
+export function promotedInputAliases(input, subgraphInput = input?._subgraphSlot ?? null) {
+  return [
+    input?.name,
+    input?.label,
+    input?.widget?.name,
+    input?.widget?.label,
+    input?._widget?.name,
+    input?._widget?.label,
+    subgraphInput?.name,
+    subgraphInput?.label,
+  ]
+    .filter((value) => value != null && String(value).length > 0)
+    .map((value) => String(value));
 }
 
 /**

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1494,20 +1494,34 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
  *   { node: null, widget: null, error }     → a deeper promotion link is unresolvable
  *   { node, widget, cycle: true }           → a promotion cycle was detected (defensive)
  */
+/** Maximum number of nested promoted containers the write path will traverse.
+ * A cycle is handled separately, but a bounded walk is still required for
+ * hostile/malformed graphs whose resolver keeps producing fresh objects. */
+export const MAX_PROMOTION_CHAIN_DEPTH = 16;
+
 export function followPromotionToConcrete(target, resolveSource) {
   let node = target?.node ?? null;
   let widget = target?.widget ?? null;
   const seen = new Set();
+  let depth = 0;
   while (node && node.subgraph) {
     if (seen.has(node)) return { node, widget, cycle: true };
+    if (depth >= MAX_PROMOTION_CHAIN_DEPTH) {
+      return {
+        node: null,
+        widget: null,
+        error: `promoted chain exceeded the maximum depth of ${MAX_PROMOTION_CHAIN_DEPTH}`,
+      };
+    }
     seen.add(node);
     const res = resolvePromotedInnerTarget(node, widget?.name, resolveSource);
     if (!res.promoted) return { node, widget, terminalVirtual: true };
     if (!res.target) return { node: null, widget: null, error: res.error };
     node = res.target.node;
     widget = res.target.widget;
+    depth += 1;
   }
-  return { node, widget };
+  return { node, widget, depth };
 }
 
 /**
@@ -1525,14 +1539,17 @@ export function collectPromotionIntermediates(target, resolveSource) {
   let node = target?.node ?? null;
   let widget = target?.widget ?? null;
   const seen = new Set();
+  let depth = 0;
   while (node && node.subgraph) {
     if (seen.has(node)) break;
+    if (depth >= MAX_PROMOTION_CHAIN_DEPTH) break;
     seen.add(node);
     out.push(node);
     const res = resolvePromotedInnerTarget(node, widget?.name, resolveSource);
     if (!res.promoted || !res.target) break;
     node = res.target.node;
     widget = res.target.widget;
+    depth += 1;
   }
   return out;
 }


### PR DESCRIPTION
## Summary\n- carry and validate expected promoted owner/workflow scope at the live graph_set_widget mutation boundary\n- advertise the receiver fence and preserve the existing graph_set_widget handler seam\n- refuse same-session owner navigation before applying a colliding inner node\n\nFixes #2314\n\nCompanion MCP changes are on PR #2323.