### PR TITLE
fix(1855): a connect that renames its target says so, instead of leaving the caller a stale title

### DIFF
--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -45,6 +45,11 @@ import {
   landedAfterThrowWarning,
   readStoredLink,
 } from "../../web/js/lib/connect-verify.js";
+import {
+  captureNodeTitles,
+  describeTitleRewrites,
+  titleRewriteWarning,
+} from "../../web/js/lib/node-title-rewrite.js";
 import { findExistingRailSlot } from "../../web/js/lib/rail-slot.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -139,6 +144,9 @@ function buildExecutors(graph, canvas = {}) {
     "findLandedRailLink",
     "isRailLinkPersisted",
     "landedAfterThrowWarning",
+    "captureNodeTitles",
+    "describeTitleRewrites",
+    "titleRewriteWarning",
     `const GRAPH_TOOL_EXECUTORS = {
 ${connectSrc}
 ${exposeOutSrc}
@@ -170,6 +178,9 @@ return GRAPH_TOOL_EXECUTORS;`,
     findLandedRailLink,
     isRailLinkPersisted,
     landedAfterThrowWarning,
+    captureNodeTitles,
+    describeTitleRewrites,
+    titleRewriteWarning,
   );
 }
 

--- a/browser_tests/unit/connect-title-rewrite.test.mjs
+++ b/browser_tests/unit/connect-title-rewrite.test.mjs
@@ -1,0 +1,545 @@
+/**
+ * #1855 — `panel_add_node` accepted `title: "Preview Mask Animation"` for a
+ * `PreviewAnimation` node and reported it back, but a `panel_query_graph` read
+ * showed `Preview Animation`. The add "reported state that was not persisted".
+ *
+ * MECHANISM, read from source rather than inferred:
+ *
+ *   - `graph_add_node`'s payload is `summarizeNode(node)`, which reads
+ *     `title: node.title` LIVE, after `graph.add(node)`. It is not a pre-add echo.
+ *   - `LGraph.add` (comfyui_frontend_package 1.49.x, the reporter's version) sets
+ *     `node.graph`, pushes the node, calls `onAdded` / `onNodeAdded`. It never
+ *     assigns `title`.
+ *   - ComfyUI-KJNodes registers `PreviewAnimation` with two title writers of its
+ *     own (web/js/jsnodes.js):
+ *         onConnectInput → this.title = "Preview Animation"
+ *         onExecuted     → this.title = "Preview Animation " + values
+ *   - The frontend invokes `onConnectInput` from `connectSlots` and
+ *     `SubgraphInput.connect` only — i.e. from WIRING.
+ *
+ * So the title is discarded when the node is CONNECTED, not when it is created,
+ * and `panel_connect` returned a plain success while the name the caller had
+ * just been told was this node's went stale with nothing in the reply to say so.
+ *
+ * These tests run the REAL shipped executors, extracted from
+ * web/js/comfyui-mcp-panel.js — the same technique as connect-throw-verdict and
+ * add-node-loaded-subgraph. A helper-only test would stay green against an
+ * unwired call site, which is the failure mode those files exist to avoid.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  isLinkPersisted,
+  removePhantomLink,
+  isWidgetBackedInput,
+  inputLinkIds,
+  railSlotLinkIds,
+  linkIdExclusionSet,
+  findLandedInboundLink,
+  findLandedRailLink,
+  isRailLinkPersisted,
+  landedAfterThrowWarning,
+} from "../../web/js/lib/connect-verify.js";
+import { findExistingRailSlot } from "../../web/js/lib/rail-slot.js";
+import {
+  captureNodeTitles,
+  describeTitleRewrites,
+  titleRewriteWarning,
+} from "../../web/js/lib/node-title-rewrite.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import {
+  applyCurrentDefWidgetValues,
+  driftedRequiredInputNames,
+  missingRequiredWidgetMaterializations,
+  registeredSocketTypes,
+  unavailableRequiredWidgetMessage,
+  unavailableRequiredWidgetReport,
+} from "../../web/js/lib/node-widget-materialization.js";
+import {
+  assertAddNodeResolvableRefreshing,
+  isRegisteredNodeType,
+} from "../../web/js/lib/node-resolve.js";
+import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
+import {
+  describeUnmaterializedRequiredWidgets,
+  snapshotBackendDef,
+} from "../../web/js/lib/add-node-widget-guard.js";
+import {
+  NODE_DEFS_FETCH_TIMEOUT_MS,
+  NODE_DEFS_NO_ANSWER,
+  WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+  addNodeCommandBudgetDeps,
+  monotonicNow,
+} from "./_panel-constants.mjs";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+/** The method source between its signature line and the first `  },` line. */
+function sliceMethod(signature) {
+  const lines = panelSrc.split("\n");
+  const start = lines.findIndex((l) => l === signature);
+  assert.ok(start >= 0, `could not locate "${signature}" in the panel source`);
+  const end = lines.findIndex((l, i) => i > start && l === "  },");
+  assert.ok(end > start, `could not locate the end of "${signature}"`);
+  return lines.slice(start, end + 1).join("\n");
+}
+
+const connectSrc = sliceMethod(
+  "  graph_connect({ from_node_id, from_output, to_node_id, to_input, auto_match }) {",
+);
+
+// ---------------------------------------------------------------------------
+// graph_connect harness — doubles for everything AROUND the code under test,
+// the REAL verification helpers injected.
+// ---------------------------------------------------------------------------
+
+function resolveNode(graph, id) {
+  const n = graph.getNodeById(id);
+  if (!n) throw new Error(`No node with id ${id}`);
+  return n;
+}
+
+function resolveSlot(slots, ref, kind) {
+  const list = slots ?? [];
+  if (typeof ref === "number") {
+    if (ref < 0 || ref >= list.length) throw new Error(`no ${kind} slot ${ref}`);
+    return ref;
+  }
+  const i = list.findIndex((s) => s?.name === ref);
+  if (i === -1) throw new Error(`no ${kind} named ${ref}`);
+  return i;
+}
+
+const railIntent = () => null;
+const resolveRail = () => null;
+const isEmptyRailSlotRef = (ref) => ref == null || ref === "";
+const slotDiagnostic = () => "slot diagnostic";
+const loopbackRefusalReason = () => "loopback";
+const findSubgraphHostNode = () => null;
+const uniqueSubgraphOutputName = (_g, base) => base;
+const uniqueSubgraphInputName = (_g, base) => base;
+
+function autoMatchSlots(origin, target, from_output, to_input) {
+  return {
+    outIdx: resolveSlot(origin.outputs, from_output ?? 0, "output"),
+    inIdx: resolveSlot(target.inputs, to_input ?? 0, "input"),
+    autoMatched: [],
+  };
+}
+
+/**
+ * Build `graph_connect` from the shipped source.
+ *
+ * `titleDeps` is how the mutation check is done: pass stand-ins that neuter the
+ * fix (a capture that records nothing) and the disclosure must vanish. That
+ * proves these tests are pinned to THIS mechanism and not to something the
+ * fixture would produce anyway.
+ */
+function buildConnect(graph, titleDeps = {}) {
+  const deps = {
+    getGraphCtx: () => ({ graph, canvas: {}, app: {}, rootGraph: graph, LG: {} }),
+    resolveNode,
+    resolveSlot,
+    resolveRail,
+    railIntent,
+    isEmptyRailSlotRef,
+    findExistingRailSlot,
+    findSubgraphHostNode,
+    autoMatchSlots,
+    slotDiagnostic,
+    loopbackRefusalReason,
+    uniqueSubgraphOutputName,
+    uniqueSubgraphInputName,
+    isLinkPersisted,
+    removePhantomLink,
+    isWidgetBackedInput,
+    inputLinkIds,
+    railSlotLinkIds,
+    linkIdExclusionSet,
+    findLandedInboundLink,
+    findLandedRailLink,
+    isRailLinkPersisted,
+    landedAfterThrowWarning,
+    captureNodeTitles,
+    describeTitleRewrites,
+    titleRewriteWarning,
+    ...titleDeps,
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const GRAPH_TOOL_EXECUTORS = {
+${connectSrc}
+};
+return GRAPH_TOOL_EXECUTORS.graph_connect;`,
+  );
+  return factory(...names.map((n) => deps[n]));
+}
+
+/** The REAL link store shape: `_links` is a number-keyed Map (see #1425). */
+function mkLinkStore() {
+  const isIndex = (prop) => typeof prop === "string" && /^(?:0|[1-9]\d*)$/.test(prop);
+  const map = new Map();
+  const proxy = new Proxy(map, {
+    get(target, prop) {
+      if (isIndex(prop)) return target.get(Number(prop));
+      const v = Reflect.get(target, prop, target);
+      return typeof v === "function" ? v.bind(target) : v;
+    },
+    has: (target, prop) => (isIndex(prop) ? target.has(Number(prop)) : Reflect.has(target, prop)),
+    ownKeys: (target) => [...target.keys()].map(String),
+    getOwnPropertyDescriptor(target, prop) {
+      if (isIndex(prop) && target.has(Number(prop))) {
+        return { value: target.get(Number(prop)), enumerable: true, configurable: true, writable: true };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  });
+  return { map, proxy };
+}
+
+function mkGraph() {
+  const store = mkLinkStore();
+  const graph = {
+    lastLinkId: 0,
+    _links: store.map,
+    links: store.proxy,
+    nodes: [],
+    outputs: [],
+    inputs: [],
+    getNodeById: (id) => graph.nodes.find((n) => String(n.id) === String(id)) ?? null,
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+    getLink: (id) => store.map.get(id) ?? null,
+  };
+  return graph;
+}
+
+function mkNode(graph, id, title, inputs, outputs) {
+  const node = { id, title, inputs, outputs, graph };
+  graph.nodes.push(node);
+  return node;
+}
+
+/**
+ * The origin node's connect(), mirroring the frontend's `connectSlots` ORDER:
+ *
+ *     t.onConnectInput?.(s, e.type, e, this, o) === false  → refuse
+ *     …write graph._links / output.links / input.link…
+ *     …then the onConnectionsChange hooks (`afterWrite` here)…
+ *
+ * KJNodes' PreviewAnimation writes its title from `onConnectInput`, i.e. in the
+ * FIRST of those three positions — before the link even exists.
+ */
+function attachConnect(node, { onConnectInput, afterWrite } = {}) {
+  node.connect = (outIdx, target, inIdx) => {
+    const graph = node.graph;
+    if (onConnectInput?.(target, inIdx) === false) return null;
+    const id = ++graph.lastLinkId;
+    const link = { id, origin_id: node.id, origin_slot: outIdx, target_id: target.id, target_slot: inIdx };
+    graph._links.set(id, link);
+    (node.outputs[outIdx].links ??= []).push(id);
+    target.inputs[inIdx].link = id;
+    afterWrite?.({ link, target, inIdx, graph });
+    return link;
+  };
+}
+
+/** The reporter's graph: an IMAGE source wired into a self-renaming PreviewAnimation. */
+function previewAnimationFixture({ clobber = true, throwAfterWrite = false } = {}) {
+  const graph = mkGraph();
+  const source = mkNode(graph, 1, "Load Image", [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
+  const preview = mkNode(
+    graph,
+    2,
+    "Preview Mask Animation",
+    [{ name: "image", type: "IMAGE", link: null }],
+    [],
+  );
+  attachConnect(source, {
+    onConnectInput: (target) => {
+      // web/js/jsnodes.js, case "PreviewAnimation" — unconditional, no guard on
+      // whether the user had named the node.
+      if (clobber) target.title = "Preview Animation";
+    },
+    afterWrite: () => {
+      if (throwAfterWrite) throw new Error("Cannot read properties of undefined (reading 'slots')");
+    },
+  });
+  return { graph, source, preview };
+}
+
+// ---------------------------------------------------------------------------
+// graph_connect: the reported path
+// ---------------------------------------------------------------------------
+
+test("#1855 shipped graph_connect: a target that renames itself on connect is DISCLOSED", () => {
+  const { graph, preview } = previewAnimationFixture();
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: 0 });
+
+  // The wire is real — the rename must never be reported as a connect failure.
+  assert.equal(res.connected.to.node_id, 2);
+  assert.equal(preview.title, "Preview Animation", "the pack really did rewrite it");
+
+  assert.deepEqual(res.title_rewritten, [
+    { node_id: 2, from: "Preview Mask Animation", to: "Preview Animation" },
+  ]);
+  assert.match(res.warning, /RENAMED/);
+  assert.match(res.warning, /"Preview Mask Animation" → "Preview Animation"/);
+  assert.match(res.warning, /panel_edit_node/);
+});
+
+test("#1855 the disclosure is produced by the FIX, not by the fixture", () => {
+  const { graph } = previewAnimationFixture();
+  // Neuter only the capture — everything else, including the fixture's rename,
+  // is unchanged. If the assertions above could pass without the call site
+  // reading the snapshot, they would pass here too.
+  const graph_connect = buildConnect(graph, { captureNodeTitles: () => [] });
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: 0 });
+
+  assert.equal(res.connected.to.node_id, 2, "the connect itself is unaffected");
+  assert.equal(res.title_rewritten, undefined);
+  assert.equal(res.warning, undefined);
+});
+
+test("#1855 an ordinary connect is byte-identical to before — no rider, no warning key", () => {
+  const { graph, preview } = previewAnimationFixture({ clobber: false });
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: 0 });
+
+  assert.equal(preview.title, "Preview Mask Animation", "nothing renamed it");
+  assert.deepEqual(Object.keys(res), ["connected"]);
+});
+
+test("#1855 the ORIGIN end is snapshotted too, not just the target", () => {
+  const graph = mkGraph();
+  const source = mkNode(graph, 1, "My Loader", [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
+  mkNode(graph, 2, "Preview Image", [{ name: "images", type: "IMAGE", link: null }], []);
+  attachConnect(source, {
+    // The output twin of the same hazard: LiteGraph calls the ORIGIN's
+    // onConnectOutput in the same expression it calls the target's
+    // onConnectInput, so a pack can rename either end.
+    afterWrite: () => {
+      source.title = "Load Image";
+    },
+  });
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: 0 });
+
+  assert.deepEqual(res.title_rewritten, [{ node_id: 1, from: "My Loader", to: "Load Image" }]);
+});
+
+test("#1855 a hook that renames AND throws after wiring keeps BOTH warnings", () => {
+  const { graph } = previewAnimationFixture({ throwAfterWrite: true });
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: 0 });
+
+  assert.equal(res.connected.to.node_id, 2, "#1272: a throw after the write is still a landed wire");
+  assert.deepEqual(res.title_rewritten, [
+    { node_id: 2, from: "Preview Mask Animation", to: "Preview Animation" },
+  ]);
+  // The #1272 warning is the louder of the two and must not be displaced by the
+  // rename rider — an append bug here would silently un-ship that fix.
+  assert.match(res.warning, /slots/, "the #1272 landed-after-throw warning survives");
+  assert.match(res.warning, /RENAMED/, "and the #1855 rename is appended to it");
+});
+
+// ---------------------------------------------------------------------------
+// node-title-rewrite.js — the two properties the call site relies on
+// ---------------------------------------------------------------------------
+
+test("#1855 captureNodeTitles dedupes by node IDENTITY (a self-connect is one node)", () => {
+  const node = { id: 7, title: "Both Ends" };
+  const snapshot = captureNodeTitles([node, node, null, "not a node"]);
+  assert.equal(snapshot.length, 1);
+  node.title = "Renamed";
+  assert.deepEqual(describeTitleRewrites(snapshot), [
+    { node_id: 7, from: "Both Ends", to: "Renamed" },
+  ]);
+});
+
+test("#1855 a node that carries no title at all is not reported as a rewrite", () => {
+  const node = { id: 3 };
+  const snapshot = captureNodeTitles([node]);
+  assert.deepEqual(describeTitleRewrites(snapshot), []);
+  assert.equal(titleRewriteWarning([]), "");
+});
+
+// ---------------------------------------------------------------------------
+// graph_add_node: the command's claim, checked against the node it just made
+// ---------------------------------------------------------------------------
+
+const addNodeMatch = panelSrc.match(
+  /\n {2}async graph_add_node\(\{ class_type, pos, title \}\) \{[\s\S]*?\n {2}\},/,
+);
+assert.ok(addNodeMatch, "could not locate graph_add_node in panel source");
+const awaitWidgetsMatch = panelSrc.match(
+  /\nasync function awaitRequiredCustomWidgetRegistration\([\s\S]*?\n\}/,
+);
+const placementMatch = panelSrc.match(/\nfunction placementFor\(graph, pos\) \{[\s\S]*?\n\}/);
+const boundedMatch = panelSrc.match(/\nasync function boundedGetNodeDefs\([\s\S]*?\n\}/);
+assert.ok(awaitWidgetsMatch && placementMatch && boundedMatch, "add-node helpers not located");
+
+const OBJECT_INFO = {
+  PreviewAnimation: { name: "PreviewAnimation", input: { required: {} }, output: [] },
+};
+
+/**
+ * `renameOnCreate` stands in for a class that writes its own title during
+ * creation (`onNodeCreated` / a `nodeCreated` extension hook). KJNodes'
+ * PreviewAnimation does NOT do this — which is exactly why the add-time check is
+ * a contract check on the command's own claim and not the #1855 repro.
+ */
+function buildAddNode({ renameOnCreate = null } = {}) {
+  let nextId = 1;
+  const ctor = function ComfyNode() {};
+  ctor.nodeData = OBJECT_INFO.PreviewAnimation;
+  ctor.comfyClass = "PreviewAnimation";
+  const registry = { PreviewAnimation: ctor };
+  const LG = {
+    registered_node_types: registry,
+    createNode(type) {
+      if (!registry[type]) return null;
+      const node = {
+        id: nextId++,
+        type,
+        title: "Preview Animation",
+        constructor: registry[type],
+        pos: [0, 0],
+        size: [210, 100],
+        widgets: [],
+        inputs: [],
+        outputs: [],
+      };
+      return node;
+    },
+  };
+  const graph = {
+    _nodes: [],
+    subgraphs: new Map(),
+    add(node) {
+      graph._nodes.push(node);
+      if (renameOnCreate) node.title = renameOnCreate;
+    },
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+  const context = { app: { widgets: {} }, LG, graph, rootGraph: graph, workflow: { uuid: "wf" } };
+  const api = {
+    async getNodeDefs() {
+      return OBJECT_INFO;
+    },
+    async fetchApi(route) {
+      const cls = decodeURIComponent(String(route).replace("/object_info/", ""));
+      const body = Object.prototype.hasOwnProperty.call(OBJECT_INFO, cls) ? { [cls]: OBJECT_INFO[cls] } : {};
+      return { status: 200, json: async () => body };
+    },
+  };
+
+  const deps = {
+    captureGraphMutationContext: () => context,
+    revalidateGraphMutationContext: () => context,
+    getGraphCtx: () => context,
+    awaitObjectInfoHistorySeed: async () => {},
+    recordObjectInfoTypes: (defs) => defs,
+    objectInfoHistory: { wasTypeEverDefined: () => true },
+    objectInfoSnapshot: { record: () => true, clear: () => {} },
+    objectInfoCache: { invalidate() {}, replace: () => true },
+    verifiedNodeDefCache: {
+      generation: () => 0,
+      invalidate() {},
+      clear() {},
+      get: () => null,
+      set() {},
+    },
+    backendReconnectEpoch: 0,
+    readPackImportFailures: async () => [],
+    managerGet: async () => null,
+    api,
+    refreshComfyNodeDefs: async () => ({ refreshed: true }),
+    // Mirrors the real summarizeNode's `title: node.title` — a live read, which
+    // is the whole reason the add's claim is checkable at all.
+    summarizeNode: (node) => ({ id: node.id, type: node.type, title: node.title }),
+    reconcileFreshDynamicWidgets: () => ({ failures: [] }),
+    sanitizeNodeAuxId: () => false,
+    clearInheritedExecutionPreview: () => {},
+    safeRemoveNode: () => {},
+    addNodeRefreshBusyMessage: (t) => `busy: ${t}`,
+    REFRESH_JOIN_ABANDONED: Symbol("abandoned"),
+    schemaAutoRefreshed: false,
+    assertAddNodeResolvableRefreshing,
+    driftedRequiredInputNames,
+    registeredSocketTypes,
+    missingRequiredWidgetMaterializations,
+    applyCurrentDefWidgetValues,
+    unavailableRequiredWidgetReport,
+    unavailableRequiredWidgetMessage,
+    snapshotBackendDef,
+    isRegisteredNodeType,
+    fetchSingleNodeInfo,
+    describeUnmaterializedRequiredWidgets,
+    NODE_DEFS_NO_ANSWER,
+    WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+    monotonicNow,
+    NODE_DEFS_FETCH_TIMEOUT_MS,
+    withTimeout,
+    ...addNodeCommandBudgetDeps(),
+  };
+  const build = new Function(
+    "api",
+    "withTimeout",
+    "NODE_DEFS_NO_ANSWER",
+    "NODE_DEFS_FETCH_TIMEOUT_MS",
+    `${boundedMatch[0]}
+     return boundedGetNodeDefs;`,
+  );
+  deps.boundedGetNodeDefs = (timeoutMs) =>
+    build(deps.api, withTimeout, NODE_DEFS_NO_ANSWER, NODE_DEFS_FETCH_TIMEOUT_MS)(timeoutMs);
+
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `${awaitWidgetsMatch[0]}
+     ${placementMatch[0]}
+     const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 200;
+     const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 5;
+     const executors = {${addNodeMatch[0]}};
+     return executors.graph_add_node;`,
+  );
+  return factory(...names.map((n) => deps[n]));
+}
+
+test("#1855 shipped graph_add_node: a title that DOES stick is reported with no rider", async () => {
+  const graph_add_node = buildAddNode();
+  const res = await graph_add_node({ class_type: "PreviewAnimation", title: "Preview Mask Animation" });
+
+  assert.equal(res.added.title, "Preview Mask Animation");
+  assert.equal(res.added.title_not_applied, undefined, "PreviewAnimation does not rename on ADD");
+  assert.equal(res.added.warning, undefined);
+});
+
+test("#1855 shipped graph_add_node: a class that renames itself on create cannot be reported as success", async () => {
+  const graph_add_node = buildAddNode({ renameOnCreate: "Preview Animation" });
+  const res = await graph_add_node({ class_type: "PreviewAnimation", title: "Preview Mask Animation" });
+
+  // The payload keeps reporting the node's ACTUAL title — never the request.
+  assert.equal(res.added.title, "Preview Animation");
+  assert.deepEqual(res.added.title_not_applied, {
+    requested: "Preview Mask Animation",
+    actual: "Preview Animation",
+  });
+  assert.match(res.added.warning, /is NOT what this node ended up with/);
+  assert.match(res.added.warning, /"Preview Mask Animation"/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -548,6 +548,11 @@ import {
   readStoredLink,
 } from "./lib/connect-verify.js";
 import {
+  captureNodeTitles,
+  describeTitleRewrites,
+  titleRewriteWarning,
+} from "./lib/node-title-rewrite.js";
+import {
   snapshotGraphState,
   describeInputLink,
   orphanedInputLinkId,
@@ -15668,6 +15673,26 @@ const GRAPH_TOOL_EXECUTORS = {
         "before creating this node, and the node was built from the CURRENT definition. Nodes " +
         "ALREADY on the canvas keep the shape they were created with.";
     }
+    // #1855 — the add's own claim, checked against the node it just made. This is
+    // NOT the fix for that issue: `added.title` is already a live read of
+    // `node.title`, and the frontend's LGraph.add does not touch `title`, so the
+    // reported reversion happens later, at CONNECT (see node-title-rewrite.js).
+    // But nothing here ever compared the two, so a class that DID rename itself
+    // during creation would have its substituted name reported in the `title`
+    // field of a success payload — the caller asked for one name, silently got
+    // another, and the reply read as confirmation. Say which name landed instead.
+    // Last of the warning writers on purpose: the blocks above ASSIGN
+    // `added.warning`, so this has to append rather than be overwritten.
+    if (typeof title === "string" && title && added.title !== title) {
+      added.title_not_applied = { requested: title, actual: added.title ?? null };
+      added.warning =
+        `${added.warning ? `${added.warning} ` : ""}` +
+        `The requested title ${JSON.stringify(title)} is NOT what this node ended up with — it ` +
+        `carries ${JSON.stringify(added.title ?? null)}. "${class_type}" rewrote its own title while it was ` +
+        `being created, so the name in this reply is the node's ACTUAL one, not the one you asked ` +
+        `for. panel_edit_node can set it again, but a class that owns its title will keep ` +
+        `rewriting it (on connect, and after every run).`;
+    }
     return { added };
   },
 
@@ -16350,6 +16375,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // nothing" and "threw after wiring it" collapse into one indistinguishable
     // answer.
     const inboundLinkIdsBefore = linkIdExclusionSet(inputLinkIds(target));
+    // #1855 — the titles both endpoints carry BEFORE the wire is made. LiteGraph
+    // calls `target.onConnectInput(...)` from inside connectSlots, and a pack is
+    // free to rewrite its own title from there: KJNodes' PreviewAnimation resets
+    // it to "Preview Animation" unconditionally, discarding the name the caller
+    // had just given it via panel_add_node. Nothing in the reply said so, which
+    // is the silent state mismatch #1855 reports. See node-title-rewrite.js for
+    // why this DISCLOSES rather than putting the old title back.
+    const titlesBefore = captureNodeTitles([origin, target]);
     graph.beforeChange();
     let link;
     let connectErr = null;
@@ -16371,6 +16404,11 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
+    // #1855 — read the endpoints' titles back the moment the mutation is over,
+    // BEFORE the verdict branches: the hook that renames runs on the throw path
+    // and the success path alike, so computing this per-branch would report it on
+    // one and drop it on the other.
+    const titleRewrites = describeTitleRewrites(titlesBefore);
     if (connectErr) {
       const landed = findLandedInboundLink(graph, origin, outIdx, target, inboundLinkIdsBefore);
       if (!landed) {
@@ -16425,14 +16463,24 @@ const GRAPH_TOOL_EXECUTORS = {
             ? { replaced_link: replacedLink }
             : {}),
         },
-        warning: landedAfterThrowWarning(
-          connectErr,
-          landed.inputIndex !== inIdx
-            ? `The node re-slotted it: the link landed on input ` +
-                `"${landedSlot?.name ?? landed.inputIndex}" (index ${landed.inputIndex}), not the ` +
-                `requested "${target.inputs?.[inIdx]?.name ?? inIdx}" (index ${inIdx}).`
-            : "",
-        ),
+        // #1855 — APPENDED to the throw-path warning, never replacing it. This
+        // path already owes the caller the louder fact that a hook threw after
+        // the wire landed; the rename is a second, independent thing that
+        // happened to the same command.
+        ...(titleRewrites.length ? { title_rewritten: titleRewrites } : {}),
+        warning: [
+          landedAfterThrowWarning(
+            connectErr,
+            landed.inputIndex !== inIdx
+              ? `The node re-slotted it: the link landed on input ` +
+                  `"${landedSlot?.name ?? landed.inputIndex}" (index ${landed.inputIndex}), not the ` +
+                  `requested "${target.inputs?.[inIdx]?.name ?? inIdx}" (index ${inIdx}).`
+              : "",
+          ),
+          titleRewriteWarning(titleRewrites),
+        ]
+          .filter(Boolean)
+          .join(" "),
       };
     }
     if (!link) {
@@ -16493,6 +16541,12 @@ const GRAPH_TOOL_EXECUTORS = {
         ...(autoMatched.length ? { auto_matched: autoMatched } : {}),
         ...(replacedLink ? { replaced_link: replacedLink } : {}),
       },
+      // #1855 — the reported path: a connect that fully succeeded and renamed its
+      // target on the way. Emitted only when a title actually moved, so an
+      // ordinary connect's payload is byte-identical to before.
+      ...(titleRewrites.length
+        ? { title_rewritten: titleRewrites, warning: titleRewriteWarning(titleRewrites) }
+        : {}),
     };
   },
 

--- a/web/js/lib/node-title-rewrite.js
+++ b/web/js/lib/node-title-rewrite.js
@@ -1,0 +1,99 @@
+// #1855 — a graph command must never leave the caller holding a node title the
+// node does not have.
+//
+// `panel_add_node` accepted `title: "Preview Mask Animation"` for a
+// `PreviewAnimation` node and reported that title back; a later
+// `panel_query_graph` showed `Preview Animation`. The reporter read that as the
+// ADD snapshotting success too early, but the add's payload is already a LIVE
+// read of `node.title` (summarizeNode), and the frontend's `LGraph.add` does not
+// touch `title` at all — it sets `node.graph`, pushes the node, and calls
+// `onAdded` / `onNodeAdded` (read from comfyui_frontend_package 1.49.x, the
+// reporter's own version). So nothing on the add path can have rewritten it.
+//
+// The class that CAN is the node pack. ComfyUI-KJNodes registers
+// `PreviewAnimation` with two title writers of its own (web/js/jsnodes.js):
+//
+//     case "PreviewAnimation":
+//       nodeType.prototype.onConnectInput = function (...) { …; this.title = "Preview Animation"; … }
+//       nodeType.prototype.onExecuted     = function (message) { …; this.title = "Preview Animation " + values; … }
+//
+// and the frontend invokes `onConnectInput` from exactly one place —
+// `connectSlots` / `SubgraphInput.connect`, i.e. WIRING. So the title is
+// discarded when the node is connected (and rewritten again after every run),
+// not when it is created. `panel_connect` reported a plain success while the
+// name the caller had just been told was this node's silently became stale, with
+// nothing in the reply to say so.
+//
+// This module does NOT restore the old title. That is deliberate: the pack owns
+// the field on purpose — the reset exists so a stale "Preview Animation 24" from
+// an earlier run is cleared when the node is rewired — and from here a
+// user-chosen name and a leftover run status are indistinguishable strings.
+// Putting one back would silently reinstate the other, and would be undone by
+// the next run regardless. Disclosure is the honest answer, and it is the one
+// the reporter also accepted: "return the actual final title plus a warning
+// instead of echoing the requested title as successful".
+
+/**
+ * Snapshot the titles of the nodes a command is about to touch, BEFORE it runs.
+ *
+ * Duplicates are dropped by node IDENTITY, so a self-connect (origin === target)
+ * is captured once and cannot report itself as two rewrites. Non-objects are
+ * skipped rather than throwing: this is a disclosure rider, and it must never be
+ * the reason a wire that landed is reported as a failure.
+ */
+export function captureNodeTitles(nodes) {
+  const snapshot = [];
+  for (const node of nodes ?? []) {
+    if (!node || typeof node !== "object") continue;
+    if (snapshot.some((entry) => entry.node === node)) continue;
+    snapshot.push({ node, title: node.title });
+  }
+  return snapshot;
+}
+
+/**
+ * Which of the snapshotted nodes the command's own side effects renamed.
+ *
+ * Compared with `===` against the captured value, so a node that carries no
+ * title at all (`undefined` before and after) is not reported as a rewrite.
+ */
+export function describeTitleRewrites(snapshot) {
+  const rewrites = [];
+  for (const entry of snapshot ?? []) {
+    const node = entry?.node;
+    if (!node || typeof node !== "object") continue;
+    if (node.title === entry.title) continue;
+    rewrites.push({
+      node_id: node.id,
+      from: entry.title ?? null,
+      to: node.title ?? null,
+    });
+  }
+  return rewrites;
+}
+
+/**
+ * The prose that rides alongside `title_rewritten`.
+ *
+ * It has to do two things the structured field cannot: say that the rename came
+ * from the NODE PACK rather than from the panel (otherwise this reads as the
+ * panel corrupting the graph), and say that re-applying the title is a real
+ * repair but not a durable one, because `onExecuted` rewrites it again after
+ * every run.
+ */
+export function titleRewriteWarning(rewrites) {
+  if (!rewrites?.length) return "";
+  const list = rewrites
+    .map((r) => `node ${r.node_id}: ${JSON.stringify(r.from)} → ${JSON.stringify(r.to)}`)
+    .join(", ");
+  return (
+    `This connect RENAMED ${rewrites.length === 1 ? "a node" : `${rewrites.length} nodes`} — ${list}. ` +
+    `The panel did not do this: LiteGraph runs the target node's own onConnectInput hook from ` +
+    `inside the connect, and some packs rewrite their title there (ComfyUI-KJNodes' ` +
+    `PreviewAnimation resets it to "Preview Animation" on every connect, then to ` +
+    `"Preview Animation <frames>" after every run). Any title panel_add_node or panel_edit_node ` +
+    `reported for ${rewrites.length === 1 ? "that node" : "those nodes"} is now STALE. ` +
+    `Re-apply the name you want with panel_edit_node AFTER wiring — and expect a node that ` +
+    `owns its own title to overwrite it again once the graph runs.`
+  );
+}


