### PR TITLE
fix(panel): preserve chat autoscroll through anchored scroll events (#1841)

### DIFF
--- a/browser_tests/unit/chat-render-containment.test.mjs
+++ b/browser_tests/unit/chat-render-containment.test.mjs
@@ -28,6 +28,18 @@ test("#1801 contains every direct chat message without changing the feed surface
     source,
     /import \{ createChatScrollStabilizer \} from "\.\/lib\/chat-scroll-stabilizer\.js";/,
   );
+  assert.match(
+    source,
+    /import \{ createChatScrollIntentTracker, updateChatStickiness \} from "\.\/lib\/chat-scroll-intent\.js";/,
+  );
+
+  const scrollIntentStart = source.indexOf("const scrollIntent = createChatScrollIntentTracker();");
+  assert.ok(scrollIntentStart >= 0, "the production scroll listener must track user intent");
+  const scrollListenerEnd = source.indexOf("  const chatScrollStabilizer =", scrollIntentStart);
+  const scrollListener = source.slice(scrollIntentStart, scrollListenerEnd);
+  assert.match(scrollListener, /scrollIntent\.consume\(\)/);
+  assert.match(scrollListener, /updateChatStickiness\(/);
+  assert.doesNotMatch(scrollListener, /stickToBottom\s*=\s*atBottom\(\)/);
 
   const ruleStart = source.indexOf(".cmcp-log > :not(.cmcp-empty) {");
   assert.ok(ruleStart >= 0, "the production chat feed must contain its message rule");

--- a/browser_tests/unit/chat-render-containment.test.mjs
+++ b/browser_tests/unit/chat-render-containment.test.mjs
@@ -38,8 +38,11 @@ test("#1801 contains every direct chat message without changing the feed surface
   const scrollListenerEnd = source.indexOf("  const chatScrollStabilizer =", scrollIntentStart);
   const scrollListener = source.slice(scrollIntentStart, scrollListenerEnd);
   assert.match(scrollListener, /scrollIntent\.consume\(\)/);
+  assert.match(scrollListener, /scrollIntent\.endProgrammaticScroll\(\)/);
   assert.match(scrollListener, /updateChatStickiness\(/);
   assert.doesNotMatch(scrollListener, /stickToBottom\s*=\s*atBottom\(\)/);
+  assert.match(source, /scrollIntent\.noteProgrammaticScroll\(\{ behavior: "smooth" \}\);\s*log\.scrollTo\(/);
+  assert.match(source, /beforeScroll: \(\) => scrollIntent\.noteProgrammaticScroll\(\)/);
 
   const ruleStart = source.indexOf(".cmcp-log > :not(.cmcp-empty) {");
   assert.ok(ruleStart >= 0, "the production chat feed must contain its message rule");

--- a/browser_tests/unit/chat-scroll-intent.test.mjs
+++ b/browser_tests/unit/chat-scroll-intent.test.mjs
@@ -1,11 +1,51 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   createChatScrollIntentTracker,
   isUserScrollIntent,
   updateChatStickiness,
 } from "../../web/js/lib/chat-scroll-intent.js";
+
+const panelSource = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+).replace(/\r\n/g, "\n");
+const listenerStart = panelSource.indexOf("  const scrollIntent = createChatScrollIntentTracker();");
+const listenerEnd = panelSource.indexOf("  const chatScrollStabilizer =", listenerStart);
+assert.ok(listenerStart >= 0 && listenerEnd > listenerStart, "production chat scroll listener block not found");
+const productionListener = panelSource.slice(listenerStart, listenerEnd);
+
+class ChatLog extends EventTarget {
+  scrollHeight = 1000;
+  scrollTop = 400;
+  clientHeight = 100;
+}
+
+function emit(log, type, props = {}) {
+  const event = new Event(type);
+  for (const [key, value] of Object.entries(props)) {
+    if (key !== "type") event[key] = value;
+  }
+  log.dispatchEvent(event);
+}
+
+function buildProductionScrollSurface() {
+  const log = new ChatLog();
+  const newMsgBtn = { hidden: true };
+  const atBottom = () => log.scrollHeight - log.scrollTop - log.clientHeight <= 48;
+  const build = new Function(
+    "log",
+    "newMsgBtn",
+    "atBottom",
+    "createChatScrollIntentTracker",
+    "updateChatStickiness",
+    `let stickToBottom = true;\n${productionListener}\nreturn {\n  log,\n  newMsgBtn,\n  scrollIntent,\n  get stickToBottom() { return stickToBottom; },\n};`,
+  );
+  return build(log, newMsgBtn, atBottom, createChatScrollIntentTracker, updateChatStickiness);
+}
 
 test("programmatic and anchoring scroll events do not count as user intent", () => {
   const tracker = createChatScrollIntentTracker();
@@ -15,6 +55,22 @@ test("programmatic and anchoring scroll events do not count as user intent", () 
   assert.equal(tracker.consume(), false);
   assert.equal(isUserScrollIntent({ type: "scroll" }), false);
   assert.equal(isUserScrollIntent({ type: "keydown", key: "a" }), false);
+});
+
+test("programmatic scroll cancellation preserves the real marker for the following user scroll", () => {
+  const tracker = createChatScrollIntentTracker();
+  tracker.note({ type: "pointerdown" });
+  tracker.noteProgrammaticScroll();
+  assert.equal(tracker.consume(), false);
+  assert.equal(tracker.consume(), true);
+
+  tracker.note({ type: "wheel" });
+  tracker.noteProgrammaticScroll({ behavior: "smooth" });
+  tracker.noteProgrammaticScroll();
+  assert.equal(tracker.consume(), false);
+  tracker.endProgrammaticScroll();
+  assert.equal(tracker.consume(), true);
+  tracker.dispose();
 });
 
 test("wheel, touch, pointer, and vertical keyboard scrolling preserve user intent", () => {
@@ -54,4 +110,44 @@ test("non-bottom browser scrolls preserve stickiness, while user scrolls unstick
     true,
     "reaching the bottom always re-sticks",
   );
+});
+
+test("production DOM wiring expires input that never scrolls before a later browser scroll", async () => {
+  const surfaces = [
+    [{ type: "pointerdown" }],
+    [{ type: "wheel" }],
+    [{ type: "touchmove" }],
+    [{ type: "keydown", key: "PageDown" }],
+  ].map(([event]) => {
+    const surface = buildProductionScrollSurface();
+    emit(surface.log, event.type, event);
+    return surface;
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  for (const surface of surfaces) {
+    surface.log.scrollTop = 300;
+    emit(surface.log, "scroll");
+    assert.equal(surface.stickToBottom, true, "an unrelated later scroll must not unstick the feed");
+    surface.scrollIntent.dispose();
+  }
+});
+
+test("production DOM wiring skips an app scroll, preserves the marker, and re-sticks at bottom", () => {
+  const surface = buildProductionScrollSurface();
+
+  emit(surface.log, "pointerdown");
+  surface.scrollIntent.noteProgrammaticScroll();
+  surface.log.scrollTop = 350;
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, true, "the app scroll must not spend the user marker");
+
+  surface.log.scrollTop = 250;
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, false, "the following genuine user scroll must still unstick");
+
+  surface.log.scrollTop = 900;
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, true, "reaching bottom must re-stick in the production listener");
+  surface.scrollIntent.dispose();
 });

--- a/browser_tests/unit/chat-scroll-intent.test.mjs
+++ b/browser_tests/unit/chat-scroll-intent.test.mjs
@@ -19,17 +19,45 @@ assert.ok(listenerStart >= 0 && listenerEnd > listenerStart, "production chat sc
 const productionListener = panelSource.slice(listenerStart, listenerEnd);
 
 class ChatLog extends EventTarget {
+  constructor() {
+    super();
+    this.listeners = new Map();
+  }
+
   scrollHeight = 1000;
   scrollTop = 400;
   clientHeight = 100;
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type, listener) {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter((entry) => entry !== listener),
+    );
+  }
+
+  dispatchEvent(event) {
+    return this.dispatchEventFrom(this, event);
+  }
+
+  dispatchEventFrom(target, event) {
+    const delivered = { ...event, target, currentTarget: this };
+    for (const listener of [...(this.listeners.get(event.type) ?? [])]) listener(delivered);
+    return true;
+  }
+
+  listenerCount() {
+    return [...this.listeners.values()].reduce((count, listeners) => count + listeners.length, 0);
+  }
 }
 
-function emit(log, type, props = {}) {
-  const event = new Event(type);
-  for (const [key, value] of Object.entries(props)) {
-    if (key !== "type") event[key] = value;
-  }
-  log.dispatchEvent(event);
+function emit(log, type, props = {}, target = log) {
+  log.dispatchEventFrom(target, { type, ...props });
 }
 
 function buildProductionScrollSurface() {
@@ -42,7 +70,7 @@ function buildProductionScrollSurface() {
     "atBottom",
     "createChatScrollIntentTracker",
     "updateChatStickiness",
-    `let stickToBottom = true;\n${productionListener}\nreturn {\n  log,\n  newMsgBtn,\n  scrollIntent,\n  get stickToBottom() { return stickToBottom; },\n};`,
+    `let stickToBottom = true;\n${productionListener}\nreturn {\n  log,\n  newMsgBtn,\n  scrollIntent,\n  disposeChatScrollListeners,\n  get stickToBottom() { return stickToBottom; },\n};`,
   );
   return build(log, newMsgBtn, atBottom, createChatScrollIntentTracker, updateChatStickiness);
 }
@@ -71,6 +99,29 @@ test("programmatic scroll cancellation preserves the real marker for the followi
   tracker.endProgrammaticScroll();
   assert.equal(tracker.consume(), true);
   tracker.dispose();
+});
+
+test("production wiring preserves a root marker across multiple app writes before scroll delivery", () => {
+  const surface = buildProductionScrollSurface();
+
+  emit(surface.log, "pointerdown");
+  // These are the two production callers' writes before the browser delivers
+  // either scroll event (for example, reveal/anchoring corrections in one turn).
+  surface.scrollIntent.noteProgrammaticScroll();
+  surface.log.scrollTop = 350;
+  surface.scrollIntent.noteProgrammaticScroll();
+  surface.log.scrollTop = 300;
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, true, "the first app write must not spend the marker");
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, true, "the second app write must not spend the marker");
+
+  surface.log.scrollTop = 250;
+  emit(surface.log, "wheel");
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, false, "the following root user scroll must still unstick");
+  surface.disposeChatScrollListeners();
+  surface.scrollIntent.dispose();
 });
 
 test("wheel, touch, pointer, and vertical keyboard scrolling preserve user intent", () => {
@@ -129,6 +180,7 @@ test("production DOM wiring expires input that never scrolls before a later brow
     surface.log.scrollTop = 300;
     emit(surface.log, "scroll");
     assert.equal(surface.stickToBottom, true, "an unrelated later scroll must not unstick the feed");
+    surface.disposeChatScrollListeners();
     surface.scrollIntent.dispose();
   }
 });
