### PR TITLE
fix(1839): the reload fence fails CLOSED when it cannot read the blocker state

### DIFF
--- a/browser_tests/unit/reload-blocked.test.mjs
+++ b/browser_tests/unit/reload-blocked.test.mjs
@@ -20,6 +20,7 @@ import {
   RELOAD_BLOCKED_AFTER_MS,
   unsavedReloadBlockers,
   reloadWouldBeBlockedMessage,
+  reloadBlockerUnreadableMessage,
 } from "../../web/js/lib/reload-blocked.js";
 import { commandFingerprint, createCommandDedupeLedger } from "../../web/js/lib/command-dedupe.js";
 import { createRehelloGate, routeIsStale } from "../../web/js/lib/rehello-gate.js";
@@ -484,3 +485,57 @@ test("#1830 WIRING: the frontend soft_reload awaits the decision and returns its
   assert.match(block, /else \{[\s\S]*setTimeout\(\(\) => onReload\(scope\), 60\)/)
   assert.doesNotMatch(block, /setTimeout\(\(\) => onReload\(scope\), 60\)[\s\S]*if \(scope === "frontend"\)/)
 })
+
+// #1839 — a destructive reload used to fail OPEN when the blocker read threw.
+// blockersNow() caught and returned [], and [] is the CLEAN signal that permits
+// navigation — so an unreadable dirtiness state meant "nothing is dirty" and the
+// tab navigated, discarding exactly the unsaved work the fence exists to protect.
+// The #1830 reporter was saved by this refusal firing correctly, so the throw path
+// is not theoretical.
+for (const stage of ["initial", "post-prime", "pre-navigation"]) {
+  test(`#1839: a blocker read that throws at the ${stage} fence refuses, never navigates`, async () => {
+    let reads = 0;
+    let navigations = 0;
+    let armed = 0;
+    const surfaced = [];
+    // Throw only at the fence under test, so each gate is pinned on its own.
+    const throwAt = { "initial": 1, "post-prime": 2, "pre-navigation": 3 }[stage];
+    const result = await runAgentFrontendReload({
+      getBlockers: () => {
+        reads += 1;
+        if (reads === throwAt) throw new Error("openWorkflows unavailable");
+        return [];
+      },
+      prime: async () => {},
+      clearSidebarReopen: () => {},
+      appendSystem: (m) => surfaced.push(m),
+      armNotice: () => { armed += 1; },
+      navigate: () => { navigations += 1; },
+    });
+    assert.equal(result.ok, false, "an unreadable blocker state must not read as clean");
+    assert.equal(result.stage, stage);
+    assert.equal(navigations, 0, "nothing may navigate while dirtiness is UNKNOWN");
+    assert.equal(armed, 0, "a refused command never arms the cancelled-navigation notice");
+    // It must say what happened, not invent dirty workflows it never saw (#796).
+    assert.equal(result.error, reloadBlockerUnreadableMessage());
+    assert.match(result.error, /could not read/i);
+    assert.doesNotMatch(result.error, /unsaved changes — /);
+    assert.deepEqual(surfaced, [result.error]);
+  });
+}
+
+test("#1839 control: a readable, clean blocker state still navigates", async () => {
+  // Without this, the three cases above are satisfiable by refusing everything —
+  // which would break every legitimate reload instead of fixing the fail-open.
+  let navigations = 0;
+  const result = await runAgentFrontendReload({
+    getBlockers: () => [],
+    prime: async () => {},
+    clearSidebarReopen: () => {},
+    appendSystem: () => {},
+    armNotice: () => {},
+    navigate: () => { navigations += 1; },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(navigations, 1);
+});

--- a/web/js/lib/reload-blocked.js
+++ b/web/js/lib/reload-blocked.js
@@ -137,6 +137,22 @@ export function reloadWouldBeBlockedMessage(blockers) {
 }
 
 /**
+ * The refusal for a blocker state that could not be READ.
+ *
+ * Deliberately not reloadWouldBeBlockedMessage(): that one names the dirty
+ * workflows, and naming none while claiming unsaved changes would be a claim
+ * about something nobody observed. This says what actually happened.
+ */
+export function reloadBlockerUnreadableMessage() {
+  return (
+    `Did NOT reload the panel: could not read which workflows have unsaved changes, ` +
+    `so whether reloading would discard work is UNKNOWN. A reload is not reversible, ` +
+    `so this refuses rather than guess. Nothing was changed. Try again, or reload the ` +
+    `tab yourself (Ctrl+Shift+R) once you have checked your open workflows.`
+  );
+}
+
+/**
  * Run an agent-commanded frontend reload through every dirtiness fence.
  *
  * The command reply must not call a clean, pre-prime snapshot "scheduled": the
@@ -161,15 +177,23 @@ export async function runAgentFrontendReload({
   armNotice,
   navigate,
 } = {}) {
+  // #1839 — an empty array is the CLEAN signal that permits navigation, so
+  // returning [] on a throw made an unreadable blocker state mean "nothing is
+  // dirty" and navigated: a destructive, irreversible action failing OPEN on the
+  // exact check that exists to prevent it. The #1830 reporter was saved by this
+  // refusal firing correctly, which is what makes the throw path worth closing.
+  //
+  // Unreadable is reported as its own outcome rather than folded into either
+  // answer: "could not determine" is not "determined not" (#796).
   const blockersNow = () => {
     try {
-      return typeof getBlockers === "function" ? getBlockers() : [];
+      return { readable: true, blockers: typeof getBlockers === "function" ? getBlockers() : [] };
     } catch {
-      return [];
+      return { readable: false, blockers: [] };
     }
   };
-  const refuse = (stage, blockers) => {
-    const error = reloadWouldBeBlockedMessage(blockers);
+  const refuse = (stage, blockers, readable = true) => {
+    const error = readable ? reloadWouldBeBlockedMessage(blockers) : reloadBlockerUnreadableMessage();
     try {
       clearSidebarReopen?.();
     } catch {}
@@ -180,7 +204,8 @@ export async function runAgentFrontendReload({
   };
 
   const initial = blockersNow();
-  if (initial.length) return refuse("initial", initial);
+  if (!initial.readable) return refuse("initial", [], false);
+  if (initial.blockers.length) return refuse("initial", initial.blockers);
 
   try {
     await prime?.();
@@ -188,10 +213,12 @@ export async function runAgentFrontendReload({
     // A failed or timed-out cache prime does not waive the dirtiness fences.
   }
   const postPrime = blockersNow();
-  if (postPrime.length) return refuse("post-prime", postPrime);
+  if (!postPrime.readable) return refuse("post-prime", [], false);
+  if (postPrime.blockers.length) return refuse("post-prime", postPrime.blockers);
 
   const beforeNavigation = blockersNow();
-  if (beforeNavigation.length) return refuse("pre-navigation", beforeNavigation);
+  if (!beforeNavigation.readable) return refuse("pre-navigation", [], false);
+  if (beforeNavigation.blockers.length) return refuse("pre-navigation", beforeNavigation.blockers);
 
   armNotice?.();
   navigate?.();


### PR DESCRIPTION
Refs #1839 — **P1(a) only.** The issue stays open for P1(b) (deferred completion rows never rehydrated on a route switch), which is not in this change.

## The bug

`blockersNow()` caught a throwing `getBlockers()` and returned `[]`:

```js
try { return typeof getBlockers === "function" ? getBlockers() : []; }
catch { return []; }        // <- [] is the CLEAN signal that permits navigation
```

An empty array is how the fence says *nothing is dirty*. So an **unreadable** dirtiness state read as clean and `runAgentFrontendReload` navigated — a destructive, irreversible action failing **open** on the exact check that exists to prevent it, discarding the unsaved work it was protecting.

Not theoretical. The #1830 reporter was saved by this refusal firing correctly — *"a frontend reload was attempted once and safely refused because two workflows had unsaved changes."* That is the path this made conditional on a read never throwing.

## The fix

`blockersNow()` reports readability as its own outcome instead of folding it into either answer, and all three fences — initial, post-prime, pre-navigation — consult it.

Unreadable gets its **own message**. Reusing `reloadWouldBeBlockedMessage()` would name zero workflows while claiming unsaved changes, asserting something nobody observed — the "could not determine" vs "determined not" collapse (#796). It now says the state could not be read, that a reload is not reversible, and that it refused rather than guess.

## Verification

- **Mutation:** flipping the catch back to `readable: true` fails exactly the three fence tests; the control and all 16 pre-existing tests stay green (17 pass / 3 fail).
- Three tests, one per fence, each throwing **only** at the fence under test — so the gates are pinned individually rather than collectively. A single test would have passed on whichever fence happened to fire first.
- **A control that a readable, clean state still navigates.** Without it, all three cases are satisfiable by refusing everything, which would break every legitimate reload instead of fixing the fail-open — a strictly worse outcome than the bug.
- `node --test browser_tests/unit/reload-blocked.test.mjs` → 20 pass, 0 fail.
- `check-panel-scope` OK. (It first refused to run — no `node_modules` in a fresh worktree — and said so instead of printing OK, which is why that gate is worth having.)

## Provenance

Found by an adversarial gate run against #1833's diff **after** that PR merged, and shipped in v0.15.99. Filed by someone who explicitly did not claim it. Their structural verification was control-flow only; the mutation above is the executed half.