### PR DESCRIPTION
Fixes #1855

## What the reporter saw

`panel_add_node` accepted `title: "Preview Mask Animation"` for a `PreviewAnimation` node and returned that title in its success payload; a `panel_query_graph` read showed `Preview Animation`. The add reported state that was not persisted.

## Why the prescribed fix would have been inert

The issue asks for the add to "reapply the requested custom title and read back the final title before returning success". **The add already reads back.** `added` is `summarizeNode(node)`, which does `title: node.title` — a live read taken after `graph.add(node)`. And the frontend's `LGraph.add` (read from `comfyui_frontend_package` 1.49.x, the reporter's own version) never assigns `title`: it sets `node.graph`, pushes onto `_nodes`, then calls `onAdded` / `onNodeAdded`. Nothing on the add path can rewrite a title, so an add-time re-read would have changed nothing and shipped green and dormant.

## Where it actually goes

ComfyUI-KJNodes registers `PreviewAnimation` with two title writers of its own — `web/js/jsnodes.js`, `case "PreviewAnimation"`:

```js
nodeType.prototype.onConnectInput = function (...) { …; this.title = "Preview Animation"; … }
nodeType.prototype.onExecuted     = function (message) { …; this.title = "Preview Animation " + values; … }
```

and the frontend invokes `onConnectInput` from exactly two places, both in the connect path (`connectSlots`, `SubgraphInput.connect`). So the title is discarded when the node is **wired**, and rewritten again after **every run**. `graph_connect` returned a plain success while the name the caller had just been told was this node's went silently stale — which is why `panel_edit_node` afterwards "works": nothing has connected the node since.