@@ -149,5 +201,41 @@ test("production DOM wiring skips an app scroll, preserves the marker, and re-st
   surface.log.scrollTop = 900;
   emit(surface.log, "scroll");
   assert.equal(surface.stickToBottom, true, "reaching bottom must re-stick in the production listener");
+  surface.disposeChatScrollListeners();
   surface.scrollIntent.dispose();
+});
+
+test("production wiring ignores nested input and scroll targets while preserving root scrolling", () => {
+  const surface = buildProductionScrollSurface();
+  const nestedInput = {};
+
+  surface.log.scrollTop = 300;
+  emit(surface.log, "pointerdown", {}, nestedInput);
+  emit(surface.log, "scroll", {}, nestedInput);
+  assert.equal(surface.stickToBottom, true, "nested code/card/thinking activity is not root intent");
+
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, true, "nested activity must not unstick a root anchoring scroll");
+
+  emit(surface.log, "wheel");
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, false, "root user scrolling remains intentional");
+  surface.disposeChatScrollListeners();
+  surface.scrollIntent.dispose();
+});
+
+test("production teardown removes every scroll listener and leaves the tracker inert", () => {
+  const surface = buildProductionScrollSurface();
+  assert.equal(surface.log.listenerCount(), 6, "the production surface installs six scroll listeners");
+
+  surface.disposeChatScrollListeners();
+  surface.scrollIntent.dispose();
+  assert.equal(surface.log.listenerCount(), 0, "teardown removes every production scroll listener");
+
+  surface.log.scrollTop = 250;
+  emit(surface.log, "pointerdown");
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, true, "post-dispose input cannot change stickiness");
+  surface.scrollIntent.note({ type: "wheel" });
+  assert.equal(surface.scrollIntent.consume(), false, "post-dispose tracker calls are inert");
 });

