### PR TITLE
fix(1864): a save that named nothing is never told to "choose a different name"

### DIFF
--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -1677,6 +1677,44 @@ test('#1864 (codex gate r2): a NAMED save is untouched by a concurrent title edi
   assert.deepEqual(svc.calls, [['saveWorkflow', 'workflows/Foo.json']], 'the requested save landed')
 })
 
+test('#1864 (codex gate r3): a traversal path is not ownership — the redirect declines it', async () => {
+  // `normalizePath` collapses separators but does not RESOLVE them, so a path can carry the
+  // managed "workflows/" prefix and still point outside the folder. The redirect ends in a
+  // forced write and skips the collision guard, so it must not accept one. Defensive: the
+  // frontend builds its records from the /userdata listing and never produces "..".
+  const active = {
+    path: 'workflows/../settings/Foo.json',
+    filename: 'Foo',
+    directory: 'workflows/../settings',
+    initialMode: 'app', // ⇒ reconstructed target diverges, and it is occupied below
+    isPersisted: true,
+    isTemporary: false,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({
+    files: ['workflows/../settings/Foo.json', 'workflows/../settings/Foo.app.json'],
+    active
+  })
+
+  await assert.rejects(
+    () =>
+      saveActiveWorkflow(svc, undefined, {
+        autoWorkflowName: () => 'Untitled',
+        existsOnDisk: async (p) => svc.disk.has(p)
+      }),
+    (err) => {
+      assert.match(err.message, /409 Conflict/)
+      return true
+    }
+  )
+
+  assert.ok(
+    !svc.calls.some((c) => c[0] === 'saveWorkflow'),
+    'no forced write outside the managed workflows folder'
+  )
+})
+
 // ---------------------------------------------------------------------------
 // ComfyUI frontend 1.47.x (issue #268). The workflow store no longer exposes
 // `saveWorkflowAs`; it exposes the low-level pair `saveAs(wf, path)` (builds a

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -1610,6 +1610,73 @@ test('#1864 (codex gate P1): a same-object rename DURING the probes declines the
   )
 })
 
+test('#1864 (codex gate r2): a name drift during the in-place probe refuses, and writes nothing', async () => {
+  // The path-drift guard in the in-place branch re-reads `path` only. For a NO-NAME save
+  // the destination was derived from the tab's own NAME, so a same-object rename landing
+  // inside `classifyInPlaceOverwrite`'s awaited disk read moves the tab off the identity
+  // the write was authorized on while `path` stays put — and "Foo.json" would be written
+  // for a tab that now reports "Bar". This is reachable on the plain in-place route (no
+  // redirect involved); the redirect merely brings more tabs onto it.
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: false, // drifted ⇒ classifyInPlaceOverwrite actually reads disk
+    isTemporary: true,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({ files: ['workflows/Foo.json'], active })
+
+  await assert.rejects(
+    () =>
+      saveActiveWorkflow(svc, undefined, {
+        autoWorkflowName: () => 'Untitled',
+        existsOnDisk: async (p) => svc.disk.has(p),
+        readDiskBytes: async () => {
+          active.filename = 'Bar' // the rename lands inside this await
+          return new TextEncoder().encode('{"id":"a"}')
+        }
+      }),
+    (err) => {
+      assert.match(err.message, /name changed during the save/)
+      assert.match(err.message, /Nothing was written/)
+      return true
+    }
+  )
+
+  assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflow'), 'nothing was written')
+})
+
+test('#1864 (codex gate r2): a NAMED save is untouched by a concurrent title edit', async () => {
+  // The scoping half. The caller chose "Foo" itself, so `filename` never fed the
+  // destination — a title edit landing mid-save must not reject the save that was
+  // explicitly asked for.
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: false,
+    isTemporary: true,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({ files: ['workflows/Foo.json'], active })
+
+  const saved = await saveActiveWorkflow(svc, 'Foo', {
+    existsOnDisk: async (p) => svc.disk.has(p),
+    readDiskBytes: async () => {
+      active.filename = 'Bar'
+      return new TextEncoder().encode('{"id":"a"}')
+    }
+  })
+
+  assert.equal(saved, 'Foo')
+  assert.deepEqual(svc.calls, [['saveWorkflow', 'workflows/Foo.json']], 'the requested save landed')
+})
+
 // ---------------------------------------------------------------------------
 // ComfyUI frontend 1.47.x (issue #268). The workflow store no longer exposes
 // `saveWorkflowAs`; it exposes the low-level pair `saveAs(wf, path)` (builds a

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -1342,6 +1342,224 @@ test('#1535 boundary: a filename that no longer matches the path does NOT author
 })
 
 // ---------------------------------------------------------------------------
