### PR TITLE
fix(panel): fence recovered completion remounts (#1830)

### DIFF
--- a/browser_tests/unit/bundle-version.test.mjs
+++ b/browser_tests/unit/bundle-version.test.mjs
@@ -17,9 +17,66 @@ import { dirname, join } from "node:path";
 
 import {
   collectRelativeImportSpecifiers,
+  createDirtySafeBundleHealRetry,
   primeModuleCache,
   resolveBundleStaleness,
 } from "../../web/js/lib/bundle-version.js";
+
+test("#1830 dirty-safe bundle heal waits for every unsaved workflow to become clean", async () => {
+  const timers = [];
+  let blocked = true;
+  let heals = 0;
+  const retry = createDirtySafeBundleHealRetry({
+    isBlocked: () => blocked,
+    heal: () => {
+      heals += 1;
+    },
+    setTimer: (fn, ms) => {
+      const timer = { fn, ms, cancelled: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimer: (timer) => {
+      timer.cancelled = true;
+    },
+    retryMs: 25,
+  });
+
+  assert.equal(retry.schedule(), true);
+  assert.equal(retry.schedule(), false, "repeated stale probes share one waiter");
+  assert.equal(timers[0].ms, 25);
+  timers[0].fn();
+  await Promise.resolve();
+  assert.equal(heals, 0, "dirty work never triggers navigation/healing");
+  assert.equal(timers.length, 2, "the cheap blocker poll remains armed");
+
+  blocked = false;
+  timers[1].fn();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(heals, 1, "healing is retried once the workflows are clean");
+  assert.equal(retry.pending(), false);
+});
+
+test("#1830 dirty-safe bundle heal cancellation prevents a stale timer from navigating", () => {
+  let timer;
+  let heals = 0;
+  const retry = createDirtySafeBundleHealRetry({
+    isBlocked: () => false,
+    heal: () => {
+      heals += 1;
+    },
+    setTimer: (fn) => (timer = { fn, cancelled: false }),
+    clearTimer: (value) => {
+      value.cancelled = true;
+    },
+  });
+  retry.schedule();
+  retry.cancel();
+  if (!timer.cancelled) timer.fn();
+  assert.equal(heals, 0);
+  assert.equal(retry.pending(), false);
+});
 
 test("resolveBundleStaleness: equal versions are current", () => {
   assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: "0.11.39" }), "current");

--- a/browser_tests/unit/bundle-version.test.mjs
+++ b/browser_tests/unit/bundle-version.test.mjs
@@ -78,6 +78,30 @@ test("#1830 dirty-safe bundle heal cancellation prevents a stale timer from navi
   assert.equal(retry.pending(), false);
 });
 
+test("#1830 root-new/child-old ESM linking tolerates a missing optional healer export", async () => {
+  const oldChildUrl =
+    "data:text/javascript," +
+    encodeURIComponent("export const primeModuleCache = () => {}; export const resolveBundleStaleness = () => 'stale';");
+  const rootUrl =
+    "data:text/javascript," +
+    encodeURIComponent(
+      `import * as bundleVersion from ${JSON.stringify(oldChildUrl)};
+       export const linked = typeof bundleVersion.createDirtySafeBundleHealRetry === "function";
+       export const prime = typeof bundleVersion.primeModuleCache === "function";`,
+    );
+  const linked = await import(rootUrl);
+  assert.equal(linked.linked, false, "the stale child has no optional healer export");
+  assert.equal(linked.prime, true, "the old child still links its existing required exports");
+
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  assert.match(source, /import \* as bundleVersion from "\.\/lib\/bundle-version\.js";/);
+  assert.match(source, /typeof bundleVersion\.createDirtySafeBundleHealRetry === "function"/);
+  assert.doesNotMatch(source, /import \{[\s\S]*createDirtySafeBundleHealRetry[\s\S]*\} from "\.\/lib\/bundle-version\.js";/);
+});
+
 test("resolveBundleStaleness: equal versions are current", () => {
   assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: "0.11.39" }), "current");
 });
