### PR TITLE
fix(panel): preserve unsaved workflow identity across proxy reads

### DIFF
--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -142,7 +142,8 @@ test("WIRING #847: the filter's key set carries the PRIOR tmp: id", () => {
   // The helper accepting a priorRouteId proves nothing if the panel never passes
   // one. This is the whole fix: `_priorTempWorkflowIds` already retains that id for
   // the live workflow object's lifetime, and `workflowRecordMatchesSelector` already
-  // honours it — the history filter was the one reader that did not.
+  // honours it — the history filter was the one reader that did not. The accessor
+  // normalizes Vue proxies to the same raw object as the route cache.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const site = src.slice(
     src.indexOf("const currentWorkflowKeys = currentWorkflowIdentityKeys({"),
@@ -150,11 +151,11 @@ test("WIRING #847: the filter's key set carries the PRIOR tmp: id", () => {
   );
   assert.ok(site.length > 0, "the filter must build its key set through the shared builder");
   assert.ok(site.includes("priorRouteId:"), "it must pass a prior route id");
-  assert.ok(site.includes("_priorTempWorkflowIds.get(activeWf)"), "…read from the map that retains it");
+  assert.ok(site.includes("priorTempWorkflowId(activeWf)"), "…read from the map that retains it");
   // Guarded: activeWorkflowRef() is null with no canvas, and a WeakMap.get(null)
   // throws. A history pane that crashes on an empty canvas would be a worse bug
   // than the one being fixed.
-  assert.ok(site.includes("activeWf ? _priorTempWorkflowIds.get(activeWf) : null"), "the lookup must be guarded");
+  assert.ok(site.includes("activeWf ? priorTempWorkflowId(activeWf) : null"), "the lookup must be guarded");
 });
 
 // ── #847: a first SAVE moves both identity forms at once ───────────────────

--- a/browser_tests/unit/workflow-list-unsaved-identity.test.mjs
+++ b/browser_tests/unit/workflow-list-unsaved-identity.test.mjs
@@ -1,0 +1,181 @@
+// #1790 recurrence — exercise the shipped workflow_list boundary through the
+// carrier split seen during reconnect: activeWorkflowRef() has the raw
+// ComfyWorkflow while openWorkflows has its Vue proxy. The same unsaved tab must
+// produce one routing handle, remain the sole active list entry, and keep doing
+// so across the four production probe reads used by the orchestrator.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { rawWorkflowObject } from "../../web/js/lib/workflow-chat-identity.js";
+import { savedWorkflowHandle } from "../../web/js/lib/bridge-route.js";
+import { dedupeWorkflowTabRecords } from "../../web/js/lib/session-rebind.js";
+
+const PANEL_JS = join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js");
+const PANEL_SRC = readFileSync(PANEL_JS, "utf8");
+const WORKFLOW_UUID = "11111111-1111-4111-8111-111111111111";
+
+function balancedBlock(src, marker) {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `missing source marker: ${marker}`);
+  const open = src.indexOf("{", start + marker.length);
+  assert.notEqual(open, -1, `missing opening brace: ${marker}`);
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === "/" && src[i + 1] === "/") {
+      i = src.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "*") {
+      i = src.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < src.length; i += 1) {
+        if (src[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (src[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return src.slice(open, i + 1);
+  }
+  throw new Error(`unterminated source block: ${marker}`);
+}
+
+function functionSource(name) {
+  const marker = `function ${name}(`;
+  const start = PANEL_SRC.indexOf(marker);
+  assert.notEqual(start, -1, `missing function: ${name}`);
+  const open = PANEL_SRC.indexOf("{", start + marker.length);
+  assert.notEqual(open, -1, `missing opening brace: ${name}`);
+  return PANEL_SRC.slice(start, open) + balancedBlock(PANEL_SRC, marker);
+}
+
+function workflowListSource() {
+  const marker = "async workflow_list()";
+  return `async function workflow_list()${balancedBlock(PANEL_SRC, marker)}`;
+}
+
+function buildWorkflowList({ activeWorkflow, openWorkflows, workflowUuids }) {
+  const bundle = `
+    const WORKFLOW_UUID_FIELD = "workflow_uuid";
+    const _tempWorkflowInstanceIds = new WeakMap();
+    const _priorTempWorkflowIds = new WeakMap();
+    ${rawWorkflowObject.toString()}
+    function workflowObjectUuid(wf) {
+      return workflowUuids.get(rawWorkflowObject(wf));
+    }
+    ${functionSource("savedWorkflowPath")}
+    ${functionSource("tempWorkflowInstanceId")}
+    ${functionSource("setTempWorkflowInstanceId")}
+    ${functionSource("priorTempWorkflowId")}
+    ${functionSource("setPriorTempWorkflowId")}
+    ${functionSource("workflowTabId")}
+    ${functionSource("isCanonicalWorkflowInstanceUuid")}
+    ${functionSource("establishedWorkflowReplyIdentity")}
+    ${functionSource("liveWorkflowListActive")}
+    ${functionSource("workflowDiskIdentityPath")}
+    ${workflowListSource()}
+    return workflow_list;
+  `;
+  return new Function(
+    "app",
+    "activeWorkflowRef",
+    "workflowUuids",
+    "crypto",
+    "savedWorkflowHandle",
+    "dedupeWorkflowTabRecords",
+    "comfyBackendIsDown",
+    "postReconnectSettleWindow",
+    "nodeDefRefreshInFlight",
+    "postReconnectBindingProofEpoch",
+    "backendReconnectEpoch",
+    "waitForReconnectHandshakeBeforeOpen",
+    "workflowListReadinessRefusalError",
+    "activeWorkflowPossiblyStale",
+    "activeWorkflowResyncEpoch",
+    "backendReconnectedAt",
+    "monotonicNow",
+    "summarizeOpenReceipt",
+    "latestOpenReceipt",
+    "openReceipts",
+    "lateWorkflowSaveReceipts",
+    "backendSocketReplyFields",
+    "getWorkflowTitle",
+    bundle,
+  )(
+    { extensionManager: { workflow: { openWorkflows } } },
+    () => activeWorkflow,
+    workflowUuids,
+    globalThis.crypto,
+    savedWorkflowHandle,
+    dedupeWorkflowTabRecords,
+    () => false,
+    () => false,
+    null,
+    0,
+    0,
+    async ({ needsWait, isReady }) => (needsWait() && isReady() ? "ready" : "ready"),
+    (reason) => new Error(reason),
+    () => false,
+    0,
+    null,
+    () => 1_000,
+    () => null,
+    () => null,
+    [],
+    () => [],
+    () => ({}),
+    () => "Unsaved Workflow",
+  );
+}
+
+test("#1790 production boundary: raw active + proxy list preserves one unsaved identity across four probes", async () => {
+  const raw = {
+    path: undefined,
+    filename: undefined,
+    key: "Unsaved Workflow",
+    isPersisted: false,
+    isTemporary: true,
+  };
+  const proxy = {
+    __v_raw: raw,
+    path: undefined,
+    filename: undefined,
+    key: "Unsaved Workflow",
+    isPersisted: false,
+    isTemporary: true,
+  };
+  const workflowUuids = new WeakMap([[raw, WORKFLOW_UUID]]);
+  const workflowList = buildWorkflowList({
+    activeWorkflow: raw,
+    openWorkflows: [proxy],
+    workflowUuids,
+  });
+
+  assert.notEqual(raw, proxy, "the reconnect carrier split must be a real proxy/raw split");
+  assert.equal(rawWorkflowObject(proxy), raw);
+  const handles = [];
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const reply = await workflowList();
+    assert.equal(reply.active.workflow_uuid, WORKFLOW_UUID);
+    assert.equal(reply.workflows.length, 1);
+    assert.equal(reply.workflows[0].active, true, `probe ${attempt + 1} must mark the live row active`);
+    assert.equal(reply.active.routing_key, reply.workflows[0].routing_key);
+    assert.equal(reply.active.key, reply.workflows[0].key);
+    handles.push(reply.active.routing_key);
+  }
+  assert.equal(new Set(handles).size, 1, "repeated corroboration reads must not churn the tmp handle");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3479,6 +3479,37 @@ const _tempWorkflowInstanceIds = new WeakMap(); // wf object -> "tmp:<uuid>"
 // recognize it as naming this same instance (#186).
 const _priorTempWorkflowIds = new WeakMap();
 
+// The workflow service exposes Vue proxies from openWorkflows while the active
+// binding and lifecycle callbacks can expose the raw ComfyWorkflow object. Route
+// identity is per OBJECT INSTANCE, so key both temporary-id stores on the same
+// raw object as the UUID store; otherwise one unsaved tab can mint different
+// `tmp:` handles in the active record and its open-list record during a
+// reconnect/probe race.
+function tempWorkflowInstanceId(wf) {
+  const raw = rawWorkflowObject(wf);
+  return raw && typeof raw === "object" ? _tempWorkflowInstanceIds.get(raw) : undefined;
+}
+
+function setTempWorkflowInstanceId(wf, id) {
+  const raw = rawWorkflowObject(wf);
+  if (raw && typeof raw === "object") _tempWorkflowInstanceIds.set(raw, id);
+}
+
+function deleteTempWorkflowInstanceId(wf) {
+  const raw = rawWorkflowObject(wf);
+  if (raw && typeof raw === "object") _tempWorkflowInstanceIds.delete(raw);
+}
+
+function priorTempWorkflowId(wf) {
+  const raw = rawWorkflowObject(wf);
+  return raw && typeof raw === "object" ? _priorTempWorkflowIds.get(raw) : undefined;
+}
+
+function setPriorTempWorkflowId(wf, id) {
+  const raw = rawWorkflowObject(wf);
+  if (raw && typeof raw === "object") _priorTempWorkflowIds.set(raw, id);
+}
+
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
 // `graph_load` replaces the graph while intentionally keeping the active workflow object
@@ -3817,7 +3848,7 @@ function workflowDiskIdentityPath(wf) {
 function workflowRecordMatchesSelector(w, sel) {
   if (!w || typeof sel !== "string" || !sel) return false;
   if (workflowTabId(w) === sel) return true;
-  if (_priorTempWorkflowIds.get(w) === sel) return true;
+  if (priorTempWorkflowId(w) === sel) return true;
   if (!workflowDiskIdentityPath(w)) return false;
   return (
     w.path === sel ||
@@ -4812,16 +4843,16 @@ function workflowTabId(wf = activeWorkflowRef()) {
   // Key on the STABLE object instance, not the mutable wf.key (see the note at
   // _tempWorkflowInstanceIds): the same unsaved workflow must keep ONE tmp: id for
   // its lifetime, or the 600ms poll churns it into a re-hello storm.
-  let id = _tempWorkflowInstanceIds.get(wf);
+  let id = tempWorkflowInstanceId(wf);
   if (!id) {
     id = "tmp:" + crypto.randomUUID();
-    _tempWorkflowInstanceIds.set(wf, id);
+    setTempWorkflowInstanceId(wf, id);
     // Retain the FIRST tmp: id ever minted for this object, for its whole life, so a
     // create-time pin survives the tab's first save (tmp:→wf:) — see
     // _priorTempWorkflowIds. Never overwrite it: save-adopt clears the routing map
     // above, and a later isTemporary flag-drift (#215) would otherwise mint a fresh
     // tmp: here and clobber the original create-time pin (guard-off-by-one).
-    if (!_priorTempWorkflowIds.has(wf)) _priorTempWorkflowIds.set(wf, id);
+    if (!priorTempWorkflowId(wf)) setPriorTempWorkflowId(wf, id);
   }
   return id;
 }
@@ -7794,7 +7825,7 @@ async function groundUnsavedWorkflow() {
       // ("clear all … preserves workflow identity") red. The tmp: id this tab already
       // routes on is enough — threads carry it as `workflowRouteKey`, which is what the
       // filter matches — and if none exists yet there is nothing to bridge anyway.
-      identityProbe: (wf) => ({ routeId: (wf ? _tempWorkflowInstanceIds.get(wf) : null) ?? null }),
+      identityProbe: (wf) => ({ routeId: (wf ? tempWorkflowInstanceId(wf) : null) ?? null }),
       // #1263 — grounding is a FIRST SAVE, and a first save swaps the active
       // ComfyWorkflow object. Without this carry the successor's next identity
       // read re-minted the workflow uuid mid-session (no object cache on the new
@@ -27211,7 +27242,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               // (same-instance save), the orchestrator keeps injecting the pre-save
               // "tmp:<uuid>" pin (it moves the pin unchanged across the save's tab-id
               // migration), so this same instance must still be recognized (#186).
-              const priorTemp = wf ? _priorTempWorkflowIds.get(wf) : null;
+              const priorTemp = wf ? priorTempWorkflowId(wf) : null;
               const forms = wf ? workflowIdentityForms(wf, workflowTabId(wf), [priorTemp]) : [];
               const verdict = classifyPinnedTarget(pinnedPath, forms);
               if (verdict === "unknown") {
@@ -36581,7 +36612,7 @@ function buildPanel() {
     // drives via a one-shot context on the next message.
     if (followsPanel) {
       // tmp→wf adopt bookkeeping (a save gave the unsaved workflow a real id).
-      if (wfid.startsWith("wf:") && wf) _tempWorkflowInstanceIds.delete(wf);
+      if (wfid.startsWith("wf:") && wf) deleteTempWorkflowInstanceId(wf);
       // #847 — CARRY THE ROUTE STAMP ACROSS THE SAVE, on every thread that holds it.
       //
       // A first save moves the tab from `tmp:<uuid>` to `wf:<path>` and re-mints the
@@ -36638,7 +36669,7 @@ function buildPanel() {
       // that made an earlier cut re-attribute one workflow's chats to another.
       const priorRouteIds = migratableRouteIds({
         newRouteId: wfid,
-        candidateRouteIds: [currentWorkflowId, wf ? _priorTempWorkflowIds.get(wf) : null],
+        candidateRouteIds: [currentWorkflowId, wf ? priorTempWorkflowId(wf) : null],
         openRouteIds: stillOpenRouteIds,
       });
 
@@ -36742,7 +36773,7 @@ function buildPanel() {
       wfid.startsWith("wf:");
     if (adopting) {
       const t = threadForWorkflow(historyKey);
-      if (wf) _tempWorkflowInstanceIds.delete(wf);
+      if (wf) deleteTempWorkflowInstanceId(wf);
       currentWorkflowId = wfid;
       currentWorkflowKey = wfkey;
       currentWorkflowRef = wf;
@@ -36843,7 +36874,7 @@ function buildPanel() {
       const currentWorkflowKeys = currentWorkflowIdentityKeys({
         storageKey: workflowStorageKey(),
         routeId: liveRouteId,
-        priorRouteId: activeWf ? _priorTempWorkflowIds.get(activeWf) : null,
+        priorRouteId: activeWf ? priorTempWorkflowId(activeWf) : null,
       });
       // #847 — and the identity this tab held before GROUNDING created this path. The
       // WeakMap above cannot help here: grounding replaces the workflow object, so it has


### PR DESCRIPTION
Fixes #1790

The reconnect recurrence was caused by the active workflow arriving as a raw object while openWorkflows exposed its Vue proxy. Temporary route and prior-route WeakMaps now normalize through rawWorkflowObject, so workflow_list keeps one unsaved tmp handle and marks the active list row across the four corroboration reads. Graph identity fencing and fail-closed behavior are unchanged.

Validation: focused identity/reconnect suite 181 passed; full unit glob 7010 passed, 4 unrelated pre-existing #2314 failures, 1 todo; typecheck passed. check:scope is blocked because this worktree has no local node_modules/typescript; package has no lint script.

No changes to init.py, apps_routes.py, or release metadata.