+// #1864 — a save that supplied NO name must never be refused with "choose a
+// different name".
+//
+// The target is RECONSTRUCTED from the workflow's directory + reported filename +
+// mode-derived extension. When any of those drifts from the path the tab occupies, a
+// no-name save quietly becomes a Save-As; and when a file already sits at that
+// reconstructed path, the #309 collision guard refused with "a workflow named X
+// already exists (409 Conflict) — choose a different name". The reporter had given no
+// name, so there was no different one to choose: their workflow went unwritten and the
+// only way forward was a third file under a new name.
+//
+// The repair is stated against the SHAPE (a reconstructed destination the tab does not
+// occupy), not against any one cause, and it fires ONLY when that destination is
+// occupied — an absent one is a save that completes, which is P0-b's deliberate
+// direction and is pinned below.
+
+test('#1864: a NO-NAME save whose reconstructed target is OCCUPIED writes the tab OWN file', async () => {
+  // The drifted-".app.json" shape. `isTemporary` is derived from `size` and drifts after
+  // an open-ack race (#215/#442), which skips the #1535 pin (it requires `!wasUnsaved`),
+  // so the target reconstructs as ".json" — and the ".json" sibling is already there,
+  // left by an earlier fork of exactly the kind #1535 was filed about.
+  const active = {
+    path: 'workflows/Anima Turbo.app.json',
+    filename: 'Anima Turbo',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: false, // drifted
+    isTemporary: true,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({
+    files: ['workflows/Anima Turbo.app.json', 'workflows/Anima Turbo.json'],
+    active
+  })
+
+  const saved = await saveActiveWorkflow(svc, undefined, {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk: async (p) => svc.disk.has(p)
+  })
+
+  assert.equal(saved, 'Anima Turbo')
+  assert.ok(
+    svc.calls.some((c) => c[0] === 'saveWorkflow' && c[1] === 'workflows/Anima Turbo.app.json'),
+    'the write lands on the file the tab occupies'
+  )
+  assert.ok(!svc.calls.some((c) => c[0] === 'saveAs'), 'no Save-As copy was invented')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'and nothing was moved (#226)')
+  assert.deepEqual(
+    [...svc.disk].sort(),
+    ['workflows/Anima Turbo.app.json', 'workflows/Anima Turbo.json'],
+    'the file that "already exists" is neither written nor removed'
+  )
+})
+
+test('#1864: an app-mode tab whose .app.json sibling ALREADY exists saves its own .json in place', async () => {
+  // The mirror shape, and the one a user reaches by repeating P0-b: an on-disk
+  // "Foo.json" that reads app-mode reconstructs a target of "Foo.app.json", the copy
+  // route creates it, and a later no-name save of the ".json" tab then dead-ended on
+  // the sibling its own earlier save had produced.
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo',
+    directory: 'workflows',
+    initialMode: 'app',
+    isPersisted: true,
+    isTemporary: false,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({ files: ['workflows/Foo.json', 'workflows/Foo.app.json'], active })
+
+  await saveActiveWorkflow(svc, undefined, {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk: async (p) => svc.disk.has(p)
+  })
+
+  assert.deepEqual(svc.calls, [['saveWorkflow', 'workflows/Foo.json']], 'in place, and only that')
+  assert.ok(svc.disk.has('workflows/Foo.app.json'), 'the pre-existing sibling is untouched')
+})
+
+test('#1864 boundary: an ABSENT reconstructed target still COPIES — P0-b is unchanged', async () => {
+  // The same tab as above with the sibling REMOVED. A save that can complete is not the
+  // failure this fix is about, so the redirect must not fire here: #1535 deliberately
+  // left this direction ("Foo.json" in app mode forks "Foo.app.json") standing, and
+  // reversing it is a product decision, not a bug fix. Runs WITH a disk oracle — the
+  // pre-existing P0-b test passes none, so without this one the "only when occupied"
+  // condition would be pinned by nothing production actually reaches.
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo',
+    directory: 'workflows',
+    initialMode: 'app',
+    isPersisted: true,
+    isTemporary: false,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({ files: ['workflows/Foo.json'], active })
+
+  await saveActiveWorkflow(svc, undefined, {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk: async (p) => svc.disk.has(p)
+  })
+
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'still the atomic copy route')
+  assert.ok(svc.disk.has('workflows/Foo.app.json'), 'the app-mode sibling is created')
+  assert.ok(svc.disk.has('workflows/Foo.json'), 'and the source survives (#226)')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'nothing moved')
+})
+
+test('#1864: a rename in flight is NOT proof of ownership — the stale path is never written', async () => {
+  // The #1535 boundary, re-asserted with the reconstructed target OCCUPIED so it runs
+  // through the new redirect. A tab whose `filename` has moved on from its `path` holds
+  // two destinations, and the file at the OLD path is not the one being edited — so the
+  // redirect must refuse it, exactly as the pre-existing boundary test demands for the
+  // absent-target case.
+  const active = {
+    path: 'workflows/Old Name.app.json',
+    filename: 'Fresh Name',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: true,
+    isTemporary: false,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({
+    files: ['workflows/Old Name.app.json', 'workflows/Fresh Name.json'],
+    active
+  })
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, undefined, { existsOnDisk: async (p) => svc.disk.has(p) }),
+    (err) => {
+      assert.ok(
+        !svc.calls.some((c) => c[0] === 'saveWorkflow' && c[1] === 'workflows/Old Name.app.json'),
+        'the file at the stale path must not be written on the strength of its path'
+      )
+      // …but the refusal must still not hand a no-name caller the one instruction it
+      // cannot follow.
+      assert.ok(!/choose a different name/.test(err.message), err.message)
+      assert.match(err.message, /supplied NO name/)
+      return true
+    }
+  )
+  assert.deepEqual(
+    [...svc.disk].sort(),
+    ['workflows/Fresh Name.json', 'workflows/Old Name.app.json'],
+    'nothing was written'
+  )
+})
+
+test('#1864: an EXTERNALLY-loaded source keeps refusing, but says what it actually needs', async () => {
+  // An absolute path is not addressable by the /userdata write at all (#285), so "save
+  // in place" does not exist for it and the refusal stands. Only the ADVICE changes: a
+  // caller that named nothing is told to pass a name or rebind the tab, instead of being
+  // sent to pick a different one it never had.
+  const active = {
+    path: 'C:/packs/Anima Turbo.json',
+    filename: 'Anima Turbo',
+    directory: 'C:/packs',
+    initialMode: 'graph',
+    isPersisted: true,
+    isTemporary: false,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({
+    files: ['C:/packs/Anima Turbo.json', 'workflows/Anima Turbo.json'],
+    active
+  })
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, undefined, { existsOnDisk: async (p) => svc.disk.has(p) }),
+    (err) => {
+      assert.ok(!/choose a different name/.test(err.message), err.message)
+      assert.match(err.message, /409 Conflict/)
+      assert.match(err.message, /Nothing was written/)
+      return true
+    }
+  )
+  assert.deepEqual(
+    [...svc.disk].sort(),
+    ['C:/packs/Anima Turbo.json', 'workflows/Anima Turbo.json'],
+    'the external original and the managed file are both untouched (#226/#285)'
+  )
+})
+
+test('#1864: a NAMED Save-As collision keeps the exact #309 wording comfyui-mcp matches on', async () => {
+  // panel-tools.ts `isSaveAsNameConflict` tests this text verbatim to attach the
+  // rename remedy (mcp#1873). That remedy is right for a Save-As, so the named wording
+  // is deliberately byte-identical to before — only the no-name case diverges.
+  const active = {
+    path: 'workflows/Source.json',
+    filename: 'Source',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({ files: ['workflows/Source.json', 'workflows/Taken.json'], active })
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Taken', { existsOnDisk: async (p) => svc.disk.has(p) }),
+    (err) => {
+      assert.equal(
+        err.message,
+        'a workflow named "Taken" already exists (409 Conflict) — choose a different name. ' +
+          'The active tab was left unchanged (issue #309).'
+      )
+      return true
+    }
+  )
+})
+
+// ---------------------------------------------------------------------------
 // ComfyUI frontend 1.47.x (issue #268). The workflow store no longer exposes
 // `saveWorkflowAs`; it exposes the low-level pair `saveAs(wf, path)` (builds a
 // NEW copy object at `path`, leaving the source object and its file untouched)

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -1715,6 +1715,43 @@ test('#1864 (codex gate r3): a traversal path is not ownership — the redirect 
   )
 })
 