--- a/browser_tests/unit/chat-scroll-intent.test.mjs
+++ b/browser_tests/unit/chat-scroll-intent.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createChatScrollIntentTracker,
+  isUserScrollIntent,
+  updateChatStickiness,
+} from "../../web/js/lib/chat-scroll-intent.js";
+
+test("programmatic and anchoring scroll events do not count as user intent", () => {
+  const tracker = createChatScrollIntentTracker();
+
+  tracker.note({ type: "scroll" });
+  tracker.note({ type: "resize" });
+  assert.equal(tracker.consume(), false);
+  assert.equal(isUserScrollIntent({ type: "scroll" }), false);
+  assert.equal(isUserScrollIntent({ type: "keydown", key: "a" }), false);
+});
+
+test("wheel, touch, pointer, and vertical keyboard scrolling preserve user intent", () => {
+  for (const event of [
+    { type: "wheel" },
+    { type: "touchmove" },
+    { type: "pointerdown" },
+    { type: "keydown", key: "ArrowUp" },
+    { type: "keydown", key: "PageDown" },
+    { type: "keydown", key: "End" },
+  ]) {
+    const tracker = createChatScrollIntentTracker();
+    tracker.note(event);
+    assert.equal(tracker.consume(), true, `${event.type}/${event.key ?? ""} is user intent`);
+    assert.equal(tracker.consume(), false, "one user action is consumed by one scroll event");
+  }
+});
+
+test("non-bottom browser scrolls preserve stickiness, while user scrolls unstick", () => {
+  assert.equal(
+    updateChatStickiness(true, { atBottom: false, userScrollIntent: false }),
+    true,
+    "anchoring must not disable autoscroll",
+  );
+  assert.equal(
+    updateChatStickiness(true, { atBottom: false, userScrollIntent: true }),
+    false,
+    "intentional user scrolling must disable autoscroll",
+  );
+  assert.equal(
+    updateChatStickiness(false, { atBottom: false, userScrollIntent: false }),
+    false,
+    "an already detached reader remains detached",
+  );
+  assert.equal(
+    updateChatStickiness(false, { atBottom: true, userScrollIntent: false }),
+    true,
+    "reaching the bottom always re-sticks",
+  );
+});