@@ -309,6 +333,12 @@ test("#584 healer navigation guards: unsaved-work refusal, socket-down defer, ca
   const prime = body.indexOf("primeModuleCache({");
   const socketDown = body.indexOf("if (comfyBackendIsDown())", prime);
   assert.ok(socketDown > prime, "the socket is re-checked after the prime, before navigating");
+  const postPrimeDirty = body.indexOf("const postPrimeHealBlockers", prime);
+  assert.ok(postPrimeDirty > prime && postPrimeDirty < socketDown, "dirtiness is rechecked after the bounded prime");
+  assert.ok(
+    body.indexOf("dirtySafeBundleHealRetry.schedule();", postPrimeDirty) < socketDown,
+    "new edits after the prime return the heal to its dirty-safe retry loop",
+  );
   const deferUnarm = body.indexOf("ssSet(BUNDLE_HEAL_KEY, null);", socketDown);
   assert.ok(
     deferUnarm !== -1 && deferUnarm < body.indexOf("window.location.replace", socketDown),
@@ -321,6 +351,12 @@ test("#584 healer navigation guards: unsaved-work refusal, socket-down defer, ca
   // never happened and the heal attempt must not be counted as spent.
   const notice = body.indexOf("armReloadBlockedNotice({");
   const navigate = body.indexOf("window.location.replace");
+  const finalDirty = body.indexOf("const finalHealBlockers", postPrimeDirty);
+  assert.ok(finalDirty > postPrimeDirty && finalDirty < navigate, "dirtiness is rechecked immediately before navigation");
+  assert.ok(
+    body.indexOf("ssSet(BUNDLE_HEAL_KEY, null);", finalDirty) < navigate,
+    "the final TOCTOU refusal un-arms the marker",
+  );
   assert.ok(notice !== -1 && notice < navigate, "the cancelled-navigation notice is armed before navigating");
   const noticeBlock = body.slice(notice, navigate);
   assert.ok(

--- a/browser_tests/unit/reload-blocked.test.mjs
+++ b/browser_tests/unit/reload-blocked.test.mjs
@@ -15,11 +15,14 @@ import { dirname, join } from "node:path";
 
 import {
   armReloadBlockedNotice,
+  runAgentFrontendReload,
   reloadBlockedMessage,
   RELOAD_BLOCKED_AFTER_MS,
   unsavedReloadBlockers,
   reloadWouldBeBlockedMessage,
 } from "../../web/js/lib/reload-blocked.js";
+import { commandFingerprint, createCommandDedupeLedger } from "../../web/js/lib/command-dedupe.js";
+import { createRehelloGate, routeIsStale } from "../../web/js/lib/rehello-gate.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -28,6 +31,204 @@ const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 function fakeTimer() {
   const calls = [];
   return { setTimer: (fn, ms) => (calls.push({ fn, ms }), calls.length), calls };
+}
+
+function extractFunctionSource(source, marker, endMarker = null) {
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `could not locate ${marker}`);
+  if (endMarker) {
+    const end = source.indexOf(endMarker, start);
+    assert.notEqual(end, -1, `could not locate the end of ${marker}`);
+    return source.slice(start, end + 2);
+  }
+  const open = source.indexOf("{", start);
+  assert.notEqual(open, -1, `could not locate the body of ${marker}`);
+  let depth = 1;
+  let quote = null;
+  let lineComment = false;
+  let blockComment = false;
+  for (let i = open + 1; i < source.length; i += 1) {
+    const c = source[i];
+    const n = source[i + 1];
+    if (lineComment) {
+      if (c === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (c === "*" && n === "/") {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (c === "\\") i += 1;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === "/" && n === "/") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+    if (c === "/" && n === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+    if (c === "\"" || c === "'" || c === "`") {
+      quote = c;
+      continue;
+    }
+    if (c === "{") depth += 1;
+    else if (c === "}" && --depth === 0) return source.slice(start, i + 1);
+  }
+  assert.fail(`could not close ${marker}`);
+}
+
+const CREATE_BRIDGE_CLIENT = extractFunctionSource(
+  readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n"),
+  "function createBridgeClient(",
+  "\n}\n\n// ---------------------------------------------------------------------------\n// Panel DOM",
+);
+
+class CommandReplySocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSED = 3;
+  static instances = [];
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = CommandReplySocket.CONNECTING;
+    this.sent = [];
+    this.listeners = new Map();
+    CommandReplySocket.instances.push(this);
+  }
+
+  addEventListener(type, listener) {
+    this.listeners.set(type, listener);
+  }
+
+  send(raw) {
+    if (this.readyState !== CommandReplySocket.OPEN) throw new Error("socket is not open");
+    this.sent.push(JSON.parse(raw));
+  }
+
+  open() {
+    this.readyState = CommandReplySocket.OPEN;
+    this.listeners.get("open")?.();
+  }
+
+  receive(frame) {
+    const event = { data: JSON.stringify(frame) };
+    void this.listeners.get("message")?.(event);
+  }
+
+  close() {
+    if (this.readyState === CommandReplySocket.CLOSED) return;
+    this.readyState = CommandReplySocket.CLOSED;
+    this.listeners.get("close")?.();
+  }
+}
+
+function buildCommandReplyClient(onReload) {
+  CommandReplySocket.instances = [];
+  const storage = new Map();
+  const noop = () => {};
+  const routeRef = { current: "panel-route-1830" };
+  const bridgeOutage = { noteHandshake: noop, noteBridgeClosed: noop };
+  const lostReplies = { list: () => [], size: () => 0, summaries: () => [], replace: noop, record: noop };
+  const localStorage = {
+    getItem: (key) => storage.get(key) ?? null,
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: (key) => storage.delete(key),
+  };
+  const webWindow = { localStorage, dispatchEvent: noop };
+  const env = new Proxy(
+    {
+      WebSocket: CommandReplySocket,
+      DEFAULT_BRIDGE_URL: "ws://bridge.test",
+      RECONNECT_BASE_MS: 1000,
+      RECONNECT_MAX_MS: 15000,
+      STORAGE_KEY_BACKEND: "backend",
+      window: webWindow,
+      location: { protocol: "http:", href: "http://panel.test/" },
+      document: { addEventListener: noop, removeEventListener: noop, querySelector: () => null },
+      MutationObserver: class { observe() {} disconnect() {} },
+      loadBridgeUrl: () => "ws://bridge.test",
+      saveBridgeUrl: noop,
+      bridgeRouteId: () => routeRef.current,
+      tabRouteIdentity: { adopt: noop, settled: () => true },
+      describeRefusedRoute: () => "route unavailable",
+      routeIsStale,
+      createRehelloGate,
+      monotonicNow: () => performance.now(),
+      buildHelloPayload: ({ tabId } = {}) => ({ type: "hello", tab_id: tabId ?? routeRef.current }),
+      sendBridgeHello: async ({ socket, isCurrent, makePayload }) => {
+        if (!isCurrent()) return false;
+        const payload = makePayload("tab-session-1830");
+        if (!payload) return false;
+        socket.send(JSON.stringify(payload));
+        return true;
+      },
+      createRestartTabIdentity: () => ({ resolve: async () => "tab-session-1830" }),
+      bridgeOutage,
+      lostReplies,
+      pruneAttempts: (items) => items,
+      shouldReRegister: () => false,
+      reRegisterExhaustedHint: () => "re-register exhausted",
+      describeUndeliveredReply: () => "undelivered",
+      lsSet: (key, value) => (value == null ? localStorage.removeItem(key) : localStorage.setItem(key, value)),
+      lsGet: (key) => localStorage.getItem(key),
+      SESSION_ORDERED_FRAMES: new Set(),
+      AGENT_SESSION_RESET_FRAMES: new Set(),
+      AGENT_MUTED: false,
+      AGENT_BLIND: false,
+      commandFingerprint,
+      createCommandDedupeLedger,
+      commandRidLedger: createCommandDedupeLedger(),
+      coerceMessageText: (value) => (value == null ? "" : typeof value === "string" ? value : String(value)),
+      isAbandonedInteractive: () => false,
+      abandonedInteractiveError: () => "abandoned",
+      readReconnectRefusal: () => null,
+      readWorkflowListReadinessRefusal: () => null,
+      readRouteRegistrationReadinessRefusal: () => null,
+      markOpenReceiptReplySent: noop,
+      openReceipts: [],
+      deferChangeTrackerSnapshot: noop,
+      trackerStillOwnsCanvas: () => true,
+      getWorkflowTitle: () => "Untitled",
+      comfyuiUrlForAgent: () => "http://comfy.test",
+      localComfyuiPathForAgent: () => null,
+      workflowStableUuid: () => "workflow-1830",
+      PANEL_VERSION: "test",
+      VENDORED_VOCABULARY_HASH: "test",
+      onCommand: noop,
+      onCommandReceived: noop,
+      onModels: noop,
+      onLog: noop,
+    },
+    {
+      has: () => true,
+      get(target, key) {
+        if (key in target) return target[key];
+        if (key in globalThis) return globalThis[key];
+        return noop;
+      },
+    },
+  );
+  const create = new Function("env", `with (env) { return (${CREATE_BRIDGE_CLIENT}); }`)(env);
+  const client = create({
+    onStatus: noop,
+    onSay: noop,
+    onStream: noop,
+    onLog: noop,
+    onReload,
+    onModels: noop,
+    onBridgeClosed: noop,
+  });
+  return { client, socket: () => CommandReplySocket.instances.at(-1) };
 }
 
 test("#701 the notice fires only if the page SURVIVED the deadline", () => {
@@ -140,7 +341,7 @@ test("#701 a blocked reload names the tabs, the mechanism, and BOTH ways out", (
   assert.match(msg, /Ctrl\+Shift\+R/)
 })
 
-test("#701 WIRING: only the AGENT path refuses, and it refuses BEFORE navigating", async () => {
+test("#701 WIRING: only the AGENT path runs the reload decision before navigating", async () => {
   const { readFileSync } = await import("node:fs")
   const { fileURLToPath } = await import("node:url")
   const { dirname, join } = await import("node:path")
@@ -148,24 +349,126 @@ test("#701 WIRING: only the AGENT path refuses, and it refuses BEFORE navigating
     join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
     "utf8",
   )
-  const i = src.indexOf('if (scope === "frontend")')
+  const i = src.indexOf('if (scope === "frontend")', src.indexOf("async function softReload("))
   assert.ok(i > 0)
-  const block = src.slice(i, i + 2600)
+  const block = src.slice(i, i + 3200)
   // The guard is gated on the commanded path — a user standing at the keyboard
   // can answer the dialog, so their reload must still proceed.
-  assert.match(block, /if \(origin === "agent"\)[\s\S]{0,400}unsavedReloadBlockers/)
-  // …and it must return BEFORE the navigation, not merely warn about it.
-  const guardAt = block.indexOf("unsavedReloadBlockers")
-  const navAt = block.indexOf("cmcpReload")
-  assert.ok(guardAt > 0 && navAt > guardAt, "the blocker check must precede the navigation")
-  assert.match(block.slice(guardAt, navAt), /return;/)
+  assert.match(block, /if \(origin === "agent"\)[\s\S]{0,1200}runAgentFrontendReload/)
+  // …and a refusal is thrown into the command reply rather than merely logged.
+  const guardAt = block.indexOf("runAgentFrontendReload")
+  const refusalAt = block.indexOf("if (!reloadResult.ok) throw new Error(reloadResult.error)")
+  assert.ok(guardAt > 0 && refusalAt > guardAt, "the decision must feed the command refusal")
 })
 
-test("#701 WIRING: the soft_reload REPLY reports the refusal, before scheduling anything", async () => {
-  // Live-verified on the rig that the guard works and the socket survives — and
-  // that the agent was still told "soft reload (frontend) scheduled", with the
-  // panel-side notice nowhere the agent can read it. A command that reports the
-  // REQUEST instead of the observed EFFECT is the defect, not the navigation.
+test("#1830 lifecycle: a clean command that becomes dirty during prime refuses visibly", async () => {
+  let dirty = false;
+  let blockerReads = 0;
+  let navigations = 0;
+  let armed = 0;
+  let cleared = 0;
+  const surfaced = [];
+  const result = await runAgentFrontendReload({
+    getBlockers: () => {
+      blockerReads += 1;
+      return dirty ? ["Untitled.json"] : [];
+    },
+    prime: async () => {
+      assert.equal(dirty, false, "the command starts with a clean blocker snapshot");
+      dirty = true;
+    },
+    clearSidebarReopen: () => {
+      cleared += 1;
+    },
+    appendSystem: (message) => surfaced.push(message),
+    armNotice: () => {
+      armed += 1;
+    },
+    navigate: () => {
+      navigations += 1;
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.stage, "post-prime");
+  assert.match(result.error, /Did NOT reload/);
+  assert.equal(blockerReads, 2, "the clean and post-prime snapshots both ran");
+  assert.equal(navigations, 0, "a new edit during prime prevents navigation");
+  assert.equal(armed, 0, "a refused command never arms the cancelled-navigation notice");
+  assert.equal(cleared, 1, "the refused command clears its sidebar reopen marker");
+  assert.deepEqual(surfaced, [result.error], "the same refusal is visible in the panel and command result");
+});
+
+test("#1830 lifecycle: the final pre-navigation fence refuses a new edit", async () => {
+  let dirty = false;
+  let reads = 0;
+  let navigations = 0;
+  const result = await runAgentFrontendReload({
+    getBlockers: () => {
+      reads += 1;
+      const blockers = dirty ? ["Untitled.json"] : [];
+      if (reads === 2) dirty = true;
+      return blockers;
+    },
+    prime: async () => {},
+    clearSidebarReopen: () => {},
+    appendSystem: () => {},
+    armNotice: () => {},
+    navigate: () => {
+      navigations += 1;
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.stage, "pre-navigation");
+  assert.equal(reads, 3, "the final snapshot ran after the post-prime snapshot");
+  assert.equal(navigations, 0, "a new edit immediately before navigation is refused");
+});
+
+test("#1830 lifecycle: the bridge returns the post-prime refusal to the agent", async () => {
+  let dirty = false;
+  let navigations = 0;
+  const surfaced = [];
+  const onReload = async (scope) => {
+    assert.equal(scope, "frontend");
+    const decision = await runAgentFrontendReload({
+      getBlockers: () => (dirty ? ["Untitled.json"] : []),
+      prime: async () => {
+        assert.equal(dirty, false, "the command begins from a clean workflow");
+        dirty = true;
+      },
+      clearSidebarReopen: () => {},
+      appendSystem: (message) => surfaced.push(message),
+      armNotice: () => assert.fail("a refused reload must not arm the delayed notice"),
+      navigate: () => {
+        navigations += 1;
+      },
+    });
+    if (!decision.ok) throw new Error(decision.error);
+    return `soft reload (${scope}) scheduled`;
+  };
+  const built = buildCommandReplyClient(onReload);
+  try {
+    built.client.start();
+    const socket = built.socket();
+    socket.open();
+    socket.receive({ type: "models", epoch: "epoch-1830", models: [] });
+    await new Promise((resolve) => setImmediate(resolve));
+    socket.receive({ rid: "reload-rid-1830", cmd: "soft_reload", scope: "frontend", epoch: "epoch-1830" });
+    await new Promise((resolve) => setImmediate(resolve));
+    const reply = socket.sent.find((frame) => frame.rid === "reload-rid-1830");
+    assert.deepEqual(reply, {
+      rid: "reload-rid-1830",
+      ok: false,
+      error: surfaced[0],
+    });
+    assert.match(reply.error, /Did NOT reload/);
+    assert.equal(navigations, 0, "the refusal never navigates");
+    assert.equal(surfaced.length, 1, "the panel records the same refusal returned to the agent");
+  } finally {
+    built.client.stop();
+  }
+});
+
+test("#1830 WIRING: the frontend soft_reload awaits the decision and returns its refusal", async () => {
   const { readFileSync } = await import("node:fs")
   const { fileURLToPath } = await import("node:url")
   const { dirname, join } = await import("node:path")
@@ -176,16 +479,8 @@ test("#701 WIRING: the soft_reload REPLY reports the refusal, before scheduling 
   const i = src.indexOf('msg.cmd === "soft_reload"')
   assert.ok(i > 0)
   const block = src.slice(i, i + 1800)
-  // The blockers are consulted in the command handler…
-  assert.match(block, /unsavedReloadBlockers\(app\?\.extensionManager\?\.workflow\?\.openWorkflows\)/)
-  // …the refusal becomes the REPLY…
-  assert.match(block, /result = reloadWouldBeBlockedMessage\(reloadBlockers\)/)
-  // …and "scheduled" + the actual reload are the ELSE branch, so a blocked
-  // reload can never be reported as scheduled.
-  const refusalAt = block.indexOf("reloadWouldBeBlockedMessage(reloadBlockers)")
-  const schedAt = block.indexOf("scheduled`")
-  assert.ok(refusalAt > 0 && schedAt > refusalAt, "the refusal must be decided before the scheduled reply")
-  assert.match(block.slice(refusalAt, schedAt), /\} else \{/)
-  // Only the frontend scope is gated — an orchestrator respawn does not navigate.
-  assert.match(block, /scope === "frontend"\s*\?\s*unsavedReloadBlockers/)
+  assert.match(block, /if \(scope === "frontend"\)\s*\{\s*result = await onReload\(scope\)/)
+  assert.match(block, /if \(result == null\) throw new Error\("The frontend reload did not produce a decision\."\)/)
+  assert.match(block, /else \{[\s\S]*setTimeout\(\(\) => onReload\(scope\), 60\)/)
+  assert.doesNotMatch(block, /setTimeout\(\(\) => onReload\(scope\), 60\)[\s\S]*if \(scope === "frontend"\)/)
 })

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -529,6 +529,29 @@ test("#1824: restart adoption preserves the keyed completion route and session",
   }]);
 });
 
+test("#1830: restart adoption preserves multiple same-prompt completion nonces", () => {
+  const keyA = JSON.stringify(["panel-route-1830", "session-1830", "P", "nonce-a"]);
+  const keyB = JSON.stringify(["panel-route-1830", "session-1830", "P", "nonce-b"]);
+  const rows = [keyA, keyB].map((completionKey) => ({
+    promptId: "P",
+    completionKey,
+    routeId: "panel-route-1830",
+    sessionId: "session-1830",
+  }));
+  const marker = decodeRebootMarker(
+    encodeRebootMarker({ at: 1000, runs: ["P"], completionMeta: rows }),
+  );
+  assert.deepEqual(marker.completionMeta, rows);
+
+  const fresh = makeTracker();
+  assert.deepEqual(adoptRebootRuns(marker.runs, fresh, marker.completionMeta), ["P"]);
+  assert.deepEqual(
+    fresh.completionMetadata().map((entry) => entry.completionKey),
+    [keyA, keyB],
+    "marker adoption passes every exact row to the tracker",
+  );
+});
+
 test("#1824: a timeout-released terminal batch survives teardown and late prompt adoption", async () => {
   const firstFlushes = [];
   const first = makeTracker((payload) => firstFlushes.push(payload));

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -667,7 +667,7 @@ test("#1565 P0: a run abandoned at its bound still FENCES its own late post, wit
  * technique add-node-command-budget.test.mjs uses) so the wiring can be exercised in
  * milliseconds; the shipped VALUES are pinned separately below.
  */
-function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef, runReceiptSender, runReceiptRouteRef, panelRunOwnerRef }) {
+function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef, runReceiptSender, runReceiptRouteRef, runReceiptSessionRef, panelRunOwnerRef }) {
   const seen = { dispatchArgs: null };
   const deps = {
     RUN_COMMAND_BUDGET_MS: budgetMs,
@@ -724,6 +724,7 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
     armRunReconcileSweepRef: armRunReconcileSweepRef ?? (() => {}),
     runReceiptSender: runReceiptSender ?? null,
     runReceiptRouteRef: runReceiptRouteRef ?? (() => null),
+    runReceiptSessionRef: runReceiptSessionRef ?? (() => null),
     panelRunOwnerRef: panelRunOwnerRef ?? { current: {} },
   };
   const names = Object.keys(deps);
@@ -1229,6 +1230,7 @@ test("#1824 CALL SITE: a long panel_run completion stays replayable until the or
       armRunReconcileSweepRef: () => sweep.arm(),
       panelRunOwnerRef: owner,
       runReceiptRouteRef: () => "panel-route-1824",
+      runReceiptSessionRef: () => "1824",
       runReceiptSender: () => {},
       dispatch: async (args) => {
         latePromptId = () => args.onPromptId("long-prompt-1824");

--- a/browser_tests/unit/run-completion-persistence.test.mjs
+++ b/browser_tests/unit/run-completion-persistence.test.mjs
@@ -9,12 +9,13 @@ import {
   normalizeRunCompletionMetadata,
   parseRunCompletionIdentity,
   partitionRunCompletionMetadata,
+  runCompletionKeyMatchesContext,
   runCompletionKeyMatchesRoute,
 } from "../../web/js/lib/run-completion-persistence.js";
 
 const row = ({
   routeId = "tab-a::wf:workflows/a.json",
-  sessionId = "mount-7",
+  sessionId = "agent-session-7",
   promptId = "prompt-a",
   nonce = "queue-a",
 } = {}) => ({
@@ -48,7 +49,7 @@ test("#1830 remount restores only the active route and retains foreign routes", 
     promptId: "prompt-b",
     nonce: "queue-b",
   });
-  const partitioned = partitionRunCompletionMetadata([foreign, active], active.routeId);
+  const partitioned = partitionRunCompletionMetadata([foreign, active], active.routeId, active.sessionId);
   assert.deepEqual(partitioned.current, [active]);
   assert.deepEqual(partitioned.deferred, [foreign]);
 
@@ -70,6 +71,8 @@ test("#1830 keyed completion cannot leave on a replacement workflow route", () =
   assert.equal(runCompletionKeyMatchesRoute(completion.completionKey, completion.routeId), true);
   assert.equal(runCompletionKeyMatchesRoute(completion.completionKey, "replacement-route"), false);
   assert.equal(runCompletionKeyMatchesRoute("malformed", completion.routeId), false);
+  assert.equal(runCompletionKeyMatchesContext(completion.completionKey, completion.routeId, completion.sessionId), true);
+  assert.equal(runCompletionKeyMatchesContext(completion.completionKey, completion.routeId, "replacement-session"), false);
 });
 
 test("#1830 id-less events never become persisted completion identities", () => {
@@ -83,10 +86,10 @@ test("#1830 production wiring owner-gates stale mount persistence and restores b
     join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
     "utf8",
   ).replace(/\r\n/g, "\n");
-  assert.match(source, /partitionRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*completionRestoreRoute/);
+  assert.match(source, /partitionRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*completionRestoreRoute,\s*completionRestoreSession/);
   assert.match(source, /if \(panelRunOwnerRef\.current !== mountOwner\) return;/);
   assert.match(source, /mergeRunCompletionMetadata\(entries, deferredRunCompletionMetadata\)/);
   assert.match(source, /restoreRunCompletionMetadata\(runCompletion, completionRestore\.current\)/);
-  assert.match(source, /if \(!runCompletionKeyMatchesRoute\(frame\.completion_key, liveRoute\)\) return false;/);
+  assert.match(source, /if \(!runCompletionKeyMatchesContext\(frame\.completion_key, liveRoute, liveSession\)\) return false;/);
   assert.match(source, /sendFrame: sendRunCompletionFrame/);
 });

--- a/browser_tests/unit/run-completion-persistence.test.mjs
+++ b/browser_tests/unit/run-completion-persistence.test.mjs
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  mergeRunCompletionMetadata,
+  normalizeRunCompletionMetadata,
+  parseRunCompletionIdentity,
+  partitionRunCompletionMetadata,
+  runCompletionKeyMatchesRoute,
+} from "../../web/js/lib/run-completion-persistence.js";
+
+const row = ({
+  routeId = "tab-a::wf:workflows/a.json",
+  sessionId = "mount-7",
+  promptId = "prompt-a",
+  nonce = "queue-a",
+} = {}) => ({
+  routeId,
+  sessionId,
+  promptId,
+  completionKey: JSON.stringify([routeId, sessionId, promptId, nonce]),
+});
+
+test("#1830 persisted completion identity requires matching route/session/prompt and nonce", () => {
+  const valid = row();
+  assert.deepEqual(parseRunCompletionIdentity(valid.completionKey), {
+    completionKey: valid.completionKey,
+    routeId: valid.routeId,
+    sessionId: valid.sessionId,
+    promptId: valid.promptId,
+    nonce: "queue-a",
+  });
+  assert.deepEqual(normalizeRunCompletionMetadata([valid]), [valid]);
+
+  assert.deepEqual(normalizeRunCompletionMetadata([{ ...valid, routeId: "foreign-route" }]), []);
+  assert.deepEqual(normalizeRunCompletionMetadata([{ ...valid, sessionId: "foreign-session" }]), []);
+  assert.deepEqual(normalizeRunCompletionMetadata([{ ...valid, promptId: "foreign-prompt" }]), []);
+  assert.equal(parseRunCompletionIdentity(JSON.stringify([valid.routeId, valid.sessionId, valid.promptId])), null);
+});
+
+test("#1830 remount restores only the active route and retains foreign routes", () => {
+  const active = row();
+  const foreign = row({
+    routeId: "tab-b::wf:workflows/b.json",
+    promptId: "prompt-b",
+    nonce: "queue-b",
+  });
+  const partitioned = partitionRunCompletionMetadata([foreign, active], active.routeId);
+  assert.deepEqual(partitioned.current, [active]);
+  assert.deepEqual(partitioned.deferred, [foreign]);
+
+  assert.deepEqual(
+    mergeRunCompletionMetadata([], partitioned.deferred),
+    [foreign],
+    "acknowledging the active-route completion must not erase another route's pending row",
+  );
+});
+
+test("#1830 reused prompt ids remain distinct by completion nonce", () => {
+  const first = row({ nonce: "queue-a" });
+  const second = row({ nonce: "queue-b" });
+  assert.deepEqual(normalizeRunCompletionMetadata([first, second]), [first, second]);
+});
+
+test("#1830 keyed completion cannot leave on a replacement workflow route", () => {
+  const completion = row();
+  assert.equal(runCompletionKeyMatchesRoute(completion.completionKey, completion.routeId), true);
+  assert.equal(runCompletionKeyMatchesRoute(completion.completionKey, "replacement-route"), false);
+  assert.equal(runCompletionKeyMatchesRoute("malformed", completion.routeId), false);
+});
+
+test("#1830 id-less events never become persisted completion identities", () => {
+  const invalid = row({ promptId: "" });
+  assert.equal(parseRunCompletionIdentity(invalid.completionKey), null);
+  assert.deepEqual(normalizeRunCompletionMetadata([invalid]), []);
+});
+
+test("#1830 production wiring owner-gates stale mount persistence and restores by route", () => {
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  assert.match(source, /partitionRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*completionRestoreRoute/);
+  assert.match(source, /if \(panelRunOwnerRef\.current !== mountOwner\) return;/);
+  assert.match(source, /mergeRunCompletionMetadata\(entries, deferredRunCompletionMetadata\)/);
+  assert.match(source, /restoreRunCompletionMetadata\(runCompletion, completionRestore\.current\)/);
+  assert.match(source, /if \(!runCompletionKeyMatchesRoute\(frame\.completion_key, liveRoute\)\) return false;/);
+  assert.match(source, /sendFrame: sendRunCompletionFrame/);
+});

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -21,6 +21,7 @@ import {
 } from "../../web/js/lib/run-completion.js";
 import { createRunCompletionFlushHandler } from "../../web/js/lib/run-completion-delivery.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+import { runCompletionKeyMatchesContext } from "../../web/js/lib/run-completion-persistence.js";
 
 /** Deterministic scheduler: timers are held until tick() fires the due ones. */
 function makeHarness({ debounceMs = 1500, maxRearms = 40 } = {}) {
@@ -334,6 +335,85 @@ function makeFrameDeps(overrides = {}) {
   };
   return { deps, frames, painted, uploadCalls };
 }
+
+test("#1830 keeps two same-prompt nonce rows and retires them by exact key", () => {
+  const h = makeHarness();
+  const P = "same-prompt";
+  const keyA = JSON.stringify(["route-a", "session-a", P, "nonce-a"]);
+  const keyB = JSON.stringify(["route-a", "session-a", P, "nonce-b"]);
+
+  h.tracker.onQueued(P, { routeId: "route-a", sessionId: "session-a", completionKey: keyA });
+  h.tracker.onQueued(P, { routeId: "route-a", sessionId: "session-a", completionKey: keyB });
+  assert.deepEqual(
+    h.tracker.completionMetadata().map((row) => row.completionKey),
+    [keyA, keyB],
+    "restoring/queueing the same prompt id does not overwrite the other nonce",
+  );
+
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, imgs([img("same-prompt.png")]));
+  h.tracker.onExecutionSuccess(P);
+  assert.deepEqual(
+    h.flushes.map((payload) => payload.completionKey),
+    [keyA, keyB],
+    "the lifecycle sends one exact completion identity for each retained row",
+  );
+
+  assert.equal(h.tracker.acknowledgeDelivery(P, keyA), true);
+  assert.deepEqual(h.tracker.completionMetadata().map((row) => row.completionKey), [keyB]);
+  assert.equal(h.tracker.acknowledgeDelivery(P, keyA), false, "a stale duplicate receipt is harmless");
+  assert.equal(h.tracker.acknowledgeDelivery(P, keyB), true);
+  assert.equal(h.tracker.completionMetadata().length, 0);
+  assert.equal(h.tracker.hasPending(), false);
+});
+
+test("#1830 lifecycle send fence rejects a session switch on the same route and retries exact identity", async () => {
+  const { deps } = makeFrameDeps();
+  const P = "session-switch-prompt";
+  const completionKey = JSON.stringify(["route-a", "session-a", P, "nonce-a"]);
+  let activeSession = "session-a";
+  const rejected = [];
+  const accepted = [];
+  let tracker;
+  const productionOnFlush = createRunCompletionFlushHandler({
+    ...deps,
+    sendFrame: (frame) => {
+      if (!runCompletionKeyMatchesContext(frame.completion_key, "route-a", activeSession)) {
+        rejected.push(frame);
+        return false;
+      }
+      accepted.push(frame);
+      return true;
+    },
+    markDelivered: (promptId, key) => tracker.markDelivered(promptId, key),
+    markUndelivered: (promptId, key) => tracker.markUndelivered(promptId, key),
+    pruneRebootMarker: () => {},
+    isAgentMuted: () => false,
+  });
+  tracker = createRunCompletionTracker({
+    onFlush: productionOnFlush,
+    setTimer: () => 0,
+    clearTimer: () => {},
+  });
+  tracker.onQueued(P, { routeId: "route-a", sessionId: "session-a", completionKey });
+  tracker.onExecutionStart(P);
+  tracker.onExecuted(P, imgs([img("session-switch.png", "temp")]));
+  tracker.onExecutionSuccess(P);
+  activeSession = "session-b";
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(rejected.length, 1, "a same-route session switch rejects the in-flight completion");
+  assert.equal(rejected[0].completion_key, completionKey);
+  assert.equal(tracker.hasPending(), true, "the rejected completion remains recoverable");
+
+  activeSession = "session-a";
+  await tracker.reconcile();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(accepted.length, 1, "the exact completion is retried once its original session returns");
+  assert.equal(accepted[0].completion_key, completionKey);
+  assert.equal(tracker.acknowledgeDelivery(P, completionKey), true);
+  assert.equal(tracker.hasPending(), false);
+});
 
 test("#269/#468 presentation: a MIXED run (stills + 2 videos) emits EXACTLY ONE agent_event with all outputs", async () => {
   const { deps, frames } = makeFrameDeps();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -73,7 +73,12 @@ import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
 import { missingAssetScanMayBeStale, missingAssetScopeNote } from "./lib/missing-asset-scope.js";
-import { armReloadBlockedNotice, unsavedReloadBlockers, reloadWouldBeBlockedMessage } from "./lib/reload-blocked.js";
+import {
+  armReloadBlockedNotice,
+  runAgentFrontendReload,
+  unsavedReloadBlockers,
+  reloadWouldBeBlockedMessage,
+} from "./lib/reload-blocked.js";
 // #1180 — the repo's one bounded-step primitive. A second timeout helper written alongside
 // it is how this repo keeps producing near-duplicate bugs, per that file's own header.
 import { withTimeout } from "./lib/bounded-step.js";
@@ -26341,26 +26346,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // undeliverable-reply path has nothing of the user's to redact.
             if (isAbandonedInteractive(result)) throw new Error(abandonedInteractiveError(msg.cmd));
           } else if (msg.cmd === "soft_reload") {
-            // Agent-triggered soft reload. Reply FIRST (below), then bounce —
-            // an "orchestrator" scope kills this very session, so the resume
-            // flow (SOFT_RELOAD_KEY) continues the conversation afterward.
+            // Agent-triggered soft reload. A frontend reload awaits every
+            // dirtiness fence before replying; an orchestrator reload still
+            // replies first because it deliberately kills this very session.
             if (!onReload) throw new Error("This panel build can't soft-reload.");
             const scope = msg.scope === "frontend" ? "frontend" : "orchestrator";
-            // #701 — decide BEFORE replying. The guard that stops a doomed
-            // frontend reload runs 60ms later inside onReload, by which point
-            // this command has already told the agent "scheduled". Live-verified
-            // on the rig: the tab correctly did NOT navigate and its socket
-            // survived, and the agent was still told the reload was scheduled —
-            // so it has no reason to look, and the panel-side notice it does
-            // emit is not something the agent can read.
-            //
-            // Report what will actually happen, on the reply the caller gets.
-            const reloadBlockers =
-              scope === "frontend"
-                ? unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows)
-                : [];
-            if (reloadBlockers.length) {
-              result = reloadWouldBeBlockedMessage(reloadBlockers);
+            if (scope === "frontend") {
+              result = await onReload(scope);
+              if (result == null) throw new Error("The frontend reload did not produce a decision.");
             } else {
               result = `soft reload (${scope}) scheduled`;
               setTimeout(() => onReload(scope), 60);
@@ -37304,7 +37297,7 @@ function buildPanel() {
     },
     // The agent called panel_reload — perform the soft reload it asked for.
     onReload(scope) {
-      softReload("agent", scope);
+      return softReload("agent", scope);
     },
     onAction(name) {
       // A tool/operation started (or changed). Only meaningful while a turn is
@@ -40130,27 +40123,46 @@ function buildPanel() {
   async function softReload(origin = "user", scope = "orchestrator") {
     if (reloading) return;
     if (scope === "frontend") {
+      const primeFrontendModuleCache = async () => {
+        try {
+          await Promise.race([
+            primeModuleCache({
+              entryUrl: import.meta.url,
+              fetchImpl: (url, opts) => fetch(url, { credentials: "same-origin", ...opts }),
+            }),
+            new Promise((resolve) => setTimeout(resolve, 5000)),
+          ]);
+        } catch {
+          /* reload decision continues; dirtiness is checked independently */
+        }
+      };
+      if (origin === "agent") {
+        ssSet(SIDEBAR_REOPEN_KEY, "1");
+        appendSystem(tr("panel.reloading_the_panel_ui_new_frontend_code", "Reloading the panel UI (new frontend code)…"));
+        const reloadResult = await runAgentFrontendReload({
+          getBlockers: () =>
+            unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows),
+          prime: primeFrontendModuleCache,
+          clearSidebarReopen: () => ssSet(SIDEBAR_REOPEN_KEY, null),
+          appendSystem,
+          armNotice: () => armReloadBlockedNotice({ notify: (m) => appendSystem(m) }),
+          navigate: () => {
+            try {
+              const u = new URL(window.location.href);
+              u.searchParams.set("cmcpReload", String(Date.now()));
+              window.location.replace(u.toString());
+            } catch {
+              window.location.reload();
+            }
+          },
+        });
+        if (!reloadResult.ok) throw new Error(reloadResult.error);
+        return `soft reload (${scope}) scheduled`;
+      }
       // Nothing to respawn — just re-fetch the panel with a cache-bust. The
       // session id persists in sessionStorage, so we reconnect + resume on load.
       // Arm the reopen flag so our sidebar tab re-activates after the reload
       // (ComfyUI won't, since our tab isn't registered yet when it restores).
-      // #701 defect (2) — an AGENT-commanded reload must not start something the
-      // browser will refuse to finish. With unsaved work open, `beforeunload`
-      // blocks the navigation, and it drops this tab's socket BEFORE raising the
-      // dialog: the tab ends up with no reload and no bridge, and nobody is at the
-      // keyboard to answer the prompt. Reproduced on the rig with 3 unsaved
-      // workflows — "soft reload (frontend) scheduled", then a disconnect, then
-      // nothing, with the page never navigating.
-      //
-      // A USER-initiated reload still proceeds: they are right there and can
-      // answer the dialog. Only the commanded path refuses.
-      if (origin === "agent") {
-        const blockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
-        if (blockers.length) {
-          appendSystem(reloadWouldBeBlockedMessage(blockers));
-          return;
-        }
-      }
       ssSet(SIDEBAR_REOPEN_KEY, "1");
       appendSystem(tr("panel.reloading_the_panel_ui_new_frontend_code", "Reloading the panel UI (new frontend code)…"));
       // #584 — the cmcpReload page-URL param busts only the top document; the
@@ -40159,37 +40171,11 @@ function buildPanel() {
       // the pack's module graph with cache:"reload" first. Best-effort and
       // time-bounded: a commanded reload must never hang on a slow server,
       // and a failed prime must not cancel it.
-      try {
-        await Promise.race([
-          primeModuleCache({
-            entryUrl: import.meta.url,
-            fetchImpl: (url, opts) => fetch(url, { credentials: "same-origin", ...opts }),
-          }),
-          new Promise((resolve) => setTimeout(resolve, 5000)),
-        ]);
-      } catch {
-        /* reload regardless — worst case is the pre-#584 behaviour */
-      }
-      if (origin === "agent") {
-        const postPrimeBlockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
-        if (postPrimeBlockers.length) {
-          ssSet(SIDEBAR_REOPEN_KEY, null);
-          appendSystem(reloadWouldBeBlockedMessage(postPrimeBlockers));
-          return;
-        }
-      }
+      await primeFrontendModuleCache();
       // #701(2) — the navigation below can be CANCELLED by ComfyUI's unsaved-work
       // beforeunload, after the browser has already torn down our socket. If that
       // happens this code survives the deadline and says so; if the reload works, the
       // document is destroyed and the notice never fires. Arm it BEFORE navigating.
-      if (origin === "agent") {
-        const finalBlockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
-        if (finalBlockers.length) {
-          ssSet(SIDEBAR_REOPEN_KEY, null);
-          appendSystem(reloadWouldBeBlockedMessage(finalBlockers));
-          return;
-        }
-      }
       armReloadBlockedNotice({ notify: (m) => appendSystem(m) });
       try {
         const u = new URL(window.location.href);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -80,6 +80,12 @@ import { withTimeout } from "./lib/bounded-step.js";
 import { createChatScrollStabilizer } from "./lib/chat-scroll-stabilizer.js";
 import { createRunReceiptOutbox } from "./lib/run-receipt-outbox.js";
 import {
+  mergeRunCompletionMetadata,
+  normalizeRunCompletionMetadata,
+  partitionRunCompletionMetadata,
+  runCompletionKeyMatchesRoute,
+} from "./lib/run-completion-persistence.js";
+import {
   arbitratePanelCopy,
   countExtensionsNamed,
   describeDuplicatePanelCopies,
@@ -779,7 +785,11 @@ import { createRehelloGate, routeIsStale } from "./lib/rehello-gate.js";
  *  where nobody is going to act on an answer it cannot give. Everything else is refused
  *  while the route is stale (see sendFrame). */
 const SESSION_ORDERED_FRAMES = new Set(["resume_session", "new_session"]);
-import { primeModuleCache, resolveBundleStaleness } from "./lib/bundle-version.js";
+import {
+  createDirtySafeBundleHealRetry,
+  primeModuleCache,
+  resolveBundleStaleness,
+} from "./lib/bundle-version.js";
 import { describeModuleCache, readModuleCacheSummary } from "./lib/module-cache-report.js";
 import { classifyManager404 } from "./lib/manager-404.js";
 import { probeConsoleRoute, UNBUILT_ROUTE_TITLE } from "./lib/console-route-probe.js";
@@ -5306,32 +5316,14 @@ function readRunCompletionMetadata() {
   const raw = ssGet(RUN_COMPLETION_META_KEY);
   if (!raw) return [];
   try {
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed
-      .filter(
-        (entry) =>
-          entry &&
-          typeof entry.promptId === "string" &&
-          entry.promptId.trim() &&
-          typeof entry.completionKey === "string" &&
-          entry.completionKey.trim() &&
-          entry.completionKey.length <= 512,
-      )
-      .slice(0, 256)
-      .map((entry) => ({
-        promptId: entry.promptId.trim(),
-        completionKey: entry.completionKey.trim(),
-        routeId: entry.routeId == null ? null : String(entry.routeId),
-        sessionId: entry.sessionId == null ? null : String(entry.sessionId),
-      }));
+    return normalizeRunCompletionMetadata(JSON.parse(raw));
   } catch {
     return [];
   }
 }
 
 function persistRunCompletionMetadata(entries) {
-  const safe = Array.isArray(entries) ? entries.slice(0, 256) : [];
+  const safe = normalizeRunCompletionMetadata(entries);
   if (!safe.length) {
     ssSet(RUN_COMPLETION_META_KEY, null);
     return;
@@ -5343,17 +5335,18 @@ function persistRunCompletionMetadata(entries) {
   }
 }
 
-function restoreRunCompletionMetadata(tracker) {
+function restoreRunCompletionMetadata(tracker, entries) {
   if (!tracker || typeof tracker.onQueued !== "function") return 0;
-  const entries = readRunCompletionMetadata();
-  for (const entry of entries) {
+  let restored = 0;
+  for (const entry of normalizeRunCompletionMetadata(entries)) {
     try {
       tracker.onQueued(entry.promptId, entry);
+      restored += 1;
     } catch {
       // A malformed persisted row must not prevent the panel from mounting.
     }
   }
-  return entries.length;
+  return restored;
 }
 
 function readRunCompletionTerminals() {
@@ -37997,11 +37990,52 @@ function buildPanel() {
   // flushes a true orphan (outputs with no start/executing signal), so a partial
   // batch can't be emitted for a legitimately long run.
   //
+  // Partition the durable ledger before the tracker is created. A remount can
+  // happen while a different workflow route is active; replaying an old row on
+  // that route would stamp the frame for the wrong canvas. Keep foreign rows in
+  // storage for a later mount of their own route, and merge them back on every
+  // write from this tracker.
+  let completionRestoreRoute = null;
+  try {
+    completionRestoreRoute = bridgeRouteId();
+  } catch {}
+  const completionRestore = partitionRunCompletionMetadata(
+    readRunCompletionMetadata(),
+    completionRestoreRoute,
+  );
+  const deferredRunCompletionMetadata = completionRestore.deferred;
+  const persistOwnedRunCompletionMetadata = (entries) => {
+    // Async composition from a torn-down mount can settle after its replacement
+    // has already acknowledged and cleared a completion. Never let that stale
+    // frontend instance resurrect its old pending snapshot.
+    if (panelRunOwnerRef.current !== mountOwner) return;
+    persistRunCompletionMetadata(
+      mergeRunCompletionMetadata(entries, deferredRunCompletionMetadata),
+    );
+  };
+  const persistOwnedRunCompletionTerminals = (entries) => {
+    if (panelRunOwnerRef.current !== mountOwner) return;
+    persistRunCompletionTerminals(entries);
+  };
+  const sendRunCompletionFrame = (frame) => {
+    if (typeof frame?.completion_key === "string") {
+      let liveRoute = null;
+      try {
+        liveRoute = bridgeRouteId();
+      } catch {}
+      // A workflow switch can race the async completion composer. Refuse the
+      // write and let markUndelivered + the safety sweep retain it until its
+      // original route is live again; never stamp it onto the replacement tab.
+      if (!runCompletionKeyMatchesRoute(frame.completion_key, liveRoute)) return false;
+    }
+    return client.sendFrame(frame);
+  };
+
   // This closure owns ONLY presentation: it receives the full, correctly-scoped
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
-    onCompletionStateChange: (entries) => persistRunCompletionMetadata(entries),
-    onTerminalCompletionStateChange: (entries) => persistRunCompletionTerminals(entries),
+    onCompletionStateChange: persistOwnedRunCompletionMetadata,
+    onTerminalCompletionStateChange: persistOwnedRunCompletionTerminals,
     // comfyui-mcp#1739 — a run re-pended by markUndelivered (the completion frame's
     // sendFrame failed: bridge/socket churn, e.g. around a workflow-tab switch
     // re-hello) re-enters a ledger that may have NO sweeper left: flush() retired
@@ -38030,7 +38064,7 @@ function buildPanel() {
     // #1199 — `finishedAt` and `reconciled` are forwarded by the production
     // delivery seam so recovered completions retain their real finish time.
     onFlush: createRunCompletionFlushHandler({
-      sendFrame: (frame) => client.sendFrame(frame),
+      sendFrame: sendRunCompletionFrame,
       markDelivered: (promptId) => runCompletion.markDelivered(promptId),
       markUndelivered: (promptId) => runCompletion.markUndelivered(promptId),
       pruneRebootMarker,
@@ -38235,7 +38269,7 @@ function buildPanel() {
   // before the first reconcile probe, so a retained completion can be replayed
   // as the same panel_run receipt rather than downgraded to a fresh run.
   if (
-    restoreRunCompletionMetadata(runCompletion) > 0 ||
+    restoreRunCompletionMetadata(runCompletion, completionRestore.current) > 0 ||
     restoreRunCompletionTerminals(runCompletion) > 0
   ) {
     armRunReconcileSweep();
@@ -42652,8 +42686,8 @@ function buildPanel() {
       // reconcile await (codex P1 unmount-resurrection leak). Only null the shared
       // refs if they still point at THIS instance — a newer mount may already own them.
       runReconcileSweep.dispose();
-      persistRunCompletionMetadata(runCompletion.completionMetadata?.() ?? []);
-      persistRunCompletionTerminals(runCompletion.terminalCompletionMetadata?.() ?? []);
+      persistOwnedRunCompletionMetadata(runCompletion.completionMetadata?.() ?? []);
+      persistOwnedRunCompletionTerminals(runCompletion.terminalCompletionMetadata?.() ?? []);
       runCompletion.dispose?.();
       if (panelRunOwnerRef.current === mountOwner) {
         panelRunOwnerRef.current = null;
@@ -42754,6 +42788,11 @@ function installSidebarTabGuard(tabId, getRoot, onDetach) {
 // orchestrator's fence message (#709) already names. There is no panel-side
 // channel that can retrofit self-healing into already-shipped JS.
 const BUNDLE_HEAL_KEY = "comfyui-mcp.panel.bundleHealAttempted";
+const dirtySafeBundleHealRetry = createDirtySafeBundleHealRetry({
+  isBlocked: () =>
+    unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows).length > 0,
+  heal: () => healStaleBundleIfNeeded(),
+});
 
 async function healStaleBundleIfNeeded() {
   try {
@@ -42777,6 +42816,7 @@ async function healStaleBundleIfNeeded() {
     const installed = body?.version;
     const staleness = resolveBundleStaleness({ running: PANEL_VERSION, installed });
     if (staleness === "current") {
+      dirtySafeBundleHealRetry.cancel();
       // A previous heal took — clear the marker so the NEXT update heals too.
       if (ssGet(BUNDLE_HEAL_KEY)) ssSet(BUNDLE_HEAL_KEY, null);
       // #584 — "current" IS THE BLIND SPOT. This compares one number: the
@@ -42834,12 +42874,15 @@ async function healStaleBundleIfNeeded() {
     // reload-blocked.js: an unknown flag is not evidence of unsaved work.)
     const healBlockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
     if (healBlockers.length) {
+      dirtySafeBundleHealRetry.schedule();
       console.warn(
         `[comfyui-mcp-panel] this tab is running a STALE panel bundle (running ${PANEL_VERSION}, ` +
-          `installed ${installed}). ${reloadWouldBeBlockedMessage(healBlockers)}`,
+          `installed ${installed}). ${reloadWouldBeBlockedMessage(healBlockers)} ` +
+          `The panel will retry its safe reload after those workflows are saved.`,
       );
       return;
     }
+    dirtySafeBundleHealRetry.cancel();
     ssSet(BUNDLE_HEAL_KEY, marker);
     if (ssGet(BUNDLE_HEAL_KEY) !== marker) {
       // codex gate round 3 — the loop guard is itself an operation that can

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -83,7 +83,7 @@ import {
   mergeRunCompletionMetadata,
   normalizeRunCompletionMetadata,
   partitionRunCompletionMetadata,
-  runCompletionKeyMatchesRoute,
+  runCompletionKeyMatchesContext,
 } from "./lib/run-completion-persistence.js";
 import {
   arbitratePanelCopy,
@@ -785,11 +785,58 @@ import { createRehelloGate, routeIsStale } from "./lib/rehello-gate.js";
  *  where nobody is going to act on an answer it cannot give. Everything else is refused
  *  while the route is stale (see sendFrame). */
 const SESSION_ORDERED_FRAMES = new Set(["resume_session", "new_session"]);
-import {
-  createDirtySafeBundleHealRetry,
-  primeModuleCache,
-  resolveBundleStaleness,
-} from "./lib/bundle-version.js";
+// Namespace linking keeps a newer root compatible with a cached older child
+// bundle: optional exports must be feature-detected, not statically imported.
+import * as bundleVersion from "./lib/bundle-version.js";
+const { primeModuleCache, resolveBundleStaleness } = bundleVersion;
+const createDirtySafeBundleHealRetry =
+  typeof bundleVersion.createDirtySafeBundleHealRetry === "function"
+    ? bundleVersion.createDirtySafeBundleHealRetry
+    : ({
+        isBlocked,
+        heal,
+        setTimer = (fn, ms) => setTimeout(fn, ms),
+        clearTimer = (timer) => clearTimeout(timer),
+        retryMs = 1000,
+      } = {}) => {
+        let timer = null;
+        const schedule = () => {
+          if (timer !== null || typeof isBlocked !== "function" || typeof heal !== "function") {
+            return false;
+          }
+          try {
+            timer = setTimer(() => {
+              timer = null;
+              let blocked = true;
+              try {
+                blocked = isBlocked() === true;
+              } catch {
+                blocked = true;
+              }
+              if (blocked) {
+                schedule();
+                return;
+              }
+              Promise.resolve().then(() => heal()).catch(() => {});
+            }, retryMs);
+            return true;
+          } catch {
+            timer = null;
+            return false;
+          }
+        };
+        return {
+          schedule,
+          cancel() {
+            if (timer === null) return;
+            try {
+              clearTimer(timer);
+            } catch {}
+            timer = null;
+          },
+          pending: () => timer !== null,
+        };
+      };
 import { describeModuleCache, readModuleCacheSummary } from "./lib/module-cache-report.js";
 import { classifyManager404 } from "./lib/manager-404.js";
 import { probeConsoleRoute, UNBUILT_ROUTE_TITLE } from "./lib/console-route-probe.js";
@@ -872,6 +919,9 @@ let runReceiptSender = null;
 // enqueue into a replacement mount, but the outbox will only flush when that same
 // route is live, so a remount cannot misattribute a receipt to another workflow.
 let runReceiptRouteRef = null;
+// The dispatch captures the actual agent conversation session, not the panel
+// mount generation. A route can remain stable while SESSION_KEY changes.
+let runReceiptSessionRef = null;
 // A callback from an old mount must never register into a replacement tracker or
 // sweep. This owner is a stable object per mount rather than a mutable generation
 // number that an old callback could accidentally match after wrap/reuse.
@@ -18000,6 +18050,11 @@ const GRAPH_TOOL_EXECUTORS = {
     try {
       dispatchReceiptRoute = typeof runReceiptRouteRef === "function" ? runReceiptRouteRef() : null;
     } catch {}
+    let dispatchReceiptSession = null;
+    try {
+      dispatchReceiptSession =
+        typeof runReceiptSessionRef === "function" ? runReceiptSessionRef() : null;
+    } catch {}
     const dispatchOwner = panelRunOwnerRef.current;
     const dispatchRunCompletion = runCompletionRef;
     const dispatchArmRunReconcileSweep = armRunReconcileSweepRef;
@@ -18293,13 +18348,14 @@ const GRAPH_TOOL_EXECUTORS = {
         panelRunOwnerRef.current === dispatchOwner &&
         runCompletionRef === dispatchRunCompletion &&
         armRunReconcileSweepRef === dispatchArmRunReconcileSweep;
+      let registeredCompletionKey = null;
       if (ownsDispatch) {
         try {
-          dispatchRunCompletion?.onQueued(id, {
+          registeredCompletionKey = dispatchRunCompletion?.onQueued(id, {
             routeId: dispatchReceiptRoute,
-            sessionId: dispatchOwner?.generation ?? null,
+            sessionId: dispatchReceiptSession,
             dispatchToken: dispatchPanelRunToken,
-          });
+          }) ?? null;
         } catch {}
         try {
           dispatchArmRunReconcileSweep?.();
@@ -18314,7 +18370,13 @@ const GRAPH_TOOL_EXECUTORS = {
             receiptRid,
             id,
             dispatchReceiptRoute,
-            dispatchRunCompletion?.completionKeyFor?.(id) ?? null,
+            registeredCompletionKey ||
+              dispatchRunCompletion?.completionKeyFor?.(
+                id,
+                dispatchReceiptRoute,
+                dispatchReceiptSession,
+              ) ||
+              null,
           );
         } catch {}
       }
@@ -37880,6 +37942,8 @@ function buildPanel() {
   };
   runReceiptOutbox.setTransport(panelRunReceiptTransport);
   runReceiptRouteRef = panelRunReceiptRouteRef;
+  const panelRunReceiptSessionRef = () => ssGet(SESSION_KEY);
+  runReceiptSessionRef = panelRunReceiptSessionRef;
   runReceiptSender = panelRunReceiptSender;
 
   // #758 — announce an update once the transcript exists to receive it. Deliberately
@@ -37999,9 +38063,11 @@ function buildPanel() {
   try {
     completionRestoreRoute = bridgeRouteId();
   } catch {}
+  const completionRestoreSession = ssGet(SESSION_KEY);
   const completionRestore = partitionRunCompletionMetadata(
     readRunCompletionMetadata(),
     completionRestoreRoute,
+    completionRestoreSession,
   );
   const deferredRunCompletionMetadata = completionRestore.deferred;
   const persistOwnedRunCompletionMetadata = (entries) => {
@@ -38023,10 +38089,12 @@ function buildPanel() {
       try {
         liveRoute = bridgeRouteId();
       } catch {}
+      const liveSession = ssGet(SESSION_KEY);
       // A workflow switch can race the async completion composer. Refuse the
-      // write and let markUndelivered + the safety sweep retain it until its
-      // original route is live again; never stamp it onto the replacement tab.
-      if (!runCompletionKeyMatchesRoute(frame.completion_key, liveRoute)) return false;
+      // write when either route OR agent conversation changed, and let
+      // markUndelivered + the safety sweep retain it until the exact context is
+      // live again; never stamp it onto a replacement tab/session.
+      if (!runCompletionKeyMatchesContext(frame.completion_key, liveRoute, liveSession)) return false;
     }
     return client.sendFrame(frame);
   };
@@ -38065,8 +38133,8 @@ function buildPanel() {
     // delivery seam so recovered completions retain their real finish time.
     onFlush: createRunCompletionFlushHandler({
       sendFrame: sendRunCompletionFrame,
-      markDelivered: (promptId) => runCompletion.markDelivered(promptId),
-      markUndelivered: (promptId) => runCompletion.markUndelivered(promptId),
+      markDelivered: (promptId, completionKey) => runCompletion.markDelivered(promptId, completionKey),
+      markUndelivered: (promptId, completionKey) => runCompletion.markUndelivered(promptId, completionKey),
       pruneRebootMarker,
       coerceMessageText,
       formatDuration,
@@ -40102,10 +40170,26 @@ function buildPanel() {
       } catch {
         /* reload regardless — worst case is the pre-#584 behaviour */
       }
+      if (origin === "agent") {
+        const postPrimeBlockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
+        if (postPrimeBlockers.length) {
+          ssSet(SIDEBAR_REOPEN_KEY, null);
+          appendSystem(reloadWouldBeBlockedMessage(postPrimeBlockers));
+          return;
+        }
+      }
       // #701(2) — the navigation below can be CANCELLED by ComfyUI's unsaved-work
       // beforeunload, after the browser has already torn down our socket. If that
       // happens this code survives the deadline and says so; if the reload works, the
       // document is destroyed and the notice never fires. Arm it BEFORE navigating.
+      if (origin === "agent") {
+        const finalBlockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
+        if (finalBlockers.length) {
+          ssSet(SIDEBAR_REOPEN_KEY, null);
+          appendSystem(reloadWouldBeBlockedMessage(finalBlockers));
+          return;
+        }
+      }
       armReloadBlockedNotice({ notify: (m) => appendSystem(m) });
       try {
         const u = new URL(window.location.href);
@@ -42701,6 +42785,7 @@ function buildPanel() {
       if (armRunReconcileSweepRef === armRunReconcileSweep) armRunReconcileSweepRef = null;
       if (runCompletionRef === runCompletion) runCompletionRef = null;
       if (runReceiptRouteRef === panelRunReceiptRouteRef) runReceiptRouteRef = null;
+      if (runReceiptSessionRef === panelRunReceiptSessionRef) runReceiptSessionRef = null;
       if (runReceiptSender === panelRunReceiptSender) runReceiptSender = null;
       // Drop the Settings→panel hooks so the dialog can't drive a torn-down panel
       // (a freshly-mounted panel re-registers them).
@@ -42918,6 +43003,20 @@ async function healStaleBundleIfNeeded() {
           `panel still reports ${PANEL_VERSION} afterwards, hard-refresh (Ctrl+Shift+R).`,
       );
     }
+    // The cache prime can take the full five-second budget. A workflow may have
+    // become dirty while it was in flight, so re-check before any marker-backed
+    // navigation and return the heal attempt to the retry loop.
+    const postPrimeHealBlockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
+    if (postPrimeHealBlockers.length) {
+      ssSet(BUNDLE_HEAL_KEY, null);
+      dirtySafeBundleHealRetry.schedule();
+      console.warn(
+        `[comfyui-mcp-panel] the stale-bundle heal found new unsaved work after refreshing the ` +
+          `module graph. ${reloadWouldBeBlockedMessage(postPrimeHealBlockers)} ` +
+          `The panel will retry its safe reload after those workflows are saved.`,
+      );
+      return;
+    }
     // #584 — the probe + prime above can span a NEW backend disconnect (a
     // restart still in progress): reloading into a down server re-fetches
     // whatever the half-restarted backend serves and strands the tab on the
@@ -42945,6 +43044,19 @@ async function healStaleBundleIfNeeded() {
     // loop-guard marker: the reload never happened, and the next page load or
     // reconnect must get its heal attempt back. Same arm-before-navigate order
     // as the commanded reload path.
+    // This is the final TOCTOU fence: do not arm the blocked-navigation notice or
+    // navigate if a workflow became dirty after the post-prime check.
+    const finalHealBlockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
+    if (finalHealBlockers.length) {
+      ssSet(BUNDLE_HEAL_KEY, null);
+      dirtySafeBundleHealRetry.schedule();
+      console.warn(
+        `[comfyui-mcp-panel] the stale-bundle heal was cancelled because workflow edits appeared ` +
+          `immediately before navigation. ${reloadWouldBeBlockedMessage(finalHealBlockers)} ` +
+          `The panel will retry its safe reload after those workflows are saved.`,
+      );
+      return;
+    }
     armReloadBlockedNotice({
       notify: (m) => {
         ssSet(BUNDLE_HEAL_KEY, null);

--- a/web/js/lib/bundle-version.js
+++ b/web/js/lib/bundle-version.js
@@ -40,6 +40,66 @@ export function resolveBundleStaleness({ running, installed } = {}) {
 }
 
 /**
+ * Retry a proven-stale bundle heal after unsaved-work blockers become clean.
+ * The poll only reads blocker state; the expensive version probe/cache prime is
+ * invoked once, after navigation is safe. Multiple stale probes share one poll.
+ */
+export function createDirtySafeBundleHealRetry({
+  isBlocked,
+  heal,
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  clearTimer = (timer) => clearTimeout(timer),
+  retryMs = 1000,
+} = {}) {
+  let timer = null;
+
+  const schedule = () => {
+    if (timer !== null || typeof isBlocked !== "function" || typeof heal !== "function") {
+      return false;
+    }
+    try {
+      timer = setTimer(() => {
+        timer = null;
+        let blocked = true;
+        try {
+          blocked = isBlocked() === true;
+        } catch {
+          // An unreadable workflow list is not permission to navigate. The
+          // production blocker helper itself fails open only on readable rows;
+          // an exception here is weaker evidence, so wait and inspect again.
+          blocked = true;
+        }
+        if (blocked) {
+          schedule();
+          return;
+        }
+        Promise.resolve()
+          .then(() => heal())
+          .catch(() => {});
+      }, retryMs);
+      return true;
+    } catch {
+      timer = null;
+      return false;
+    }
+  };
+
+  return {
+    schedule,
+    cancel() {
+      if (timer === null) return;
+      try {
+        clearTimer(timer);
+      } catch {}
+      timer = null;
+    },
+    pending() {
+      return timer !== null;
+    },
+  };
+}
+
+/**
  * Extract RELATIVE module specifiers ("./x.js", "../y.js") from a module's
  * static import/export statements AND its literal dynamic import("...") calls
  * (e.g. cmcp-a2ui-lit-adapter.js's lazily-loaded vendor bundle — omitting it

--- a/web/js/lib/reload-blocked.js
+++ b/web/js/lib/reload-blocked.js
@@ -135,3 +135,65 @@ export function reloadWouldBeBlockedMessage(blockers) {
     `(Ctrl+Shift+R) and confirm the dialog.`
   );
 }
+
+/**
+ * Run an agent-commanded frontend reload through every dirtiness fence.
+ *
+ * The command reply must not call a clean, pre-prime snapshot "scheduled": the
+ * cache prime can yield to a user edit, and the final check can race one too.
+ * Returning the refusal lets the command handler throw it through its normal
+ * `{ok:false,error}` reply path while keeping navigation out of the refused path.
+ *
+ * @param {object} deps
+ * @param {() => string[]} deps.getBlockers
+ * @param {() => Promise<unknown>} deps.prime
+ * @param {() => void} deps.clearSidebarReopen
+ * @param {(message: string) => void} deps.appendSystem
+ * @param {() => void} deps.armNotice
+ * @param {() => void} deps.navigate
+ * @returns {Promise<{ok: true}|{ok: false, stage: string, error: string}>}
+ */
+export async function runAgentFrontendReload({
+  getBlockers,
+  prime,
+  clearSidebarReopen,
+  appendSystem,
+  armNotice,
+  navigate,
+} = {}) {
+  const blockersNow = () => {
+    try {
+      return typeof getBlockers === "function" ? getBlockers() : [];
+    } catch {
+      return [];
+    }
+  };
+  const refuse = (stage, blockers) => {
+    const error = reloadWouldBeBlockedMessage(blockers);
+    try {
+      clearSidebarReopen?.();
+    } catch {}
+    try {
+      appendSystem?.(error);
+    } catch {}
+    return { ok: false, stage, error };
+  };
+
+  const initial = blockersNow();
+  if (initial.length) return refuse("initial", initial);
+
+  try {
+    await prime?.();
+  } catch {
+    // A failed or timed-out cache prime does not waive the dirtiness fences.
+  }
+  const postPrime = blockersNow();
+  if (postPrime.length) return refuse("post-prime", postPrime);
+
+  const beforeNavigation = blockersNow();
+  if (beforeNavigation.length) return refuse("pre-navigation", beforeNavigation);
+
+  armNotice?.();
+  navigate?.();
+  return { ok: true };
+}

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -78,8 +78,8 @@ function normalizeCompletionMeta(entries) {
   for (const raw of Array.isArray(entries) ? entries : []) {
     const promptId = typeof raw?.promptId === "string" ? raw.promptId.trim() : "";
     const completionKey = typeof raw?.completionKey === "string" ? raw.completionKey.trim() : "";
-    if (!promptId || !completionKey || completionKey.length > 512 || seen.has(promptId)) continue;
-    seen.add(promptId);
+    if (!promptId || !completionKey || completionKey.length > 512 || seen.has(completionKey)) continue;
+    seen.add(completionKey);
     out.push({
       promptId,
       completionKey,
@@ -417,18 +417,27 @@ export function adoptRebootRuns(runs, tracker, completionMeta = []) {
   const adopted = [];
   const ids = normalizeRunIds(runs);
   if (!ids.length || !tracker || typeof tracker.onQueued !== "function") return adopted;
-  const metaByPrompt = new Map(
-    normalizeCompletionMeta(completionMeta).map((entry) => [entry.promptId, entry]),
-  );
+  const metaByPrompt = new Map();
+  for (const entry of normalizeCompletionMeta(completionMeta)) {
+    const rows = metaByPrompt.get(entry.promptId) ?? [];
+    rows.push(entry);
+    metaByPrompt.set(entry.promptId, rows);
+  }
   for (const id of ids) {
     try {
       if (typeof tracker.isKnown === "function" && tracker.isKnown(id)) continue;
-      const meta = metaByPrompt.get(id);
-      tracker.onQueued(id, meta ? {
-        routeId: meta.routeId,
-        sessionId: meta.sessionId,
-        completionKey: meta.completionKey,
-      } : undefined);
+      const metas = metaByPrompt.get(id) ?? [];
+      if (metas.length) {
+        for (const meta of metas) {
+          tracker.onQueued(id, {
+            routeId: meta.routeId,
+            sessionId: meta.sessionId,
+            completionKey: meta.completionKey,
+          });
+        }
+      } else {
+        tracker.onQueued(id, undefined);
+      }
       adopted.push(id);
     } catch {
       /* a malformed id must never wedge the resume flow */

--- a/web/js/lib/run-completion-delivery.js
+++ b/web/js/lib/run-completion-delivery.js
@@ -149,13 +149,13 @@ export function createRunCompletionFlushHandler({
         // permanent suppression (sendFrame returns false for both a down socket
         // AND AGENT_MUTED): a muted completion must NOT be recovered/replayed on
         // a later unmute+reconnect, so treat it as delivered (codex P1).
-        if (frame == null && !awaitsCompletionKey) markDelivered(promptId);
-        else if (framePushed && !awaitsReceipt && !awaitsCompletionKey) markDelivered(promptId);
+        if (frame == null && !awaitsCompletionKey) markDelivered(promptId, completionKey);
+        else if (framePushed && !awaitsReceipt && !awaitsCompletionKey) markDelivered(promptId, completionKey);
         else if (framePushed && (awaitsReceipt || awaitsCompletionKey)) {
           // A receipt retires keyed delivery; a delayed prompt identity retires
           // the recoverable unkeyed fallback by replaying it keyed.
-        } else if (isAgentMuted()) markDelivered(promptId);
-        else markUndelivered(promptId);
+        } else if (isAgentMuted()) markDelivered(promptId, completionKey);
+        else markUndelivered(promptId, completionKey);
         // #585: for legacy/unkeyed frames this is the moment "the agent was
         // told" becomes true (or is re-pended). Keyed panel_run frames update
         // the marker from the orchestrator acknowledgement callback instead.
@@ -178,10 +178,10 @@ export function createRunCompletionFlushHandler({
         // Composition threw before/around the send — treat as undelivered so a
         // reconnect can recover the outcome from /history rather than lose it
         // (but respect an intentional mute, as above).
-        if ((framePushed && !awaitsReceipt && !awaitsCompletionKey) || isAgentMuted()) markDelivered(promptId);
+        if ((framePushed && !awaitsReceipt && !awaitsCompletionKey) || isAgentMuted()) markDelivered(promptId, completionKey);
         else if (framePushed && (awaitsReceipt || awaitsCompletionKey)) {
           // The already-pushed frame remains recoverable until its key/receipt.
-        } else markUndelivered(promptId);
+        } else markUndelivered(promptId, completionKey);
         if ((!awaitsReceipt && !awaitsCompletionKey) || isAgentMuted()) {
           pruneRebootMarker(); // #585 — see the .then branch above
         }

--- a/web/js/lib/run-completion-persistence.js
+++ b/web/js/lib/run-completion-persistence.js
@@ -12,7 +12,7 @@ function text(value) {
 
 /**
  * Validate the current completion-key wire shape:
- *   [workflow route, panel mount generation, prompt id, queue nonce]
+ *   [workflow route, agent conversation session, prompt id, queue nonce]
  *
  * The nonce is what distinguishes a genuinely reused ComfyUI prompt id. An
  * older three-part key is not safe to adopt as the current shape because doing
@@ -39,6 +39,22 @@ export function parseRunCompletionIdentity(value) {
 export function runCompletionKeyMatchesRoute(completionKey, activeRouteId) {
   const identity = parseRunCompletionIdentity(completionKey);
   return !!identity && identity.routeId === text(activeRouteId);
+}
+
+/**
+ * True only when a keyed completion belongs to the exact live route/session.
+ * A route can stay unchanged while the agent conversation changes, so route
+ * equality alone is not a sufficient send fence.
+ */
+export function runCompletionKeyMatchesContext(
+  completionKey,
+  activeRouteId,
+  activeSessionId,
+) {
+  const identity = parseRunCompletionIdentity(completionKey);
+  const routeId = text(activeRouteId);
+  const sessionId = activeSessionId == null ? null : text(activeSessionId);
+  return !!identity && identity.routeId === routeId && identity.sessionId === sessionId;
 }
 
 /** Normalize and cross-check rows read from sessionStorage. */
@@ -85,12 +101,13 @@ export function normalizeRunCompletionMetadata(
  * Split persisted rows at remount. Only the active workflow route is safe to
  * reconcile now; foreign rows remain durable for a later mount of their route.
  */
-export function partitionRunCompletionMetadata(entries, activeRouteId) {
+export function partitionRunCompletionMetadata(entries, activeRouteId, activeSessionId) {
   const routeId = text(activeRouteId);
+  const sessionId = activeSessionId == null ? null : text(activeSessionId);
   const current = [];
   const deferred = [];
   for (const entry of normalizeRunCompletionMetadata(entries)) {
-    (routeId && entry.routeId === routeId ? current : deferred).push(entry);
+    (routeId && entry.routeId === routeId && entry.sessionId === sessionId ? current : deferred).push(entry);
   }
   return { current, deferred };
 }

--- a/web/js/lib/run-completion-persistence.js
+++ b/web/js/lib/run-completion-persistence.js
@@ -1,0 +1,104 @@
+// Persisted panel_run completion metadata is a recovery ledger, not a hint.
+// Only restore rows whose redundant route/session/prompt fields agree with the
+// opaque completion key, and never replay a foreign workflow route through the
+// route that happens to be active after a remount.
+
+const MAX_COMPLETION_KEY_LENGTH = 512;
+const MAX_COMPLETION_METADATA_ENTRIES = 256;
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Validate the current completion-key wire shape:
+ *   [workflow route, panel mount generation, prompt id, queue nonce]
+ *
+ * The nonce is what distinguishes a genuinely reused ComfyUI prompt id. An
+ * older three-part key is not safe to adopt as the current shape because doing
+ * so would erase that generation fence.
+ */
+export function parseRunCompletionIdentity(value) {
+  const raw = text(value);
+  if (!raw || raw.length > MAX_COMPLETION_KEY_LENGTH) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length !== 4) return null;
+    const routeId = text(parsed[0]);
+    const promptId = text(parsed[2]);
+    const nonce = text(parsed[3]);
+    const sessionId = parsed[1] == null ? null : text(parsed[1]);
+    if (!routeId || !promptId || !nonce || (parsed[1] != null && !sessionId)) return null;
+    return { completionKey: raw, routeId, sessionId, promptId, nonce };
+  } catch {
+    return null;
+  }
+}
+
+/** True only when a keyed completion is leaving on the route named by its key. */
+export function runCompletionKeyMatchesRoute(completionKey, activeRouteId) {
+  const identity = parseRunCompletionIdentity(completionKey);
+  return !!identity && identity.routeId === text(activeRouteId);
+}
+
+/** Normalize and cross-check rows read from sessionStorage. */
+export function normalizeRunCompletionMetadata(
+  entries,
+  { maxEntries = MAX_COMPLETION_METADATA_ENTRIES } = {},
+) {
+  if (!Array.isArray(entries)) return [];
+  const safeLimit = Math.max(0, Math.floor(Number(maxEntries) || 0));
+  if (safeLimit === 0) return [];
+  const out = [];
+  const seen = new Set();
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const identity = parseRunCompletionIdentity(entry.completionKey);
+    const promptId = text(entry.promptId);
+    const routeId = text(entry.routeId);
+    const sessionId = entry.sessionId == null ? null : text(entry.sessionId);
+    if (
+      !identity ||
+      !promptId ||
+      !routeId ||
+      (entry.sessionId != null && !sessionId) ||
+      identity.promptId !== promptId ||
+      identity.routeId !== routeId ||
+      identity.sessionId !== sessionId ||
+      seen.has(identity.completionKey)
+    ) {
+      continue;
+    }
+    seen.add(identity.completionKey);
+    out.push({
+      promptId,
+      completionKey: identity.completionKey,
+      routeId,
+      sessionId,
+    });
+    if (out.length >= safeLimit) break;
+  }
+  return out;
+}
+
+/**
+ * Split persisted rows at remount. Only the active workflow route is safe to
+ * reconcile now; foreign rows remain durable for a later mount of their route.
+ */
+export function partitionRunCompletionMetadata(entries, activeRouteId) {
+  const routeId = text(activeRouteId);
+  const current = [];
+  const deferred = [];
+  for (const entry of normalizeRunCompletionMetadata(entries)) {
+    (routeId && entry.routeId === routeId ? current : deferred).push(entry);
+  }
+  return { current, deferred };
+}
+
+/** Merge the live tracker's snapshot with untouched foreign-route rows. */
+export function mergeRunCompletionMetadata(current, deferred) {
+  return normalizeRunCompletionMetadata([
+    ...(Array.isArray(current) ? current : []),
+    ...(Array.isArray(deferred) ? deferred : []),
+  ]);
+}

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -196,10 +196,99 @@ export function createRunCompletionTracker({
   const panelRunCompletionKeys = new Set();
   let panelRunLateCapture = false;
   // A panel_run completion is not retired when the browser socket accepts the
-  // frame. Keep the stable route+prompt key with the run so /history retries
-  // carry the same idempotency key until the orchestrator acknowledges it.
-  const completionKeys = new Map(); // key -> route-scoped completion key
-  const completionMeta = new Map(); // key -> { completionKey, routeId, sessionId }
+  // frame. Keep every exact route+agent-session+prompt+nonce identity with the
+  // run so restored same-prompt rows cannot overwrite one another.
+  const completionKeys = new Map(); // composite identity -> completion key
+  const completionMeta = new Map(); // composite identity -> { promptId, completionKey, routeId, sessionId }
+  const completionIdentitiesByPrompt = new Map(); // prompt key -> Set(composite identity)
+
+  function completionIdentity(k, routeId, sessionId, completionKey) {
+    const route = routeId == null ? "" : String(routeId).trim();
+    const session = sessionId == null ? null : String(sessionId).trim();
+    const exactKey = typeof completionKey === "string" ? completionKey.trim() : "";
+    if (!route || !exactKey) return null;
+    return JSON.stringify([route, session, k, exactKey]);
+  }
+
+  function completionRecords(k) {
+    const identities = completionIdentitiesByPrompt.get(k);
+    if (!identities) return [];
+    return [...identities]
+      .map((identity) => completionMeta.get(identity))
+      .filter(Boolean);
+  }
+
+  function hasCompletionRecords(k) {
+    return completionRecords(k).length > 0;
+  }
+
+  function addCompletionRecord(k, { routeId, sessionId, completionKey }) {
+    const identity = completionIdentity(k, routeId, sessionId, completionKey);
+    if (!identity || completionKeys.has(identity)) return false;
+    const route = String(routeId).trim();
+    const session = sessionId == null ? null : String(sessionId).trim();
+    const exactKey = String(completionKey).trim();
+    completionKeys.set(identity, exactKey);
+    completionMeta.set(identity, {
+      promptId: promptIdOf(k),
+      completionKey: exactKey,
+      routeId: route,
+      sessionId: session,
+    });
+    let identities = completionIdentitiesByPrompt.get(k);
+    if (!identities) {
+      identities = new Set();
+      completionIdentitiesByPrompt.set(k, identities);
+    }
+    identities.add(identity);
+    return true;
+  }
+
+  function removeCompletionRecord(k, completionKey) {
+    const identities = completionIdentitiesByPrompt.get(k);
+    if (!identities) return false;
+    let removed = false;
+    for (const identity of [...identities]) {
+      const meta = completionMeta.get(identity);
+      if (meta?.completionKey !== completionKey) continue;
+      completionKeys.delete(identity);
+      completionMeta.delete(identity);
+      identities.delete(identity);
+      removed = true;
+    }
+    if (!identities.size) completionIdentitiesByPrompt.delete(k);
+    return removed;
+  }
+
+  function clearCompletionRecords(k) {
+    const identities = completionIdentitiesByPrompt.get(k);
+    if (!identities) return;
+    for (const identity of identities) {
+      completionKeys.delete(identity);
+      completionMeta.delete(identity);
+    }
+    completionIdentitiesByPrompt.delete(k);
+  }
+
+  function completionRecordFor(k, routeId, sessionId) {
+    const records = completionRecords(k);
+    if (routeId === undefined && sessionId === undefined) return records.at(-1) ?? null;
+    const route = routeId == null ? null : String(routeId).trim();
+    const session = sessionId == null ? null : String(sessionId).trim();
+    return records.find((record) => record.routeId === route && record.sessionId === session) ?? null;
+  }
+
+  function flushWithCompletionRecords(k, payload) {
+    const records = completionRecords(k);
+    if (!records.length) {
+      onFlush(payload);
+      return false;
+    }
+    for (const record of records) {
+      onFlush({ ...payload, completionKey: record.completionKey });
+    }
+    return true;
+  }
   // Far beyond any realistic WS-replay-after-reconnect delay, so pruning an entry
   // older than this can never re-open the double-delivery window it guards.
   const deliveredTtlMs = 10 * 60 * 1000;
@@ -430,7 +519,7 @@ export function createRunCompletionTracker({
   }
 
   function completionMetadataSnapshot() {
-    return [...completionMeta.entries()].map(([promptId, value]) => ({ promptId, ...value }));
+    return [...completionMeta.values()].map((value) => ({ ...value }));
   }
 
   function terminalCompletionMetadataSnapshot() {
@@ -570,7 +659,7 @@ export function createRunCompletionTracker({
     // A successful browser write is not proof the orchestrator received the
     // completion. Keep panel_run in pending until the matching completion ack;
     // the stable key makes every /history replay idempotent downstream.
-    const completionKey = completionKeys.get(k);
+    const hasCompletionKey = hasCompletionRecords(k);
     const payload = {
       key: k,
       promptId: promptIdOf(k),
@@ -578,7 +667,6 @@ export function createRunCompletionTracker({
       videos: buf.videos,
       durationMs,
       finishedAt: now(),
-      ...(completionKey ? { completionKey } : {}),
       // #986 — the agent is TOLD this output was already announced, never denied it.
       // Which of a replay or a fast re-render it is cannot be proven, so the panel
       // reports what it observed and lets the reader decide.
@@ -587,7 +675,7 @@ export function createRunCompletionTracker({
         : {}),
     };
     if (
-      !completionKey &&
+      !hasCompletionKey &&
       (panelRunDispatches.size || panelRunCompletionKeys.has(k)) &&
       k !== NO_PROMPT_KEY
     ) {
@@ -605,14 +693,14 @@ export function createRunCompletionTracker({
     }
     markTerminal(k);
     markDispatched(k);
-    if (!completionKey) markDelivered(k);
+    if (!hasCompletionKey) markDelivered(k);
     if (
       k !== NO_PROMPT_KEY &&
       payload.images.some((image) => image?.type === "temp")
     ) {
       liveReplays.set(k, payload);
     }
-    onFlush(payload);
+    flushWithCompletionRecords(k, payload);
   }
 
   /**
@@ -649,7 +737,7 @@ export function createRunCompletionTracker({
     // delayed /prompt identity has not supplied the completion key yet. Do not
     // replace that recoverable record with an unkeyed /history delivery: the
     // later onQueued callback must still be able to bind and replay it.
-    if (terminalNoKeyCompletion.has(k) && !completionKeys.has(k)) {
+    if (terminalNoKeyCompletion.has(k) && !hasCompletionRecords(k)) {
       return { promptId, status: "success", delivered: false };
     }
     // #1619 — a live executed batch is stronger than a remote history probe:
@@ -658,10 +746,10 @@ export function createRunCompletionTracker({
     // bridge send failed, and replay it without requiring /history to succeed.
     const liveReplay = liveReplays.get(k);
     if (liveReplay) {
-      if (completionKeys.has(k)) markTerminal(k);
+      if (hasCompletionRecords(k)) markTerminal(k);
       else markDelivered(k);
       markDispatched(k);
-      onFlush({ ...liveReplay, replayed: true });
+      flushWithCompletionRecords(k, { ...liveReplay, replayed: true });
       return { promptId, status: "success", delivered: true };
     }
     let entry = null;
@@ -727,9 +815,9 @@ export function createRunCompletionTracker({
     // media-less recovery below would never fire — the mistake this line exists to
     // prevent, and the one the reconcile test caught.
     const wasPanelQueued = panelQueued.has(k);
-    const completionKey = completionKeys.get(k);
+    const hasCompletionKey = hasCompletionRecords(k);
     const holdsForCompletionAck =
-      wasPanelQueued && parsed.status === "success" && completionKey != null;
+      wasPanelQueued && parsed.status === "success" && hasCompletionKey;
     if (holdsForCompletionAck) {
       // The terminal fence is needed to suppress late ComfyUI lifecycle events,
       // but the recovery ledger must remain until the orchestrator receipt.
@@ -806,13 +894,12 @@ export function createRunCompletionTracker({
       // Recorded, never suppressed: a reconcile exists to deliver something the agent
       // has NOT been told about, so it always goes through.
       deduper.record({ signature: mediaSignature(parsed.images, parsed.videos), promptId });
-      onFlush({
+      flushWithCompletionRecords(k, {
         key: k,
         promptId,
         images: parsed.images,
         videos: parsed.videos,
         durationMs,
-        ...(completionKey ? { completionKey } : {}),
         // Epoch ms of the REAL finish, or null when history records none (#1199).
         finishedAt: historyFinishedAt,
         reconciled: true,
@@ -855,7 +942,7 @@ export function createRunCompletionTracker({
     pending.delete(k); // EVICT — bounds the ledger
     panelQueued.delete(k); // #356 Bug 2 — evicted with it
     liveReplays.delete(k);
-    completionKeys.delete(k);
+    clearCompletionRecords(k);
     panelRunCompletionKeys.delete(k);
     terminalNoKeyCompletion.delete(k);
     terminalNoKeyFlushed.delete(k);
@@ -1031,12 +1118,11 @@ export function createRunCompletionTracker({
         markTerminal(k);
         clearReconcileRetry(k);
         markDispatched(k);
-        onFlush({
+        flushWithCompletionRecords(k, {
           key: k,
           promptId: promptIdOf(k),
           images: [],
           videos: [],
-          ...(completionKeys.get(k) ? { completionKey: completionKeys.get(k) } : {}),
           durationMs: mediaLessStart != null ? now() - mediaLessStart : null,
           finishedAt: now(),
           noMedia: true,
@@ -1060,7 +1146,7 @@ export function createRunCompletionTracker({
       // A panel_run remains owed until the orchestrator explicitly acknowledges
       // the completion frame. Ordinary canvas runs retain the legacy transport
       // confirmation behavior.
-      if (!completionKeys.has(k)) markDelivered(k);
+      if (!hasCompletionRecords(k)) markDelivered(k);
     },
 
     /** ComfyUI `execution_error` — drop this prompt's buffer, deliver no batch. */
@@ -1137,20 +1223,16 @@ export function createRunCompletionTracker({
     onQueued(id, { routeId, sessionId = null, completionKey, dispatchToken = null } = {}) {
       const k = key(id);
       trackPending(id);
+      let nextKey = null;
       // #356 Bug 2 — records that THIS run carried panel_run's wait-for-it promise.
       if (id != null) {
         panelQueued.add(k);
         const suppliedKey = typeof completionKey === "string" && completionKey.trim() ? completionKey.trim() : null;
-        const existingKey = completionKeys.get(k);
-        const nextKey = suppliedKey || existingKey || createRunCompletionKey(routeId, sessionId, k);
+        nextKey = suppliedKey || createRunCompletionKey(routeId, sessionId, k);
         if (nextKey) {
-          completionKeys.set(k, nextKey);
-          completionMeta.set(k, {
-            completionKey: nextKey,
-            routeId: routeId == null ? null : String(routeId),
-            sessionId: sessionId == null ? null : String(sessionId),
-          });
-          notifyCompletionStateChange();
+          if (addCompletionRecord(k, { completionKey: nextKey, routeId, sessionId })) {
+            notifyCompletionStateChange();
+          }
         }
       }
       if (dispatchToken && panelRunDispatches.has(dispatchToken)) {
@@ -1164,12 +1246,12 @@ export function createRunCompletionTracker({
         panelRunCompletionKeys.delete(k);
         notifyTerminalCompletionStateChange();
         delivered.delete(k);
-        if (completionKeys.has(k)) {
+        if (hasCompletionRecords(k)) {
           if (!pending.has(k)) pending.set(k, { promptId: k, at: now() });
           markTerminal(k);
           clearReconcileRetry(k);
           markDispatched(k);
-          onFlush({ ...lateMedia, key: k, completionKey: completionKeys.get(k) });
+          flushWithCompletionRecords(k, { ...lateMedia, key: k });
         } else {
           releaseUnkeyedCompletion(k, lateMedia, { retire: true });
         }
@@ -1184,7 +1266,7 @@ export function createRunCompletionTracker({
         terminalNoMediaSuccess.delete(k);
         panelRunCompletionKeys.delete(k);
         delivered.delete(k);
-        if (completionKeys.has(k)) {
+        if (hasCompletionRecords(k)) {
           if (!pending.has(k)) pending.set(k, { promptId: k, at: now() });
           markTerminal(k);
           clearReconcileRetry(k);
@@ -1192,17 +1274,17 @@ export function createRunCompletionTracker({
           markDelivered(k);
         }
         markDispatched(k);
-        onFlush({
+        flushWithCompletionRecords(k, {
           key: k,
           promptId: lateSuccess.promptId,
           images: [],
           videos: [],
-          ...(completionKeys.get(k) ? { completionKey: completionKeys.get(k) } : {}),
           durationMs: lateSuccess.durationMs,
           finishedAt: lateSuccess.finishedAt,
           noMedia: true,
         });
       }
+      return nextKey;
     },
 
     /**
@@ -1210,17 +1292,26 @@ export function createRunCompletionTracker({
      * agent (legacy transport confirmation, an empty batch, or the keyed
      * orchestrator receipt). Retires it from pending and drops any retained replay.
      */
-    markDelivered(id) {
+    markDelivered(id, completionKey) {
+      const k = key(id);
+      const exactKey = typeof completionKey === "string" && completionKey.trim() ? completionKey.trim() : null;
+      if (exactKey) {
+        if (!removeCompletionRecord(k, exactKey)) return;
+        if (hasCompletionRecords(k)) {
+          notifyCompletionStateChange();
+          return;
+        }
+      } else {
+        clearCompletionRecords(k);
+      }
       // The CALLER confirming delivery is the only proof the agent was told, so
       // this — not the tracker's own optimistic retire — is what releases the
       // delivery hold isSettled() reports on (#585).
-      clearAwaitingDelivery(key(id));
+      clearAwaitingDelivery(k);
       // #356 Bug 2 — and it is the only point at which the panel-queued mark can be
       // retired safely, for the same reason: before this, a re-pend is still possible.
-      panelQueued.delete(key(id));
-      liveReplays.delete(key(id));
-      completionKeys.delete(key(id));
-      completionMeta.delete(key(id));
+      panelQueued.delete(k);
+      liveReplays.delete(k);
       terminalNoKeyCompletion.delete(key(id));
       terminalNoKeyFlushed.delete(key(id));
       panelRunCompletionKeys.delete(key(id));
@@ -1236,12 +1327,14 @@ export function createRunCompletionTracker({
     acknowledgeDelivery(id, completionKey) {
       if (id == null || typeof completionKey !== "string") return false;
       const k = key(id);
-      if (completionKeys.get(k) !== completionKey) return false;
+      if (!removeCompletionRecord(k, completionKey)) return false;
+      if (hasCompletionRecords(k)) {
+        notifyCompletionStateChange();
+        return true;
+      }
       clearAwaitingDelivery(k);
       panelQueued.delete(k);
       liveReplays.delete(k);
-      completionKeys.delete(k);
-      completionMeta.delete(k);
       terminalNoKeyCompletion.delete(k);
       terminalNoKeyFlushed.delete(k);
       panelRunCompletionKeys.delete(k);
@@ -1257,9 +1350,11 @@ export function createRunCompletionTracker({
      * the live batch, then falls back to /history when the lifecycle output was
      * not observed (#370/#1619).
      */
-    markUndelivered(id) {
+    markUndelivered(id, completionKey) {
       if (id == null) return;
       const k = key(id);
+      const exactKey = typeof completionKey === "string" && completionKey.trim() ? completionKey.trim() : null;
+      if (exactKey && !completionRecords(k).some((record) => record.completionKey === exactKey)) return;
       // Clear ONLY the delivery/reconcile fence so the outcome is re-reconciled and
       // re-delivered. The `terminal` REPLAY fence is deliberately LEFT intact: the
       // run already completed, so a late/replayed execution_start for it must stay
@@ -1300,8 +1395,8 @@ export function createRunCompletionTracker({
     },
 
     /** Stable key used by the matching run_receipt control frame. */
-    completionKeyFor(id) {
-      return completionKeys.get(key(id)) ?? null;
+    completionKeyFor(id, routeId, sessionId) {
+      return completionRecordFor(key(id), routeId, sessionId)?.completionKey ?? null;
     },
 
     /** Persistable route/session/key metadata for pending panel-run ids. */


### PR DESCRIPTION
Closes #1830

## What changed

- validates persisted `panel_run` completion metadata against the exact route/session/prompt/nonce tuple encoded by `completion_key`
- restores pending completions only for the active workflow route, retains foreign-route rows, and refuses keyed completion sends on a replacement route
- owner-gates completion and terminal persistence so async callbacks from a torn-down Panel mount cannot resurrect an acknowledged completion
- extends the existing stale-bundle healer with a single cheap dirty-workflow waiter; it preserves the unsaved-work refusal and retries the bounded cache-prime/reload only after every blocker is clean
- leaves legacy/id-less completion delivery unchanged; the existing back-to-back id-less regression remains green

The durable stale-frontend scheduling fence belongs at the MCP agent-turn boundary and is being handled separately by comfyui-mcp#2341 / PR #2343. This PR is the Panel-side companion only and does not edit the MCP repository.

## Evidence

Head: `05dac03b6e7325d1a8574a80e58d693296cca748`
Base inspected: `origin/main` at `869feeb1feb311d181e2e1da0638a7e260d161cd`

- focused completion/bundle regressions: 93 passed, 0 failed
- full `npm.cmd run test:unit`: 6900 passed, 0 failed, 1 todo
- `npm.cmd run typecheck`: passed
- `npm.cmd run check:scope`: passed
- `python -m py_compile __init__.py`: passed
- `git diff --check`: passed

`package.json` has no generic build script; the repository CI/release build-equivalent gates above were run. No Playwright/ComfyUI-instance E2E was run.

Do not merge until independent review and hosted CI are green.