### PR TITLE
fix(1873): a connect that re-addresses its target's slots says so

### DIFF
--- a/browser_tests/unit/connect-slot-rename.test.mjs
+++ b/browser_tests/unit/connect-slot-rename.test.mjs
@@ -463,6 +463,39 @@ test("#1873 the disclosure is produced by the FIX, not by the fixture", () => {
   assert.equal(res.warning, undefined);
 });
 
+test("#1873 a node that becomes unreadable mid-connect does not fail a LANDED wire", () => {
+  const { graph, sw } = loadedSwitchFixture();
+  // The pack breaks its own `widgets` accessor from inside the connect. This is
+  // the one property `describeSlotRewrites` reads that `graph_connect` does not,
+  // so a throw here can ONLY escape through the disclosure rider — which is
+  // exactly the contract its header promises it never does. The capture already
+  // happened, so the BEFORE snapshot exists and the read-back is what throws.
+  let broken = false;
+  const original = sw.widgets;
+  Object.defineProperty(sw, "widgets", {
+    configurable: true,
+    get() {
+      if (broken) throw new TypeError("widgets accessor removed by the pack");
+      return original;
+    },
+  });
+  const source = graph.getNodeById(1);
+  const prior = source.connect;
+  source.connect = (outIdx, target, inIdx) => {
+    const link = prior(outIdx, target, inIdx);
+    broken = true;
+    return link;
+  };
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "input3" });
+
+  // The wire landed; the unreadable node must cost the caller nothing but the
+  // disclosure it could not compute.
+  assert.equal(res.connected.to.node_id, 2);
+  assert.equal(res.slots_rewritten, undefined);
+});
+
 test("#1873 a connect that changes nothing addressable stays byte-identical", () => {
   const graph = mkGraph();
   const source = mkNodeWithOutput(graph, 1, "Load Image");

--- a/browser_tests/unit/connect-slot-rename.test.mjs
+++ b/browser_tests/unit/connect-slot-rename.test.mjs
@@ -496,6 +496,43 @@ test("#1873 a node that becomes unreadable mid-connect does not fail a LANDED wi
   assert.equal(res.slots_rewritten, undefined);
 });
 
+test("#1873 a hostile widget VALUE cannot fail a landed wire (gate P1)", () => {
+  // A widget value is whatever the pack put there, and it is interpolated into
+  // the warning sentence. `JSON.stringify` throws on two shapes that a pack can
+  // genuinely produce, and the throw would come from a rider running AFTER the
+  // wire landed — reporting a successful connect as an error.
+  const circular = { name: "loop" };
+  circular.self = circular;
+  for (const [label, hostile, expected] of [
+    ["BigInt", 2n, /widget "select" 1 → 2n/],
+    ["circular", circular, /widget "select" 1 → \(unrenderable\)/],
+  ]) {
+    const graph = mkGraph();
+    const source = mkNodeWithOutput(graph, 1, "Load Image");
+    const node = {
+      id: 2,
+      title: "Switch",
+      graph,
+      inputs: [{ name: "input1", type: "IMAGE", link: null }],
+      outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+      widgets: [{ name: "select", value: 1, options: { max: 1 } }],
+    };
+    graph.nodes.push(node);
+    attachConnect(source, {
+      onChange: () => {
+        node.widgets[0].value = hostile;
+      },
+    });
+    const graph_connect = buildConnect(graph);
+
+    const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "input1" });
+
+    assert.equal(res.connected.to.node_id, 2, `${label}: the wire landed`);
+    assert.equal(res.slots_rewritten.length, 1, `${label}: the change is still disclosed`);
+    assert.match(res.warning, expected, `${label}: the value is rendered, not stringified raw`);
+  }
+});
+
 test("#1873 a connect that changes nothing addressable stays byte-identical", () => {
   const graph = mkGraph();
   const source = mkNodeWithOutput(graph, 1, "Load Image");

--- a/browser_tests/unit/connect-slot-rename.test.mjs
+++ b/browser_tests/unit/connect-slot-rename.test.mjs
@@ -511,8 +511,11 @@ test("#1873 hostile widget VALUES are safe in the full bridge envelope (gate P1)
     },
   });
   const oversized = { payload: "x".repeat(1000) };
+  const giantBigIntDigits = "9".repeat(100_000);
+  const giantBigInt = BigInt(giantBigIntDigits);
   for (const [label, hostile, expected] of [
     ["BigInt", 2n, "2n"],
+    ["giant BigInt", giantBigInt, null],
     ["circular", circular, "(unrenderable)"],
     ["oversized", oversized, null],
     ["throwing getter", throwingGetter, "(unrenderable)"],
@@ -553,9 +556,24 @@ test("#1873 hostile widget VALUES are safe in the full bridge envelope (gate P1)
       assert.equal(typeof rewrite?.to, "string", `${label}: oversized value is represented as text`);
       assert.ok(rewrite.to.length <= 121, `${label}: disclosure value is bounded`);
       assert.equal(rewrite.to.endsWith("…"), true, `${label}: truncation is disclosed`);
-      assert.equal(encoded.includes("x".repeat(1000)), false, `${label}: raw object is not leaked`);
+      const rawValue = label === "giant BigInt" ? `${giantBigIntDigits}n` : "x".repeat(1000);
+      assert.equal(encoded.includes(rawValue), false, `${label}: raw value is not leaked`);
     }
   }
+});
+
+test("#1873 warning rendering bounds a direct giant BigInt too", () => {
+  const giantDigits = "9".repeat(100_000);
+  const giant = BigInt(giantDigits);
+  const warning = slotRewriteWarning([
+    { node_id: 2, slots: [], widgets: [{ name: "select", from: 1, to: giant }] },
+  ]);
+  const reply = { rid: "giant-warning-rid", ok: true, result: { warning } };
+
+  assert.doesNotThrow(() => JSON.stringify(reply), "the direct warning envelope must serialize");
+  assert.ok(warning.length < 2000, "the warning stays bounded");
+  assert.equal(warning.includes(`${giantDigits}n`), false, "the giant BigInt is not leaked");
+  assert.match(warning, /widget "select" 1 → 9+…/);
 });
 
 test("#1873 a connect that changes nothing addressable stays byte-identical", () => {

--- a/browser_tests/unit/connect-slot-rename.test.mjs
+++ b/browser_tests/unit/connect-slot-rename.test.mjs
@@ -1,0 +1,486 @@
+/**
+ * #1873 — `panel_connect` reported links into dynamic-input selector nodes, the
+ * live graph showed them, and the queued prompt did not carry the selected input:
+ *
+ *     NodeInputError: Node 550 says it needs input image0, but there is no
+ *     input to that node at all
+ *     ImpactSwitch: invalid select index (ignored)
+ *
+ * MECHANISM, read from source rather than inferred:
+ *
+ *   - That backend message means the prompt has no KEY by that name.
+ *     `comfy_execution/graph.py:123`, `TopologicalSort.make_input_strong_link`:
+ *         inputs = self.dynprompt.get_node(to_node_id)["inputs"]
+ *         if to_input not in inputs: raise NodeInputError(f"Node {to_node_id} says it needs
+ *             input {to_input}, but there is no input to that node at all")
+ *     `easy imageIndexSwitch` declares image0..image19 optional+lazy and its
+ *     `check_lazy_status` asks for `"image%d" % index`, so it fires on a missing key.
+ *
+ *   - The prompt is keyed on the LIVE SLOT NAME at serialize time.
+ *     `graphToPrompt`, comfyui_frontend_package 1.49.6 (the reporter's version):
+ *         for (const [i, slot] of dto.inputs.entries()) {
+ *           const resolved = dto.resolveInput(i)
+ *           if (resolved) inputs[slot.name] = [String(origin_id), parseInt(origin_slot)]
+ *         }
+ *     with `dto.inputs = node.inputs.map(s => ({ linkId, name: s.name, type: s.type }))`.
+ *     So "image0 is not there at all" means no live slot is CALLED image0.
+ *
+ *   - The packs rename them from inside the connect. LiteGraph runs
+ *     `onConnectionsChange` from within `connectSlots`, and ComfyUI-Impact-Pack
+ *     (js/impact-pack.js, verified byte-identical against the installed pack)
+ *     rebuilds every name from its POSITION on each change, then clamps `select`.
+ *     The fixture below transcribes that hook rather than paraphrasing it.
+ *
+ * These tests run the REAL shipped `graph_connect`, extracted from
+ * web/js/comfyui-mcp-panel.js — the same technique as connect-title-rewrite and
+ * connect-throw-verdict. A helper-only test would stay green against an unwired
+ * call site, which is the failure mode those files exist to avoid.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  isLinkPersisted,
+  removePhantomLink,
+  isWidgetBackedInput,
+  inputLinkIds,
+  railSlotLinkIds,
+  linkIdExclusionSet,
+  findLandedInboundLink,
+  findLandedRailLink,
+  isRailLinkPersisted,
+  landedAfterThrowWarning,
+} from "../../web/js/lib/connect-verify.js";
+import { findExistingRailSlot } from "../../web/js/lib/rail-slot.js";
+import {
+  captureNodeTitles,
+  describeTitleRewrites,
+  titleRewriteWarning,
+} from "../../web/js/lib/node-title-rewrite.js";
+import {
+  captureSlotNames,
+  describeSlotRewrites,
+  slotRewriteWarning,
+} from "../../web/js/lib/slot-rename-disclosure.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+function sliceMethod(signature) {
+  const lines = panelSrc.split("\n");
+  const start = lines.findIndex((l) => l === signature);
+  assert.ok(start >= 0, `could not locate "${signature}" in the panel source`);
+  const end = lines.findIndex((l, i) => i > start && l === "  },");
+  assert.ok(end > start, `could not locate the end of "${signature}"`);
+  return lines.slice(start, end + 1).join("\n");
+}
+
+const connectSrc = sliceMethod(
+  "  graph_connect({ from_node_id, from_output, to_node_id, to_input, auto_match }) {",
+);
+
+// ---------------------------------------------------------------------------
+// Doubles for everything AROUND the code under test. The disclosure helpers are
+// the REAL modules — stubbing them would let this pass against a describe that
+// always said "renamed".
+// ---------------------------------------------------------------------------
+
+function resolveNode(graph, id) {
+  const n = graph.getNodeById(id);
+  if (!n) throw new Error(`No node with id ${id}`);
+  return n;
+}
+
+function resolveSlot(slots, ref, kind) {
+  const list = slots ?? [];
+  if (typeof ref === "number") {
+    if (ref < 0 || ref >= list.length) throw new Error(`no ${kind} slot ${ref}`);
+    return ref;
+  }
+  const i = list.findIndex((s) => s?.name === ref);
+  if (i === -1) throw new Error(`no ${kind} named ${ref}`);
+  return i;
+}
+
+const railIntent = () => null;
+const resolveRail = () => null;
+const isEmptyRailSlotRef = (ref) => ref == null || ref === "";
+const slotDiagnostic = () => "slot diagnostic";
+const loopbackRefusalReason = () => "loopback";
+const findSubgraphHostNode = () => null;
+const uniqueSubgraphOutputName = (_g, base) => base;
+const uniqueSubgraphInputName = (_g, base) => base;
+
+function autoMatchSlots(origin, target, from_output, to_input) {
+  return {
+    outIdx: resolveSlot(origin.outputs, from_output ?? 0, "output"),
+    inIdx: resolveSlot(target.inputs, to_input ?? 0, "input"),
+    autoMatched: [],
+  };
+}
+
+/**
+ * Build `graph_connect` from the shipped source.
+ *
+ * `overrides` is how the mutation check is done: pass a capture that records
+ * nothing and the disclosure must vanish, proving these assertions are pinned to
+ * THIS mechanism and not to something the fixture would produce anyway.
+ */
+function buildConnect(graph, overrides = {}) {
+  const deps = {
+    getGraphCtx: () => ({ graph, canvas: {}, app: {}, rootGraph: graph, LG: {} }),
+    resolveNode,
+    resolveSlot,
+    resolveRail,
+    railIntent,
+    isEmptyRailSlotRef,
+    findExistingRailSlot,
+    findSubgraphHostNode,
+    autoMatchSlots,
+    slotDiagnostic,
+    loopbackRefusalReason,
+    uniqueSubgraphOutputName,
+    uniqueSubgraphInputName,
+    isLinkPersisted,
+    removePhantomLink,
+    isWidgetBackedInput,
+    inputLinkIds,
+    railSlotLinkIds,
+    linkIdExclusionSet,
+    findLandedInboundLink,
+    findLandedRailLink,
+    isRailLinkPersisted,
+    landedAfterThrowWarning,
+    captureNodeTitles,
+    describeTitleRewrites,
+    titleRewriteWarning,
+    captureSlotNames,
+    describeSlotRewrites,
+    slotRewriteWarning,
+    ...overrides,
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const GRAPH_TOOL_EXECUTORS = {
+${connectSrc}
+};
+return GRAPH_TOOL_EXECUTORS.graph_connect;`,
+  );
+  return factory(...names.map((n) => deps[n]));
+}
+
+/** The REAL link store shape: `_links` is a number-keyed Map (see #1425). */
+function mkLinkStore() {
+  const isIndex = (prop) => typeof prop === "string" && /^(?:0|[1-9]\d*)$/.test(prop);
+  const map = new Map();
+  const proxy = new Proxy(map, {
+    get(target, prop) {
+      if (isIndex(prop)) return target.get(Number(prop));
+      const v = Reflect.get(target, prop, target);
+      return typeof v === "function" ? v.bind(target) : v;
+    },
+    has: (target, prop) => (isIndex(prop) ? target.has(Number(prop)) : Reflect.has(target, prop)),
+    ownKeys: (target) => [...target.keys()].map(String),
+    getOwnPropertyDescriptor(target, prop) {
+      if (isIndex(prop) && target.has(Number(prop))) {
+        return { value: target.get(Number(prop)), enumerable: true, configurable: true, writable: true };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  });
+  return { map, proxy };
+}
+
+function mkGraph() {
+  const store = mkLinkStore();
+  const graph = {
+    lastLinkId: 0,
+    _links: store.map,
+    links: store.proxy,
+    nodes: [],
+    outputs: [],
+    inputs: [],
+    getNodeById: (id) => graph.nodes.find((n) => String(n.id) === String(id)) ?? null,
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+    getLink: (id) => store.map.get(id) ?? null,
+  };
+  return graph;
+}
+
+// ---------------------------------------------------------------------------
+// ImpactSwitch, transcribed from ComfyUI-Impact-Pack js/impact-pack.js.
+//
+// The `!connected` branch there is guarded by a stack-trace test
+// (`!stackTrace.includes('LGraphNode.connect')`) whose purpose is to skip the
+// removal when the disconnect is the internal half of a RECONNECT. That guard
+// reads a MINIFIED frontend's stack in production, where the class name it looks
+// for is not present — so it fails open, which is what `removeOnDisconnect`
+// models here. It is a fixture switch, not an assertion about every build.
+// ---------------------------------------------------------------------------
+
+const IMPACT_WIDGET_COUNT = 1; // ImpactSwitch / LatentSwitch / SEGSSwitch
+
+function impactOnConnectionsChange(node, { index, connected, inputName = "input", removeOnDisconnect }) {
+  if (!connected && node.inputs.length > IMPACT_WIDGET_COUNT + 1 && removeOnDisconnect) {
+    if (node.inputs[index].name !== "select") node.inputs.splice(index, 1);
+  }
+  let slot_i = 1;
+  for (let i = 0; i < node.inputs.length; i++) {
+    const input_i = node.inputs[i];
+    if (input_i.name !== "select" && input_i.name !== "sel_mode") {
+      input_i.name = `${inputName}${slot_i}`;
+      slot_i++;
+    }
+  }
+  if (connected) {
+    node.inputs.push({ name: `${inputName}${slot_i}`, type: node.outputs[0].type, link: null });
+  }
+  if (node.widgets?.[0]) {
+    node.widgets[0].options.max = node.inputs.length - 3;
+    node.widgets[0].value = Math.min(node.widgets[0].value, node.widgets[0].options.max);
+  }
+}
+
+/**
+ * The origin's connect(), mirroring `connectSlots` ORDER: the link is written to
+ * `graph._links` / `output.links` / `input.link` FIRST, and the nodes'
+ * `onConnectionsChange` hooks run only after (see connect-verify.js). A
+ * reconnect onto an occupied input drops the old link first, which fires the
+ * hook a second time with `connected === false`.
+ */
+function attachConnect(node, { onChange, throwAfterWrite = false } = {}) {
+  node.connect = (outIdx, target, inIdx) => {
+    const graph = node.graph;
+    const prev = target.inputs[inIdx]?.link;
+    if (prev != null) {
+      graph._links.delete(prev);
+      target.inputs[inIdx].link = null;
+      onChange?.({ index: inIdx, connected: false });
+    }
+    const id = ++graph.lastLinkId;
+    const link = { id, origin_id: node.id, origin_slot: outIdx, target_id: target.id, target_slot: inIdx };
+    graph._links.set(id, link);
+    (node.outputs[outIdx].links ??= []).push(id);
+    target.inputs[inIdx].link = id;
+    onChange?.({ index: inIdx, connected: true });
+    if (throwAfterWrite) throw new Error("Cannot read properties of undefined (reading 'slots')");
+    return link;
+  };
+}
+
+/**
+ * A switch node whose dynamic slot names are NOT canonical for their positions.
+ *
+ * This is the state a LOADED workflow is in: the pack's hook returns early when
+ * the stack contains `loadGraphData`, so the saved names survive the load
+ * untouched, and the FIRST connect afterwards runs the renumbering loop over all
+ * of them. `input3` at index 3 becomes `input2`.
+ */
+function loadedSwitchFixture({ select = 1, throwAfterWrite = false } = {}) {
+  const graph = mkGraph();
+  const source = mkNodeWithOutput(graph, 1, "Load Image");
+  const sw = {
+    id: 2,
+    title: "ImpactSwitch",
+    graph,
+    inputs: [
+      { name: "select", type: "INT", link: null },
+      { name: "sel_mode", type: "BOOLEAN", link: null },
+      { name: "input1", type: "IMAGE", link: 900 },
+      { name: "input3", type: "IMAGE", link: null },
+    ],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+    widgets: [{ name: "select", value: select, options: { max: 1 } }],
+  };
+  graph.nodes.push(sw);
+  attachConnect(source, {
+    throwAfterWrite,
+    onChange: ({ index, connected }) =>
+      impactOnConnectionsChange(sw, { index, connected, removeOnDisconnect: false }),
+  });
+  return { graph, source, sw };
+}
+
+/** A canonically-named switch with one empty trailing slot — the ordinary case. */
+function canonicalSwitchFixture() {
+  const graph = mkGraph();
+  const source = mkNodeWithOutput(graph, 1, "Load Image");
+  const sw = {
+    id: 2,
+    title: "ImpactSwitch",
+    graph,
+    inputs: [
+      { name: "select", type: "INT", link: null },
+      { name: "sel_mode", type: "BOOLEAN", link: null },
+      { name: "input1", type: "IMAGE", link: null },
+    ],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+    widgets: [{ name: "select", value: 1, options: { max: 1 } }],
+  };
+  graph.nodes.push(sw);
+  attachConnect(source, {
+    onChange: ({ index, connected }) =>
+      impactOnConnectionsChange(sw, { index, connected, removeOnDisconnect: false }),
+  });
+  return { graph, source, sw };
+}
+
+/**
+ * A fully-wired switch, reconnected onto an already-occupied input — the path
+ * where the pack drops a slot and re-clamps `select`.
+ */
+function reconnectSwitchFixture() {
+  const graph = mkGraph();
+  const source = mkNodeWithOutput(graph, 1, "Load Image");
+  const sw = {
+    id: 2,
+    title: "ImpactSwitch",
+    graph,
+    inputs: [
+      { name: "select", type: "INT", link: null },
+      { name: "sel_mode", type: "BOOLEAN", link: null },
+      { name: "input1", type: "IMAGE", link: 901 },
+      { name: "input2", type: "IMAGE", link: 902 },
+      { name: "input3", type: "IMAGE", link: 903 },
+      { name: "input4", type: "IMAGE", link: null },
+    ],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+    widgets: [{ name: "select", value: 3, options: { max: 3 } }],
+  };
+  graph.nodes.push(sw);
+  for (const id of [901, 902, 903]) {
+    graph._links.set(id, { id, origin_id: 99, origin_slot: 0, target_id: 2, target_slot: 0 });
+  }
+  attachConnect(source, {
+    onChange: ({ index, connected }) =>
+      impactOnConnectionsChange(sw, { index, connected, removeOnDisconnect: true }),
+  });
+  return { graph, source, sw };
+}
+
+function mkNodeWithOutput(graph, id, title) {
+  const node = { id, title, inputs: [], outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }], graph };
+  graph.nodes.push(node);
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// The reported path
+// ---------------------------------------------------------------------------
+
+test("#1873 shipped graph_connect: a slot the pack RENAMES is disclosed", () => {
+  const { graph, sw } = loadedSwitchFixture();
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "input3" });
+
+  // The wire is real — a rename must never be reported as a connect failure.
+  assert.equal(res.connected.to.node_id, 2);
+  // The pack really did renumber it: the slot the caller addressed as "input3"
+  // is called "input2" now, and it is the name the queued prompt will carry.
+  assert.equal(sw.inputs[3].name, "input2");
+
+  assert.deepEqual(res.slots_rewritten, [
+    { node_id: 2, slots: [{ kind: "input", index: 3, from: "input3", to: "input2" }], widgets: [] },
+  ]);
+  assert.match(res.warning, /RE-ADDRESSED/);
+  assert.match(res.warning, /"input3" → "input2"/);
+  assert.match(res.warning, /no input to that node at all/);
+  assert.match(res.warning, /panel_query_graph/);
+});
+
+test("#1873 the appended trailing slot is NOT reported — an ordinary connect is unchanged", () => {
+  const { graph, sw } = canonicalSwitchFixture();
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "input1" });
+
+  // The pack DID materialise the next empty input — this is the state the
+  // suppression has to stay silent about, not an absence of pack behaviour.
+  assert.deepEqual(
+    sw.inputs.map((s) => s.name),
+    ["select", "sel_mode", "input1", "input2"],
+  );
+  assert.equal(res.connected.to.input, "input1");
+  assert.equal(res.slots_rewritten, undefined, "a new trailing slot is not a rewrite");
+  assert.equal(res.warning, undefined);
+});
+
+test("#1873 the select widget the pack CLAMPS is disclosed", () => {
+  const { graph, sw } = reconnectSwitchFixture();
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "input1" });
+
+  // This is the reporter's second symptom: "ImpactSwitch: invalid select index".
+  // The pack re-clamped `select` from inside the connect, so the value the
+  // caller chose now selects a different input than the one they meant.
+  assert.equal(sw.widgets[0].value, 2, "the pack really did clamp it");
+  assert.equal(res.slots_rewritten.length, 1);
+  assert.deepEqual(res.slots_rewritten[0].widgets, [{ name: "select", from: 3, to: 2 }]);
+  assert.match(res.warning, /widget "select" 3 → 2/);
+});
+
+test("#1873 the disclosure survives the THROW path", () => {
+  const { graph } = loadedSwitchFixture({ throwAfterWrite: true });
+  const graph_connect = buildConnect(graph);
+
+  // #1272: the link is written before the hooks run, so a throw still leaves a
+  // landed wire — and a node left mid-reshape is exactly when the caller most
+  // needs to be told its slot names moved.
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "input3" });
+
+  assert.equal(res.connected.to.node_id, 2);
+  assert.deepEqual(res.slots_rewritten, [
+    { node_id: 2, slots: [{ kind: "input", index: 3, from: "input3", to: "input2" }], widgets: [] },
+  ]);
+  assert.match(res.warning, /RE-ADDRESSED/);
+  // The throw-path warning is not REPLACED by the new rider.
+  assert.match(res.warning, /Do NOT retry this connect/);
+});
+
+// ---------------------------------------------------------------------------
+// Mutation check — the assertions above must come from the FIX
+// ---------------------------------------------------------------------------
+
+test("#1873 the disclosure is produced by the FIX, not by the fixture", () => {
+  const { graph, sw } = loadedSwitchFixture();
+  // Neuter only the capture. The fixture's rename is untouched: if the
+  // assertions above could pass without the call site reading the snapshot,
+  // they would pass here too.
+  const graph_connect = buildConnect(graph, { captureSlotNames: () => [] });
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "input3" });
+
+  assert.equal(sw.inputs[3].name, "input2", "the pack still renamed it");
+  assert.equal(res.connected.to.node_id, 2, "the connect itself is unaffected");
+  assert.equal(res.slots_rewritten, undefined);
+  assert.equal(res.warning, undefined);
+});
+
+test("#1873 a connect that changes nothing addressable stays byte-identical", () => {
+  const graph = mkGraph();
+  const source = mkNodeWithOutput(graph, 1, "Load Image");
+  const plain = {
+    id: 2,
+    title: "SaveImage",
+    graph,
+    inputs: [{ name: "images", type: "IMAGE", link: null }],
+    outputs: [],
+  };
+  graph.nodes.push(plain);
+  attachConnect(source, {});
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "images" });
+
+  assert.equal(res.connected.to.input, "images");
+  assert.equal(res.slots_rewritten, undefined);
+  assert.equal(res.title_rewritten, undefined);
+  assert.equal(res.warning, undefined);
+});

--- a/browser_tests/unit/connect-slot-rename.test.mjs
+++ b/browser_tests/unit/connect-slot-rename.test.mjs
@@ -496,16 +496,28 @@ test("#1873 a node that becomes unreadable mid-connect does not fail a LANDED wi
   assert.equal(res.slots_rewritten, undefined);
 });
 
-test("#1873 a hostile widget VALUE cannot fail a landed wire (gate P1)", () => {
-  // A widget value is whatever the pack put there, and it is interpolated into
-  // the warning sentence. `JSON.stringify` throws on two shapes that a pack can
-  // genuinely produce, and the throw would come from a rider running AFTER the
-  // wire landed — reporting a successful connect as an error.
+test("#1873 hostile widget VALUES are safe in the full bridge envelope (gate P1)", () => {
+  // A widget value is whatever the pack put there. The bridge serializes the
+  // FULL reply envelope after the executor returns, so protecting only the
+  // warning sentence is insufficient: raw values in slots_rewritten would still
+  // turn a landed wire into a missing reply.
   const circular = { name: "loop" };
   circular.self = circular;
+  const throwingGetter = {};
+  Object.defineProperty(throwingGetter, "secret", {
+    enumerable: true,
+    get() {
+      throw new Error("hostile getter");
+    },
+  });
+  const oversized = { payload: "x".repeat(1000) };
   for (const [label, hostile, expected] of [
-    ["BigInt", 2n, /widget "select" 1 → 2n/],
-    ["circular", circular, /widget "select" 1 → \(unrenderable\)/],
+    ["BigInt", 2n, "2n"],
+    ["circular", circular, "(unrenderable)"],
+    ["oversized", oversized, null],
+    ["throwing getter", throwingGetter, "(unrenderable)"],
+    ["symbol", Symbol("secret"), "(symbol)"],
+    ["function", () => "secret", "(function)"],
   ]) {
     const graph = mkGraph();
     const source = mkNodeWithOutput(graph, 1, "Load Image");
@@ -526,10 +538,23 @@ test("#1873 a hostile widget VALUE cannot fail a landed wire (gate P1)", () => {
     const graph_connect = buildConnect(graph);
 
     const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "input1" });
+    const rewrite = res.slots_rewritten?.[0]?.widgets?.[0];
+    const reply = { rid: `${label}-rid`, ok: true, result: res };
+    let encoded;
+    assert.doesNotThrow(() => {
+      encoded = JSON.stringify(reply);
+    }, `${label}: the production bridge envelope must serialize`);
 
     assert.equal(res.connected.to.node_id, 2, `${label}: the wire landed`);
     assert.equal(res.slots_rewritten.length, 1, `${label}: the change is still disclosed`);
-    assert.match(res.warning, expected, `${label}: the value is rendered, not stringified raw`);
+    assert.notEqual(rewrite?.to, hostile, `${label}: the raw value is not returned`);
+    if (expected) assert.equal(rewrite?.to, expected, `${label}: hostile value has a fixed safe form`);
+    else {
+      assert.equal(typeof rewrite?.to, "string", `${label}: oversized value is represented as text`);
+      assert.ok(rewrite.to.length <= 121, `${label}: disclosure value is bounded`);
+      assert.equal(rewrite.to.endsWith("…"), true, `${label}: truncation is disclosed`);
+      assert.equal(encoded.includes("x".repeat(1000)), false, `${label}: raw object is not leaked`);
+    }
   }
 });
 

--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -50,6 +50,11 @@ import {
   describeTitleRewrites,
   titleRewriteWarning,
 } from "../../web/js/lib/node-title-rewrite.js";
+import {
+  captureSlotNames,
+  describeSlotRewrites,
+  slotRewriteWarning,
+} from "../../web/js/lib/slot-rename-disclosure.js";
 import { findExistingRailSlot } from "../../web/js/lib/rail-slot.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -147,6 +152,9 @@ function buildExecutors(graph, canvas = {}) {
     "captureNodeTitles",
     "describeTitleRewrites",
     "titleRewriteWarning",
+    "captureSlotNames",
+    "describeSlotRewrites",
+    "slotRewriteWarning",
     `const GRAPH_TOOL_EXECUTORS = {
 ${connectSrc}
 ${exposeOutSrc}
@@ -181,6 +189,9 @@ return GRAPH_TOOL_EXECUTORS;`,
     captureNodeTitles,
     describeTitleRewrites,
     titleRewriteWarning,
+    captureSlotNames,
+    describeSlotRewrites,
+    slotRewriteWarning,
   );
 }
 

--- a/browser_tests/unit/connect-title-rewrite.test.mjs
+++ b/browser_tests/unit/connect-title-rewrite.test.mjs
@@ -49,6 +49,11 @@ import {
   describeTitleRewrites,
   titleRewriteWarning,
 } from "../../web/js/lib/node-title-rewrite.js";
+import {
+  captureSlotNames,
+  describeSlotRewrites,
+  slotRewriteWarning,
+} from "../../web/js/lib/slot-rename-disclosure.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import {
   applyCurrentDefWidgetValues,
@@ -167,6 +172,9 @@ function buildConnect(graph, titleDeps = {}) {
     captureNodeTitles,
     describeTitleRewrites,
     titleRewriteWarning,
+    captureSlotNames,
+    describeSlotRewrites,
+    slotRewriteWarning,
     ...titleDeps,
   };
   const names = Object.keys(deps);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -556,6 +556,11 @@ import {
   titleRewriteWarning,
 } from "./lib/node-title-rewrite.js";
 import {
+  captureSlotNames,
+  describeSlotRewrites,
+  slotRewriteWarning,
+} from "./lib/slot-rename-disclosure.js";
+import {
   snapshotGraphState,
   describeInputLink,
   orphanedInputLinkId,
@@ -16417,6 +16422,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // is the silent state mismatch #1855 reports. See node-title-rewrite.js for
     // why this DISCLOSES rather than putting the old title back.
     const titlesBefore = captureNodeTitles([origin, target]);
+    // #1873 — the same hook that rewrites a title also RE-ADDRESSES the node.
+    // Impact-Pack's ImpactSwitch renames every non-`select` input from its
+    // POSITION on each onConnectionsChange and clamps `select`; Easy-Use's
+    // *IndexSwitch nodes append/remove position-named slots. ComfyUI keys the
+    // queued prompt on the LIVE slot name, so a name this panel reported on an
+    // earlier connect can stop existing without anything saying so — which is
+    // how a link the canvas shows becomes "no input to that node at all" at run
+    // time. Captured alongside the titles, for the same reason: the rename
+    // happens on the throw path and the success path alike.
+    const slotsBefore = captureSlotNames([origin, target]);
     graph.beforeChange();
     let link;
     let connectErr = null;
@@ -16443,6 +16458,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // and the success path alike, so computing this per-branch would report it on
     // one and drop it on the other.
     const titleRewrites = describeTitleRewrites(titlesBefore);
+    // #1873 — read back in the SAME place as the titles, before the verdict
+    // branches, so a re-addressed node is disclosed on both of them.
+    const slotRewrites = describeSlotRewrites(slotsBefore);
     if (connectErr) {
       const landed = findLandedInboundLink(graph, origin, outIdx, target, inboundLinkIdsBefore);
       if (!landed) {
@@ -16502,6 +16520,10 @@ const GRAPH_TOOL_EXECUTORS = {
         // the wire landed; the rename is a second, independent thing that
         // happened to the same command.
         ...(titleRewrites.length ? { title_rewritten: titleRewrites } : {}),
+        // #1873 — a throw from a dynamic-input hook is exactly when the node is
+        // most likely to have been left re-addressed, so this path needs the
+        // disclosure at least as much as the clean one.
+        ...(slotRewrites.length ? { slots_rewritten: slotRewrites } : {}),
         warning: [
           landedAfterThrowWarning(
             connectErr,
@@ -16512,6 +16534,7 @@ const GRAPH_TOOL_EXECUTORS = {
               : "",
           ),
           titleRewriteWarning(titleRewrites),
+          slotRewriteWarning(slotRewrites),
         ]
           .filter(Boolean)
           .join(" "),
@@ -16578,8 +16601,21 @@ const GRAPH_TOOL_EXECUTORS = {
       // #1855 — the reported path: a connect that fully succeeded and renamed its
       // target on the way. Emitted only when a title actually moved, so an
       // ordinary connect's payload is byte-identical to before.
-      ...(titleRewrites.length
-        ? { title_rewritten: titleRewrites, warning: titleRewriteWarning(titleRewrites) }
+      ...(titleRewrites.length ? { title_rewritten: titleRewrites } : {}),
+      // #1873 — same shape for the slot names and widget values the connect
+      // re-addressed. Emitted only when something the caller could already be
+      // holding actually moved: a brand-new trailing input slot is the expected
+      // behaviour of every dynamic-input node and is never reported, so an
+      // ordinary connect's payload stays byte-identical to before.
+      ...(slotRewrites.length ? { slots_rewritten: slotRewrites } : {}),
+      // Both riders share the single `warning` key, so neither can drop the
+      // other's sentence when one connect does both at once.
+      ...(titleRewrites.length || slotRewrites.length
+        ? {
+            warning: [titleRewriteWarning(titleRewrites), slotRewriteWarning(slotRewrites)]
+              .filter(Boolean)
+              .join(" "),
+          }
         : {}),
     };
   },

--- a/web/js/lib/slot-rename-disclosure.js
+++ b/web/js/lib/slot-rename-disclosure.js
@@ -203,10 +203,42 @@ export function describeSlotRewrites(snapshot) {
   return rewrites;
 }
 
+/**
+ * A never-throwing, bounded rendering of an arbitrary value.
+ *
+ * Slot NAMES arrive here already coerced to `string | null` by `slotNames`, but
+ * WIDGET VALUES are whatever the pack put on the widget, and a bare
+ * `JSON.stringify` on those has two failure modes that both end in a `TypeError`
+ * thrown from a disclosure rider — i.e. a landed connect reported as an error,
+ * the precise thing this module must never cause:
+ *
+ *   - a BigInt: "Do not know how to serialize a BigInt"
+ *   - a circular object: "Converting circular structure to JSON"
+ *
+ * Length is bounded for a third reason that is not a throw: a widget holding a
+ * large object (a Load3D transform, a serialized curve) would otherwise paste its
+ * entire JSON into a warning sentence.
+ */
+function renderValue(value) {
+  try {
+    if (value === null || value === undefined) return "null";
+    const type = typeof value;
+    if (type === "bigint") return `${value}n`;
+    if (type === "number" || type === "boolean") return String(value);
+    if (type === "symbol" || type === "function") return `(${type})`;
+    const json = JSON.stringify(value);
+    // `undefined` when the value is not serialisable at all — never interpolate that.
+    if (typeof json !== "string") return `(${type})`;
+    return json.length > 120 ? `${json.slice(0, 120)}…` : json;
+  } catch {
+    return "(unrenderable)";
+  }
+}
+
 /** `"input3" → "input2"`, or `"input4" → (removed)` for a slot that is gone. */
 function renderSlot(change) {
-  const to = change.to == null ? "(removed)" : JSON.stringify(change.to);
-  return `${change.kind} ${change.index} ${JSON.stringify(change.from)} → ${to}`;
+  const to = change.to == null ? "(removed)" : renderValue(change.to);
+  return `${change.kind} ${change.index} ${renderValue(change.from)} → ${to}`;
 }
 
 /**
@@ -220,15 +252,26 @@ function renderSlot(change) {
  */
 export function slotRewriteWarning(rewrites) {
   if (!rewrites?.length) return "";
-  const list = rewrites
-    .map((r) => {
-      const parts = r.slots.map(renderSlot);
-      for (const w of r.widgets) {
-        parts.push(`widget ${JSON.stringify(w.name)} ${JSON.stringify(w.from ?? null)} → ${JSON.stringify(w.to ?? null)}`);
-      }
-      return `node ${r.node_id}: ${parts.join(", ")}`;
-    })
-    .join("; ");
+  // Every value that reaches the template goes through `renderValue`, and the
+  // whole list is built inside a try: this function is called from the RETURN
+  // EXPRESSION of a connect whose wire has already landed, so a throw here would
+  // report a successful mutation as a failure. When the list cannot be rendered
+  // the disclosure still goes out — the caller needs to know their names moved
+  // far more than they need the itemisation.
+  let list = "";
+  try {
+    list = rewrites
+      .map((r) => {
+        const parts = r.slots.map(renderSlot);
+        for (const w of r.widgets) {
+          parts.push(`widget ${renderValue(w.name)} ${renderValue(w.from)} → ${renderValue(w.to)}`);
+        }
+        return `node ${renderValue(r.node_id)}: ${parts.join(", ")}`;
+      })
+      .join("; ");
+  } catch {
+    list = "the details could not be rendered";
+  }
   return (
     `This connect RE-ADDRESSED ${rewrites.length === 1 ? "a node" : `${rewrites.length} nodes`} — ${list}. ` +
     `The panel did not do this: LiteGraph runs the target's own onConnectionsChange hook from ` +

--- a/web/js/lib/slot-rename-disclosure.js
+++ b/web/js/lib/slot-rename-disclosure.js
@@ -216,6 +216,12 @@ export function describeSlotRewrites(snapshot) {
 
 const MAX_DISCLOSURE_VALUE_LENGTH = 120;
 
+function boundDisclosureText(text) {
+  return text.length > MAX_DISCLOSURE_VALUE_LENGTH
+    ? `${text.slice(0, MAX_DISCLOSURE_VALUE_LENGTH)}…`
+    : text;
+}
+
 /**
  * Convert an arbitrary live graph value to a bounded JSON-safe scalar. The
  * comparison above deliberately retains the original values so Object.is()
@@ -227,14 +233,12 @@ function safeDisclosureValue(value) {
     if (value === null || value === undefined) return null;
     switch (typeof value) {
       case "string":
-        return value.length > MAX_DISCLOSURE_VALUE_LENGTH
-          ? `${value.slice(0, MAX_DISCLOSURE_VALUE_LENGTH)}…`
-          : value;
+        return boundDisclosureText(value);
       case "number":
       case "boolean":
         return value;
       case "bigint":
-        return `${value}n`;
+        return boundDisclosureText(`${value}n`);
       case "symbol":
         return "(symbol)";
       case "function":
@@ -242,9 +246,7 @@ function safeDisclosureValue(value) {
       default: {
         const json = JSON.stringify(value);
         if (typeof json !== "string") return "(unrenderable)";
-        return json.length > MAX_DISCLOSURE_VALUE_LENGTH
-          ? `${json.slice(0, MAX_DISCLOSURE_VALUE_LENGTH)}…`
-          : json;
+        return boundDisclosureText(json);
       }
     }
   } catch {
@@ -272,15 +274,13 @@ function renderValue(value) {
   try {
     if (value === null || value === undefined) return "null";
     const type = typeof value;
-    if (type === "bigint") return `${value}n`;
+    if (type === "bigint") return boundDisclosureText(`${value}n`);
     if (type === "number" || type === "boolean") return String(value);
     if (type === "symbol" || type === "function") return `(${type})`;
     const json = JSON.stringify(value);
     // `undefined` when the value is not serialisable at all — never interpolate that.
     if (typeof json !== "string") return `(${type})`;
-    return json.length > MAX_DISCLOSURE_VALUE_LENGTH
-      ? `${json.slice(0, MAX_DISCLOSURE_VALUE_LENGTH)}…`
-      : json;
+    return boundDisclosureText(json);
   } catch {
     return "(unrenderable)";
   }

--- a/web/js/lib/slot-rename-disclosure.js
+++ b/web/js/lib/slot-rename-disclosure.js
@@ -164,30 +164,41 @@ export function describeSlotRewrites(snapshot) {
   for (const entry of snapshot ?? []) {
     const node = entry?.node;
     if (!node || typeof node !== "object") continue;
-    const slots = [];
-    for (const kind of ["input", "output"]) {
-      const before = (kind === "input" ? entry.inputs : entry.outputs) ?? [];
-      const after = slotNames(kind === "input" ? node.inputs : node.outputs);
-      for (let i = 0; i < before.length; i++) {
-        // `i >= after.length` is a REMOVAL, reported as `to: null`. Indices at or
-        // beyond `before.length` are new slots and are deliberately not read.
-        const to = i < after.length ? after[i] : null;
-        if (before[i] === to) continue;
-        slots.push({ kind, index: i, from: before[i] ?? null, to });
+    // Per-node try, matching `captureSlotNames`. `node.inputs` / `node.outputs` /
+    // `node.widgets` / `node.id` are property READS, and an extension is free to
+    // install a throwing getter or a Proxy over any of them (cg-use-everywhere
+    // already replaces frontend API surface this panel calls). Without this, such
+    // a read escapes AFTER the wire has landed and turns a successful connect
+    // into a reported failure — the exact outcome the "never throws" contract in
+    // the header exists to prevent, and the one #1272 spent a whole issue undoing.
+    try {
+      const slots = [];
+      for (const kind of ["input", "output"]) {
+        const before = (kind === "input" ? entry.inputs : entry.outputs) ?? [];
+        const after = slotNames(kind === "input" ? node.inputs : node.outputs);
+        for (let i = 0; i < before.length; i++) {
+          // `i >= after.length` is a REMOVAL, reported as `to: null`. Indices at or
+          // beyond `before.length` are new slots and are deliberately not read.
+          const to = i < after.length ? after[i] : null;
+          if (before[i] === to) continue;
+          slots.push({ kind, index: i, from: before[i] ?? null, to });
+        }
       }
+      const widgets = [];
+      const widgetsBefore = entry.widgets ?? [];
+      const widgetsAfter = widgetValues(node.widgets);
+      for (let i = 0; i < widgetsBefore.length && i < widgetsAfter.length; i++) {
+        const was = widgetsBefore[i];
+        const now = widgetsAfter[i];
+        if (was?.name !== now?.name) continue;
+        if (Object.is(was?.value, now?.value)) continue;
+        widgets.push({ name: was?.name ?? null, from: was?.value, to: now?.value });
+      }
+      if (!slots.length && !widgets.length) continue;
+      rewrites.push({ node_id: node.id, slots, widgets });
+    } catch {
+      /* an unreadable node contributes no disclosure, never a thrown verdict */
     }
-    const widgets = [];
-    const widgetsBefore = entry.widgets ?? [];
-    const widgetsAfter = widgetValues(node.widgets);
-    for (let i = 0; i < widgetsBefore.length && i < widgetsAfter.length; i++) {
-      const was = widgetsBefore[i];
-      const now = widgetsAfter[i];
-      if (was?.name !== now?.name) continue;
-      if (Object.is(was?.value, now?.value)) continue;
-      widgets.push({ name: was?.name ?? null, from: was?.value, to: now?.value });
-    }
-    if (!slots.length && !widgets.length) continue;
-    rewrites.push({ node_id: node.id, slots, widgets });
   }
   return rewrites;
 }

--- a/web/js/lib/slot-rename-disclosure.js
+++ b/web/js/lib/slot-rename-disclosure.js
@@ -1,0 +1,236 @@
+/**
+ * #1873 — a connect that silently RE-ADDRESSES its target must say so.
+ *
+ * The reporter wired IMAGE producers into a dynamic-input selector node with
+ * `panel_connect`, every call reported success, `panel_query_graph` showed the
+ * links — and the queued prompt did not carry the selected input:
+ *
+ *     NodeInputError: Node 550 says it needs input image0, but there is no
+ *     input to that node at all
+ *     ImpactSwitch: invalid select index (ignored)
+ *
+ * ## Why a live link can be absent from the prompt, read from source
+ *
+ * ComfyUI keys a prompt's inputs on the LIVE SLOT NAME at serialization time.
+ * From `graphToPrompt` in comfyui_frontend_package 1.49.6 — the reporter's own
+ * version — the prompt entry for a node is built as:
+ *
+ *     for (const [i, slot] of dto.inputs.entries()) {
+ *       const resolved = dto.resolveInput(i)
+ *       if (resolved) { … inputs[slot.name] = [String(origin_id), origin_slot] }
+ *     }
+ *
+ * and `dto.inputs` is `node.inputs.map(s => ({ linkId: …, name: s.name, … }))`,
+ * captured at serialize time. So the key the backend sees is whatever the slot
+ * is called AT THE MOMENT OF THE RUN — not what it was called when the wire was
+ * made. `image0` is "not there at all" precisely when no live slot is NAMED
+ * `image0` any more, however many wires the canvas shows.
+ *
+ * ## What renames them
+ *
+ * The node packs do, from inside the connect itself. LiteGraph runs
+ * `onConnectionsChange` from within `connectSlots`, and these packs rebuild
+ * their slot names FROM POSITION every time it fires.
+ *
+ * ComfyUI-Impact-Pack (js/impact-pack.js, verified against the installed pack)
+ * registers this for ImpactSwitch / LatentSwitch / SEGSSwitch and the
+ * ImpactMake / Combine family:
+ *
+ *     let slot_i = 1;
+ *     for (let i = 0; i < this.inputs.length; i++) {
+ *       let input_i = this.inputs[i];
+ *       if (input_i.name != 'select' && input_i.name != 'sel_mode') {
+ *         input_i.name = `${input_name}${slot_i}`      // <-- renames EVERY slot
+ *         slot_i++;
+ *       }
+ *     }
+ *     if (connected) this.addInput(`${input_name}${slot_i}`, this.outputs[0].type);
+ *     if (this.widgets?.[0]) {
+ *       this.widgets[0].options.max = this.inputs.length - 3;
+ *       this.widgets[0].value = Math.min(this.widgets[0].value, …);  // <-- and CLAMPS select
+ *     }
+ *
+ * It also rewrites `this.outputs[0].name` to the propagated type when the
+ * output was still `*`. ComfyUI-Easy-Use does the positional-name variant for
+ * its *IndexSwitch nodes (web_version/v2, verified in the installed pack):
+ * `this.addInput(prefix + s.length, "*")` when every slot is filled, and
+ * `this.removeInput(i + 1)` when a trailing one empties — so a slot removed
+ * ahead of others shifts the names that follow it.
+ *
+ * None of that is wrong of the packs; it is how a dynamic-input node works. What
+ * was wrong is that `panel_connect` reported the name it saw and said nothing
+ * when the NEXT `panel_connect` to the same node moved it. The caller then set
+ * `index` / `select` against a name that had already shifted, and the run failed
+ * with the message above — from the backend, several steps later, naming a slot
+ * the panel had told them was connected.
+ *
+ * ## What this module does — and does NOT do
+ *
+ * It DISCLOSES. It does not rename anything back: the pack owns these names on
+ * purpose (positional naming is the contract that makes `select`/`index` mean
+ * anything), and putting an old name back would break the very addressing the
+ * node depends on. This is the same call the sibling #1855 disclosure made for
+ * node titles — see node-title-rewrite.js, same hook, same "the caller is left
+ * holding a stale name" defect.
+ *
+ * Only state the caller COULD ALREADY HOLD is reported: a slot index that
+ * existed before the connect and now carries a different name, or no longer
+ * exists at all. A brand-new trailing slot is never reported — materialising the
+ * next empty input is the expected behaviour of every node in this class, and
+ * reporting it would put a warning on every correct ImpactSwitch connect.
+ *
+ * Never throws. It is a rider on a verdict that has already been decided, and it
+ * must never turn a wire that landed into a reported failure.
+ */
+
+/** A slot list's names, in order. Never throws. */
+function slotNames(slots) {
+  const names = [];
+  for (const slot of Array.isArray(slots) ? slots : []) {
+    try {
+      names.push(typeof slot?.name === "string" ? slot.name : null);
+    } catch {
+      names.push(null);
+    }
+  }
+  return names;
+}
+
+/**
+ * A widget list's `{ name, value }` pairs, in order. Never throws — a widget may
+ * expose `value` as a getter that does, and a disclosure rider must not be the
+ * thing that raises.
+ */
+function widgetValues(widgets) {
+  const entries = [];
+  for (const widget of Array.isArray(widgets) ? widgets : []) {
+    try {
+      entries.push({ name: typeof widget?.name === "string" ? widget.name : null, value: widget?.value });
+    } catch {
+      entries.push({ name: null, value: undefined });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Snapshot the addressable state of the nodes a connect is about to touch,
+ * BEFORE it runs: input slot names, output slot names, and widget values.
+ *
+ * Deduplicated by node IDENTITY so a self-connect (origin === target) is
+ * captured once and cannot report itself twice. Non-objects are skipped rather
+ * than throwing, for the same reason `captureNodeTitles` skips them.
+ */
+export function captureSlotNames(nodes) {
+  const snapshot = [];
+  for (const node of nodes ?? []) {
+    if (!node || typeof node !== "object") continue;
+    if (snapshot.some((entry) => entry.node === node)) continue;
+    try {
+      snapshot.push({
+        node,
+        inputs: slotNames(node.inputs),
+        outputs: slotNames(node.outputs),
+        widgets: widgetValues(node.widgets),
+      });
+    } catch {
+      /* an unreadable node contributes no disclosure */
+    }
+  }
+  return snapshot;
+}
+
+/**
+ * Which slot names the connect's own side effects moved, and which widget values
+ * it changed.
+ *
+ * Compared BY INDEX, and only over indices that existed BEFORE the mutation —
+ * that bound is what keeps the expected "materialise the next empty slot"
+ * behaviour silent while still catching a rename or a removal. `to: null` means
+ * the slot at that index is gone entirely.
+ *
+ * Widget entries are reported only when the widget at that index still has the
+ * SAME name: a name change at an index is a widget-list reshape, not a value
+ * the caller set going stale, and describing it as one would be a guess.
+ * `Object.is` rather than `!==` so a NaN-valued widget is not reported as
+ * changing on every connect.
+ *
+ * @returns {Array<{node_id: unknown, slots: Array<{kind: string, index: number,
+ *   from: string|null, to: string|null}>, widgets: Array<{name: string|null,
+ *   from: unknown, to: unknown}>}>} one entry per node that actually changed.
+ */
+export function describeSlotRewrites(snapshot) {
+  const rewrites = [];
+  for (const entry of snapshot ?? []) {
+    const node = entry?.node;
+    if (!node || typeof node !== "object") continue;
+    const slots = [];
+    for (const kind of ["input", "output"]) {
+      const before = (kind === "input" ? entry.inputs : entry.outputs) ?? [];
+      const after = slotNames(kind === "input" ? node.inputs : node.outputs);
+      for (let i = 0; i < before.length; i++) {
+        // `i >= after.length` is a REMOVAL, reported as `to: null`. Indices at or
+        // beyond `before.length` are new slots and are deliberately not read.
+        const to = i < after.length ? after[i] : null;
+        if (before[i] === to) continue;
+        slots.push({ kind, index: i, from: before[i] ?? null, to });
+      }
+    }
+    const widgets = [];
+    const widgetsBefore = entry.widgets ?? [];
+    const widgetsAfter = widgetValues(node.widgets);
+    for (let i = 0; i < widgetsBefore.length && i < widgetsAfter.length; i++) {
+      const was = widgetsBefore[i];
+      const now = widgetsAfter[i];
+      if (was?.name !== now?.name) continue;
+      if (Object.is(was?.value, now?.value)) continue;
+      widgets.push({ name: was?.name ?? null, from: was?.value, to: now?.value });
+    }
+    if (!slots.length && !widgets.length) continue;
+    rewrites.push({ node_id: node.id, slots, widgets });
+  }
+  return rewrites;
+}
+
+/** `"input3" → "input2"`, or `"input4" → (removed)` for a slot that is gone. */
+function renderSlot(change) {
+  const to = change.to == null ? "(removed)" : JSON.stringify(change.to);
+  return `${change.kind} ${change.index} ${JSON.stringify(change.from)} → ${to}`;
+}
+
+/**
+ * The prose that rides alongside `slots_rewritten`.
+ *
+ * It carries the two things the structured field cannot: that the rename came
+ * from the NODE PACK and not from the panel, and — the part that actually saves
+ * the caller — that ComfyUI keys the queued prompt on the LIVE slot name, so a
+ * selector widget left pointing at the old name fails at RUN time with a message
+ * that names the panel's own reported slot.
+ */
+export function slotRewriteWarning(rewrites) {
+  if (!rewrites?.length) return "";
+  const list = rewrites
+    .map((r) => {
+      const parts = r.slots.map(renderSlot);
+      for (const w of r.widgets) {
+        parts.push(`widget ${JSON.stringify(w.name)} ${JSON.stringify(w.from ?? null)} → ${JSON.stringify(w.to ?? null)}`);
+      }
+      return `node ${r.node_id}: ${parts.join(", ")}`;
+    })
+    .join("; ");
+  return (
+    `This connect RE-ADDRESSED ${rewrites.length === 1 ? "a node" : `${rewrites.length} nodes`} — ${list}. ` +
+    `The panel did not do this: LiteGraph runs the target's own onConnectionsChange hook from ` +
+    `inside the connect, and a dynamic-input pack rebuilds its slot names FROM POSITION there ` +
+    `(ComfyUI-Impact-Pack renames every non-select input to "<prefix><n>" on each change and ` +
+    `clamps its "select" widget; ComfyUI-Easy-Use's *IndexSwitch nodes append and remove ` +
+    `position-named slots). ` +
+    `Any input or output NAME an earlier panel_connect, panel_add_node or panel_query_graph ` +
+    `reported for ${rewrites.length === 1 ? "that node" : "those nodes"} is now STALE — including ` +
+    `the slot you may have picked a "select" / "index" value for. ` +
+    `This matters at RUN time, not now: ComfyUI keys the queued prompt on the LIVE slot name, so ` +
+    `a selector still naming the old slot fails with "Node <id> says it needs input <name>, but ` +
+    `there is no input to that node at all" (#1873). ` +
+    `Re-read the node with panel_query_graph before wiring anything else to it or setting its selector.`
+  );
+}

--- a/web/js/lib/slot-rename-disclosure.js
+++ b/web/js/lib/slot-rename-disclosure.js
@@ -157,7 +157,9 @@ export function captureSlotNames(nodes) {
  *
  * @returns {Array<{node_id: unknown, slots: Array<{kind: string, index: number,
  *   from: string|null, to: string|null}>, widgets: Array<{name: string|null,
- *   from: unknown, to: unknown}>}>} one entry per node that actually changed.
+ *   from: string|number|boolean|null, to: string|number|boolean|null}>}>} one
+ *   entry per node that actually changed. Widget values and node ids are safe,
+ *   bounded JSON scalars; the live values remain private to this comparison.
  */
 export function describeSlotRewrites(snapshot) {
   const rewrites = [];
@@ -181,7 +183,12 @@ export function describeSlotRewrites(snapshot) {
           // beyond `before.length` are new slots and are deliberately not read.
           const to = i < after.length ? after[i] : null;
           if (before[i] === to) continue;
-          slots.push({ kind, index: i, from: before[i] ?? null, to });
+          slots.push({
+            kind,
+            index: i,
+            from: safeDisclosureValue(before[i] ?? null),
+            to: safeDisclosureValue(to),
+          });
         }
       }
       const widgets = [];
@@ -192,15 +199,57 @@ export function describeSlotRewrites(snapshot) {
         const now = widgetsAfter[i];
         if (was?.name !== now?.name) continue;
         if (Object.is(was?.value, now?.value)) continue;
-        widgets.push({ name: was?.name ?? null, from: was?.value, to: now?.value });
+        widgets.push({
+          name: safeDisclosureValue(was?.name ?? null),
+          from: safeDisclosureValue(was?.value),
+          to: safeDisclosureValue(now?.value),
+        });
       }
       if (!slots.length && !widgets.length) continue;
-      rewrites.push({ node_id: node.id, slots, widgets });
+      rewrites.push({ node_id: safeDisclosureValue(node.id), slots, widgets });
     } catch {
       /* an unreadable node contributes no disclosure, never a thrown verdict */
     }
   }
   return rewrites;
+}
+
+const MAX_DISCLOSURE_VALUE_LENGTH = 120;
+
+/**
+ * Convert an arbitrary live graph value to a bounded JSON-safe scalar. The
+ * comparison above deliberately retains the original values so Object.is()
+ * can distinguish real changes; this is the boundary where those values must
+ * stop being able to enter a graph_connect reply.
+ */
+function safeDisclosureValue(value) {
+  try {
+    if (value === null || value === undefined) return null;
+    switch (typeof value) {
+      case "string":
+        return value.length > MAX_DISCLOSURE_VALUE_LENGTH
+          ? `${value.slice(0, MAX_DISCLOSURE_VALUE_LENGTH)}…`
+          : value;
+      case "number":
+      case "boolean":
+        return value;
+      case "bigint":
+        return `${value}n`;
+      case "symbol":
+        return "(symbol)";
+      case "function":
+        return "(function)";
+      default: {
+        const json = JSON.stringify(value);
+        if (typeof json !== "string") return "(unrenderable)";
+        return json.length > MAX_DISCLOSURE_VALUE_LENGTH
+          ? `${json.slice(0, MAX_DISCLOSURE_VALUE_LENGTH)}…`
+          : json;
+      }
+    }
+  } catch {
+    return "(unrenderable)";
+  }
 }
 
 /**
@@ -229,7 +278,9 @@ function renderValue(value) {
     const json = JSON.stringify(value);
     // `undefined` when the value is not serialisable at all — never interpolate that.
     if (typeof json !== "string") return `(${type})`;
-    return json.length > 120 ? `${json.slice(0, 120)}…` : json;
+    return json.length > MAX_DISCLOSURE_VALUE_LENGTH
+      ? `${json.slice(0, MAX_DISCLOSURE_VALUE_LENGTH)}…`
+      : json;
   } catch {
     return "(unrenderable)";
   }


### PR DESCRIPTION
Fixes #1873.

## What the reporter saw

`panel_add_node` + `panel_connect` reported successful links into dynamic-input
selector nodes (`easy imageIndexSwitch`, `ImpactSwitch`), `panel_query_graph`
showed them, and the queued prompt did not carry the selected input:

```
NodeInputError: Node 550 says it needs input image0, but there is no input to that node at all
ImpactSwitch: invalid select index (ignored)
```

## Root cause, read from source rather than inferred

**1. That backend message means the prompt has no key by that name.**
`comfy_execution/graph.py:123`, `TopologicalSort.make_input_strong_link`:

```python
inputs = self.dynprompt.get_node(to_node_id)["inputs"]
if to_input not in inputs:
    raise NodeInputError(f"Node {to_node_id} says it needs input {to_input}, but there is no input to that node at all")
```

`easy imageIndexSwitch` declares `image0..image19` as **optional + lazy** and its
`check_lazy_status` asks for `"image%d" % index`, so this fires when the prompt's
`inputs` dict has no `image0` key.

**2. The prompt is keyed on the LIVE SLOT NAME at serialize time.** From
`graphToPrompt` in `comfyui_frontend_package` **1.49.6** — the reporter's exact
version, read out of the installed bundle:

```js
for (const [i, slot] of dto.inputs.entries()) {
  const resolved = dto.resolveInput(i)
  if (resolved) { ... inputs[slot.name] = [String(origin_id), parseInt(origin_slot)] }
}
```

with `dto.inputs = node.inputs.map(s => ({ linkId: ..., name: s.name, type: s.type }))`.
So `image0` being absent does **not** mean a wire is missing — it means **no live
slot is called `image0` any more**.

**3. The packs rename the slots, from inside the connect.** LiteGraph runs
`onConnectionsChange` from within `connectSlots`. ComfyUI-Impact-Pack
(`js/impact-pack.js`, verified byte-identical against the installed pack) rebuilds
every name from its **position** on every change:

```js
let slot_i = 1;
for (let i = 0; i < this.inputs.length; i++) {
  let input_i = this.inputs[i];
  if (input_i.name != 'select' && input_i.name != 'sel_mode') {
    input_i.name = `${input_name}${slot_i}`;   // renames EVERY slot
    slot_i++;
  }
}
if (connected) this.addInput(`${input_name}${slot_i}`, this.outputs[0].type);
if (this.widgets?.[0]) {
  this.widgets[0].options.max = this.inputs.length - 3;
  this.widgets[0].value = Math.min(this.widgets[0].value, ...);  // and CLAMPS select
}
```

It also rewrites `outputs[0].name` to the propagated type. ComfyUI-Easy-Use's
`*IndexSwitch` nodes do the positional variant: `addInput(prefix + s.length, "*")`
when every slot is filled, `removeInput(i + 1)` when a trailing one empties.

**So:** `panel_connect` reported the name it saw and said nothing when a *later*
`panel_connect` to the same node moved it. The caller then set `index` / `select`
against a name that had already shifted, and the failure surfaced several steps
later, from the backend, naming a slot the panel had reported as connected.

## The change

Discloses the re-addressing — `slots_rewritten` plus a `warning` — exactly as
`node-title-rewrite.js` does for titles in **#1855** (merged yesterday: same hook,
same "the caller is left holding a stale name" defect).

It renames nothing back. Positional naming is the contract that makes
`select`/`index` mean anything, so restoring an old name would break the
addressing the node depends on.

**Noise control (the load-bearing design choice):** only state the caller *could
already hold* is reported — a slot index that existed **before** the connect and
now carries a different name or is gone. A brand-new trailing slot is never
reported, because materialising the next empty input is the expected behaviour of
every node in this class. An ordinary connect's payload is byte-identical to
before.

Widget values are captured the same way, which covers the second reported
symptom (`ImpactSwitch: invalid select index`) — the pack silently clamps
`select` during the connect.

## Please look hardest at

- **`describeSlotRewrites`'s index bound** (`i < before.length`) — this is what
  separates "the pack renamed your slot" from "the pack added the next empty
  slot". Get it wrong and every correct ImpactSwitch connect gets a warning.
- **Both reply paths.** The rename happens on the throw path and the success path
  alike; `slotRewrites` is computed once before the verdict branches for exactly
  that reason. The success path now merges two riders into the single `warning`
  key so neither can drop the other's sentence.
- **`Object.is` for widget values** (not `!==`) so a NaN-valued widget is not
  reported as changing on every connect.

## Verification

- `node --test browser_tests/unit/` — full unit suite.
- Mutation-checked: the new assertions are pinned to this mechanism via the
  harness's `titleDeps`-style dependency-neutering, and by reverting the call-site
  wiring. See the comment below for the recorded runs.

## What I did NOT do

- **I could not run the Playwright browser gate.** It requires a live ComfyUI at
  `localhost:8188` (`playwright.config.ts`: "this suite does NOT start ComfyUI for
  you"); none is listening on this machine and this run was allocated no instance.
  So there is **no browser coverage for this change** — the evidence here is the
  pack/frontend/backend source quoted above plus the unit + call-site tests.
- **This does not make the packs' lifecycle correct**, and it does not retro-fix a
  graph that is already mis-addressed. It stops the panel reporting a slot name
  that its own next call invalidates, which is the part the panel owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
