### PR TITLE
fix(#1998): retire old wrappers before creating new drives

### DIFF
--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -612,6 +612,22 @@ export function driveControlHooksAcrossScopedBatch(nodes, { batchCount = null } 
   const armed = [];
   const armedWidgets = new Set();
   const restores = [];
+
+  // #1998 — retire any existing wrappers on this widget BEFORE wrapping them again.
+  // When graph_run handlers execute concurrently (async), drive2 can wrap drive1's wrapper
+  // before drive1's restore() has a chance to set state.retired=true. Retiring early prevents
+  // the old wrapper from counting calls that belong to the new drive.
+  const retireExistingWrappersOnWidget = (w) => {
+    try {
+      const beforeState = w.beforeQueued?._cmcpWrapperState;
+      const afterState = w.afterQueued?._cmcpWrapperState;
+      if (beforeState) beforeState.retired = true;
+      if (afterState) afterState.retired = true;
+    } catch {
+      /* widget mutation is best-effort */
+    }
+  };
+
   if (Array.isArray(nodes)) {
     for (const node of nodes) {
       try {
@@ -626,6 +642,9 @@ export function driveControlHooksAcrossScopedBatch(nodes, { batchCount = null } 
           if (!isControlAfterGenerateWidget(w)) continue;
           if (typeof w.beforeQueued !== "function") continue;
           if (typeof w.afterQueued !== "function") continue;
+
+          // #1998 — retire old wrappers before wrapping again
+          retireExistingWrappersOnWidget(w);
           const paired = governedValueWidget(widgets, w, i);
           const target = paired.widget ?? null;
           const entry = {
@@ -677,6 +696,21 @@ export function driveControlHooksAcrossScopedBatch(nodes, { batchCount = null } 
           const state = { retired: false, calls: 0 };
           const wrappedBefore = forced(before);
           const wrappedAfter = forced(after);
+          // #1998 — attach state to wrapper so future drives can retire it early
+          try {
+            Object.defineProperty(wrappedBefore, '_cmcpWrapperState', {
+              value: state,
+              enumerable: false,
+              configurable: true,
+            });
+            Object.defineProperty(wrappedAfter, '_cmcpWrapperState', {
+              value: state,
+              enumerable: false,
+              configurable: true,
+            });
+          } catch {
+            /* wrapper is not extensible, state will be discovered via inheritance or retirement logic */
+          }
           w.beforeQueued = wrappedBefore;
           w.afterQueued = wrappedAfter;
           armedWidgets.add(w);


### PR DESCRIPTION
## Summary

Fixes a concurrent race condition in scoped batch control wrapping that caused:
- Partial advance rates (86/100 instead of all-or-nothing)  
- 14 duplicate seed groups in a 100-item batch
- Mixed attribution causing old wrappers to count calls from new batches

## Root Cause

When multiple `graph_run` handlers execute asynchronously (due to async/await on dispatchScopedRun), drive2 can wrap drive1's wrappers before drive1's `restore()` completes. Both wrappers then count the same hook calls:

1. graph_run#1 creates drive1, arms wrappers (state1.retired = false)
2. [event loop suspends at await dispatchScopedRun]
3. graph_run#2 creates drive2, wraps drive1's wrappers (creates state2)
4. Batch executes: state2 counts calls, then forwards to state1 which ALSO counts them
5. graph_run#1 resumes, finally block calls drive1.restore() (too late)

Result: state1.calls = 38 + 48 = 86 for a 48-call batch

## Fix

1. Add `retireExistingWrappersOnWidget()` to set `state.retired=true` on any existing wrappers BEFORE creating new ones
2. Attach state object to each wrapper as `_cmcpWrapperState` so it's discoverable
3. Call the retirement function before wrapping each widget

Even if graph_run#2 starts before graph_run#1's finally block, old wrappers are immediately marked as retired and forward transparently without counting.

## Testing

Tested locally with a race condition simulation:
- Without fix: both wrappers increment their counters (state1.calls increased during state2's batch)
- With fix: old wrapper is retired before new batch runs (state1.retired = true prevents counting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp