### PR TITLE
fix(1839): re-partition the run-completion ledger when the LIVE route moves

### DIFF
--- a/browser_tests/unit/run-completion-persistence.test.mjs
+++ b/browser_tests/unit/run-completion-persistence.test.mjs
@@ -88,7 +88,14 @@ test("#1830 production wiring owner-gates stale mount persistence and restores b
   ).replace(/\r\n/g, "\n");
   assert.match(source, /partitionRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*completionRestoreRoute,\s*completionRestoreSession/);
   assert.match(source, /if \(panelRunOwnerRef\.current !== mountOwner\) return;/);
-  assert.match(source, /mergeRunCompletionMetadata\(entries, deferredRunCompletionMetadata\)/);
+  // #1839 P1(b) — the foreign set merged back on every write is RE-READ from the
+  // ledger and filtered by the contexts this mount has adopted. It used to be the
+  // mount-time `completionRestore.deferred` snapshot, which the route-change
+  // rehydrate leaves stale (see run-completion-route-rehydrate.test.mjs).
+  assert.match(
+    source,
+    /mergeRunCompletionMetadata\(\s*entries,[\s\S]{0,400}?selectDeferredRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*adoptedRunCompletionContexts,\s*\),\s*\),\s*\);/,
+  );
   assert.match(source, /restoreRunCompletionMetadata\(runCompletion, completionRestore\.current\)/);
   assert.match(source, /if \(!runCompletionKeyMatchesContext\(frame\.completion_key, liveRoute, liveSession\)\) return false;/);
   assert.match(source, /sendFrame: sendRunCompletionFrame/);

--- a/browser_tests/unit/run-completion-persistence.test.mjs
+++ b/browser_tests/unit/run-completion-persistence.test.mjs
@@ -86,7 +86,12 @@ test("#1830 production wiring owner-gates stale mount persistence and restores b
     join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
     "utf8",
   ).replace(/\r\n/g, "\n");
-  assert.match(source, /partitionRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*completionRestoreRoute,\s*completionRestoreSession/);
+  // #1839 P1(b) — still partitioned by the mount's route/session, but read
+  // through readRunCompletionMetadataOrUnknown so an UNREADABLE store is not
+  // mistaken for an empty one (adoption is irreversible; see the route-rehydrate
+  // suite).
+  assert.match(source, /const completionRestoreStored = readRunCompletionMetadataOrUnknown\(\);/);
+  assert.match(source, /partitionRunCompletionMetadata\(\s*completionRestoreStored \?\? \[\],\s*completionRestoreRoute,\s*completionRestoreSession/);
   assert.match(source, /if \(panelRunOwnerRef\.current !== mountOwner\) return;/);
   // #1839 P1(b) — the foreign set merged back on every write is RE-READ from the
   // ledger and filtered by the contexts this mount has adopted. It used to be the
@@ -94,7 +99,7 @@ test("#1830 production wiring owner-gates stale mount persistence and restores b
   // rehydrate leaves stale (see run-completion-route-rehydrate.test.mjs).
   assert.match(
     source,
-    /mergeRunCompletionMetadata\(\s*entries,[\s\S]{0,400}?selectDeferredRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*adoptedRunCompletionContexts,\s*\),\s*\),\s*\);/,
+    /mergeRunCompletionMetadata\(\s*entries,\s*selectDeferredRunCompletionMetadata\(stored, adoptedRunCompletionContexts\),\s*\),\s*\);/,
   );
   assert.match(source, /restoreRunCompletionMetadata\(runCompletion, completionRestore\.current\)/);
   assert.match(source, /if \(!runCompletionKeyMatchesContext\(frame\.completion_key, liveRoute, liveSession\)\) return false;/);

--- a/browser_tests/unit/run-completion-route-rehydrate.test.mjs
+++ b/browser_tests/unit/run-completion-route-rehydrate.test.mjs
@@ -42,14 +42,14 @@ function slice(from, to, { inclusive = false } = {}) {
   return text;
 }
 
-// readRunCompletionMetadata / persistRunCompletionMetadata / restoreRunCompletionMetadata
+// the ledger read/write/restore helpers, including the read that can say "unknown"
 const SRC_STORAGE = slice(
   "function readRunCompletionMetadata() {",
   "function readRunCompletionTerminals() {",
 );