This is also why the node in the report is called `Preview Mask Animation`: a mask was wired into it.

## The change

`graph_connect` snapshots both endpoints' titles before the mutation and discloses any the connect's own hooks rewrote:

```json
{ "connected": { … },
  "title_rewritten": [{ "node_id": 2, "from": "Preview Mask Animation", "to": "Preview Animation" }],
  "warning": "This connect RENAMED a node — … The panel did not do this: LiteGraph runs the target node's own onConnectInput hook from inside the connect … Re-apply the name you want with panel_edit_node AFTER wiring …" }
```

`graph_add_node` separately gains a check on its **own claim**: if the requested title is not the one the node ended up with, it emits `title_not_applied` and says which name landed, instead of presenting the substitution as success.

## It DISCLOSES; it does not restore. That is deliberate.

The pack owns the field on purpose — the reset exists so a stale `Preview Animation 24` from an earlier run is cleared when the node is rewired. From inside `graph_connect` a user-chosen name and a leftover run status are indistinguishable strings, so putting one back would silently reinstate the other, and `onExecuted` would undo it at the next run regardless. Disclosure is also the resolution the reporter offered: *"return the actual final title plus a warning instead of echoing the requested title as successful"*.

## Where to look hardest

- **The throw-path warning is now an array `.join(" ")`, not a single expression.** If that append is wrong, it silently un-ships #1272's landed-after-throw warning — the louder of the two. Pinned by a test that asserts *both* strings survive; mutating the append back to a plain assignment turns that test red.
- **The snapshot must be taken before `graph.beforeChange()` and compared after `setDirtyCanvas`.** Moving the capture after the mutation makes the comparison trivially always-equal and the whole disclosure vanishes silently. Mutation-checked (below).
- **The add-node check is a contract check, not the #1855 repro.** `PreviewAnimation` does not rename on add, so its production trigger is a class that renames during creation, which I have not observed in the wild. It is 6 lines, labelled as such in the source, and it is the last of the warning writers because the blocks above *assign* `added.warning`.
- `describeTitleRewrites` compares with `===`, so a node carrying no title (`undefined` both sides) is not reported. `captureNodeTitles` dedupes by node identity so a self-connect cannot report itself twice.