--- a/browser_tests/unit/chat-scroll-intent.test.mjs
+++ b/browser_tests/unit/chat-scroll-intent.test.mjs
@@ -8,6 +8,7 @@ import {
   isUserScrollIntent,
   updateChatStickiness,
 } from "../../web/js/lib/chat-scroll-intent.js";
+import { revealInteractiveCard } from "../../web/js/lib/interactive-card-reveal.js";
 
 const panelSource = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -19,14 +20,29 @@ assert.ok(listenerStart >= 0 && listenerEnd > listenerStart, "production chat sc
 const productionListener = panelSource.slice(listenerStart, listenerEnd);
 
 class ChatLog extends EventTarget {
-  constructor() {
+  constructor({ dispatchScrollOnWrite = false } = {}) {
     super();
     this.listeners = new Map();
+    this._scrollTop = 400;
+    this.dispatchScrollOnWrite = dispatchScrollOnWrite;
+    this.programmaticWrites = [];
   }
 
   scrollHeight = 1000;
-  scrollTop = 400;
   clientHeight = 100;
+
+  get scrollTop() {
+    return this._scrollTop;
+  }
+
+  set scrollTop(value) {
+    this.programmaticWrites.push(value);
+    if (this.dispatchScrollOnWrite) {
+      this.dispatchEventFrom(this, { type: "scroll" });
+    } else {
+      this._scrollTop = value;
+    }
+  }
 
   addEventListener(type, listener) {
     const listeners = this.listeners.get(type) ?? [];
@@ -60,8 +76,8 @@ function emit(log, type, props = {}, target = log) {
   log.dispatchEventFrom(target, { type, ...props });
 }
 
-function buildProductionScrollSurface() {
-  const log = new ChatLog();
+function buildProductionScrollSurface(options) {
+  const log = new ChatLog(options);
   const newMsgBtn = { hidden: true };
   const atBottom = () => log.scrollHeight - log.scrollTop - log.clientHeight <= 48;
   const build = new Function(
@@ -73,6 +89,36 @@ function buildProductionScrollSurface() {
     `let stickToBottom = true;\n${productionListener}\nreturn {\n  log,\n  newMsgBtn,\n  scrollIntent,\n  disposeChatScrollListeners,\n  get stickToBottom() { return stickToBottom; },\n};`,
   );
   return build(log, newMsgBtn, atBottom, createChatScrollIntentTracker, updateChatStickiness);
+}
+
+function productionRevealScrollNowSource(painterName) {
+  const painterStart = panelSource.indexOf(`function ${painterName}(`);
+  assert.ok(painterStart >= 0, `${painterName} production painter not found`);
+  const callbackStart = panelSource.indexOf("scrollNow: () => {", painterStart);
+  assert.ok(callbackStart > painterStart, `${painterName} production reveal callback not found`);
+  const bodyStart = panelSource.indexOf("{", callbackStart);
+  let depth = 0;
+  for (let i = bodyStart; i < panelSource.length; i += 1) {
+    if (panelSource[i] === "{") depth += 1;
+    if (panelSource[i] === "}" && --depth === 0) return panelSource.slice(bodyStart + 1, i);
+  }
+  assert.fail(`${painterName} production reveal callback is not balanced`);
+}
+
+function buildProductionRevealScrollNow(painterName, surface) {
+  const card = {
+    scrollIntoView() {
+      surface.cardScrolls += 1;
+      surface.log.dispatchEventFrom(surface.log, { type: "scroll" });
+    },
+  };
+  const scrollNow = new Function(
+    "scrollIntent",
+    "log",
+    "card",
+    productionRevealScrollNowSource(painterName),
+  );
+  return () => scrollNow(surface.scrollIntent, surface.log, card);
 }
 
 test("programmatic and anchoring scroll events do not count as user intent", () => {
@@ -122,6 +168,34 @@ test("production wiring preserves a root marker across multiple app writes befor
   assert.equal(surface.stickToBottom, false, "the following root user scroll must still unstick");
   surface.disposeChatScrollListeners();
   surface.scrollIntent.dispose();
+});
+
+test("production reveal paths fence both writes before preserving a later root scroll", () => {
+  for (const painterName of ["paintQuestion", "paintSecret"]) {
+    const surface = buildProductionScrollSurface({ dispatchScrollOnWrite: true });
+    surface.cardScrolls = 0;
+    const scrollNow = buildProductionRevealScrollNow(painterName, surface);
+
+    emit(surface.log, "pointerdown");
+    revealInteractiveCard({ scrollNow, retryMs: 0 });
+    assert.deepEqual(surface.log.programmaticWrites, [surface.log.scrollHeight]);
+    assert.equal(surface.cardScrolls, 1, `${painterName} must deliver its card reveal scroll`);
+    assert.equal(
+      surface.stickToBottom,
+      true,
+      `${painterName} must fence both synchronous programmatic scroll deliveries`,
+    );
+
+    surface.log._scrollTop = 250;
+    emit(surface.log, "scroll");
+    assert.equal(
+      surface.stickToBottom,
+      false,
+      `${painterName} must preserve the marker for the later root scroll`,
+    );
+    surface.disposeChatScrollListeners();
+    surface.scrollIntent.dispose();
+  }
 });
 
 test("wheel, touch, pointer, and vertical keyboard scrolling preserve user intent", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -34692,6 +34692,7 @@ function buildPanel() {
         scrollIntent.noteProgrammaticScroll();
         log.scrollTop = log.scrollHeight;
         try {
+          scrollIntent.noteProgrammaticScroll();
           card.scrollIntoView({ block: "nearest" });
         } catch {
           /* detached keep-alive root: the tab-forward above re-attaches it */
@@ -34979,6 +34980,7 @@ function buildPanel() {
         scrollIntent.noteProgrammaticScroll();
         log.scrollTop = log.scrollHeight;
         try {
+          scrollIntent.noteProgrammaticScroll();
           card.scrollIntoView({ block: "nearest" });
         } catch {
           /* detached keep-alive root: the tab-forward above re-attaches it */

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -30911,6 +30911,7 @@ function buildPanel() {
   newMsgBtn.addEventListener("click", () => {
     stickToBottom = true;
     newMsgBtn.hidden = true;
+    scrollIntent.noteProgrammaticScroll({ behavior: "smooth" });
     log.scrollTo({ top: log.scrollHeight, behavior: "smooth" });
     chatScrollStabilizer.schedule();
   });
@@ -30922,6 +30923,7 @@ function buildPanel() {
   for (const eventName of ["wheel", "touchmove", "pointerdown", "keydown"]) {
     log.addEventListener(eventName, (event) => scrollIntent.note(event), { passive: true });
   }
+  log.addEventListener("scrollend", () => scrollIntent.endProgrammaticScroll(), { passive: true });
   log.addEventListener("scroll", () => {
     const isAtBottom = atBottom();
     stickToBottom = updateChatStickiness(stickToBottom, {
@@ -30933,6 +30935,7 @@ function buildPanel() {
   const chatScrollStabilizer = createChatScrollStabilizer({
     log,
     shouldStick: () => stickToBottom,
+    beforeScroll: () => scrollIntent.noteProgrammaticScroll(),
   });
   body.appendChild(newMsgBtn);
   root.appendChild(body);
@@ -34667,6 +34670,7 @@ function buildPanel() {
         newMsgBtn.hidden = true;
       },
       scrollNow: () => {
+        scrollIntent.noteProgrammaticScroll();
         log.scrollTop = log.scrollHeight;
         try {
           card.scrollIntoView({ block: "nearest" });
@@ -34953,6 +34957,7 @@ function buildPanel() {
         newMsgBtn.hidden = true;
       },
       scrollNow: () => {
+        scrollIntent.noteProgrammaticScroll();
         log.scrollTop = log.scrollHeight;
         try {
           card.scrollIntoView({ block: "nearest" });
@@ -42733,6 +42738,7 @@ function buildPanel() {
       if (workWordTimer) { clearInterval(workWordTimer); workWordTimer = null; }
       if (thinkingSafety) { clearTimeout(thinkingSafety); thinkingSafety = null; }
       chatScrollStabilizer.dispose();
+      scrollIntent.dispose();
       document.removeEventListener("keydown", onInterruptKeydown, true);
       // Stop any chat audio before the panel's DOM goes away — a detached
       // <audio> keeps playing, and after an unmount there is no card left to

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -30908,30 +30908,49 @@ function buildPanel() {
     arrow.className = "pi pi-arrow-down";
     newMsgBtn.append(arrow, document.createTextNode(" " + tr("panel.new_messages", "New messages")));
   }
-  newMsgBtn.addEventListener("click", () => {
+  const onNewMessagesClick = () => {
     stickToBottom = true;
     newMsgBtn.hidden = true;
     scrollIntent.noteProgrammaticScroll({ behavior: "smooth" });
     log.scrollTo({ top: log.scrollHeight, behavior: "smooth" });
     chatScrollStabilizer.schedule();
-  });
+  };
+  newMsgBtn.addEventListener("click", onNewMessagesClick);
   // Track actual user input separately from scroll events. `content-visibility: auto`
   // (#1801) lets off-screen messages replace their intrinsic-size estimate with their
   // real height; scroll anchoring then emits a browser scroll event with no user intent.
   // Such an event must not latch stickToBottom off while the transcript settles.
   const scrollIntent = createChatScrollIntentTracker();
-  for (const eventName of ["wheel", "touchmove", "pointerdown", "keydown"]) {
-    log.addEventListener(eventName, (event) => scrollIntent.note(event), { passive: true });
-  }
-  log.addEventListener("scrollend", () => scrollIntent.endProgrammaticScroll(), { passive: true });
-  log.addEventListener("scroll", () => {
+  const chatScrollIntentListenerOptions = { passive: true };
+  const onChatScrollIntent = (event) => {
+    if (event.target !== event.currentTarget) return;
+    scrollIntent.note(event);
+  };
+  const onChatScrollEnd = (event) => {
+    if (event.target !== event.currentTarget) return;
+    scrollIntent.endProgrammaticScroll();
+  };
+  const onChatLogScroll = (event) => {
+    if (event.target !== event.currentTarget) return;
     const isAtBottom = atBottom();
     stickToBottom = updateChatStickiness(stickToBottom, {
       atBottom: isAtBottom,
       userScrollIntent: scrollIntent.consume(),
     });
     if (isAtBottom) newMsgBtn.hidden = true;
-  });
+  };
+  const disposeChatScrollListeners = () => {
+    for (const eventName of ["wheel", "touchmove", "pointerdown", "keydown"]) {
+      log.removeEventListener(eventName, onChatScrollIntent, chatScrollIntentListenerOptions);
+    }
+    log.removeEventListener("scrollend", onChatScrollEnd, chatScrollIntentListenerOptions);
+    log.removeEventListener("scroll", onChatLogScroll);
+  };
+  for (const eventName of ["wheel", "touchmove", "pointerdown", "keydown"]) {
+    log.addEventListener(eventName, onChatScrollIntent, chatScrollIntentListenerOptions);
+  }
+  log.addEventListener("scrollend", onChatScrollEnd, chatScrollIntentListenerOptions);
+  log.addEventListener("scroll", onChatLogScroll);
   const chatScrollStabilizer = createChatScrollStabilizer({
     log,
     shouldStick: () => stickToBottom,
@@ -42737,6 +42756,8 @@ function buildPanel() {
       // running (a remount would otherwise stack a second word cycler / backstop).
       if (workWordTimer) { clearInterval(workWordTimer); workWordTimer = null; }
       if (thinkingSafety) { clearTimeout(thinkingSafety); thinkingSafety = null; }
+      newMsgBtn.removeEventListener("click", onNewMessagesClick);
+      disposeChatScrollListeners();
       chatScrollStabilizer.dispose();
       scrollIntent.dispose();
       document.removeEventListener("keydown", onInterruptKeydown, true);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -83,6 +83,7 @@ import {
 // it is how this repo keeps producing near-duplicate bugs, per that file's own header.
 import { withTimeout } from "./lib/bounded-step.js";
 import { createChatScrollStabilizer } from "./lib/chat-scroll-stabilizer.js";
+import { createChatScrollIntentTracker, updateChatStickiness } from "./lib/chat-scroll-intent.js";
 import { createRunReceiptOutbox } from "./lib/run-receipt-outbox.js";
 import {
   mergeRunCompletionMetadata,
@@ -30913,10 +30914,21 @@ function buildPanel() {
     log.scrollTo({ top: log.scrollHeight, behavior: "smooth" });
     chatScrollStabilizer.schedule();
   });
-  // Track the user's scroll position; re-stick (and hide the pill) at the bottom.
+  // Track actual user input separately from scroll events. `content-visibility: auto`
+  // (#1801) lets off-screen messages replace their intrinsic-size estimate with their
+  // real height; scroll anchoring then emits a browser scroll event with no user intent.
+  // Such an event must not latch stickToBottom off while the transcript settles.
+  const scrollIntent = createChatScrollIntentTracker();
+  for (const eventName of ["wheel", "touchmove", "pointerdown", "keydown"]) {
+    log.addEventListener(eventName, (event) => scrollIntent.note(event), { passive: true });
+  }
   log.addEventListener("scroll", () => {
-    stickToBottom = atBottom();
-    if (stickToBottom) newMsgBtn.hidden = true;
+    const isAtBottom = atBottom();
+    stickToBottom = updateChatStickiness(stickToBottom, {
+      atBottom: isAtBottom,
+      userScrollIntent: scrollIntent.consume(),
+    });
+    if (isAtBottom) newMsgBtn.hidden = true;
   });
   const chatScrollStabilizer = createChatScrollStabilizer({
     log,

--- a/web/js/lib/chat-scroll-intent.js
+++ b/web/js/lib/chat-scroll-intent.js
@@ -25,7 +25,8 @@ export function isUserScrollIntent(event) {
 export function createChatScrollIntentTracker() {
   let pending = false;
   let pendingTimer = null;
-  let programmatic = null;
+  let programmatic = [];
+  let disposed = false;
 
   const clearPendingTimer = () => {
     if (pendingTimer !== null) {
@@ -35,10 +36,10 @@ export function createChatScrollIntentTracker() {
   };
 
   const clearProgrammatic = () => {
-    if (programmatic?.timer !== null && programmatic?.timer !== undefined) {
-      clearTimeout(programmatic.timer);
+    for (const scroll of programmatic) {
+      if (scroll.timer !== null) clearTimeout(scroll.timer);
     }
-    programmatic = null;
+    programmatic = [];
   };
 
   const clearPending = () => {
@@ -48,6 +49,7 @@ export function createChatScrollIntentTracker() {
 
   return {
     note(event) {
+      if (disposed) return;
       if (!isUserScrollIntent(event)) return;
       // A new user event owns the next scroll transaction, even if it interrupts
       // an in-flight smooth programmatic scroll.
@@ -60,31 +62,39 @@ export function createChatScrollIntentTracker() {
       }, USER_SCROLL_INTENT_EXPIRY_MS);
     },
     noteProgrammaticScroll({ behavior = "auto" } = {}) {
+      if (disposed) return;
       // A smooth jump can also schedule an instant stabilizer pass. Keep the
       // longer-lived guard for the same scroll transaction instead of letting
       // that follow-up downgrade it to a one-event guard.
-      if (programmatic?.smooth && behavior !== "smooth") return;
-      clearProgrammatic();
-      if (behavior === "smooth") {
-        const timer = setTimeout(() => {
-          programmatic = null;
-        }, PROGRAMMATIC_SCROLL_GUARD_MS);
-        programmatic = { smooth: true, timer };
-      } else {
-        // The next scroll event belongs to this synchronous/auto operation. Do
-        // not discard `pending`: a real user scroll may follow it.
-        programmatic = { smooth: false, timer: null };
-      }
+      if (programmatic.some(({ smooth }) => smooth)) return;
+
+      const scroll = { smooth: behavior === "smooth", timer: null };
+      scroll.timer = setTimeout(() => {
+        const index = programmatic.indexOf(scroll);
+        if (index !== -1) programmatic.splice(index, 1);
+      }, PROGRAMMATIC_SCROLL_GUARD_MS);
+      programmatic.push(scroll);
     },
     endProgrammaticScroll() {
-      clearProgrammatic();
+      if (disposed) return;
+      const smooth = programmatic.filter(({ smooth }) => smooth);
+      for (const scroll of smooth) {
+        if (scroll.timer !== null) clearTimeout(scroll.timer);
+      }
+      programmatic = programmatic.filter(({ smooth }) => !smooth);
     },
     consume() {
-      if (programmatic) {
+      if (disposed) return false;
+      if (programmatic.some(({ smooth }) => smooth)) {
         // An app-owned scroll must not spend a genuine user marker. Auto scrolls
         // have one event; smooth scrolls remain guarded until scrollend (or the
         // bounded fallback above).
-        if (programmatic.timer === null) clearProgrammatic();
+        return false;
+      }
+      const autoIndex = programmatic.findIndex(({ smooth }) => !smooth);
+      if (autoIndex !== -1) {
+        const [scroll] = programmatic.splice(autoIndex, 1);
+        if (scroll.timer !== null) clearTimeout(scroll.timer);
         return false;
       }
       const wasPending = pending;
@@ -92,6 +102,7 @@ export function createChatScrollIntentTracker() {
       return wasPending;
     },
     dispose() {
+      disposed = true;
       clearPending();
       clearProgrammatic();
     },

--- a/web/js/lib/chat-scroll-intent.js
+++ b/web/js/lib/chat-scroll-intent.js
@@ -1,0 +1,36 @@
+const VERTICAL_SCROLL_KEYS = new Set([
+  "ArrowDown",
+  "ArrowUp",
+  "End",
+  "Home",
+  "PageDown",
+  "PageUp",
+  " ",
+  "Spacebar",
+]);
+
+export function isUserScrollIntent(event) {
+  if (!event) return false;
+  if (event.type === "wheel" || event.type === "touchmove" || event.type === "pointerdown") return true;
+  return event.type === "keydown" && VERTICAL_SCROLL_KEYS.has(event.key);
+}
+
+export function createChatScrollIntentTracker() {
+  let pending = false;
+
+  return {
+    note(event) {
+      if (isUserScrollIntent(event)) pending = true;
+    },
+    consume() {
+      const wasPending = pending;
+      pending = false;
+      return wasPending;
+    },
+  };
+}
+
+export function updateChatStickiness(stickToBottom, { atBottom, userScrollIntent }) {
+  if (atBottom) return true;
+  return userScrollIntent ? false : stickToBottom;
+}

--- a/web/js/lib/chat-scroll-intent.js
+++ b/web/js/lib/chat-scroll-intent.js
@@ -9,6 +9,13 @@ const VERTICAL_SCROLL_KEYS = new Set([
   "Spacebar",
 ]);
 
+// Chromium dispatches a user wheel event before its scroll event, but the scroll
+// can land on the next rendering opportunity. Keep the association long enough
+// for that browser ordering without allowing an input that did not scroll to
+// authorize a later content-visibility/anchoring scroll.
+const USER_SCROLL_INTENT_EXPIRY_MS = 100;
+const PROGRAMMATIC_SCROLL_GUARD_MS = 1000;
+
 export function isUserScrollIntent(event) {
   if (!event) return false;
   if (event.type === "wheel" || event.type === "touchmove" || event.type === "pointerdown") return true;
@@ -17,15 +24,76 @@ export function isUserScrollIntent(event) {
 
 export function createChatScrollIntentTracker() {
   let pending = false;
+  let pendingTimer = null;
+  let programmatic = null;
+
+  const clearPendingTimer = () => {
+    if (pendingTimer !== null) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+  };
+
+  const clearProgrammatic = () => {
+    if (programmatic?.timer !== null && programmatic?.timer !== undefined) {
+      clearTimeout(programmatic.timer);
+    }
+    programmatic = null;
+  };
+
+  const clearPending = () => {
+    pending = false;
+    clearPendingTimer();
+  };
 
   return {
     note(event) {
-      if (isUserScrollIntent(event)) pending = true;
+      if (!isUserScrollIntent(event)) return;
+      // A new user event owns the next scroll transaction, even if it interrupts
+      // an in-flight smooth programmatic scroll.
+      clearProgrammatic();
+      pending = true;
+      clearPendingTimer();
+      pendingTimer = setTimeout(() => {
+        pending = false;
+        pendingTimer = null;
+      }, USER_SCROLL_INTENT_EXPIRY_MS);
+    },
+    noteProgrammaticScroll({ behavior = "auto" } = {}) {
+      // A smooth jump can also schedule an instant stabilizer pass. Keep the
+      // longer-lived guard for the same scroll transaction instead of letting
+      // that follow-up downgrade it to a one-event guard.
+      if (programmatic?.smooth && behavior !== "smooth") return;
+      clearProgrammatic();
+      if (behavior === "smooth") {
+        const timer = setTimeout(() => {
+          programmatic = null;
+        }, PROGRAMMATIC_SCROLL_GUARD_MS);
+        programmatic = { smooth: true, timer };
+      } else {
+        // The next scroll event belongs to this synchronous/auto operation. Do
+        // not discard `pending`: a real user scroll may follow it.
+        programmatic = { smooth: false, timer: null };
+      }
+    },
+    endProgrammaticScroll() {
+      clearProgrammatic();
     },
     consume() {
+      if (programmatic) {
+        // An app-owned scroll must not spend a genuine user marker. Auto scrolls
+        // have one event; smooth scrolls remain guarded until scrollend (or the
+        // bounded fallback above).
+        if (programmatic.timer === null) clearProgrammatic();
+        return false;
+      }
       const wasPending = pending;
-      pending = false;
+      clearPending();
       return wasPending;
+    },
+    dispose() {
+      clearPending();
+      clearProgrammatic();
     },
   };
 }

--- a/web/js/lib/chat-scroll-stabilizer.js
+++ b/web/js/lib/chat-scroll-stabilizer.js
@@ -18,6 +18,7 @@ const defaultRequestFrame = (fn) =>
 export function createChatScrollStabilizer({
   log,
   shouldStick = () => true,
+  beforeScroll = () => {},
   requestFrame = defaultRequestFrame,
   ResizeObserverCtor = typeof ResizeObserver === "function" ? ResizeObserver : null,
   MutationObserverCtor = typeof MutationObserver === "function" ? MutationObserver : null,
@@ -53,6 +54,11 @@ export function createChatScrollStabilizer({
   const scrollNow = () => {
     framePending = false;
     if (!canStick()) return;
+    try {
+      beforeScroll();
+    } catch {
+      // A teardown hook must not prevent the best-effort scroll itself.
+    }
     try {
       log.scrollTop = log.scrollHeight;
     } catch {


### PR DESCRIPTION
Fixes #1841.

The chat log now records explicit user scroll intent separately from scroll events. Browser scroll anchoring and content-visibility layout corrections no longer disable stickToBottom, while wheel, touch, pointer, and vertical keyboard scrolling still intentionally detach the reader. Reaching the bottom always re-sticks.

Validation: focused scroll/containment tests, full npm test:unit, npm run typecheck, and npm run check:scope.