-// the adopted-context set, the mount-time adoption, and the persist merge
-const SRC_ADOPT = slice(
-  "  const adoptedRunCompletionContexts = new Set();",
+// the mount-time partition, the adopted-context set, and the persist merge
+const SRC_MOUNT = slice(
+  "  const completionRestoreStored = readRunCompletionMetadataOrUnknown();",
   "  const persistOwnedRunCompletionTerminals = ",
 );
 // the route-change rehydrate + its module-ref publication
@@ -76,39 +76,70 @@ const mkRow = (routeId, promptId, nonce) => ({
 const wireProduction = new Function(
   "deps",
   [
-    "const { ssGet, ssSet, RUN_COMPLETION_META_KEY, normalizeRunCompletionMetadata,",
+    "const { ssGet, ssSet, window, RUN_COMPLETION_META_KEY, normalizeRunCompletionMetadata,",
     "  mergeRunCompletionMetadata, selectDeferredRunCompletionMetadata, runCompletionContextKey,",
     "  partitionRunCompletionMetadata, panelRunOwnerRef, mountOwner, bridgeRouteId, SESSION_KEY,",
     "  runCompletion, armRunReconcileSweep, completionRestoreRoute, completionRestoreSession } = deps;",
     "let rehydrateRunCompletionForLiveRouteRef = null;",
     SRC_STORAGE,
-    SRC_ADOPT,
+    SRC_MOUNT,
     SRC_REHYDRATE,
     "return {",
-    "  readRunCompletionMetadata, restoreRunCompletionMetadata,",
-    "  adoptedRunCompletionContexts, adoptRunCompletionContext,",
-    "  persistOwnedRunCompletionMetadata, rehydrateRunCompletionForLiveRoute,",
+    "  readRunCompletionMetadata, readRunCompletionMetadataOrUnknown, restoreRunCompletionMetadata,",
+    "  completionRestore, adoptedRunCompletionContexts, adoptRunCompletionContext,",
+    "  runCompletionContextNeedsAdoption, persistOwnedRunCompletionMetadata,",
+    "  rehydrateRunCompletionForLiveRoute,",
     "  rehydrateRef: () => rehydrateRunCompletionForLiveRouteRef,",
     "};",
   ].join("\n"),
 );
 
+/** A sessionStorage that can be made to THROW, the way a blocked origin does. */
+function makeStorage(rows) {
+  const map = new Map([[SESSION_KEY, SESSION]]);
+  if (rows) map.set(RUN_COMPLETION_META_KEY, JSON.stringify(rows));
+  const state = { failRead: false };
+  const sessionStorage = {
+    getItem(k) {
+      if (state.failRead) throw new DOMException("blocked", "SecurityError");
+      return map.has(k) ? map.get(k) : null;
+    },
+    setItem(k, v) {
+      map.set(k, v);
+    },
+    removeItem(k) {
+      map.delete(k);
+    },
+  };
+  return { map, state, window: { sessionStorage } };
+}
+
 /**
- * A mount of the REAL wiring: the shipped storage helpers, the shipped adopt/persist
- * block, the shipped rehydrate, the real tracker and the real safety sweep.
+ * A mount of the REAL wiring: the shipped storage helpers, the shipped mount
+ * partition / adopt / persist block, the shipped rehydrate, the real tracker and
+ * the real safety sweep.
  *
- * `withRehydrate:false` re-creates the pre-fix behaviour WITHOUT deleting the shipped
- * code: the route-change hook simply never fires, exactly as it never fired before
- * this change existed. Everything else is the same production text.
+ * `withRehydrate:false` reproduces the pre-fix behaviour WITHOUT deleting the
+ * shipped code: the route-change hook simply never fires, exactly as it never
+ * fired before this change existed. Everything else is the same production text.
  */
 function mount(storage, { liveRoute, withRehydrate = true } = {}) {
   let route = liveRoute;
   const flushed = [];
   const reconciled = [];
-  const ssGet = (k) => (storage.has(k) ? storage.get(k) : null);
-  const ssSet = (k, v) => {
-    if (v == null) storage.delete(k);
-    else storage.set(k, v);
+  // verbatim from comfyui-mcp-panel.js — a throwing store reads as null.
+  const ssGet = (key) => {
+    try {
+      return storage.window.sessionStorage.getItem(key) || null;
+    } catch {
+      return null;
+    }
+  };
+  const ssSet = (key, val) => {
+    try {
+      if (val == null) storage.window.sessionStorage.removeItem(key);
+      else storage.window.sessionStorage.setItem(key, val);
+    } catch {}
   };
   const mountOwner = {};
   const panelRunOwnerRef = { current: mountOwner };
@@ -134,12 +165,10 @@ function mount(storage, { liveRoute, withRehydrate = true } = {}) {
   });
   const armRunReconcileSweep = () => sweep.arm();
 
-  const completionRestoreRoute = route;
-  const completionRestoreSession = ssGet(SESSION_KEY);
-
   wired = wireProduction({
     ssGet,
     ssSet,
+    window: storage.window,
     RUN_COMPLETION_META_KEY,
     normalizeRunCompletionMetadata,
     mergeRunCompletionMetadata,
@@ -152,17 +181,14 @@ function mount(storage, { liveRoute, withRehydrate = true } = {}) {
     SESSION_KEY,
     runCompletion,
     armRunReconcileSweep,
-    completionRestoreRoute,
-    completionRestoreSession,
+    completionRestoreRoute: route,
+    completionRestoreSession: ssGet(SESSION_KEY),
   });
 
   // The mount-time restore, exactly as buildPanel() performs it.
-  const restore = partitionRunCompletionMetadata(
-    wired.readRunCompletionMetadata(),
-    completionRestoreRoute,
-    completionRestoreSession,
-  );
-  if (wired.restoreRunCompletionMetadata(runCompletion, restore.current) > 0) armRunReconcileSweep();
+  if (wired.restoreRunCompletionMetadata(runCompletion, wired.completionRestore.current) > 0) {
+    armRunReconcileSweep();
+  }
 
   return {
     wired,
@@ -170,37 +196,30 @@ function mount(storage, { liveRoute, withRehydrate = true } = {}) {
     flushed,
     reconciled,
     sweepArmed: () => sweep._hasTimer(),
-    ledger: () => normalizeRunCompletionMetadata(JSON.parse(ssGet(RUN_COMPLETION_META_KEY) ?? "[]")),
-    /** The user switches the canvas. The 600 ms poll then drives the hook. */
-    switchWorkflowTo(next) {
-      route = next;
+    ledger: () =>
+      normalizeRunCompletionMetadata(JSON.parse(storage.map.get(RUN_COMPLETION_META_KEY) ?? "[]")),
+    /** One 600 ms poll tick with the canvas on `next` (or wherever it already is). */
+    poll(next) {
+      if (next !== undefined) route = next;
       if (withRehydrate) wired.rehydrateRef()?.();
     },
   };
 }
 
-const seed = (...rows) => {
-  const storage = new Map();
-  storage.set(SESSION_KEY, SESSION);
-  storage.set(RUN_COMPLETION_META_KEY, JSON.stringify(rows));
-  return storage;
-};
-
 const rowB = mkRow(ROUTE_B, "prompt-b", "queue-b");
 const rowC = mkRow(ROUTE_C, "prompt-c", "queue-c");
 
 test("#1839 P1(b) the pre-fix path: a deferred row is undeliverable for the life of the mount", () => {
-  const m = mount(seed(rowB, rowC), { liveRoute: ROUTE_A, withRehydrate: false });
+  const m = mount(makeStorage([rowB, rowC]), { liveRoute: ROUTE_A, withRehydrate: false });
   assert.equal(m.runCompletion.isKnown("prompt-b"), false, "mounted on A: B's row is deferred");
 
-  m.switchWorkflowTo(ROUTE_B);
+  m.poll(ROUTE_B);
 
   assert.equal(m.runCompletion.isKnown("prompt-b"), false, "switching to B never adopts B's row");
   assert.equal(m.runCompletion.completionKeyFor("prompt-b"), null);
   // ...and this is why the reconcile sweep cannot be the recovery hook: it arms on
   // hasPending(), which a deferred row cannot make true.
   assert.equal(m.runCompletion.hasPending(), false);
-  m.wired.rehydrateRef; // (the hook exists; it simply is not fired on this path)
   assert.equal(m.sweepArmed(), false, "the sweep stays disarmed for exactly the row that needs it");
   assert.deepEqual(m.reconciled, [], "no /history reconcile ever runs for B");
   assert.deepEqual(m.flushed, [], "no completion frame is ever composed for B");
@@ -212,10 +231,10 @@ test("#1839 P1(b) the pre-fix path: a deferred row is undeliverable for the life
 });
 
 test("#1839 P1(b) a route change inside one mount adopts the rows that became current", () => {
-  const m = mount(seed(rowB, rowC), { liveRoute: ROUTE_A });
+  const m = mount(makeStorage([rowB, rowC]), { liveRoute: ROUTE_A });
   assert.equal(m.runCompletion.isKnown("prompt-b"), false, "not adopted while A is the canvas");
 
-  m.switchWorkflowTo(ROUTE_B);
+  m.poll(ROUTE_B);
 
   assert.equal(m.runCompletion.isKnown("prompt-b"), true, "B's row is adopted on the switch");
   assert.equal(
@@ -228,8 +247,8 @@ test("#1839 P1(b) a route change inside one mount adopts the rows that became cu
 });
 
 test("#1839 P1(b) CONTROL — a foreign row is still never restored", () => {
-  const m = mount(seed(rowB, rowC), { liveRoute: ROUTE_A });
-  m.switchWorkflowTo(ROUTE_B);
+  const m = mount(makeStorage([rowB, rowC]), { liveRoute: ROUTE_A });
+  m.poll(ROUTE_B);
 
   // C is not on the canvas. Replaying it here would stamp a completion frame for a
   // workflow the user is not looking at — the exact harm the partition exists to
@@ -251,10 +270,13 @@ test("#1839 P1(b) CONTROL — a foreign row is still never restored", () => {
 test("#1839 P1(b) CONTROL — a session change on the same route is still foreign", () => {
   // The route can stay put while the agent conversation changes, and a completion
   // owed to a retired conversation must not be replayed into the new one.
-  const otherSession = { ...rowB, sessionId: "agent-session-9" };
-  otherSession.completionKey = JSON.stringify([ROUTE_B, "agent-session-9", "prompt-b", "queue-b"]);
-  const m = mount(seed(otherSession), { liveRoute: ROUTE_A });
-  m.switchWorkflowTo(ROUTE_B);
+  const otherSession = {
+    ...rowB,
+    sessionId: "agent-session-9",
+    completionKey: JSON.stringify([ROUTE_B, "agent-session-9", "prompt-b", "queue-b"]),
+  };
+  const m = mount(makeStorage([otherSession]), { liveRoute: ROUTE_A });
+  m.poll(ROUTE_B);
   assert.equal(m.runCompletion.isKnown("prompt-b"), false, "same route, other session ⇒ deferred");
 });
 
@@ -262,22 +284,23 @@ test("#1839 P1(b) CONTROL — an unestablished route adopts nothing", () => {
   // bridgeRouteId() REFUSES (returns null) until this tab's route identity leases.
   // Adopting under it would claim every row in storage for a route that does not
   // exist yet.
-  const m = mount(seed(rowB, rowC), { liveRoute: null });
+  const m = mount(makeStorage([rowB, rowC]), { liveRoute: null });
   assert.equal(m.wired.adoptRunCompletionContext(null, SESSION), false);
+  assert.equal(m.wired.runCompletionContextNeedsAdoption(null, SESSION), false);
   assert.equal(m.wired.adoptedRunCompletionContexts.size, 0);
   assert.equal(m.runCompletion.isKnown("prompt-b"), false);
   assert.equal(m.runCompletion.isKnown("prompt-c"), false);
 
   // ...and the null → id edge IS a route change, so the lease landing recovers the
   // rows the mount-time partition had to defer.
-  m.switchWorkflowTo(ROUTE_B);
+  m.poll(ROUTE_B);
   assert.equal(m.runCompletion.isKnown("prompt-b"), true);
   assert.equal(m.runCompletion.isKnown("prompt-c"), false);
 });
 
 test("#1839 P1(b) an adopted row is retired for good — the deferred set is no longer frozen", () => {
-  const m = mount(seed(rowB, rowC), { liveRoute: ROUTE_A });
-  m.switchWorkflowTo(ROUTE_B);
+  const m = mount(makeStorage([rowB, rowC]), { liveRoute: ROUTE_A });
+  m.poll(ROUTE_B);
   assert.equal(m.runCompletion.isKnown("prompt-b"), true);
 
   // The recovered completion reaches the agent and is acknowledged.
@@ -286,10 +309,53 @@ test("#1839 P1(b) an adopted row is retired for good — the deferred set is no 
   // A mount-time `partition().deferred` snapshot still calls B's row foreign and
   // re-merges it into this very write, resurrecting a completion the agent already
   // received. Re-reading the ledger at persist time is what retires it.
+  assert.deepEqual(m.ledger().map((r) => r.promptId), ["prompt-c"], "B's row is gone once delivered");
+});
+
+test("#1839 P1(b) an UNREADABLE ledger is never adopted — a silence is not an empty ledger", () => {
+  // codex P1: ssGet swallows a throwing sessionStorage, so readRunCompletionMetadata()
+  // answers `[]` for both "nothing here" and "could not look". Adoption is
+  // irreversible for the life of the mount, so adopting on that answer would strand
+  // the rows for good AND make the next persist delete them as no-longer-foreign.
+  const storage = makeStorage([rowB]);
+  storage.state.failRead = true;
+
+  const m = mount(storage, { liveRoute: ROUTE_B });
+  assert.equal(m.wired.readRunCompletionMetadataOrUnknown(), null, "the read reports UNKNOWN");
+  assert.equal(m.wired.readRunCompletionMetadata().length, 0, "...where the plain read says empty");
+  assert.equal(m.wired.adoptedRunCompletionContexts.size, 0, "the mount context is NOT adopted");
+  assert.equal(m.runCompletion.isKnown("prompt-b"), false);
+
+  // A tick while it is still unreadable must not adopt either.
+  m.poll();
+  assert.equal(m.wired.adoptedRunCompletionContexts.size, 0);
+
+  // The store recovers, and the very next poll adopts and restores.
+  storage.state.failRead = false;
+  m.poll();
+  assert.equal(m.runCompletion.isKnown("prompt-b"), true, "recovered on the next tick");
+  assert.equal(m.runCompletion.completionKeyFor("prompt-b"), rowB.completionKey);
+  assert.equal(m.sweepArmed(), true);
+});
+
+test("#1839 P1(b) an UNREADABLE ledger at persist time never deletes another route's rows", () => {
+  const m = mount(makeStorage([rowB, rowC]), { liveRoute: ROUTE_B });
+  assert.equal(m.runCompletion.isKnown("prompt-b"), true);
+
+  // Re-reading at persist time is what retires an adopted row; if the read fails,
+  // the same write would drop every FOREIGN row instead — a completion nobody ever
+  // delivers. Refusing the write is the same trade the delivery path makes.
+  m.wired.persistOwnedRunCompletionMetadata([]);
+  assert.deepEqual(m.ledger().map((r) => r.promptId), ["prompt-c"], "readable: B retires, C stays");
+
+  const storage2 = makeStorage([rowB, rowC]);
+  const m2 = mount(storage2, { liveRoute: ROUTE_B });
+  storage2.state.failRead = true;
+  m2.wired.persistOwnedRunCompletionMetadata([]);
   assert.deepEqual(
-    m.ledger().map((r) => r.promptId),
-    ["prompt-c"],
-    "B's row is gone once delivered",
+    m2.ledger().map((r) => r.promptId).sort(),
+    ["prompt-b", "prompt-c"],
+    "unreadable: the write is refused and NOTHING is deleted",
   );
 });
 
@@ -304,7 +370,10 @@ test("#1839 P1(b) selectDeferredRunCompletionMetadata keeps exactly the unadopte
   );
   // A context key separates route AND session, and a null session is its own value.
   assert.notEqual(runCompletionContextKey(ROUTE_B, SESSION), runCompletionContextKey(ROUTE_B, null));
-  assert.equal(runCompletionContextKey(" " + ROUTE_B + " ", " " + SESSION + " "), runCompletionContextKey(ROUTE_B, SESSION));
+  assert.equal(
+    runCompletionContextKey(` ${ROUTE_B} `, ` ${SESSION} `),
+    runCompletionContextKey(ROUTE_B, SESSION),
+  );
 });
 
 test("#1839 P1(b) production WIRING — the poll drives the rehydrate and the persist re-reads", () => {
@@ -326,15 +395,16 @@ test("#1839 P1(b) production WIRING — the poll drives the rehydrate and the pe
     PANEL_SRC,
     /if \(rehydrateRunCompletionForLiveRouteRef === rehydrateRunCompletionForLiveRoute\) \{\n\s*rehydrateRunCompletionForLiveRouteRef = null;/,
   );
-  // The persist path re-reads the ledger instead of closing over a mount-time set.
+  // The persist path re-reads the ledger instead of closing over a mount-time set,
+  // and refuses the write when that read could not answer.
   assert.match(
     PANEL_SRC,
-    /mergeRunCompletionMetadata\(\s*entries,[\s\S]{0,400}?selectDeferredRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*adoptedRunCompletionContexts,\s*\),\s*\),\s*\);/,
+    /mergeRunCompletionMetadata\(\s*entries,\s*selectDeferredRunCompletionMetadata\(stored, adoptedRunCompletionContexts\),\s*\),\s*\);/,
   );
   assert.doesNotMatch(PANEL_SRC, /deferredRunCompletionMetadata/);
   // The restore is still RE-COMPUTED against the live route, never widened.
   assert.match(
     PANEL_SRC,
-    /partitionRunCompletionMetadata\(readRunCompletionMetadata\(\), liveRoute, liveSession\)\.current/,
+    /partitionRunCompletionMetadata\(stored, liveRoute, liveSession\)\.current/,
   );
 });

--- a/browser_tests/unit/run-completion-route-rehydrate.test.mjs
+++ b/browser_tests/unit/run-completion-route-rehydrate.test.mjs
@@ -1,0 +1,340 @@
+// #1839 P1(b) — the durable run-completion ledger is partitioned against the LIVE
+// bridge route, and that route moves under a MOUNTED panel with no remount. Before
+// this fix the partition ran exactly once, at mount, so a completion still owed on
+// workflow B was deferred when the panel reloaded while workflow A was the canvas,
+// and switching back to B inside the same mount never adopted it. The row survived
+// in storage and only a LATER mount picked it up — "successful run, no completion
+// event" (#1739 / #585 / #370) with a workflow switch in front of it.
+//
+// These tests do NOT re-implement the wiring. They SLICE the production text out of
+// web/js/comfyui-mcp-panel.js and execute it, so a mutation to the shipped function
+// bodies — not just to the lib helpers they call — turns them red.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  mergeRunCompletionMetadata,
+  normalizeRunCompletionMetadata,
+  partitionRunCompletionMetadata,
+  runCompletionContextKey,
+  selectDeferredRunCompletionMetadata,
+} from "../../web/js/lib/run-completion-persistence.js";
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+import { createRunReconcileSweep } from "../../web/js/lib/run-reconcile-sweep.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+
+/** Cut the production text between two anchors, refusing rather than guessing. */
+function slice(from, to, { inclusive = false } = {}) {
+  const start = PANEL_SRC.indexOf(from);
+  assert.notEqual(start, -1, `production anchor missing: ${from}`);
+  const end = PANEL_SRC.indexOf(to, start + from.length);
+  assert.notEqual(end, -1, `production anchor missing: ${to}`);
+  const text = PANEL_SRC.slice(start, inclusive ? end + to.length : end);
+  assert.ok(text.length > 0, "empty production slice");
+  return text;
+}
+
+// readRunCompletionMetadata / persistRunCompletionMetadata / restoreRunCompletionMetadata
+const SRC_STORAGE = slice(
+  "function readRunCompletionMetadata() {",
+  "function readRunCompletionTerminals() {",
+);
+// the adopted-context set, the mount-time adoption, and the persist merge
+const SRC_ADOPT = slice(
+  "  const adoptedRunCompletionContexts = new Set();",
+  "  const persistOwnedRunCompletionTerminals = ",
+);
+// the route-change rehydrate + its module-ref publication
+const SRC_REHYDRATE = slice(
+  "  const rehydrateRunCompletionForLiveRoute = () => {",
+  "  rehydrateRunCompletionForLiveRouteRef = rehydrateRunCompletionForLiveRoute;",
+  { inclusive: true },
+);
+
+const RUN_COMPLETION_META_KEY = "comfyui-mcp.panel.runCompletionMeta.v1";
+const SESSION_KEY = "comfyui-mcp.panel.sessionId";
+const SESSION = "agent-session-7";
+const ROUTE_A = "tab-1::wf:workflows/a.json";
+const ROUTE_B = "tab-1::wf:workflows/b.json";
+const ROUTE_C = "tab-1::wf:workflows/c.json";
+
+const mkRow = (routeId, promptId, nonce) => ({
+  routeId,
+  sessionId: SESSION,
+  promptId,
+  completionKey: JSON.stringify([routeId, SESSION, promptId, nonce]),
+});
+
+const wireProduction = new Function(
+  "deps",
+  [
+    "const { ssGet, ssSet, RUN_COMPLETION_META_KEY, normalizeRunCompletionMetadata,",
+    "  mergeRunCompletionMetadata, selectDeferredRunCompletionMetadata, runCompletionContextKey,",
+    "  partitionRunCompletionMetadata, panelRunOwnerRef, mountOwner, bridgeRouteId, SESSION_KEY,",
+    "  runCompletion, armRunReconcileSweep, completionRestoreRoute, completionRestoreSession } = deps;",
+    "let rehydrateRunCompletionForLiveRouteRef = null;",
+    SRC_STORAGE,
+    SRC_ADOPT,
+    SRC_REHYDRATE,
+    "return {",
+    "  readRunCompletionMetadata, restoreRunCompletionMetadata,",
+    "  adoptedRunCompletionContexts, adoptRunCompletionContext,",
+    "  persistOwnedRunCompletionMetadata, rehydrateRunCompletionForLiveRoute,",
+    "  rehydrateRef: () => rehydrateRunCompletionForLiveRouteRef,",
+    "};",
+  ].join("\n"),
+);
+
+/**
+ * A mount of the REAL wiring: the shipped storage helpers, the shipped adopt/persist
+ * block, the shipped rehydrate, the real tracker and the real safety sweep.
+ *
+ * `withRehydrate:false` re-creates the pre-fix behaviour WITHOUT deleting the shipped
+ * code: the route-change hook simply never fires, exactly as it never fired before
+ * this change existed. Everything else is the same production text.
+ */
+function mount(storage, { liveRoute, withRehydrate = true } = {}) {
+  let route = liveRoute;
+  const flushed = [];
+  const reconciled = [];
+  const ssGet = (k) => (storage.has(k) ? storage.get(k) : null);
+  const ssSet = (k, v) => {
+    if (v == null) storage.delete(k);
+    else storage.set(k, v);
+  };
+  const mountOwner = {};
+  const panelRunOwnerRef = { current: mountOwner };
+
+  let wired = null;
+  const runCompletion = createRunCompletionTracker({
+    onFlush: (payload) => flushed.push(payload),
+    onCompletionStateChange: (entries) => wired?.persistOwnedRunCompletionMetadata(entries),
+    // The tracker's own fence-prune timer would otherwise hold the test runner's
+    // event loop open after the assertions finish.
+    setTimer: (fn, ms) => {
+      const t = setTimeout(fn, ms);
+      t.unref?.();
+      return t;
+    },
+  });
+  const sweep = createRunReconcileSweep({
+    hasPending: () => runCompletion.hasPending(),
+    reconcile: () => reconciled.push(runCompletion.unsettledPromptIds()),
+    setTimer: (fn) => ({ fn }),
+    clearTimer: () => {},
+    intervalMs: 1,
+  });
+  const armRunReconcileSweep = () => sweep.arm();
+
+  const completionRestoreRoute = route;
+  const completionRestoreSession = ssGet(SESSION_KEY);
+
+  wired = wireProduction({
+    ssGet,
+    ssSet,
+    RUN_COMPLETION_META_KEY,
+    normalizeRunCompletionMetadata,
+    mergeRunCompletionMetadata,
+    selectDeferredRunCompletionMetadata,
+    runCompletionContextKey,
+    partitionRunCompletionMetadata,
+    panelRunOwnerRef,
+    mountOwner,
+    bridgeRouteId: () => route,
+    SESSION_KEY,
+    runCompletion,
+    armRunReconcileSweep,
+    completionRestoreRoute,
+    completionRestoreSession,
+  });
+
+  // The mount-time restore, exactly as buildPanel() performs it.
+  const restore = partitionRunCompletionMetadata(
+    wired.readRunCompletionMetadata(),
+    completionRestoreRoute,
+    completionRestoreSession,
+  );
+  if (wired.restoreRunCompletionMetadata(runCompletion, restore.current) > 0) armRunReconcileSweep();
+
+  return {
+    wired,
+    runCompletion,
+    flushed,
+    reconciled,
+    sweepArmed: () => sweep._hasTimer(),
+    ledger: () => normalizeRunCompletionMetadata(JSON.parse(ssGet(RUN_COMPLETION_META_KEY) ?? "[]")),
+    /** The user switches the canvas. The 600 ms poll then drives the hook. */
+    switchWorkflowTo(next) {
+      route = next;
+      if (withRehydrate) wired.rehydrateRef()?.();
+    },
+  };
+}
+
+const seed = (...rows) => {
+  const storage = new Map();
+  storage.set(SESSION_KEY, SESSION);
+  storage.set(RUN_COMPLETION_META_KEY, JSON.stringify(rows));
+  return storage;
+};
+
+const rowB = mkRow(ROUTE_B, "prompt-b", "queue-b");
+const rowC = mkRow(ROUTE_C, "prompt-c", "queue-c");
+
+test("#1839 P1(b) the pre-fix path: a deferred row is undeliverable for the life of the mount", () => {
+  const m = mount(seed(rowB, rowC), { liveRoute: ROUTE_A, withRehydrate: false });
+  assert.equal(m.runCompletion.isKnown("prompt-b"), false, "mounted on A: B's row is deferred");
+
+  m.switchWorkflowTo(ROUTE_B);
+
+  assert.equal(m.runCompletion.isKnown("prompt-b"), false, "switching to B never adopts B's row");
+  assert.equal(m.runCompletion.completionKeyFor("prompt-b"), null);
+  // ...and this is why the reconcile sweep cannot be the recovery hook: it arms on
+  // hasPending(), which a deferred row cannot make true.
+  assert.equal(m.runCompletion.hasPending(), false);
+  m.wired.rehydrateRef; // (the hook exists; it simply is not fired on this path)
+  assert.equal(m.sweepArmed(), false, "the sweep stays disarmed for exactly the row that needs it");
+  assert.deepEqual(m.reconciled, [], "no /history reconcile ever runs for B");
+  assert.deepEqual(m.flushed, [], "no completion frame is ever composed for B");
+  assert.deepEqual(
+    m.ledger().map((r) => r.promptId).sort(),
+    ["prompt-b", "prompt-c"],
+    "the row is durable, not lost — only a LATER mount would ever pick it up",
+  );
+});
+
+test("#1839 P1(b) a route change inside one mount adopts the rows that became current", () => {
+  const m = mount(seed(rowB, rowC), { liveRoute: ROUTE_A });
+  assert.equal(m.runCompletion.isKnown("prompt-b"), false, "not adopted while A is the canvas");
+
+  m.switchWorkflowTo(ROUTE_B);
+
+  assert.equal(m.runCompletion.isKnown("prompt-b"), true, "B's row is adopted on the switch");
+  assert.equal(
+    m.runCompletion.completionKeyFor("prompt-b"),
+    rowB.completionKey,
+    "adopted with its EXACT persisted key, so the replay is the same panel_run receipt",
+  );
+  assert.equal(m.runCompletion.hasPending(), true);
+  assert.equal(m.sweepArmed(), true, "the /history safety sweep is armed for the recovered run");
+});
+
+test("#1839 P1(b) CONTROL — a foreign row is still never restored", () => {
+  const m = mount(seed(rowB, rowC), { liveRoute: ROUTE_A });
+  m.switchWorkflowTo(ROUTE_B);
+
+  // C is not on the canvas. Replaying it here would stamp a completion frame for a
+  // workflow the user is not looking at — the exact harm the partition exists to
+  // prevent, and the reason this fix RE-COMPUTES rather than widening.
+  assert.equal(m.runCompletion.isKnown("prompt-c"), false, "C's row must stay deferred");
+  assert.equal(m.runCompletion.completionKeyFor("prompt-c"), null);
+  assert.deepEqual(
+    m.runCompletion.unsettledPromptIds().sort(),
+    ["prompt-b"],
+    "only the live route's run is pending delivery",
+  );
+  assert.deepEqual(
+    m.ledger().map((r) => r.promptId).sort(),
+    ["prompt-b", "prompt-c"],
+    "and C's row survives untouched in storage for a mount of its own route",
+  );
+});
+
+test("#1839 P1(b) CONTROL — a session change on the same route is still foreign", () => {
+  // The route can stay put while the agent conversation changes, and a completion
+  // owed to a retired conversation must not be replayed into the new one.
+  const otherSession = { ...rowB, sessionId: "agent-session-9" };
+  otherSession.completionKey = JSON.stringify([ROUTE_B, "agent-session-9", "prompt-b", "queue-b"]);
+  const m = mount(seed(otherSession), { liveRoute: ROUTE_A });
+  m.switchWorkflowTo(ROUTE_B);
+  assert.equal(m.runCompletion.isKnown("prompt-b"), false, "same route, other session ⇒ deferred");
+});
+
+test("#1839 P1(b) CONTROL — an unestablished route adopts nothing", () => {
+  // bridgeRouteId() REFUSES (returns null) until this tab's route identity leases.
+  // Adopting under it would claim every row in storage for a route that does not
+  // exist yet.
+  const m = mount(seed(rowB, rowC), { liveRoute: null });
+  assert.equal(m.wired.adoptRunCompletionContext(null, SESSION), false);
+  assert.equal(m.wired.adoptedRunCompletionContexts.size, 0);
+  assert.equal(m.runCompletion.isKnown("prompt-b"), false);
+  assert.equal(m.runCompletion.isKnown("prompt-c"), false);
+
+  // ...and the null → id edge IS a route change, so the lease landing recovers the
+  // rows the mount-time partition had to defer.
+  m.switchWorkflowTo(ROUTE_B);
+  assert.equal(m.runCompletion.isKnown("prompt-b"), true);
+  assert.equal(m.runCompletion.isKnown("prompt-c"), false);
+});
+
+test("#1839 P1(b) an adopted row is retired for good — the deferred set is no longer frozen", () => {
+  const m = mount(seed(rowB, rowC), { liveRoute: ROUTE_A });
+  m.switchWorkflowTo(ROUTE_B);
+  assert.equal(m.runCompletion.isKnown("prompt-b"), true);
+
+  // The recovered completion reaches the agent and is acknowledged.
+  assert.equal(m.runCompletion.acknowledgeDelivery("prompt-b", rowB.completionKey), true);
+
+  // A mount-time `partition().deferred` snapshot still calls B's row foreign and
+  // re-merges it into this very write, resurrecting a completion the agent already
+  // received. Re-reading the ledger at persist time is what retires it.
+  assert.deepEqual(
+    m.ledger().map((r) => r.promptId),
+    ["prompt-c"],
+    "B's row is gone once delivered",
+  );
+});
+
+test("#1839 P1(b) selectDeferredRunCompletionMetadata keeps exactly the unadopted contexts", () => {
+  const adopted = new Set([runCompletionContextKey(ROUTE_B, SESSION)]);
+  assert.deepEqual(selectDeferredRunCompletionMetadata([rowB, rowC], adopted), [rowC]);
+  assert.deepEqual(selectDeferredRunCompletionMetadata([rowB, rowC], new Set()), [rowB, rowC]);
+  assert.deepEqual(selectDeferredRunCompletionMetadata([rowB, rowC], undefined), [rowB, rowC]);
+  assert.deepEqual(
+    selectDeferredRunCompletionMetadata([rowB, rowC], [runCompletionContextKey(ROUTE_C, SESSION)]),
+    [rowB],
+  );
+  // A context key separates route AND session, and a null session is its own value.
+  assert.notEqual(runCompletionContextKey(ROUTE_B, SESSION), runCompletionContextKey(ROUTE_B, null));
+  assert.equal(runCompletionContextKey(" " + ROUTE_B + " ", " " + SESSION + " "), runCompletionContextKey(ROUTE_B, SESSION));
+});
+
+test("#1839 P1(b) production WIRING — the poll drives the rehydrate and the persist re-reads", () => {
+  // The hook has to fire on a route change INDEPENDENTLY of tracker state, and the
+  // 600 ms workflow poll is the only thing in the panel that does. Assert the call
+  // site is inside onWorkflowMaybeChanged, and that the poll drives that function.
+  const pollFn = slice("  function onWorkflowMaybeChanged() {", "\n    const wf = activeWorkflowRef();");
+  assert.match(pollFn, /rehydrateRunCompletionForLiveRouteRef\?\.\(\)/);
+  assert.match(PANEL_SRC, /setInterval\(\(\) => onWorkflowMaybeChanged\(\), 600\)/);
+  // It must run BEFORE the unchanged-route early return: `wfid` is the saved handle
+  // and the bridge route moves without it.
+  assert.ok(
+    PANEL_SRC.indexOf("rehydrateRunCompletionForLiveRouteRef?.()") <
+      PANEL_SRC.indexOf("return; // case 1: no change"),
+  );
+  // The ref is published from the mount and dropped on teardown.
+  assert.match(PANEL_SRC, /\n  rehydrateRunCompletionForLiveRouteRef = rehydrateRunCompletionForLiveRoute;/);
+  assert.match(
+    PANEL_SRC,
+    /if \(rehydrateRunCompletionForLiveRouteRef === rehydrateRunCompletionForLiveRoute\) \{\n\s*rehydrateRunCompletionForLiveRouteRef = null;/,
+  );
+  // The persist path re-reads the ledger instead of closing over a mount-time set.
+  assert.match(
+    PANEL_SRC,
+    /mergeRunCompletionMetadata\(\s*entries,[\s\S]{0,400}?selectDeferredRunCompletionMetadata\(\s*readRunCompletionMetadata\(\),\s*adoptedRunCompletionContexts,\s*\),\s*\),\s*\);/,
+  );
+  assert.doesNotMatch(PANEL_SRC, /deferredRunCompletionMetadata/);
+  // The restore is still RE-COMPUTED against the live route, never widened.
+  assert.match(
+    PANEL_SRC,
+    /partitionRunCompletionMetadata\(readRunCompletionMetadata\(\), liveRoute, liveSession\)\.current/,
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5390,6 +5390,41 @@ function readRunCompletionMetadata() {
   }
 }
 
+/**
+ * #1839 — the SAME read, but able to say "I could not read it": `[]` when the
+ * ledger is genuinely empty, `null` when it could not be read.
+ *
+ * readRunCompletionMetadata() cannot make that distinction. ssGet swallows a
+ * throwing sessionStorage (private-mode quota, a blocked origin) and returns
+ * null, and a malformed value is caught and returned as `[]` — so "no rows" and
+ * "no answer" are byte-identical to every caller.
+ *
+ * That matters because ADOPTING a route/session context is irreversible for the
+ * life of the mount: it marks the context this tracker's, so later polls skip it
+ * AND the next persist stops treating its rows as foreign — dropping rows the
+ * read never saw. Adoption must therefore be taken on an answer, never on a
+ * silence; callers refuse on null and retry on the next poll tick.
+ *
+ * Unparseable bytes ARE an answer — nothing recoverable is in there and no
+ * future read will change that — so they normalize to `[]` like any other row
+ * that fails the cross-check. Only a THROWING store, which may hold rows we
+ * simply cannot see right now, is "unknown".
+ */
+function readRunCompletionMetadataOrUnknown() {
+  let raw = null;
+  try {
+    raw = window.sessionStorage.getItem(RUN_COMPLETION_META_KEY) || null;
+  } catch {
+    return null; // storage unreadable — NOT an empty ledger
+  }
+  if (!raw) return [];
+  try {
+    return normalizeRunCompletionMetadata(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
 function persistRunCompletionMetadata(entries) {
   const safe = normalizeRunCompletionMetadata(entries);
   if (!safe.length) {
@@ -38080,8 +38115,13 @@ function buildPanel() {
     completionRestoreRoute = bridgeRouteId();
   } catch {}
   const completionRestoreSession = ssGet(SESSION_KEY);
+  // `null` here means the ledger could not be READ, which is not the same answer
+  // as an empty one — see readRunCompletionMetadataOrUnknown. Partitioning an
+  // unreadable ledger yields two empty halves, and on the old wiring the first
+  // persist then overwrote the key with them.
+  const completionRestoreStored = readRunCompletionMetadataOrUnknown();
   const completionRestore = partitionRunCompletionMetadata(
-    readRunCompletionMetadata(),
+    completionRestoreStored ?? [],
     completionRestoreRoute,
     completionRestoreSession,
   );
@@ -38108,20 +38148,38 @@ function buildPanel() {
     adoptedRunCompletionContexts.add(contextKey);
     return true;
   };
-  adoptRunCompletionContext(completionRestoreRoute, completionRestoreSession);
+  // The cheap half of the question, asked BEFORE any storage work: the
+  // overwhelming majority of the 600 ms ticks that reach the rehydrate below are
+  // already-adopted contexts and must not pay a ledger parse to learn that.
+  const runCompletionContextNeedsAdoption = (routeId, sessionId) => {
+    const route = typeof routeId === "string" ? routeId.trim() : "";
+    if (!route) return false;
+    return !adoptedRunCompletionContexts.has(runCompletionContextKey(route, sessionId));
+  };
+  // Claim the mount's own context only if the ledger was actually READ. On an
+  // unreadable store the rehydrate below retries on the next poll tick instead of
+  // permanently marking these rows as this tracker's and dropping them.
+  if (completionRestoreStored !== null) {
+    adoptRunCompletionContext(completionRestoreRoute, completionRestoreSession);
+  }
   const persistOwnedRunCompletionMetadata = (entries) => {
     // Async composition from a torn-down mount can settle after its replacement
     // has already acknowledged and cleared a completion. Never let that stale
     // frontend instance resurrect its old pending snapshot.
     if (panelRunOwnerRef.current !== mountOwner) return;
+    // Re-read at PERSIST time, never a value closed over at mount.
+    const stored = readRunCompletionMetadataOrUnknown();
+    // An unreadable ledger cannot say which rows belong to another route, and
+    // writing without them would DELETE every foreign row — a completion nobody
+    // ever delivers, which is the failure this whole ledger exists to prevent.
+    // The tracker stays authoritative in memory and the next state change
+    // re-attempts the write. Deliberately the same trade the delivery path
+    // makes: a duplicate turn beats a lost render.
+    if (stored === null) return;
     persistRunCompletionMetadata(
       mergeRunCompletionMetadata(
         entries,
-        // Re-read at PERSIST time, never a value closed over at mount.
-        selectDeferredRunCompletionMetadata(
-          readRunCompletionMetadata(),
-          adoptedRunCompletionContexts,
-        ),
+        selectDeferredRunCompletionMetadata(stored, adoptedRunCompletionContexts),
       ),
     );
   };
@@ -38429,12 +38487,22 @@ function buildPanel() {
       liveRoute = bridgeRouteId();
     } catch {}
     const liveSession = ssGet(SESSION_KEY);
-    // Already this mount's — one Set lookup on the overwhelming majority of the
-    // 600 ms ticks that reach this line, and no storage read at all.
+    // Already this mount's, or not routable — one Set lookup on the overwhelming
+    // majority of the 600 ms ticks that reach this line, and no storage read.
+    if (!runCompletionContextNeedsAdoption(liveRoute, liveSession)) return 0;
+    // READ BEFORE ADOPTING, and refuse on an unreadable ledger. Adoption is
+    // irreversible for the life of the mount: it marks the context this
+    // tracker's, so every later tick skips it AND the next persist stops
+    // treating its rows as foreign and drops them. A transient sessionStorage
+    // failure is indistinguishable from an empty ledger through
+    // readRunCompletionMetadata(), so adopting on that answer would strand — and
+    // then delete — rows that were there all along. Returning retries next tick.
+    const stored = readRunCompletionMetadataOrUnknown();
+    if (stored === null) return 0;
     if (!adoptRunCompletionContext(liveRoute, liveSession)) return 0;
     const restored = restoreRunCompletionMetadata(
       runCompletion,
-      partitionRunCompletionMetadata(readRunCompletionMetadata(), liveRoute, liveSession).current,
+      partitionRunCompletionMetadata(stored, liveRoute, liveSession).current,
     );
     // Adopted rows are pending-but-unswept until something arms the sweep: the
     // run they name finished while this panel was not listening, so no lifecycle

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -88,7 +88,9 @@ import {
   mergeRunCompletionMetadata,
   normalizeRunCompletionMetadata,
   partitionRunCompletionMetadata,
+  runCompletionContextKey,
   runCompletionKeyMatchesContext,
+  selectDeferredRunCompletionMetadata,
 } from "./lib/run-completion-persistence.js";
 import {
   arbitratePanelCopy,
@@ -916,6 +918,17 @@ let runCompletionRef = null;
 // prompt is queued so the sweep re-reconciles pending runs against /history until
 // they drain. Set in buildPanel; null while unmounted.
 let armRunReconcileSweepRef = null;
+// #1839 P1(b) — re-partitions the durable run-completion ledger against the LIVE
+// workflow route. bridgeRouteId() is derived from the active workflow, so it moves
+// under a mounted panel with no remount at all, and the ledger's mount-time
+// partition does not follow it. The 600 ms workflow poll calls this on every tick.
+//
+// Module-scoped for the SAME reason as the sweep ref above: onWorkflowMaybeChanged
+// runs once synchronously (and then on the poll) from a point in buildPanel's
+// closure ABOVE where the tracker is created, so a `let` declared alongside the
+// tracker would be in its temporal dead zone for that first call. Null while
+// unmounted, and the caller is optional-chained, so an unmounted panel is a no-op.
+let rehydrateRunCompletionForLiveRouteRef = null;
 // A late prompt receipt has to cross the bridge to the MCP consumer. Capture the
 // sender at mount time so an old graph_run cannot publish into a replacement tab
 // after teardown/reconnect.
@@ -35877,6 +35890,16 @@ function buildPanel() {
   // So everything below commits unconditionally, exactly as it did before #1095, and only
   // the hello waits. See lib/rehello-gate.js.
   function onWorkflowMaybeChanged() {
+    // #1839 P1(b) — the durable run-completion ledger is partitioned against the
+    // LIVE bridge route, and that route moves without a remount. Re-check it
+    // here, BEFORE the unchanged-route early return below: `wfid` is the saved
+    // HANDLE, and bridgeRouteId() also moves when this tab's route identity
+    // finally establishes (leased asynchronously, null until then) — a change no
+    // workflow handle reflects. Best-effort and null while unmounted; a hook
+    // throw must never break the workflow poll.
+    try {
+      rehydrateRunCompletionForLiveRouteRef?.();
+    } catch {}
     const wf = activeWorkflowRef();
     const wfid = workflowTabId();
     const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
@@ -38062,14 +38085,44 @@ function buildPanel() {
     completionRestoreRoute,
     completionRestoreSession,
   );
-  const deferredRunCompletionMetadata = completionRestore.deferred;
+  // #1839 P1(b) — the route/session CONTEXTS whose rows this mount's tracker has
+  // taken ownership of. Everything else in storage belongs to a workflow this
+  // panel is not driving and is merged back untouched on every write.
+  //
+  // A LIVE SET, deliberately not the mount-time `completionRestore.deferred`
+  // snapshot it replaces. That snapshot is frozen and the route is not: once the
+  // rehydrate below adopts a second route's rows, the snapshot still calls them
+  // foreign and re-merges them into every later persist — resurrecting rows the
+  // tracker has since retired, so the next mount replays a completion the agent
+  // already received. Membership here is what makes "foreign" a live question.
+  const adoptedRunCompletionContexts = new Set();
+  const adoptRunCompletionContext = (routeId, sessionId) => {
+    const route = typeof routeId === "string" ? routeId.trim() : "";
+    // A route this tab has not established names no canvas (bridgeRouteId()
+    // REFUSES rather than falling back). Adopting under it would claim rows for
+    // a route that does not exist yet and strip them of their own route's
+    // ownership — so refuse, exactly as the partition does.
+    if (!route) return false;
+    const contextKey = runCompletionContextKey(route, sessionId);
+    if (adoptedRunCompletionContexts.has(contextKey)) return false;
+    adoptedRunCompletionContexts.add(contextKey);
+    return true;
+  };
+  adoptRunCompletionContext(completionRestoreRoute, completionRestoreSession);
   const persistOwnedRunCompletionMetadata = (entries) => {
     // Async composition from a torn-down mount can settle after its replacement
     // has already acknowledged and cleared a completion. Never let that stale
     // frontend instance resurrect its old pending snapshot.
     if (panelRunOwnerRef.current !== mountOwner) return;
     persistRunCompletionMetadata(
-      mergeRunCompletionMetadata(entries, deferredRunCompletionMetadata),
+      mergeRunCompletionMetadata(
+        entries,
+        // Re-read at PERSIST time, never a value closed over at mount.
+        selectDeferredRunCompletionMetadata(
+          readRunCompletionMetadata(),
+          adoptedRunCompletionContexts,
+        ),
+      ),
     );
   };
   const persistOwnedRunCompletionTerminals = (entries) => {
@@ -38335,6 +38388,61 @@ function buildPanel() {
   ) {
     armRunReconcileSweep();
   }
+
+  /** #1839 P1(b) — RE-PARTITION WHEN THE LIVE ROUTE MOVES, not only at mount.
+   *
+   *  `completionRestore` above is computed ONCE, against whatever route was live
+   *  when this panel mounted. bridgeRouteId() is derived from the LIVE active
+   *  workflow, so it moves under us with NO remount — the same property #1095
+   *  documents at the hello. The partition's own comment ("keep foreign rows in
+   *  storage for a later mount of their own route") assumes a route change
+   *  implies a remount, and it does not.
+   *
+   *  Reported shape: a completion is still owed on workflow B, the user reloads
+   *  while workflow A is the canvas, B's row is deferred — and switching back to
+   *  B inside the same mount never adopts it. The row stays durable in storage,
+   *  but only a LATER mount picks it up, so the run is "successful, no completion
+   *  event, recovered by hand with get_history" (#1739 / #585 / #370) with a
+   *  workflow switch in front of it.
+   *
+   *  The reconcile sweep CANNOT be this hook. It arms on runCompletion.hasPending(),
+   *  and a deferred row is precisely one the tracker does not know about — so the
+   *  sweep is disarmed for exactly the rows that need recovering. Whatever fires
+   *  has to be independent of tracker state, which the workflow poll is.
+   *
+   *  NOTHING IS WIDENED. The partition is RE-COMPUTED against the route that is
+   *  live at the moment of restore, so a row belonging to a workflow that is not
+   *  on the canvas right now stays deferred and cannot stamp a completion frame
+   *  onto the wrong canvas. sendRunCompletionFrame still re-checks route AND
+   *  session at the instant the frame leaves, so the wrong-canvas write is fenced
+   *  twice, not once.
+   *
+   *  Also covers a route change that changes no workflow at all: this tab's route
+   *  identity is leased ASYNCHRONOUSLY (createTabRouteIdentity), so bridgeRouteId()
+   *  can still be null at mount — in which case the mount-time partition defers
+   *  EVERY row, including the active workflow's — and only becomes readable once
+   *  the lease lands. That null → id edge is a route change too, and it is picked
+   *  up here on the next poll tick. */
+  const rehydrateRunCompletionForLiveRoute = () => {
+    let liveRoute = null;
+    try {
+      liveRoute = bridgeRouteId();
+    } catch {}
+    const liveSession = ssGet(SESSION_KEY);
+    // Already this mount's — one Set lookup on the overwhelming majority of the
+    // 600 ms ticks that reach this line, and no storage read at all.
+    if (!adoptRunCompletionContext(liveRoute, liveSession)) return 0;
+    const restored = restoreRunCompletionMetadata(
+      runCompletion,
+      partitionRunCompletionMetadata(readRunCompletionMetadata(), liveRoute, liveSession).current,
+    );
+    // Adopted rows are pending-but-unswept until something arms the sweep: the
+    // run they name finished while this panel was not listening, so no lifecycle
+    // edge is coming and /history is the only place its outputs exist.
+    if (restored > 0) armRunReconcileSweep();
+    return restored;
+  };
+  rehydrateRunCompletionForLiveRouteRef = rehydrateRunCompletionForLiveRoute;
 
   // ── #585: correlated restart-resume ───────────────────────────────────────
   // After a ComfyUI restart the panel nudges the agent to continue. If a render
@@ -42769,6 +42877,9 @@ function buildPanel() {
       // suppressed resume.
       stopRebootWatch();
       if (armRunReconcileSweepRef === armRunReconcileSweep) armRunReconcileSweepRef = null;
+      if (rehydrateRunCompletionForLiveRouteRef === rehydrateRunCompletionForLiveRoute) {
+        rehydrateRunCompletionForLiveRouteRef = null;
+      }
       if (runCompletionRef === runCompletion) runCompletionRef = null;
       if (runReceiptRouteRef === panelRunReceiptRouteRef) runReceiptRouteRef = null;
       if (runReceiptSessionRef === panelRunReceiptSessionRef) runReceiptSessionRef = null;

--- a/web/js/lib/run-completion-persistence.js
+++ b/web/js/lib/run-completion-persistence.js
@@ -98,8 +98,51 @@ export function normalizeRunCompletionMetadata(
 }
 
 /**
+ * The identity of a restore CONTEXT: the workflow route plus the agent
+ * conversation a set of rows belongs to. Rows are adopted by CONTEXT rather than
+ * one at a time, so "has this mount already taken these rows" is a single
+ * comparison that cannot drift row by row.
+ */
+export function runCompletionContextKey(routeId, sessionId) {
+  const route = text(routeId);
+  const session = sessionId == null ? null : text(sessionId);
+  return JSON.stringify([route, session]);
+}
+
+/**
+ * The rows that no ADOPTED context owns — the set to merge back on every write.
+ *
+ * This replaces a mount-time `partitionRunCompletionMetadata(...).deferred`
+ * snapshot. That snapshot is frozen and the live route is not: the moment a
+ * mount adopts a second route's rows (because the user switched the canvas
+ * without remounting), the snapshot still calls those rows foreign and merges
+ * them into every later write — resurrecting rows the tracker has since retired,
+ * so a later mount replays a completion the agent was already given.
+ *
+ * Re-reading storage here is what keeps "foreign" a live question. A row is
+ * foreign because NOTHING in this mount owns it, never because of where the
+ * route happened to be at the instant the panel mounted.
+ */
+export function selectDeferredRunCompletionMetadata(entries, adoptedContextKeys) {
+  const adopted =
+    adoptedContextKeys instanceof Set ? adoptedContextKeys : new Set(adoptedContextKeys || []);
+  return normalizeRunCompletionMetadata(entries).filter(
+    (entry) => !adopted.has(runCompletionContextKey(entry.routeId, entry.sessionId)),
+  );
+}
+
+/**
  * Split persisted rows at remount. Only the active workflow route is safe to
  * reconcile now; foreign rows remain durable for a later mount of their route.
+ *
+ * #1839 — "a later mount" was the load-bearing assumption, and it is wrong: the
+ * route moves under a LIVE mount every time the user switches workflow tab, with
+ * no remount at all. So this is not a once-per-mount computation. Callers re-run
+ * it against the route that is live at the MOMENT OF RESTORE (see
+ * `rehydrateRunCompletionForLiveRoute` in the panel) and record what they took
+ * with `runCompletionContextKey`. Re-computing is the fix; widening what counts
+ * as current would replay a row onto a canvas the user is not looking at, which
+ * is worse than the bug this partition exists to prevent.
  */
 export function partitionRunCompletionMetadata(entries, activeRouteId, activeSessionId) {
   const routeId = text(activeRouteId);


### PR DESCRIPTION
Refs #1839 — the **P1(b)** half. P1(a) (the fail-open reload fence) shipped in #1840 (`caa5f4b`) and is untouched here.

Refs #1842 — the hypothesis that this fix explains that replay loop is **REFUTED**, with executable evidence. See the last section; that issue needs its own investigation.

## The defect

The durable `panel_run` completion ledger is partitioned against the live bridge route **exactly once, at mount**:

```js
const completionRestore = partitionRunCompletionMetadata(read(), completionRestoreRoute, completionRestoreSession);
…
restoreRunCompletionMetadata(runCompletion, completionRestore.current)   // called once
```

and the partition's own comment states the assumption that produced the bug — *"Keep foreign rows in storage for a **later mount** of their own route."* That assumes a route change implies a remount, and it does not. `bridgeRouteId()` is derived from the **live active workflow**, so it moves under a mounted panel; there is an in-code comment at the hello saying exactly that (`#1095`: *"bridgeRouteId() is derived from the LIVE active workflow, so it moves under us"*).

**Reported shape.** A completion is still owed on workflow B. The panel reloads while workflow A is the canvas, so B's row is deferred. Switching back to B *inside that same mount* never adopts it — the row stays durable in storage and only a **later** mount picks it up. That reads to the user as "successful run, no completion event, recovered by hand with `get_history`" (#1739 / #585 / #370) with a workflow switch in front of it.

## Reproduced first, by execution

`browser_tests/unit/run-completion-route-rehydrate.test.mjs` drives the real `run-completion.js` tracker, the real `run-reconcile-sweep.js`, and the **production text of the panel's own persistence block**, sliced out of `comfyui-mcp-panel.js` and executed with `new Function` — so a mutation to the shipped bodies, not just to the lib helpers, turns it red.

The first test is the pre-fix path, with the hook simply never fired: mount on A, switch to B, and B's row is unknown to the tracker, `completionKeyFor` is null, `hasPending()` is false, the sweep refuses to arm, zero reconciles, zero frames — while the row is still sitting in storage.

## Why the reconcile sweep cannot be the hook

`createRunReconcileSweep` arms on `hasPending: () => runCompletion.hasPending()`, and a deferred row is *precisely* one the tracker does not know about. So the sweep is disarmed for exactly the rows that need recovering. It is the obvious place and it cannot work; the hook has to fire on a route change **independently of tracker state**, which the 600 ms workflow poll does.

## The change

* `lib/run-completion-persistence.js` gains `runCompletionContextKey()` and `selectDeferredRunCompletionMetadata()`. "Foreign" becomes a **live** question: a row is foreign because *nothing in this mount owns it*, not because of where the route happened to be when the panel mounted.
* `buildPanel` keeps a live set of **adopted** route/session contexts. The mount context is adopted as before; the persist path re-reads the ledger and filters by that set instead of closing over `completionRestore.deferred`.
* `rehydrateRunCompletionForLiveRoute()` re-computes the partition against the route live *at that instant*, adopts it once, restores the rows that became current, and arms the `/history` sweep for them. Published through a module-scoped ref and dropped on teardown.
* `onWorkflowMaybeChanged` calls it **before** its unchanged-route early return.

## Where the load-bearing claims are — please look here

1. **The module-scoped ref is not stylistic.** `onWorkflowMaybeChanged` is called synchronously at `:37957`, *above* where the tracker is declared at `:38060`. A `let` next to the tracker would be in its temporal dead zone for that first call and would throw. This mirrors the existing `armRunReconcileSweepRef` and the comment there says the same thing. `node scripts/check-panel-scope.mjs` is OK (and it *refuses* rather than printing a false OK — it did refuse until `npm install` ran in the worktree).
2. **The call site is before the early return, on purpose.** `wfid` is the saved *handle*; the bridge route also moves when this tab's route identity finally leases. That lease is asynchronous (`createTabRouteIdentity`), so `bridgeRouteId()` can be **null at mount** — in which case the mount-time partition defers *every* row, including the active workflow's, and the initial restore adopts nothing. The `null → id` edge is a route change too and is picked up here. That is an additional recovery this change buys; it is asserted as its own test.
3. **`adoptRunCompletionContext` refuses an empty route.** Without that refusal an unestablished route would claim every row in storage. Mutated below.
4. **The adopted-context set is unbounded by design.** A cap would be a correctness bug, not a safety valve: evicting an adopted context makes its rows foreign again, and they would be re-persisted after the tracker retired them. Entries are ~100 bytes and only added on a genuine route/session change.
5. **Merge order.** `mergeRunCompletionMetadata(entries, deferred)` dedupes by `completionKey` with the tracker's snapshot first, so an adopted row that is *also* still in storage is not doubled.

## Nothing is widened

The partition is **re-computed** against the live route, never relaxed. A row for a workflow that is not on the canvas right now stays deferred and cannot stamp a completion frame onto the wrong canvas — and `sendRunCompletionFrame` still re-checks route **and** session at the moment the frame leaves, so the wrong-canvas write is fenced twice.

Three controls pin this, and all three are proved by mutation below:

* a foreign **route** is not restored;
* a foreign **session** on the same route is not restored;
* an **unestablished (null)** route adopts nothing.

## The frozen deferred set is fixed here, not separately

Once a mount adopts a second route's rows, a mount-time `deferred` snapshot still calls them foreign and re-merges them into every later write — resurrecting rows the tracker has since retired. On `origin/main` that is **benign** (deferred rows are never in the tracker, so nothing delivers them). It becomes load-bearing the moment the rehydrate lands, so it is one change, not two. The behaviour is pinned by *"an adopted row is retired for good"*.

## Mutation results

`git checkout -- web/js/comfyui-mcp-panel.js` between each; the fix was committed first.

| # | Mutation | Red | Green | Which tests went red |
|---|---|---|---|---|
| 1 | remove `rehydrateRunCompletionForLiveRouteRef?.()` from the poll | **1** | 13 | the production WIRING test only — the behaviour tests drive the rehydrate directly and cannot see an un-wired hook, which is exactly why the wiring test exists |
| 2 | revert the persist to the frozen `completionRestore.deferred` | **3** | 11 | `#1830 production wiring…`, `an adopted row is retired for good`, `production WIRING…` |
| 3 | widen the restore to `readRunCompletionMetadata()` (restore everything) | **4** | 10 | **all three CONTROLS** — foreign route, foreign session, unestablished route — plus the wiring test |
| 4 | drop `if (!route) return false;` from `adoptRunCompletionContext` | **1** | 7 | `CONTROL — an unestablished route adopts nothing` |
| 5 | rehydrate reads with `readRunCompletionMetadata()` (adopts on an unreadable ledger — the gate's P1, restored) | **1** | 15 | `an UNREADABLE ledger is never adopted` |
| 6 | persist writes even when the ledger could not be read | **2** | 8 | `an UNREADABLE ledger at persist time never deletes another route's rows`, `production WIRING…` |

Mutation 3 is the one that matters most: a "restore everything" fix passes the positive test and reintroduces the wrong-canvas bug, and all three controls catch it.

## Verification

* `npm run test:unit` — **6924 tests, 6923 pass, 0 fail** (includes i18n, tool-vocabulary and panel-scope gates).
* `node scripts/check-panel-scope.mjs` — OK.
* **Not run: Playwright.** This change has no rendered surface — it moves rows between an in-memory tracker and `sessionStorage` and arms an existing timer. There is nothing for the browser suite to observe that the unit suite does not, and I am stating that rather than implying coverage I do not have.

## Refs #1842 — hypothesis refuted, with evidence

The suggestion was that this same frozen-snapshot merge produces #1842's endless replay loop. It cannot. Probed against `origin/main` (`caa5f4b`), driving the real modules:

* **A deferred row can never be delivered.** `partitionRunCompletionMetadata` is a strict split, so a deferred row is never handed to the tracker. Driving every lifecycle edge for a deferred prompt yields **zero** keyed completion frames, and three successive mounts over a frozen-deferred row deliver **nothing at all**. A merge-only defect re-persists rows; it cannot emit frames.
* **A torn-down mount has no writer.** `persistOwnedRunCompletionMetadata`'s owner gate runs *before* the merge, so the proposed "later mount retires it → the old mount's snapshot puts it back" cycle has nobody to perform the second step.
* **`possible_repeat` is structurally impossible for this ledger.** It is set only when the panel frame carries **no `prompt_id`** (`run-completion-journal.ts:676-677`, `:855-869`). Every row here carries a `completionKey` whose identity *requires* a non-empty `promptId` (`parseRunCompletionIdentity`), and `composeRunCompletionFrame` emits `prompt_id` whenever `promptId != null`.
* **The id-less path is a different ledger.** `RUN_COMPLETION_TERMINAL_KEY` / `terminalNoKeyCompletion`, persisted by `persistOwnedRunCompletionTerminals` with **no merge of any deferred set**.

One observation to carry into #1842's own investigation: `replayed: true` is set for every attempt past the first (`run-completion-journal.ts:991`), and none of the ~40 reported messages carried the `(RE-DELIVERED —` prefix. Each was therefore a **first** delivery of a **new** journal entry — the panel emitted ~40 fresh id-less frames rather than the orchestrator replaying one journaled entry, which is the reporter's own prime suspect. That points at whatever in the panel re-emits id-less completions, and away from both the orchestrator journal and this persistence merge.

## Review round 2 — a real P1 from the gate

Round 1 returned NO-SHIP with one P1, and it was correct and worse than it read:

> a failed storage read is marked as an adopted context, suppressing all retries

`ssGet` swallows a throwing `sessionStorage` and returns null, and `readRunCompletionMetadata()` catches a bad parse and returns `[]` — so **"the ledger is empty" and "the ledger could not be read" were the same answer**. Adoption is irreversible for the life of the mount, so adopting on that answer does not merely suppress retries: the context is marked this tracker's, so the next persist stops treating its rows as foreign and **deletes rows the read never saw**.

Fixed in `31c731c8`:

* `readRunCompletionMetadataOrUnknown()` returns `null` only for a **throwing** store. Unparseable bytes stay `[]` — nothing recoverable is in there and no later read changes that, so refusing forever on them would wedge persistence instead of protecting it.
* The rehydrate asks the cheap already-adopted question first (no ledger parse on the overwhelming majority of 600 ms ticks), then **reads before adopting** and returns on `null` so the next tick retries.
* The mount claims its own context only when its read answered. The same hazard existed there on `origin/main`, where a failed mount read let the first persist overwrite the key with two empty halves.
* The persist path **refuses the write** on an unreadable ledger rather than writing a merge that lost every foreign row — the same trade the delivery path makes: a duplicate turn beats a lost render.

Both new guards are mutation-proved (rows 5 and 6 above). Round 2 verdict: **SHIP** on `31c731c8`.

## What I deliberately did not do

* Did not touch the reload fence (P1(a), #1840).
* Did not change `sendRunCompletionFrame` — the live send fence is correct and is what keeps this safe.
* Did not stretch this change to try to cover #1842.
* Left #1839 open is **not** proposed: both halves it named are addressed here (the route-change hook and the frozen deferred set), so `Refs`, and I will confirm the issue state after merge rather than relying on an auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