+test('#1864 (codex gate r4): a URL-derived path is judged RAW — normalization must not hide it', async () => {
+  // `normalizePath` collapses "//" to "/", so a URL-derived tab's path arrives as
+  // "workflows/http:/host/…" — the "://" the predicate requires is gone, and reading the
+  // normalized value made the guard inert. #1066's tab must keep the copy route: its path
+  // is not a file at all, and force-writing it is not a save.
+  const active = {
+    path: 'workflows/http://127.0.0.1:8188/api/view?filename=x.png/Foo.app.json',
+    filename: 'Foo',
+    directory: 'workflows/http://127.0.0.1:8188/api/view?filename=x.png',
+    initialMode: 'graph',
+    isPersisted: true,
+    isTemporary: false,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({ files: ['workflows/Foo.json'], active })
+
+  await assert.rejects(
+    () =>
+      saveActiveWorkflow(svc, undefined, {
+        autoWorkflowName: () => 'Untitled',
+        // A hostile oracle: 200 for the URL path too. Production answers 500 ⇒ null here
+        // (#1066), so the guard is what has to hold, not the probe.
+        existsOnDisk: async (p) => svc.disk.has(p) || p === 'workflows/http:/127.0.0.1:8188/api/view?filename=x.png/Foo.app.json'
+      }),
+    (err) => {
+      assert.match(err.message, /409 Conflict/)
+      return true
+    }
+  )
+
+  assert.ok(
+    !svc.calls.some((c) => c[0] === 'saveWorkflow'),
+    'a URL source is never force-written in place — it keeps the checked copy route (#1066)'
+  )
+})
+
 // ---------------------------------------------------------------------------
 // ComfyUI frontend 1.47.x (issue #268). The workflow store no longer exposes
 // `saveWorkflowAs`; it exposes the low-level pair `saveAs(wf, path)` (builds a

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -1559,6 +1559,57 @@ test('#1864: a NAMED Save-As collision keeps the exact #309 wording comfyui-mcp 
   )
 })
 
+test('#1864 (codex gate P1): a same-object rename DURING the probes declines the redirect', async () => {
+  // `assertExpect` protects the workflow OBJECT, not its fields — `path` and `filename` are
+  // plain writable properties on ComfyUI's UserFile. A rename landing while the ownership
+  // and collision probes are in flight keeps object identity, so the entry-time proof
+  // ("this tab is named Foo and occupies workflows/Foo.json") can be stale by the time the
+  // destination is fixed. Writing "Foo.json" for a tab that now calls itself "Bar" is the
+  // stale-path write the #1535 boundary forbids, so the redirect must decline and let the
+  // collision guard refuse — which is what this state already did before the redirect existed.
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo',
+    directory: 'workflows',
+    initialMode: 'app', // ⇒ reconstructed target is workflows/Foo.app.json, which is taken
+    isPersisted: true,
+    isTemporary: false,
+    originalContent: '{"id":"a"}',
+    changeTracker: { prepareForSave() {} }
+  }
+  const svc = makeFaithfulService({ files: ['workflows/Foo.json', 'workflows/Foo.app.json'], active })
+
+  await assert.rejects(
+    () =>
+      saveActiveWorkflow(svc, undefined, {
+        autoWorkflowName: () => 'Untitled',
+        existsOnDisk: async (p) => {
+          const present = svc.disk.has(p)
+          // The rename lands INSIDE the ownership probe's await — after it sampled
+          // `filename`, before the destination is fixed. (The collision probe answers
+          // from the store index and never reaches this oracle, so hooking the tab's own
+          // path is the only way to land in that window.)
+          if (p === 'workflows/Foo.json') active.filename = 'Bar'
+          return present
+        }
+      }),
+    (err) => {
+      assert.match(err.message, /409 Conflict/)
+      return true
+    }
+  )
+
+  assert.ok(
+    !svc.calls.some((c) => c[0] === 'saveWorkflow'),
+    'the tab whose name moved during the save is never written on the strength of a stale proof'
+  )
+  assert.deepEqual(
+    [...svc.disk].sort(),
+    ['workflows/Foo.app.json', 'workflows/Foo.json'],
+    'and nothing on disk changed'
+  )
+})
+
 // ---------------------------------------------------------------------------
 // ComfyUI frontend 1.47.x (issue #268). The workflow store no longer exposes
 // `saveWorkflowAs`; it exposes the low-level pair `saveAs(wf, path)` (builds a

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1279,6 +1279,23 @@ export async function saveActiveWorkflow(
       `refusing to save: the active workflow's path changed during the save (now "${wf.path}") — retry.`,
     );
   }
