### PR TITLE
fix(panel): reuse a run's completion identity on repeat registration (#1837)

### DIFF
--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -370,6 +370,32 @@ test("#1837 a repeat registration REUSES the run's identity — one finished run
   assert.equal(h.tracker.hasPending(), false);
 });
 
+test("#1837 a reused identity re-registered on another route/session does not duplicate", () => {
+  const h = makeHarness();
+  const P = "ctx-switch-prompt";
+
+  // The identity tuple is [route, session, prompt, key], so reusing one key under a
+  // second route/session would land as a DISTINCT record and flush a byte-identical
+  // duplicate frame — strictly worse than the #1837 regression, since both copies
+  // carry the same completion key and the agent cannot tell them apart.
+  const first = h.tracker.onQueued(P, { routeId: "route-a", sessionId: "session-a" });
+  h.tracker.onQueued(P, { routeId: "route-b", sessionId: "session-b" });
+  assert.deepEqual(
+    h.tracker.completionMetadata().map((row) => row.completionKey),
+    [first],
+    "one key is one receipt, whichever context re-registers it",
+  );
+
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, imgs([img("ctx-switch.png")]));
+  h.tracker.onExecutionSuccess(P);
+  assert.deepEqual(
+    h.flushes.map((payload) => payload.completionKey),
+    [first],
+    "no byte-identical duplicate frame",
+  );
+});
+
 test("#1830 keeps two same-prompt nonce rows and retires them by exact key", () => {
   const h = makeHarness();
   const P = "same-prompt";

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -336,6 +336,40 @@ function makeFrameDeps(overrides = {}) {
   return { deps, frames, painted, uploadCalls };
 }
 
+test("#1837 a repeat registration REUSES the run's identity — one finished run, one agent turn", () => {
+  const h = makeHarness();
+  const P = "repeat-registration";
+
+  // Neither call supplies a completion key, so the tracker mints one. #1833 dropped
+  // the `existingKey ||` term, and because createRunCompletionKey salts with
+  // Date.now()+Math.random() the second call invented a SECOND identity for the same
+  // prompt — an identity no orchestrator ticket ever opened. flushWithCompletionRecords
+  // emits one frame per record, so a single finished run became two agent turns: the
+  // exact symptom #1830 was filed about.
+  const first = h.tracker.onQueued(P, { routeId: "route-a", sessionId: "session-a" });
+  const second = h.tracker.onQueued(P, { routeId: "route-a", sessionId: "session-a" });
+  assert.equal(second, first, "a repeat registration reports the identity the run already carries");
+  assert.deepEqual(
+    h.tracker.completionMetadata().map((row) => row.completionKey),
+    [first],
+    "minting must not add a second row the orchestrator never asked for",
+  );
+
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, imgs([img("repeat-registration.png")]));
+  h.tracker.onExecutionSuccess(P);
+  assert.deepEqual(
+    h.flushes.map((payload) => payload.completionKey),
+    [first],
+    "ONE completion frame for one completed prompt",
+  );
+
+  // The single retained row still retires normally against its own receipt.
+  assert.equal(h.tracker.acknowledgeDelivery(P, first), true);
+  assert.equal(h.tracker.completionMetadata().length, 0);
+  assert.equal(h.tracker.hasPending(), false);
+});
+
 test("#1830 keeps two same-prompt nonce rows and retires them by exact key", () => {
   const h = makeHarness();
   const P = "same-prompt";

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -1228,7 +1228,17 @@ export function createRunCompletionTracker({
       if (id != null) {
         panelQueued.add(k);
         const suppliedKey = typeof completionKey === "string" && completionKey.trim() ? completionKey.trim() : null;
-        nextKey = suppliedKey || createRunCompletionKey(routeId, sessionId, k);
+        // #1837 — retaining several SUPPLIED identities for one prompt is deliberate:
+        // each one is a receipt the orchestrator opened, and each is owed its own
+        // frame. Minting is different. createRunCompletionKey salts with
+        // Date.now()+Math.random(), so a repeat registration of a run we already hold
+        // would invent an identity NO orchestrator ticket knows — and since the flush
+        // emits one frame per record, that invented row becomes a second agent turn
+        // for a single finished run. Reuse what the run already carries instead.
+        // This is the term 4641ed01 added alongside the salt, replacing a key its own
+        // comment called "deterministic across retries"; #1833 dropped it.
+        const existingKey = completionRecordFor(k)?.completionKey ?? null;
+        nextKey = suppliedKey || existingKey || createRunCompletionKey(routeId, sessionId, k);
         if (nextKey) {
           if (addCompletionRecord(k, { completionKey: nextKey, routeId, sessionId })) {
             notifyCompletionStateChange();

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -225,6 +225,13 @@ export function createRunCompletionTracker({
   function addCompletionRecord(k, { routeId, sessionId, completionKey }) {
     const identity = completionIdentity(k, routeId, sessionId, completionKey);
     if (!identity || completionKeys.has(identity)) return false;
+    // #1837 — the identity tuple includes route/session, so the SAME completion key
+    // re-registered under a different route/session would land as a second record and
+    // flush a byte-identical duplicate frame. One key is one receipt no matter which
+    // context re-registers it; distinct SUPPLIED keys still get their own record.
+    if (completionRecords(k).some((record) => record.completionKey === String(completionKey).trim())) {
+      return false;
+    }
     const route = String(routeId).trim();
     const session = sessionId == null ? null : String(sessionId).trim();
     const exactKey = String(completionKey).trim();


### PR DESCRIPTION
Closes #1837

Regression fix for #1833 (merged `c7a47466`, shipped in **v0.15.99**), found while reviewing
that PR — the merge landed 101s after the review, so this lands it as a follow-up.

## The defect

`#1833` dropped the `existingKey ||` term from `onQueued`:

```js
-  const nextKey = suppliedKey || existingKey || createRunCompletionKey(routeId, sessionId, k);
+  nextKey = suppliedKey || createRunCompletionKey(routeId, sessionId, k);
```

`createRunCompletionKey` salts with `Date.now()+Math.random()` (`run-completion.js:62-65`), so a
repeat registration of a run the tracker already held **minted a second identity** for the same
prompt — one no orchestrator ticket ever opened. `flushWithCompletionRecords` emits one frame per
record, so a single finished run delivered **two** agent completion events. That is the symptom
#1830 was filed to prevent.

That term was not incidental: `4641ed01` added it in the same commit that introduced the salt,
replacing a key whose own comment called it *"deterministic across retries"*. `existingKey ||` is
what preserved that determinism once the key stopped being deterministic.

## What this does NOT change

Retaining several **supplied** identities for one prompt is deliberate and stays intact. Each is a
receipt the orchestrator opened, and each is owed its own frame — collapsing them would hang a
ticket. #1833's two tests that pin this (`#1830 keeps two same-prompt nonce rows and retires them
by exact key`, `#1830: restart adoption preserves multiple same-prompt completion nonces`) are
untouched and green.

I originally fenced this at the record level and **those two tests caught it** — that told me the
multi-row design was intentional and that only *minting* is the defect. Only minting is fenced here.

## Evidence

Head `85ff62b767d9d5a3210a1ab0dad68c39d3a37b49`, base `origin/main` @ `a38e6df0` (v0.15.99).

**Verified by mutation, not by a green suite.** Re-applying the one-line regression
(`existingKey ||` removed) fails exactly the new pin and nothing else:

```
✖ #1837 a repeat registration REUSES the run's identity — one finished run, one agent turn
ℹ tests 40  ℹ pass 39  ℹ fail 1
```

Reproduced end-to-end through the real modules before the fix, on three SHAs:

| | `869feeb1` (before #1833) | `a38e6df0` (v0.15.99) | this branch |
|---|---|---|---|
| repeat `onQueued`, one prompt | 1 event | **2 events** | 1 event |

Gates, all on this head:
- full `node --test browser_tests/unit/*.test.mjs` — **6908 pass / 0 fail / 1 todo** (6909 total)
- `check-panel-scope` OK (after `npm ci` — a fresh worktree does not inherit `node_modules`)
- `tsc --noEmit` OK · `check-tool-vocabulary` OK · `py_compile` OK · `git diff --check` OK

## Where to look hardest

- **The `completionRecordFor(k)` lookup is unscoped** (no route/session args), so it returns
  `records.at(-1)`. That matches `4641ed01`'s original unscoped `completionKeys.get(k)`, and it is
  the conservative choice — scoping it would let a repeat registration on a different route mint a
  fresh identity again. But if a prompt legitimately spans two routes, this reuses the most recent
  row's key rather than minting per route. I believe a ComfyUI `prompt_id` belongs to exactly one
  queue submission and so one route, which is what makes this safe — worth a second opinion.
- `onQueued`'s return value is unchanged (`nextKey`), and `registerPromptId`
  (`comfyui-mcp-panel.js:18354`) stamps the receipt with it. With reuse, that is now the key the
  tracker actually holds, which is what `acknowledgeDelivery` matches on.

## Not covered

No browser verification. Playwright needs `http://localhost:8188` (`playwright.config.ts:26`, no
`webServer` block); nothing was listening on 8188 or 8201-8210 and this run had no ComfyUI
allocated. This change is in the completion ledger, not the rendered sidebar, but I am not
claiming e2e coverage I do not have.

A second, separate concern from the same review is **not** addressed here and remains open: the new
`sendRunCompletionFrame` fence (`comfyui-mcp-panel.js:38086-38097`) refuses permanently — not
transiently — when the agent starts a new chat mid-run, or when a key was minted pre-ack with
`sessionId: null`. Details are in the review on #1833.