## Verification

`browser_tests/unit/connect-title-rewrite.test.mjs` (9 tests) runs the **shipped** `graph_connect` and `graph_add_node`, extracted from `web/js/comfyui-mcp-panel.js` — a helper-only test would stay green against an unwired call site.

Verified by **mutation**, not by a green suite. Each mutation was applied to the panel source and the named tests went red; restoring returned all 9 to green:

| mutation to `web/js/comfyui-mcp-panel.js` | result |
|---|---|
| delete the success-return `title_rewritten` rider | 2 red |
| throw-path warning assigns instead of appending | 1 red (`…keeps BOTH warnings`) |
| delete the `graph_add_node` contract check | 1 red |
| take the title snapshot **after** the connect instead of before | 3 red |

There is also an in-test mutation (`captureNodeTitles: () => []` injected into the extracted executor) proving the disclosure comes from the fix and not from the fixture.

Full unit suite: **6972 pass / 4 fail**. The 4 failures are `#2314` in `graph-set-widget-target-fence.test.mjs` and are **pre-existing on `origin/main`** — they fail identically with this branch's changes stashed away. Untouched by this PR.

`node scripts/check-panel-scope.mjs` → OK.

## Browser gate: NOT run — no coverage claimed

`playwright.config.ts` requires a real ComfyUI on `http://localhost:8188`; I probed 8188/8189/8190/8191/8288/8388 and nothing was listening, and this run was explicitly told not to start one. So the e2e suite was **not** run and I am claiming no browser coverage.

Two things bound the risk. This change renders nothing — it adds keys to a bridge command's JSON reply. And the panel e2e harness fakes the orchestrator (MockBridge), so it could not have exercised this path even with a server up.

End-to-end reachability was checked by reading the relay instead: `panel_connect` is a bare pass-through (`ctx.call({cmd: "graph_connect", …})`) and `ok()` in `comfyui-mcp/src/orchestrator/panel-tools.ts` does `JSON.stringify(value, null, 2)` over the whole panel reply with no key whitelist — the same path `replaced_link` and the existing `warning` already travel. The new fields reach the agent verbatim.

## Deliberately not done

The rail branches of `graph_connect`, `graph_disconnect`, and every refusal/throw path of the node-to-node branch are unchanged. `onConnectInput` runs *before* the link is written, so a **refused** connect can rename its target too — real, but unreported and not what #1855 describes, so it is left for a follow-up rather than widened into this diff. An ordinary connect's payload is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
