### PR TITLE
fix(1842): bound the pre-receipt reconcile replay so it cannot storm the agent

### DIFF
--- a/browser_tests/unit/run-completion-redelivery-storm.test.mjs
+++ b/browser_tests/unit/run-completion-redelivery-storm.test.mjs
@@ -1,0 +1,279 @@
+/**
+ * panel#1842 — the pre-receipt reconcile REPLAY must be bounded.
+ *
+ * REPORTED SHAPE. After ~10 `panel_run` calls the panel began re-delivering the
+ * SAME completed-run notifications every agent turn, indefinitely: 40+
+ * consecutive turns for a fixed set of 6 already-finished prompt ids, with
+ * `running: 0, pending: 0` on the queue and no new runs — the flood continued
+ * after the agent stopped calling `panel_run` at all.
+ *
+ * MECHANISM. A KEYED `panel_run` completion deliberately stays in the tracker's
+ * `pending` ledger until the orchestrator's receipt (`acknowledgeDelivery`), and
+ * #1824 deliberately lets a /history reconcile REPLAY that completion under the
+ * same completion key before the receipt arrives — that is how a frame lost in
+ * transit is recovered. What was missing is a BOUND: `reconcileKey`'s only entry
+ * guard was `delivered.has(k) || !pending.has(k)`, which a run awaiting a receipt
+ * satisfies neither of, so the 20-second safety sweep re-emitted the same
+ * finished run on EVERY tick for as long as the panel stayed open.
+ *
+ * The replay's premise — "the key makes it idempotent downstream" — is a
+ * property of the OTHER process, and it was false for the orchestrator the
+ * reporters ran: comfyui-mcp sent no `ack {kind:"completion"}` at all before
+ * v0.52.122 (`8282e05`), so no receipt could arrive and every replay minted a
+ * fresh agent turn.
+ *
+ * WHAT IS COUNTED is deliberately "frames the transport ACCEPTED for this run
+ * and no receipt has retired", not "reconcile passes": a refusal gives its own
+ * slot back but must never reset the count, or a flapping transport mints one
+ * agent turn per flap forever and the bound is decorative (codex gate R1 P1).
+ *
+ * The tests below are pins for the bound plus CONTROLS for everything that must
+ * still be delivered. "Stop the replays" is satisfiable by delivering nothing,
+ * which is strictly worse than the bug (#1739 / #585 / #370 are all that class),
+ * so the controls are the load-bearing half — and three of them are green on
+ * unfixed main as well as on the fix, which is what makes them controls.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+const PROMPT = "122c1547-990a-4ea2-8594-95998585a364";
+const ROUTE = "route-a";
+const SESSION = "sess-1";
+const IMAGE = { filename: "out_0001.png", subfolder: "", type: "output" };
+
+/**
+ * The bound, written out here as its own literal rather than imported from the
+ * module under test. An expectation computed from the code it is checking moves
+ * with that code and stops being an expectation, so changing
+ * `maxUnackedDeliveries` must fail these tests and make someone re-argue the
+ * number.
+ */
+const BUDGET = 3;
+
+const HISTORY = {
+  outputs: { 9: { images: [IMAGE] } },
+  status: { status_str: "success", completed: true, messages: [] },
+};
+
+function makeHarness() {
+  let clock = 0;
+  const timers = new Map();
+  let seq = 0;
+  const flushes = [];
+  const tracker = createRunCompletionTracker({
+    onFlush: (p) => flushes.push(p),
+    now: () => clock,
+    setTimer: (fn, ms) => {
+      const id = ++seq;
+      timers.set(id, { at: clock + ms, fn });
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+    debounceMs: 1500,
+  });
+  const probes = { history: 0 };
+  /** One pass of the periodic safety sweep (createRunReconcileSweep -> reconcile). */
+  const sweep = () =>
+    tracker.reconcile({
+      fetchHistory: async () => {
+        probes.history += 1;
+        return HISTORY;
+      },
+      fetchQueued: async () => false,
+      isVideo: () => false,
+    });
+  return { tracker, flushes, sweep, probes, advance: (ms) => { clock += ms; } };
+}
+
+/** A panel_run that queued, rendered and succeeded — its receipt still owed. */
+function runToSuccess(tracker) {
+  const completionKey = tracker.onQueued(PROMPT, { routeId: ROUTE, sessionId: SESSION });
+  tracker.onExecutionStart(PROMPT);
+  tracker.onExecuted(PROMPT, { images: [IMAGE] });
+  tracker.onExecutionSuccess(PROMPT);
+  return completionKey;
+}
+
+test("#1842: the sweep stops re-delivering a receipt-less completion after a bounded number of frames", async () => {
+  const { tracker, flushes, sweep, probes } = makeHarness();
+  const completionKey = runToSuccess(tracker);
+
+  assert.equal(flushes.length, 1, "the live execution_success delivers exactly one frame");
+  assert.equal(tracker.hasPending(), true, "a keyed panel_run stays pending until its receipt");
+
+  // The orchestrator never acknowledges (comfyui-mcp < 0.52.122 had no ack at
+  // all). The sweep re-arms for as long as hasPending() is true, so this is what
+  // the reporter's session did every 20 seconds for 40+ turns.
+  for (let tick = 0; tick < 20; tick += 1) await sweep();
+
+  assert.equal(
+    flushes.length,
+    BUDGET,
+    "twenty sweep ticks must not compose twenty more copies of one finished run",
+  );
+  assert.equal(
+    probes.history,
+    BUDGET - 1,
+    "…and past the budget the run is refused BEFORE the /history probe, so the sweep " +
+      "also stops hammering ComfyUI once per stuck run per tick, forever",
+  );
+  assert.equal(tracker.hasPending(), true, "the run is still owed its receipt");
+  assert.equal(
+    tracker.isDeliveryUnconfirmed(PROMPT),
+    false,
+    "…and the #585 delivery evidence is untouched by the budget",
+  );
+
+  // The receipt, whenever it lands, still retires the run.
+  assert.equal(tracker.acknowledgeDelivery(PROMPT, completionKey), true);
+  assert.equal(tracker.hasPending(), false, "an acked completion drains the ledger");
+  assert.equal(flushes.length, BUDGET, "and no further frame is composed");
+});
+
+// The codex gate's R1 P1, pinned. An earlier revision RESET the count on every
+// refusal, so alternating refuse/accept — a flapping bridge, or a route that
+// keeps moving under `sendRunCompletionFrame` — minted one fresh agent turn per
+// flap, forever. The bound has to be on frames that were ACCEPTED.
+test("#1842: a FLAPPING transport cannot mint unlimited turns by resetting the budget", async () => {
+  // Shaped like production: the flush handler decides each frame's fate and
+  // reports a refusal through markUndelivered, so exactly one refusal can ever
+  // correspond to one emission.
+  let clock = 0;
+  const accepted = [];
+  const emitted = [];
+  let socketUp = true;
+  let tracker;
+  tracker = createRunCompletionTracker({
+    onFlush: (payload) => {
+      emitted.push(payload);
+      socketUp = !socketUp; // the bridge flaps between every attempt
+      if (socketUp) accepted.push(payload);
+      else tracker.markUndelivered(payload.promptId, payload.completionKey);
+    },
+    now: () => clock,
+    setTimer: () => 0,
+    clearTimer: () => {},
+    debounceMs: 1500,
+  });
+  runToSuccess(tracker);
+
+  for (let flap = 0; flap < 40; flap += 1) {
+    await tracker.reconcile({
+      fetchHistory: async () => HISTORY,
+      fetchQueued: async () => false,
+      isVideo: () => false,
+    });
+  }
+
+  assert.equal(
+    accepted.length,
+    BUDGET,
+    `a flapping transport landed ${accepted.length} frames on the agent; the bound is ${BUDGET}`,
+  );
+  const settled = emitted.length;
+  for (let flap = 0; flap < 10; flap += 1) {
+    await tracker.reconcile({
+      fetchHistory: async () => HISTORY,
+      fetchQueued: async () => false,
+      isVideo: () => false,
+    });
+  }
+  assert.equal(emitted.length, settled, "…and it has stopped composing frames entirely");
+});
+
+// #1824's own call-site test (run-command-budget.test.mjs) pins this too. It is
+// repeated here because it is the property the bound must not destroy: the FIRST
+// replay is the recovery for a frame lost in transit, and a bound that started at
+// zero would silently un-ship it.
+test("CONTROL #1824: a reconcile before the receipt still replays the SAME keyed completion", async () => {
+  const { tracker, flushes, sweep } = makeHarness();
+  const completionKey = runToSuccess(tracker);
+  assert.equal(flushes.length, 1);
+
+  await sweep();
+  assert.equal(flushes.length, 2, "the pre-receipt reconcile replays the completion");
+  assert.equal(flushes[1].reconciled, true);
+  assert.equal(
+    flushes[1].completionKey,
+    completionKey,
+    "…under the same key, so it is idempotent to an orchestrator that reads receipts",
+  );
+});
+
+// Green on unfixed `origin/main` as well as on the fix — that is what makes it a
+// control rather than a second pin. Keep the storm assertion OUT of it.
+test("CONTROL #1739: a completion the TRANSPORT refused is still re-delivered by the sweep", async () => {
+  const { tracker, flushes, sweep } = makeHarness();
+  const completionKey = runToSuccess(tracker);
+  assert.equal(flushes.length, 1);
+
+  // sendFrame returned false (bridge down when the flush fired) — the caller
+  // re-pends the run. This is the ONLY thing standing between the agent and a
+  // silently lost render, so the bound must not swallow it.
+  tracker.markUndelivered(PROMPT, completionKey);
+
+  await sweep();
+  assert.equal(flushes.length, 2, "a re-pended completion is re-delivered");
+  assert.equal(flushes[1].reconciled, true, "…from /history, as the #370 recovery");
+  assert.equal(flushes[1].promptId, PROMPT);
+});
+
+// The other half of the same guarantee, and the reason the refusal DECREMENTS
+// rather than merely being ignored: a run nothing has ever accepted is not
+// bounded at all, because no frame has ever had a chance to reach the agent.
+test("CONTROL: a run whose frames are ALWAYS refused is retried without limit", async () => {
+  const { tracker, flushes, sweep } = makeHarness();
+  const completionKey = runToSuccess(tracker);
+
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    tracker.markUndelivered(PROMPT, completionKey);
+    await sweep();
+  }
+
+  assert.equal(
+    flushes.length,
+    13,
+    "every attempt after a refusal is re-delivered — nothing ever landed, so nothing is bounded",
+  );
+  assert.equal(tracker.hasPending(), true);
+});
+
+test("REACHABILITY: production drives this exact path — the safety sweep calls tracker.reconcile", () => {
+  // The bound lives in `reconcileKey`. A green tracker test proves the mechanism
+  // works; it does not prove the panel reaches it. The reported storm is the
+  // periodic sweep re-arming on `hasPending()` and calling `reconcile()`, so pin
+  // that wiring rather than assume it.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const sweep = src.indexOf("createRunReconcileSweep({");
+  assert.notEqual(sweep, -1, "the panel still constructs the periodic safety sweep");
+  const block = src.slice(sweep, sweep + 600);
+  assert.match(block, /hasPending:\s*\(\)\s*=>\s*runCompletion\.hasPending\(\)/, "armed by the ledger");
+  assert.match(block, /reconcile:\s*\(\)\s*=>\s*reconcileRunsAfterReconnect\(\)/, "…and it reconciles");
+  assert.match(
+    src,
+    /runCompletion\.reconcile\(\{/,
+    "reconcileRunsAfterReconnect drives the tracker's own reconcile, which is where the bound is",
+  );
+});
+
+// Also green BOTH BEFORE AND AFTER, for the same reason as the #1739 control.
+test("CONTROL #370: a run whose execution_success was MISSED entirely is still recovered", async () => {
+  const { tracker, flushes, sweep } = makeHarness();
+  // Queued, then the WS drops: no execution_start, no executed, no success.
+  tracker.onQueued(PROMPT, { routeId: ROUTE, sessionId: SESSION });
+  assert.equal(flushes.length, 0);
+  assert.equal(tracker.hasPending(), true);
+
+  await sweep();
+  assert.equal(flushes.length, 1, "the sweep is still the recovery for an outcome never seen");
+  assert.equal(flushes[0].reconciled, true);
+  assert.equal(flushes[0].images.length, 1);
+});

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -292,6 +292,11 @@ export function createRunCompletionTracker({
       return false;
     }
     for (const record of records) {
+      // #1842 — every KEYED frame leaving here is a potential agent turn, and it
+      // is retired only by a receipt, so it spends one of this run's bounded
+      // delivery slots. Counted at the single funnel deliberately: a later emit
+      // site added upstream cannot quietly escape the bound.
+      noteUnackedDelivery(k);
       onFlush({ ...payload, completionKey: record.completionKey });
     }
     return true;
@@ -401,6 +406,12 @@ export function createRunCompletionTracker({
     markTerminal(id);
     touchFence(delivered, k);
     pending.delete(k);
+    // #1842 — the replay budget is scoped to runs still in `pending`; a key
+    // retired from it can never be re-composed by reconcile, so drop the record
+    // rather than let the map outlive what it counts. Deliberately does NOT
+    // touch `awaitingDelivery`/`unconfirmedDelivery` — see the note below on why
+    // this optimistic retire must not release the #585 delivery hold.
+    clearUnackedDeliveries(k);
     // #356 Bug 2 — panelQueued deliberately SURVIVES this. `markDelivered` here is
     // OPTIMISTIC (flush/execution_success/reconcile all call it before the caller has
     // confirmed the frame reached the agent), and markUndelivered can re-pend the run.
@@ -452,6 +463,79 @@ export function createRunCompletionTracker({
   // would already be the real problem, and trading a correctness property for that
   // is a bad trade.
   const unconfirmedDelivery = new Map(); // key -> ts
+  // ── #1842: BOUND the pre-receipt reconcile REPLAY ─────────────────────────
+  //
+  // A keyed panel_run completion deliberately STAYS in `pending` until the
+  // orchestrator's receipt, and #1824 deliberately lets a /history reconcile
+  // REPLAY that completion under the SAME completion key before the receipt
+  // arrives — that is how a frame lost in transit is recovered, and the key is
+  // what makes the replay idempotent downstream.
+  //
+  // What was missing is a BOUND. `reconcileKey`'s only entry guard was
+  // `delivered.has(k) || !pending.has(k)`, and a run awaiting a receipt
+  // satisfies neither — so `hasPending()` stayed true forever, the 20-second
+  // safety sweep re-armed forever, and the same finished run was re-composed and
+  // re-emitted on EVERY tick, for as long as the panel was open. Six such runs
+  // became the reported forty-plus consecutive agent turns of nothing but
+  // replays, continuing long after the agent stopped calling panel_run.
+  //
+  // The premise the unbounded replay rests on — "the key makes it idempotent
+  // downstream" — is a property of the OTHER process, and it was simply false
+  // for the orchestrator the reporters were running: comfyui-mcp did not send
+  // `ack {kind:"completion"}` at all before v0.52.122, so no receipt could ever
+  // arrive and every replay minted a fresh agent turn. A retry whose success
+  // depends on a peer capability it cannot observe must be bounded, or a peer
+  // that never answers turns it into an infinite loop.
+  //
+  // So: the replay stays, and what is counted is the only thing that can
+  // actually reach the agent — a completion frame the TRANSPORT ACCEPTED for
+  // this run which no receipt has retired. Past the budget the panel stops
+  // re-sending; the run simply remains pending-and-unconfirmed, which the #585
+  // machinery already reports honestly (isDeliveryUnconfirmed).
+  //
+  // A transport REFUSAL (markUndelivered) DECREMENTS this by one; it must never
+  // reset it. A refused frame never left the browser, so it must not spend
+  // budget — but it is not evidence about the frames that DID leave, and
+  // treating it as such is how a bound becomes decorative: with a reset, a
+  // flapping bridge (refuse → accept → refuse → accept …) mints one fresh agent
+  // turn per flap, forever, which is the exact failure this exists to stop
+  // (codex gate R1 P1). Decrementing yields precisely the wanted quantity —
+  // emissions minus known failures, i.e. frames that plausibly reached someone —
+  // so a run whose frames are ALWAYS refused is retried without limit (#370 /
+  // #1739 untouched: nothing ever landed), while the number that can LAND is
+  // capped however the transport behaves.
+  //
+  // Cleared outright only when the run is retired: a confirmed delivery
+  // (markDelivered / acknowledgeDelivery) or an eviction. Nothing else may clear
+  // it, because nothing else is evidence about frames already accepted.
+  //
+  // Deliberately NOT keyed off `awaitingDelivery`: that is a 120s watchdog whose
+  // expiry is a #585 DISCLOSURE signal, not permission to compose another frame.
+  const unackedDeliveries = new Map(); // key -> frames accepted, none acked yet
+  // Three (~60s at RUN_RECONCILE_SWEEP_MS: one live delivery + two sweeps) is a
+  // generous allowance for a frame genuinely lost in transit and still finite. A
+  // fourth would not recover anything the first three did not — nothing about
+  // the run changes between ticks except the clock.
+  const maxUnackedDeliveries = 3;
+  function clearUnackedDeliveries(k) {
+    unackedDeliveries.delete(k);
+  }
+  /** A completion frame for `k` has just been handed to the caller. */
+  function noteUnackedDelivery(k) {
+    if (k === NO_PROMPT_KEY) return;
+    if (!hasCompletionRecords(k)) return; // an unkeyed run is retired by its caller
+    unackedDeliveries.set(k, (unackedDeliveries.get(k) ?? 0) + 1);
+  }
+  /** …and the caller has reported that THAT one never left the browser. */
+  function releaseUnackedDelivery(k) {
+    const outstanding = unackedDeliveries.get(k);
+    if (outstanding === undefined) return;
+    if (outstanding <= 1) unackedDeliveries.delete(k);
+    else unackedDeliveries.set(k, outstanding - 1);
+  }
+  function unackedDeliveriesExhausted(k) {
+    return (unackedDeliveries.get(k) ?? 0) >= maxUnackedDeliveries;
+  }
   // Bound the in-flight window well past any realistic compose (metadata HEADs +
   // video storyboard sampling).
   const deliveryConfirmTimeoutMs = 120000;
@@ -740,6 +824,14 @@ export function createRunCompletionTracker({
   async function reconcileKey(promptId, fetchHistory, fetchQueued, isVideo) {
     const k = key(promptId);
     if (delivered.has(k) || !pending.has(k)) return null;
+    // #1842 — this run's bounded number of completion frames have already been
+    // handed over and no receipt has retired any of them. Refuse BEFORE the
+    // /history probe, so an orchestrator that never acks stops costing a fetch
+    // AND an agent turn on every sweep tick, forever. A frame the transport
+    // REFUSED does not count against this (markUndelivered gives that one slot
+    // back), so a run nothing ever accepted is still retried without limit —
+    // see `unackedDeliveries` for why that is a decrement and never a reset.
+    if (unackedDeliveriesExhausted(k)) return null;
     // A timeout-released panel_run already owns the exact media batch, but its
     // delayed /prompt identity has not supplied the completion key yet. Do not
     // replace that recoverable record with an unkeyed /history delivery: the
@@ -947,6 +1039,7 @@ export function createRunCompletionTracker({
     starts.delete(k);
     startObserved.delete(k);
     pending.delete(k); // EVICT — bounds the ledger
+    clearUnackedDeliveries(k); // #1842 — the run is gone; nothing left to bound
     panelQueued.delete(k); // #356 Bug 2 — evicted with it
     liveReplays.delete(k);
     clearCompletionRecords(k);
@@ -1379,6 +1472,12 @@ export function createRunCompletionTracker({
       // cancel any in-flight retry so the re-pend restarts cleanly on the next edge.
       delivered.delete(k);
       clearReconcileRetry(k);
+      // #1842 — that frame never left the browser, so it must not spend a
+      // delivery slot. Give exactly IT back, and nothing more: a refusal says
+      // nothing about the frames that DID leave, and resetting the count on one
+      // would let a flapping transport mint an unbounded number of agent turns
+      // for one finished run — the bound this change exists to impose.
+      releaseUnackedDelivery(k);
       // It is back to being OWED, not in-flight — drop the delivery hold so the
       // 120s backstop can't be what decides isSettled() for it (#585).
       clearAwaitingDelivery(k);
@@ -1620,6 +1719,7 @@ export function createRunCompletionTracker({
     _terminal: terminal,
     _awaitingDelivery: awaitingDelivery,
     _unconfirmedDelivery: unconfirmedDelivery,
+    _unackedDeliveries: unackedDeliveries,
     _terminalNoKeyCompletion: terminalNoKeyCompletion,
     _terminalNoKeyFlushed: terminalNoKeyFlushed,
     _panelRunCompletionKeys: panelRunCompletionKeys,


### PR DESCRIPTION
## What the report said

After ~10 `panel_run` calls the panel began re-delivering the **same** completed-run
notifications every agent turn, indefinitely — 40+ consecutive turns for a fixed set of
6 already-finished prompt ids, each tagged `POSSIBLE REPEAT`, with `running: 0,
pending: 0` on the queue and no new runs. It continued after the agent stopped calling
`panel_run` at all, and exhausted the session's automatic-preview budget with replayed
images, after which real results stopped being attached either.

## The mechanism, reproduced by execution

A **keyed** `panel_run` completion deliberately stays in the tracker's `pending` ledger
until the orchestrator's receipt retires it, and **#1824 deliberately lets a `/history`
reconcile REPLAY that completion under the same completion key before the receipt
arrives** — that is how a frame lost in transit is recovered.
`run-command-budget.test.mjs` pins it (*"a safety-sweep/history replay before the receipt
must send the same logical completion"*).

What was missing is a **bound**. `reconcileKey`'s only entry guard was:

```js
if (delivered.has(k) || !pending.has(k)) return null;
```

A run awaiting a receipt satisfies neither. So `hasPending()` stays true forever,
`createRunReconcileSweep` re-arms forever, and on **every** 20-second tick `reconcileKey`
re-found the same terminal `/history` record, took the `holdsForCompletionAck` branch
(marks terminal, deliberately *not* delivered) and composed and emitted the frame again.

Driving the real tracker module — one finished run, twenty sweep ticks:

| | frames emitted for ONE finished run | `/history` probes |
|---|---|---|
| before | 1, then one more per tick, unbounded | one per tick, forever |
| after | 3 | 2 |

Six stuck runs is six fresh agent turns every 20 seconds, which is the report verbatim.
The sibling report mcp#2341 measured the identical storm as *"every roughly 20–30
seconds"* — this sweep's interval.

## Why the replay could never succeed for these reporters

The replay's premise — *"the stable key makes every /history replay idempotent
downstream"* — is a property of the **other process**, and it was false for the
orchestrator they ran. comfyui-mcp sent no `ack {kind:"completion"}` **at all** before
**v0.52.122** (`8282e05`, "acknowledge panel completion receipts (#1824)"); the reporters
of #1842, #1830 and mcp#2341 were all on **0.52.95**. No receipt could ever arrive, so
every `panel_run` completion leaked into permanent `pending` and every replay minted a
fresh agent turn.

A retry whose success depends on a peer capability it cannot observe has to be bounded,
or a peer that never answers turns it into an infinite loop. That is the defect fixed
here. (The orchestrator side is separately fixed twice over: the ack in 0.52.122, and a
durable `completion_key`-scoped idempotency fence in 0.52.127 for mcp#2341.)

## This also explains three things the issue threads could not

**Why none of the ~40 messages carried the `(RE-DELIVERED —` prefix.** They were not
replays *by the journal*. Each panel frame produced a **new** orchestrator journal entry,
whose `attempts` is 0, so `replayed` is false. The panel emitted ~40 *fresh* frames.

**Why panel#1851 sees a CLIMBING dropped-completions count.** Same consequence, from the
other end: the journal caps a tab at `MAX_ENTRIES_PER_KEY = 32` and `trimEntries`
increments the `dropped` counter for each entry it evicts. A stream of genuinely new
entries overflows that cap, so the count climbs — which a stream of *replays* of one
entry would not do. (See the note on #1851's second half at the bottom.)

**Why one message paired `POSSIBLE REPEAT` with the `matched` preamble.** It is one
message, and the *wording* is wrong, not the correlation. In `run-completion-journal.ts`
`record()`, `...(idlessRepeat || alreadyDelivered ? { possibleRepeat: true } : {})` —
and `alreadyDelivered` is computed **inside** the `correlation.status !== "unidentified"`
branch, so an identified completion gets flagged too. An existing green mcp test proves
it by execution (`run-completion-continuation.test.ts:1702`: a completion **with** a
prompt id, correlating `matched`, asserts `possibleRepeat === true`). The `POSSIBLE
REPEAT` sentence in `panel-agent.ts` hardcodes *"this one carries no prompt id to tell
them apart"*, which is false on that branch — filed as **mcp#2361**; nothing here changes
how the flag is set. It is **not** evidence of an id-less frame, so
`terminalNoKeyCompletion` / `RUN_COMPLETION_TERMINAL_KEY` were never involved, and the
id-less lead was a dead end.

## The fix

`unackedDeliveries` counts — at `flushWithCompletionRecords`, the single funnel every
keyed frame leaves through — the completion frames handed to the caller for a run that no
receipt has retired, and stops at **three**. Past the budget the run is refused **before**
the `/history` probe, so it also stops costing a fetch per stuck run per tick. The run
then stays pending-and-unconfirmed, which the #585 machinery already reports honestly via
`isDeliveryUnconfirmed`.

Deliberately **not** keyed off `awaitingDelivery`: that is a 120s watchdog whose expiry
is a #585 *disclosure* signal, and fencing on it alone would only slow the storm from 20s
to 120s.

**What is counted is frames that could LAND, not reconcile passes.** A transport refusal
(`markUndelivered`) **decrements** by one — that frame never left the browser, so it must
not spend a slot — but never **resets**. A refusal is no evidence about the frames that
*did* leave, and resetting on one lets a flapping transport (refuse → accept → refuse →
accept …) mint an agent turn per flap forever: the same bug wearing the fix's clothes.
That was the review gate's R1 P1 against the previous revision of this patch, and it now
has a production-shaped test driving exactly that alternation.

## Nothing is swallowed — the risky parts, named

Every "stop the replays" fix is satisfiable by delivering nothing, which is far worse
than the bug (#1739 / #585 / #370 are all that class). Three controls:

- **a run whose frames are ALWAYS refused is retried without limit** — nothing ever
  landed, so nothing is bounded (#370/#1739);
- **a single pre-receipt reconcile still replays the same keyed frame** (#1824);
- **a run whose `execution_success` was missed entirely is still recovered** (#370).

**Where to look hardest.** (1) The decrement, `releaseUnackedDelivery` — it is what
separates "this frame did not land" from "none of them landed", and getting it wrong in
either direction is a real bug: too generous re-opens the storm, too strict loses a
render. (2) The number. Three is an argued default, not a measured one: one live delivery
plus two sweeps (~60s), and a fourth recovers nothing the first three did not, because
nothing about the run changes between ticks except the clock. The tests hard-code `3` as
their own literal so changing it fails them and forces the argument again.

## Evidence

`browser_tests/unit/run-completion-redelivery-storm.test.mjs` — 7 tests: 2 pins, 4
controls, 1 reachability check. **7 pass / 0 fail.**

Against **unfixed `origin/main`** (`045a81af`) the same file gives **2 red / 5 green**:
both pins red, and all three delivery controls plus the reachability check green. That is
what makes them controls rather than pins, and it is the evidence that the fix did not
turn delivery off.

| test | `origin/main` | this branch |
|---|---|---|
| PIN: the sweep stops after a bounded number of frames | red | green |
| PIN: a flapping transport cannot mint unlimited turns | red | green |
| CONTROL #1824: pre-receipt reconcile replays the same keyed frame | **green** | green |
| CONTROL #1739: a refused completion is re-delivered | **green** | green |
| CONTROL: always-refused frames are retried without limit | **green** | green |
| CONTROL #370: a missed `execution_success` is still recovered | **green** | green |
| REACHABILITY: the sweep drives `tracker.reconcile` | **green** | green |

Mutations, each applied alone to the fixed tree (7 tests; 7/7 green at baseline):

| mutation | red | green |
|---|---|---|
| M1 — remove the bound from `reconcileKey` | both pins | 5, incl. all 3 controls |
| M2 — restore the gate's R1 P1 (reset instead of decrement on refusal) | **the flap pin only** | 6 |
| M3 — a refusal never gives its slot back | flap pin + **CONTROL always-refused** | 5 |
| M4 — change the budget 3 → 5 | both pins | 5, incl. all 3 controls |
| M5 — never count keyed frames at the emit funnel | both pins | 5, incl. all 3 controls |

M2 is the important row: reinstating the exact defect the review gate found turns
**exactly one** test red, so that finding is now pinned rather than merely fixed. M3 is
the control-integrity row: it breaks a delivery guarantee and not the bound, which is how
you can tell the decrement is load-bearing in both directions.

Two process notes, because both changed the patch:

- **An earlier revision forbade the pre-receipt replay outright.** It passed its own
  seven tests and **hung** `run-command-budget.test.mjs` — #1824's call-site test *awaits*
  that replay, so suppressing it left an unresolved promise. That is what turned this from
  "fence it" into "bound it".
- **A mutation of that revision SURVIVED**, because a second clause caught what the first
  no longer did. Mutating clause by clause exposed it; a single "revert the whole thing"
  mutation would have reported a pin that was not pinning what it claimed.

Diff is `web/js/lib/run-completion.js` plus the new test — no change to
`comfyui-mcp-panel.js`, and no browser-visible change (no DOM, no rendering, no
user-facing strings), so Playwright coverage is not claimed for it. `check-panel-scope`
and `check-tool-vocabulary` are green; the `run-*`/`completion-*`/`restart-*` family is
456 pass / 0 fail; and the full local unit suite is **6954 tests, exit 0**.

## Deliberately NOT in scope: panel#1851's second half

#1851 reports the same storm plus *"delays or obscures the completion notification for
the prompt the agent actually queued"*. Removing the flood removes the **cause** of the
burial — the 32-entry-per-tab journal cap stops overflowing, and the agent's own
completion is no longer queued behind ~40 stale turns. It does **not** add any
**prioritisation** of the session-owned prompt over foreign ones; that would be an
ordering change in the orchestrator's journal, a different repo and a different argument.
#1851 should stay open for that half.

Fixes #1842
