### PR TITLE
fix(2314): normalise CRLF in the scope-fence source pins so they run on Windows

### DIFF
--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -4,7 +4,12 @@ import { readFileSync } from "node:fs";
 import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
 import { findSubgraphOwner } from "../../web/js/lib/subgraph-scope.js";
 
-const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+// This tree is CRLF; CI checks out LF. Every source pin below anchors on a BLANK LINE,
+// and a literal two-newline anchor never matches a CRLF blank line — so these four fence
+// pins passed on CI and were dead on Windows, one of them slicing to -1 and swallowing
+// the rest of the file as a fake "helper". The five sibling pin files already normalise
+// at read time; this one was missed (comfyui-mcp#2314).
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
 
 function extractShippingMethod(signature) {
   const start = PANEL_SRC.indexOf(signature);


### PR DESCRIPTION
Four `#2314` scope-fence pins fail on any Windows checkout of `main`, and have since they were written.

## What is actually wrong

`graph-set-widget-target-fence.test.mjs` pins the promoted-write scope fence by slicing the *shipped* panel source. Its end anchors are blank lines:

```js
const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
```

A CRLF blank line is `\r\n\r\n`, which does not contain `\n\n`. Measured against the tree:

| | offset |
|---|---|
| `function canonicalExpectedPromotedOwner` | 535238 |
| anchor, as written | **-1** |
| anchor, CRLF form | 542812 |

So three pins failed on the boundary assert, and the fourth sliced `helperStart → -1`, handing `new Function` the rest of the file — surfacing as `SyntaxError: Cannot use 'import.meta' outside a module`, which reads like a harness bug rather than a missing fence.

**The fence itself is intact.** CI checks out LF, so all four were green there the whole time. Only the defence was broken, and only on the platform this project is developed on.

## The fix

The five sibling pin files — `deferred-widget-edit`, `graph-binding`, `load-workflow-subgraph-widgets`, `panel-set-widget-live-node-id`, `run-command-budget` — all already normalise at read time. This file was missed. Same one-line treatment, no anchor rewrites.

I checked the other 10 pin sites across those files: all are downstream of an existing `.replace(/\r\n/g, "\n")`, so this is the only affected file.

## Verification

- `npm run test:unit` on `main`: **4 failing**. With this: **7016 pass / 0 fail**, exit 0.
- **The restored pins bite.** Neutering `canonicalExpectedPromotedOwner` in production (`return null` at the top) fails exactly those 4 with 2 controls surviving — they are not vacuously green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
