### PR TITLE
fix(1871): the pruned-retry note says WHY the first post is not pre-pruned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- scrolling up during a streaming turn no longer snaps back to the bottom (#1879)
+- the pruned-retry disclosure says why the first post is not pre-pruned (#1871)
+
 ## [0.15.104] - 2026-08-26
 
 ### Fixed

--- a/browser_tests/unit/partial-run-prune.test.mjs
+++ b/browser_tests/unit/partial-run-prune.test.mjs
@@ -332,4 +332,11 @@ test("#1871 the disclosure names the node ComfyUI refused, what was omitted, and
   assert.match(note, /Nothing was queued by that refusal/);
   // It must not leave the caller thinking the missing pack is now fine.
   assert.match(note, /FULL run will still fail/);
+  // #1871 was filed BECAUSE the note said WHAT happened but never why the first post was
+  // not pruned to begin with, which reads as an ordering bug the panel forgot to fix. It
+  // is a deliberate trade (see this module's header): pruning every scoped run would make
+  // ComfyUI evict the other branch's cache. Pin the reason so it travels WITH the refusal
+  // rather than living only in a source comment the reporter cannot see.
+  assert.match(note, /NOT pre-pruned, on purpose/);
+  assert.match(note, /evict the other branch's cached results/);
 });

--- a/web/js/lib/partial-run-prune.js
+++ b/web/js/lib/partial-run-prune.js
@@ -338,6 +338,10 @@ export function prunedRetryNote({ toNodeId, namedNode, removed }) {
     `to the requested branch (comfyui-mcp#1871). Nothing was queued by that refusal. The ` +
     `panel then re-posted the SAME run with the ${list.length} node(s) outside the requested ` +
     `branch omitted — ${shown.join(", ")}${more} — and that is the prompt ComfyUI accepted. ` +
+    `The first post is NOT pre-pruned, on purpose: ComfyUI drops every cached output whose `
+      + `node is absent from the prompt it was handed, so pruning every scoped run would evict `
+      + `the other branch's cached results and make your next FULL run recompute a branch it `
+      + `had already rendered. The prune is spent only where the alternative is this refusal. ` +
     `The nodes that executed are exactly node ${toNodeId} and its upstream dependencies, ` +
     `which is what run-to-node asks for; the omitted nodes are untouched on your canvas and ` +
     `a FULL run will still fail on them until the pack behind node ${namedNode} is installed.`


### PR DESCRIPTION
Closes #1871.

## The answer to #1871 is "no, deliberately" — and that is what was missing

#1871 asks why the panel posts the full prompt and only prunes after ComfyUI refuses, when the upstream closure is fully computable before the first post. It is a fair reading: the sequence looks like an ordering bug nobody got around to fixing. It has now been asked twice.

It is a deliberate trade, and it is documented — in `partial-run-prune.js`'s header, where the reporter cannot see it:

> The default (classic `HierarchicalCache`) drops every cached output whose key is not in the prompt it was just handed. A prompt pruned to one branch therefore EVICTS the other branch's cached results, so a scoped preview would quietly make the user's next full run recompute a branch it had already rendered — on the workflows where run-to-node is most useful, that is minutes of GPU time nobody asked to spend.

So pruning every scoped run trades one wasted round trip for minutes of GPU recompute. The prune is spent only where the alternative is a total refusal, and a run ComfyUI accepts is byte-for-byte unchanged by the module.

**No behaviour change here.** The mechanism is correct as designed; the disclosure just stopped short of saying why, which is the part that generates the issue.

## What changed

`prunedRetryNote()` gains one clause, so the reason travels with the refusal:

> The first post is NOT pre-pruned, on purpose: ComfyUI drops every cached output whose node is absent from the prompt it was handed, so pruning every scoped run would evict the other branch's cached results and make your next FULL run recompute a branch it had already rendered. The prune is spent only where the alternative is this refusal.

Also adds the missing `[Unreleased]` changelog line for **#1879**, which merged past the 0.15.104 cut without one and would otherwise have shipped silently.

## Verification

- Note **rendered**, not read: 1046 chars, clause present, no template artefacts.
- Mutation: stripping the clause from the source (387 bytes) fails the pin on `/NOT pre-pruned, on purpose/` with **21 controls surviving**.
- `partial-run-prune.test.mjs` 22/22.
- Local registry YARA replica: still **6** — no new finding.
- `gen-changelog-json.mjs` self-check passes on the regenerated `web/changelog.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