+  // #1864 (codex gate r2) — THE SAME DRIFT, ONE FIELD OVER. When no name was supplied the
+  // destination was derived from the tab's OWN name, so `filename` is load-bearing INPUT to
+  // it, not decoration. A same-object rename during the awaited probe above moves the tab
+  // off the identity this write was authorized on while `path` stays put, and the check
+  // directly above cannot see it — the write would land on "Foo.json" for a tab that now
+  // reports "Bar". Refuse, exactly as for a path drift.
+  //
+  // SCOPED TO A NO-NAME SAVE ON PURPOSE. A caller that PASSED a name chose the destination
+  // itself and `filename` never fed it, so a concurrent title edit is irrelevant there —
+  // refusing would reject the very save the caller explicitly asked for.
+  if (!desired && baseName(wf.filename) !== currentName) {
+    throw new Error(
+      `refusing to save: this save supplied no name, so its destination came from the workflow's ` +
+        `own name — and that name changed during the save (now "${baseName(wf.filename)}", was ` +
+        `"${currentName}"). Nothing was written — retry.`,
+    );
+  }
   if (inPlace === "conflict") {
     throw new Error(
       `refusing to save "${effectiveName}": its file "${currentPath}" changed on disk since this tab ` +

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -176,8 +176,16 @@ function isUnderWorkflowsRoot(path) {
   if (!p.startsWith(`${WORKFLOWS_ROOT}/`)) return false;
   return !p.split("/").some((segment) => segment === ".." || segment === ".");
 }
-async function ownsItsPathOnDisk(currentPath, currentName, existsOnDisk) {
+async function ownsItsPathOnDisk(rawPath, currentPath, currentName, existsOnDisk) {
   if (!currentPath || !currentName) return false;
+  // BOTH predicates read the RAW path, exactly as directoryOf reads the raw `wf.directory`.
+  // Checking the NORMALIZED one made the URL test inert (codex gate r4): normalizePath
+  // collapses "//" to "/", so "workflows/http://host/…" arrives as "workflows/http:/host/…"
+  // and the "://" this predicate requires is already gone. Verified by execution, not by
+  // reading. isExternalWorkflowPath survives normalization either way (a leading "\" becomes
+  // a leading "/", which it also matches), but it is read from the same source so the two
+  // can never disagree about which string they judged.
+  if (isExternalWorkflowPath(rawPath) || isUrlDerivedWorkflowPath(rawPath)) return false;
   if (isExternalWorkflowPath(currentPath) || isUrlDerivedWorkflowPath(currentPath)) return false;
   if (!isUnderWorkflowsRoot(currentPath)) return false;
   if (baseName(currentPath.split("/").pop()) !== currentName) return false;
@@ -919,7 +927,7 @@ export async function saveActiveWorkflow(
     !desired &&
     validatedSubfolder === undefined &&
     finalTargetPath !== currentPath &&
-    (await ownsItsPathOnDisk(currentPath, currentName, existsOnDisk))
+    (await ownsItsPathOnDisk(wf?.path, currentPath, currentName, existsOnDisk))
   ) {
     assertExpect(); // #330: the oracle awaited — still the workflow we were asked to save?
     const occupied = (await probeTargetCollision(svc, wf, finalTargetPath, existsOnDisk)) === "exists";

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -2318,14 +2318,19 @@ function isConflictError(err) {
 function conflictError(desiredName, { named = true } = {}) {
   const nm = baseName(desiredName) || "that name";
   if (!named) {
+    // NAMES NO CAUSE, deliberately — the same discipline explainUserDataStoreFailure keeps
+    // a few hundred lines down. This is reached from two places (the up-front pre-check and
+    // the post-write rollback) whose situations differ, and the causes are several (an
+    // externally-loaded path, a never-persisted tab, a rename in flight, a target that
+    // appeared mid-save), so picking one would be an inference presented as a finding. It
+    // states only what was OBSERVED and the two remedies that exist.
     return new Error(
-      `refusing to save "${nm}" in place: this save supplied NO name, and this tab could not be ` +
-        `proven to own a workflow file on disk (an externally-loaded path, or a tab whose name and ` +
-        `path disagree), so the only destination left was a workflow file that already exists ` +
-        `(409 Conflict). There is no "different name" to choose, because none was given: pass an ` +
-        `explicit name to panel_save_workflow to write a copy, or reopen the workflow from ` +
-        `panel_list_workflows so the tab is bound to its real file. Nothing was written and the ` +
-        `active tab was left unchanged (issue #309/#1864).`,
+      `refusing to save "${nm}": this save supplied NO name, so its destination was derived from ` +
+        `the workflow's own name — and a workflow file already occupies it (409 Conflict). There ` +
+        `is no "different name" to choose, because none was given: pass an explicit name to ` +
+        `panel_save_workflow to write a copy, or reopen the workflow from panel_list_workflows so ` +
+        `the tab is bound to the file it should be saving. Nothing was written and the active tab ` +
+        `was left unchanged (issue #309/#1864).`,
     );
   }
   return new Error(

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -144,6 +144,35 @@ function pathIsAppSuffixedSiblingOf(wf, base) {
   return normalizePath(`${directoryOf(wf)}${base}${APP_JSON_EXT}`) === path;
 }
 
+/** #1864 — PROVE that `currentPath` is this tab's OWN, writable workflow file: a managed
+ *  /userdata path, still carrying the name the tab reports, and CONFIRMED present on disk.
+ *
+ *  Three conditions, each load-bearing and each the fail-safe direction when unprovable:
+ *   · MANAGED — an external (absolute/UNC/drive) or URL-derived path is not addressable by
+ *     the /userdata write at all (directoryOf redirects those to the workflows root for
+ *     exactly that reason, #285/#1066), so it can never be saved "in place".
+ *   · NAME AGREES WITH PATH — a tab whose `filename` has moved on from its `path` (a rename
+ *     in flight) holds two destinations, and the file at the OLD path is not the one the
+ *     caller is editing. Writing it on the strength of the path alone is the hazard the
+ *     #1535 boundary test names; a stem mismatch therefore proves nothing.
+ *   · ON DISK (200) — the authoritative oracle, not the in-memory `isTemporary`/`isPersisted`
+ *     flags, which drift in BOTH directions after an open-ack race (#215/#442). A 404, an
+ *     inconclusive status, a throw, or no oracle at all all read as "not proven".
+ *
+ *  Compares the path's OWN basename rather than re-deriving one from the mode, so it stays
+ *  independent of the extension reconstruction that is the thing being second-guessed. */
+async function ownsItsPathOnDisk(currentPath, currentName, existsOnDisk) {
+  if (!currentPath || !currentName) return false;
+  if (isExternalWorkflowPath(currentPath) || isUrlDerivedWorkflowPath(currentPath)) return false;
+  if (baseName(currentPath.split("/").pop()) !== currentName) return false;
+  if (typeof existsOnDisk !== "function") return false;
+  try {
+    return (await existsOnDisk(currentPath)) === true;
+  } catch {
+    return false; // oracle threw ⇒ unproven ⇒ leave the save on the checked route
+  }
+}
+
 /** A readable, TOTAL description of a thrown value for an error message. Deliberately
  *  local and defensive: `String(err)` on a plain object yields "[object Object]", and
  *  `JSON.stringify` returns UNDEFINED for an object whose `toJSON()` does — so neither is
@@ -811,7 +840,7 @@ export async function saveActiveWorkflow(
   // grounding — it only ever saves a never-persisted workflow — alone), and an
   // external/URL-derived source cannot match, because directoryOf() redirects those to
   // the workflows root so the equality below can never hold for them.
-  const finalTargetPath =
+  let finalTargetPath =
     validatedSubfolder === undefined && !desired && !wasUnsaved && pathIsAppSuffixedSiblingOf(wf, currentName)
       ? currentPath
       : effectiveName
@@ -833,6 +862,54 @@ export async function saveActiveWorkflow(
       `refusing to save: cannot resolve a target filename for "${currentPath}" — saving now ` +
         `could MOVE (destroy) the original (issue #226). Pass an explicit name.`,
     );
+  }
+
+  // #1864 — A SAVE THAT NAMED NOTHING MUST NEVER BE TOLD TO "choose a different name".
+  //
+  // The target above is RECONSTRUCTED (this workflow's directory + its reported filename +
+  // its mode-derived extension). When any of those three drifts from the path the tab
+  // actually occupies, a no-name save silently becomes a Save-As — and if a file already
+  // sits at that reconstructed path, the #309 collision guard refuses with "a workflow
+  // named X already exists (409 Conflict) — choose a different name". For a call that
+  // supplied no name that is impossible advice: the reporter's own workflow was never
+  // written, and their only way out was to fork a third file under a new name.
+  //
+  // Reproduced by execution against this module (no-name save, error verbatim) from every
+  // one of: a `directory` that no longer matches the path's own folder; a ".app.json" file
+  // whose tab reads unsaved, so the #1535 pin above is skipped and the target reconstructs
+  // as ".json"; and an `initialMode` of "app" on a plain ".json" whose ".app.json" sibling
+  // exists. What they share is not a cause but a SHAPE — a reconstructed destination the
+  // tab does not occupy — so the repair is stated against the shape.
+  //
+  // THE FILE THE TAB OCCUPIES WINS, but only on PROOF (`ownsItsPathOnDisk`): a managed
+  // path, still carrying the tab's own name, CONFIRMED on disk. That is the same bar
+  // #1535 set when it pinned a no-name save to its own ".app.json"; this generalizes it
+  // from one reconstruction to any of them, and the write it produces is the one the panel
+  // makes anyway — `saveInPlace` → the store's `saveWorkflow` → `UserFile.save()` writes
+  // `this.path`, which IS `currentPath` here. Nothing relocates, so #226 has nothing to
+  // protect against on this route.
+  //
+  // ONLY WHEN THE RECONSTRUCTED TARGET IS OCCUPIED. An ABSENT target is a save that
+  // completes — it creates the sibling and refuses nobody — and that is P0-b's deliberate
+  // "an on-disk Foo.json in app mode copies to Foo.app.json" direction, which #1535
+  // explicitly left standing. Redirecting it too would reverse a decision this issue did
+  // not ask about, so the redirect fires only where the save would otherwise DEAD-END.
+  //
+  // Unprovable cases keep today's behaviour and reach the guard below: an EXTERNAL source
+  // (its absolute path is not addressable by the /userdata write at all, so "in place" does
+  // not exist for it — #285), a genuinely never-persisted tab, and a rename in flight. They
+  // get an honest refusal instead of the name advice (see `conflictError`).
+  if (
+    !desired &&
+    validatedSubfolder === undefined &&
+    finalTargetPath !== currentPath &&
+    (await ownsItsPathOnDisk(currentPath, currentName, existsOnDisk))
+  ) {
+    assertExpect(); // #330: the oracle awaited — still the workflow we were asked to save?
+    if ((await probeTargetCollision(svc, wf, finalTargetPath, existsOnDisk)) === "exists") {
+      finalTargetPath = currentPath;
+    }
+    assertExpect(); // and again after the collision probe, before the route is fixed
   }
 
   const relocates = finalTargetPath !== currentPath;
@@ -861,7 +938,7 @@ export async function saveActiveWorkflow(
     //   "no-oracle" — no disk oracle at all (older frontend / test) → legacy path.
     const targetState = await probeTargetCollision(svc, wf, finalTargetPath, existsOnDisk);
     if (targetState === "exists") {
-      throw conflictError(effectiveName);
+      throw conflictError(effectiveName, { named: !!desired });
     }
 
     // #285 — EXTERNAL source: a real file loaded from an ABSOLUTE path OUTSIDE the
@@ -901,8 +978,13 @@ export async function saveActiveWorkflow(
         copiedFrom: reportedCopySource,
         sourceExternal: true, // absolute external path — not /userdata-verifiable
       });
-      return await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
-        copyToUserDir(wf, effectiveName, finalTargetPath),
+      return await withConflictRollback(
+        svc,
+        wf,
+        effectiveName,
+        finalTargetPath,
+        () => copyToUserDir(wf, effectiveName, finalTargetPath),
+        { named: !!desired },
       );
     }
 
@@ -1017,8 +1099,13 @@ export async function saveActiveWorkflow(
       const sourceNorm = normalizePath(sourcePath);
       const sourceOnDiskBefore = await probeSourceOnDisk(existsOnDisk, sourceNorm);
       assertExpect(); // #330: the extra pre-copy probe must not open a switch window
-      const activeName = await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
-        atomicCopy(wf, effectiveName, finalTargetPath),
+      const activeName = await withConflictRollback(
+        svc,
+        wf,
+        effectiveName,
+        finalTargetPath,
+        () => atomicCopy(wf, effectiveName, finalTargetPath),
+        { named: !!desired },
       );
       // BACKSTOP: fail LOUDLY only if the copy actually REMOVED a source we CONFIRMED
       // (disk 200) was present and is now CONFIRMED absent (disk 404) — classifyOriginalOnDisk
@@ -2221,9 +2308,26 @@ function isConflictError(err) {
 }
 
 /** The clean, uniform filename-conflict error surfaced by both the pre-check and
- *  the post-write rollback (#309). */
-function conflictError(desiredName) {
+ *  the post-write rollback (#309).
+ *
+ *  `named: false` marks a save that supplied NO name (#1864). "Choose a different name" is
+ *  not advice such a caller can take — it never chose one — and following it literally is
+ *  what forced a reporter to fork a third workflow file. The wording for a NAMED Save-As is
+ *  deliberately byte-identical to before: comfyui-mcp matches it (`isSaveAsNameConflict`,
+ *  panel-tools.ts) to attach the rename remedy, and that remedy is right for a Save-As. */
+function conflictError(desiredName, { named = true } = {}) {
   const nm = baseName(desiredName) || "that name";
+  if (!named) {
+    return new Error(
+      `refusing to save "${nm}" in place: this save supplied NO name, and this tab could not be ` +
+        `proven to own a workflow file on disk (an externally-loaded path, or a tab whose name and ` +
+        `path disagree), so the only destination left was a workflow file that already exists ` +
+        `(409 Conflict). There is no "different name" to choose, because none was given: pass an ` +
+        `explicit name to panel_save_workflow to write a copy, or reopen the workflow from ` +
+        `panel_list_workflows so the tab is bound to its real file. Nothing was written and the ` +
+        `active tab was left unchanged (issue #309/#1864).`,
+    );
+  }
   return new Error(
     `a workflow named "${nm}" already exists (409 Conflict) — choose a different name. ` +
       `The active tab was left unchanged (issue #309).`,
@@ -2260,7 +2364,7 @@ function safeAssign(obj, key, value) {
  *  Derived getter-only flags are skipped via safeAssign so restoration never throws.
  *  A non-conflict error is rethrown untouched. Nothing on disk is modified here — a
  *  409 means the server wrote nothing, and the pre-existing file is never our source. */
-async function withConflictRollback(svc, wf, desiredName, finalTargetPath, fn) {
+async function withConflictRollback(svc, wf, desiredName, finalTargetPath, fn, { named = true } = {}) {
   const prevActive = svc?.activeWorkflow;
   const snap = wf
     ? {
@@ -2290,7 +2394,7 @@ async function withConflictRollback(svc, wf, desiredName, finalTargetPath, fn) {
       safeAssign(wf, "isTemporary", snap.isTemporary);
       safeAssign(wf, "isPersisted", snap.isPersisted);
     }
-    throw conflictError(desiredName);
+    throw conflictError(desiredName, { named });
   }
 }
 

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -906,10 +906,24 @@ export async function saveActiveWorkflow(
     (await ownsItsPathOnDisk(currentPath, currentName, existsOnDisk))
   ) {
     assertExpect(); // #330: the oracle awaited — still the workflow we were asked to save?
-    if ((await probeTargetCollision(svc, wf, finalTargetPath, existsOnDisk)) === "exists") {
+    const occupied = (await probeTargetCollision(svc, wf, finalTargetPath, existsOnDisk)) === "exists";
+    assertExpect(); // and again after the collision probe, before the route is fixed
+    // RE-VALIDATE THE PROOF SYNCHRONOUSLY (codex gate P1). `assertExpect` protects the
+    // workflow OBJECT, not its FIELDS: `path` and `filename` are plain writable properties
+    // on ComfyUI's UserFile, so a same-object rename landing during the two probes above
+    // keeps object identity — assertExpect passes — while moving the tab off the very
+    // identity this redirect was authorized on. `ownsItsPathOnDisk` sampled both before
+    // those awaits, and the in-place branch's own drift check re-reads `path` but not
+    // `filename`, so without this the redirect could write "Foo.json" for a tab that now
+    // calls itself "Bar" — the stale-path write the #1535 boundary test forbids.
+    //
+    // Nothing is awaited between this re-read and the assignment, so the destination cannot
+    // drift after it. A drift simply DECLINES the redirect and falls through to the
+    // collision guard below: the same refusal this state already gets today, which is the
+    // fail-safe direction rather than a new behaviour.
+    if (occupied && normalizePath(wf.path) === currentPath && baseName(wf.filename) === currentName) {
       finalTargetPath = currentPath;
     }
-    assertExpect(); // and again after the collision probe, before the route is fixed
   }
 
   const relocates = finalTargetPath !== currentPath;

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -161,9 +161,25 @@ function pathIsAppSuffixedSiblingOf(wf, base) {
  *
  *  Compares the path's OWN basename rather than re-deriving one from the mode, so it stays
  *  independent of the extension reconstruction that is the thing being second-guessed. */
+
+/** #1864 (codex gate r3) — TRUE only for a path that lands INSIDE the managed workflows
+ *  folder. `normalizePath` collapses separators but does not RESOLVE them, so
+ *  "workflows/../settings/Foo.json" carries the managed prefix while pointing at other
+ *  userdata entirely. Nothing the frontend builds contains "..": its records come from the
+ *  /userdata listing, so this is a defensive floor rather than a reported shape — but the
+ *  redirect it guards ends in a forced write, and the collision guard it bypasses is the
+ *  only other thing standing there, so the floor is worth its four lines. Mirrors the
+ *  segment rules validateWorkflowSubfolder already applies to the one input that may
+ *  select a subdirectory. */
+function isUnderWorkflowsRoot(path) {
+  const p = normalizePath(path);
+  if (!p.startsWith(`${WORKFLOWS_ROOT}/`)) return false;
+  return !p.split("/").some((segment) => segment === ".." || segment === ".");
+}
 async function ownsItsPathOnDisk(currentPath, currentName, existsOnDisk) {
   if (!currentPath || !currentName) return false;
   if (isExternalWorkflowPath(currentPath) || isUrlDerivedWorkflowPath(currentPath)) return false;
+  if (!isUnderWorkflowsRoot(currentPath)) return false;
   if (baseName(currentPath.split("/").pop()) !== currentName) return false;
   if (typeof existsOnDisk !== "function") return false;
   try {


### PR DESCRIPTION
Fixes #1864.

## The defect

`panel_save_workflow` with **no name** resolves its destination by *reconstructing* it — the workflow's `directory` + its reported `filename` + its **mode-derived** extension (`workflowExt`). When any of those three drifts from the path the tab actually occupies, a no-name save silently becomes a relocating Save-As. If a file already sits at that reconstructed path, the #309 collision guard refuses:

```
a workflow named "flux2_klein_ultimate_faceswap_v21" already exists (409 Conflict) —
choose a different name. The active tab was left unchanged (issue #309).
```

For a call that supplied **no name**, that is impossible advice. The reporter's workflow was never written, and their only way out was to fork a third file (`..._verbessert`).

## Evidence (reproduced by execution, not by reading)

I drove `saveActiveWorkflow(svc, undefined, …)` directly against current `main` and got the reporter's error **verbatim** from three distinct shapes:

| tab shape (no name supplied) | reconstructed target | result on `main` |
|---|---|---|
| `directory` no longer matches the path's own folder | `workflows/X.json` | **409, verbatim** |
| `workflows/X.app.json` whose tab reads unsaved (`isTemporary` drift) — skips the #1535 pin, which requires `!wasUnsaved` | `workflows/X.json` | **409, verbatim** |
| `initialMode: "app"` on a plain `workflows/X.json` whose `.app.json` sibling already exists | `workflows/X.app.json` | **409, verbatim** |

Single-file managed shapes (plain root, subfolder, `.app.json` with the #1535 pin) all save in place correctly — the 409 needs *a file at the reconstructed target*. So these share a **shape**, not a cause: a reconstructed destination the tab does not occupy. The fix is stated against the shape.

## The fix

**The file the tab occupies wins — but only on proof.** New `ownsItsPathOnDisk(currentPath, currentName, existsOnDisk)` requires all three:

- **managed path** — an external/absolute or URL-derived path is not addressable by the `/userdata` write at all (`directoryOf` redirects those to the workflows root for that reason, #285/#1066), so "in place" does not exist for it;
- **name agrees with path** — a tab whose `filename` has moved on from its `path` (rename in flight) holds two destinations, and the file at the old path is not the one being edited. This is the hazard the existing *#1535 boundary* test names;
- **confirmed on disk (200)** — the authoritative oracle, not the `isTemporary`/`isPersisted` flags, which drift in both directions after an open-ack race (#215/#442).

This is the same bar #1535 set when it pinned a no-name save to its own `.app.json`; it generalizes from one reconstruction to any of them. The write it produces is the one the panel makes anyway: `saveInPlace` → the **store's** `saveWorkflow` → `UserFile.save()` writes `this.path`, which *is* `currentPath` here. Nothing relocates, so **#226 has nothing to protect against on this route**.

**Only when the reconstructed target is OCCUPIED.** An absent target is a save that *completes*, and that is P0-b's deliberate direction (`Foo.json` in app mode forks `Foo.app.json`), which #1535 explicitly left standing. Reversing it is a product decision, not a bug fix — so the redirect fires only where the save would otherwise dead-end.

**What stays refused keeps its refusal, but loses the bad advice.** An external source, a never-persisted tab, and a rename in flight still refuse — with a message that says what the caller actually needs (pass a name, or rebind the tab) instead of telling a caller that named nothing to pick a different name.

That message deliberately **names no cause** (second commit). The first draft blamed "an externally-loaded path, or a tab whose name and path disagree", which is an inference presented as a finding: `conflictError` is raised from two places whose situations differ, and a *late* 409 in the copy route can hit a tab that does own its file on disk — the target simply appeared after the probe. It now states only what was observed and the two remedies that exist, the same discipline `explainUserDataStoreFailure` keeps in this module.

## Where to look hardest (the load-bearing claims)

1. **`conflictError`'s NAMED wording is byte-identical to before.** comfyui-mcp matches it verbatim — `isSaveAsNameConflict` in `panel-tools.ts` (`/already exists \(409 Conflict\)/i && /choose a different name/i`) — to attach the rename remedy for mcp#1873, and that remedy is right for a Save-As. Only the `named: false` branch diverges, and `withSaveAsNameConflictNote` is only applied by the orchestrator when `args.name` is set. A test asserts the named string **exactly**.
2. **Every `ownsItsPathOnDisk` condition fails *safe*** — unprovable ⇒ keep today's route. A throwing oracle, a missing oracle, a 404, and an inconclusive status all read as "not proven".
3. **The two new `await`s sit before any write**, each followed by `assertExpect()` (#330). Both downstream branches re-assert `assertExpect`/`assertCanvasNotForeign` synchronously at their own write sites, per the module's existing pattern.
4. **`finalTargetPath` became `let`.** The in-place branch's invariant (`finalTargetPath === currentPath`) still holds by construction on the redirect path, and `recordOutcome`/the return value both read correctly.
5. The `#1535` pin and this redirect cannot double-fire: the pin already sets `finalTargetPath = currentPath`, which makes the redirect's `finalTargetPath !== currentPath` false.
6. **The ownership proof is re-read synchronously at the point the destination is fixed** (third commit, from the codex gate's P1). `assertExpect` protects the workflow *object*, not its fields — `path` and `filename` are plain writable properties on `UserFile` — so a same-object rename landing during the two probes would otherwise let the redirect write `Foo.json` for a tab that now calls itself `Bar`. Nothing is awaited between the re-read and the assignment; a drift declines the redirect and falls through to the collision guard, which is the refusal this state got before the redirect existed.

## Verification

**Verified by mutation** — each guard is pinned by a test that goes red when the guard is removed (`node --test --test-timeout=60000`):

| mutation | tests that go red |
|---|---|
| delete the redirect block | `#1864: … OCCUPIED writes the tab OWN file`, `#1864: an app-mode tab whose .app.json sibling ALREADY exists …` |
| disable `conflictError`'s `named:false` branch | `#1864: a rename in flight …`, `#1864: an EXTERNALLY-loaded source …` |
| drop the name/path stem-agreement guard | `#1864: a rename in flight is NOT proof of ownership` |
| make the redirect fire unconditionally (drop "only when occupied") | `#1864 boundary: an ABSENT reconstructed target still COPIES`, **and the pre-existing** `#1535 boundary: a tab that READS unsaved stays on the collision-checked route` |
| drop the post-probe re-validation of the ownership proof | `#1864 (codex gate P1): a same-object rename DURING the probes declines the redirect` |
| drop the in-place name-drift guard | `#1864 (codex gate r2): a name drift during the in-place probe refuses, and writes nothing` |
| drop that guard's `!desired` scoping | `#1864 (codex gate r2): a NAMED save is untouched by a concurrent title edit` |
| drop the workflows-root boundary check | `#1864 (codex gate r3): a traversal path is not ownership` |
| judge the path normalized instead of raw | `#1864 (codex gate r4): a URL-derived path is judged RAW` |

**Production reachability** (green tests never prove production reaches the code): both real callers pass the oracle and a `undefined` name — `programmaticSave` (`comfyui-mcp-panel.js`, `existsOnDisk: workflowExistsOnDisk`, reached from the `workflow_save` command handler, which the orchestrator dispatches with **no** `name` for `panel_save_workflow({})`) and `groundActiveWorkflow` (`saveActiveWorkflow(svc, undefined, { existsOnDisk, … })`).

- `npm run test:unit` — 6994 tests, 6989 pass, **4 fail**. All 4 are the pre-existing `#2314` receiver-fence failures; they fail identically on `origin/main` with the change stashed (same 6983/6978/4 counts), so they are not from this branch.
- `npx tsc --noEmit` — clean.
- `npm run test:e2e:list` — compiles and discovers 98 tests in 44 files.
- **Re-verified against the main that moved under this PR.** `origin/main` advanced by three commits (a2ui/lit rendering, the registry network rule, release v0.15.103) while the gate rounds ran. Zero file overlap with this branch, and a local merge of current `main` into this head runs 7010 tests / 7005 pass / the same 4 pre-existing `#2314` failures. The merge was aborted afterwards so the PR head stays the gated SHA.

## What I could NOT run — no coverage claimed

**The Playwright browser gate did not run.** `playwright.config.ts` requires a real ComfyUI at `http://localhost:8188`; nothing is listening on this machine (probed 8188/8189/8288/9188/8000/8080, all refused) and this run was given no ComfyUI instance and told not to start one. `workflow-save-subfolder.spec.ts` is the spec that drives the production save command path, and it is exactly the one that needs a live ComfyUI. I am not implying browser coverage I do not have. The unit tests here exercise the same module the panel loads, with the production call shape, but a reviewer who can run the e2e suite should.

## Review history

The codex gate returned **NO-SHIP** twice, and both findings were real.

1. **Round 1 (P1)** — the redirect's ownership proof was sampled before the probes and never re-validated. Fixed in `8e892b0f`: both `path` and `filename` are re-read synchronously at the point the destination is fixed.
2. **Round 2 (P1)** — the *pre-existing* in-place drift check re-reads `path` but not `filename`, so a no-name save could still write `Foo.json` for a tab that renamed itself to `Bar` mid-probe. This one predates the branch and is reachable on the plain in-place route with no redirect involved; it is worth closing here because the redirect brings more tabs onto that route. Fixed in `6e7c566c`, **scoped to no-name saves** — a caller that passed a name chose the destination itself, so refusing there would reject the save it explicitly asked for. Both halves are mutation-pinned.

3. **Round 3 (P1)** — `ownsItsPathOnDisk` did not require the path to land *inside* the workflows folder. `normalizePath` collapses separators but does not resolve them, so `workflows/../settings/Foo.json` carries the managed prefix while pointing at other userdata; the redirect would then force a write there and skip the collision guard. Defensive rather than reported — the frontend builds its records from the /userdata listing and never produces `..` — but the redirect ends in a forced write, so the floor is worth its four lines. Fixed in `49f9f3dc`, purely restrictive (an unproven path declines the redirect and keeps the checked route).

4. **Round 4 (P1)** — and this one was a flaw in my own guard: `ownsItsPathOnDisk` tested `isUrlDerivedWorkflowPath` on the **normalized** path, but `normalizePath` collapses `//` to `/`, so `workflows/http://host/x.json` arrives as `workflows/http:/host/x.json` and the `://` the predicate requires is already gone. The guard could never fire. Confirmed by execution (`isUrl(raw) → true`, `isUrl(norm) → false`). Production would have declined anyway — a #1066 URL tab's disk probe 500s to `null`, never `true` — but a guard that cannot fire is not a guard, and the comment claimed it was one. Fixed in `f8c25fa3`: both predicates now read the raw `wf.path`, the same source `directoryOf` reads.

Rounds 1 and 2 changed behaviour; rounds 3 and 4 hardened the new guard (round 4 removed dead code). Re-gated on the final head.

**Gate verdict: `SHIP` on `f8c25fa3`** — the SHA this PR will merge (worktree HEAD and PR head both verified equal to it).

## Deliberately not done

- **P0-b is not reversed.** An on-disk `Foo.json` in app mode still forks `Foo.app.json` when that sibling is absent. #1535 named that as deliberate; this issue did not ask about it.
- **An externally-loaded source is still not saved in place.** Its absolute path cannot be written through `/userdata`, so overwriting the same-named *managed* file instead would destroy a different user file. It gets an honest refusal, not a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
