### PR TITLE
fix(1882): a release tag proves the tagged tree is the version it claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       # The registry applies .comfyignore with gitignore semantics: a bare
       # `vendor/` matches a vendor dir at ANY depth, so the exclusion meant for
       # the root CI artefact also silently dropped web/js/vendor/ (the runtime
-      # marked/DOMPurify/qrcode/a2ui-lit imports) from the pack — the browser
+      # marked/DOMPurify/qrcode imports) from the pack — the browser
       # 404'd on import and the sidebar never registered (#749). The parity
       # scan above reimplements the matching root-anchored and cannot see this
       # class of loss, so assert with git's OWN ignore engine instead (empty
@@ -218,8 +218,16 @@ jobs:
             web/js/vendor/marked.esm.js \
             web/js/vendor/purify.es.js \
             web/js/vendor/qrcode.esm.js \
-            web/js/vendor/a2ui-lit.bundle.js \
           ; do
+            # A path that no longer exists passes check-ignore trivially, so a stale
+            # entry reads as coverage while asserting nothing at all.
+            # web/js/vendor/a2ui-lit.bundle.js sat in this list after #1865 deleted the
+            # file, and every publish stayed green over it (#1882). Fail on the stale
+            # entry itself, so this list cannot rot back into a no-op.
+            if [ ! -e "$f" ]; then
+              echo "::error file=.github/workflows/ci.yml::$f is listed in the pack-contents gate but does not exist — remove the entry or restore the file; a listed-but-missing path makes this check silently vacuous"
+              exit 1
+            fi
             if git -c core.excludesFile=.comfyignore check-ignore -q "$f"; then
               echo "::error file=.comfyignore::$f is exclude-matched but imported at runtime — the published pack would 404 on import and the sidebar would never register (#749)"
               exit 1

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -38,7 +38,7 @@ jobs:
       # The registry applies .comfyignore with gitignore semantics: a bare
       # `vendor/` matches a vendor dir at ANY depth, so the exclusion meant for
       # the root CI artefact also silently dropped web/js/vendor/ (the runtime
-      # marked/DOMPurify/qrcode/a2ui-lit imports) from the pack — the browser
+      # marked/DOMPurify/qrcode imports) from the pack — the browser
       # 404'd on import and the sidebar never registered (#749). The parity
       # scan below reimplements the matching root-anchored and cannot see this
       # class of loss, so assert with git's OWN ignore engine instead (empty
@@ -54,8 +54,16 @@ jobs:
             web/js/vendor/marked.esm.js \
             web/js/vendor/purify.es.js \
             web/js/vendor/qrcode.esm.js \
-            web/js/vendor/a2ui-lit.bundle.js \
           ; do
+            # A path that no longer exists passes check-ignore trivially, so a stale
+            # entry reads as coverage while asserting nothing at all.
+            # web/js/vendor/a2ui-lit.bundle.js sat in this list after #1865 deleted the
+            # file, and every publish stayed green over it (#1882). Fail on the stale
+            # entry itself, so this list cannot rot back into a no-op.
+            if [ ! -e "$f" ]; then
+              echo "::error file=.github/workflows/publish_action.yml::$f is listed in the pack-contents gate but does not exist — remove the entry or restore the file; a listed-but-missing path makes this check silently vacuous"
+              exit 1
+            fi
             if git -c core.excludesFile=.comfyignore check-ignore -q "$f"; then
               echo "::error file=.comfyignore::$f is exclude-matched but imported at runtime — the published pack would 404 on import and the sidebar would never register (#749)"
               exit 1

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -19,7 +19,11 @@ name: Release tag guard
 # filters `on.push` by `branches: [main]`, and GitHub does not run a
 # `branches`-filtered push workflow for a tag ref — empirically confirmed by the
 # ten tags above, every one of which was pushed with no publish run appearing.
-# So creating a missing historical tag is safe: it runs this audit and nothing else.
+# So creating a missing historical tag is safe. Note the converse, which is easy
+# to get backwards: GitHub loads workflow files from the ref the event carries,
+# so a tag pushed at a commit predating THIS file runs no guard either. A
+# historical backfill is therefore safe but unaudited -- audit it after the fact
+# with the workflow_dispatch input below, which runs this file from main.
 
 on:
   push:

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -52,5 +52,5 @@ jobs:
 
       - name: Audit the release tag
         env:
-          TAG: ${{ inputs.tag || github.ref_name }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: node scripts/check-release-tag.mjs "$TAG"

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -1,0 +1,56 @@
+name: Release tag guard
+
+# "Was version X released?" is answered from `git tag`, and that operand has been
+# wrong in BOTH directions on this repo (#1882):
+#
+#   * v0.15.86..v0.15.96 are tagged but their trees all declare version "0.15.85".
+#     publish_action.yml fires on `paths: [pyproject.toml]`, so for tagged commits
+#     that never touched that file the workflow NEVER RAN — no job, no red X, no
+#     annotation. Ten consecutive versions silently never shipped.
+#   * 0.15.97 IS on the Registry (from the merge of release/0.15.97) and has no tag,
+#     so two reporters were told it "was never released".
+#
+# The guard therefore hangs off the TAG PUSH, not off the publish job: the first
+# failure mode is precisely that the publish job did not execute, and a guard
+# inside a workflow that never runs is not a guard. A tag push is an event that
+# did occur all ten times.
+#
+# THIS WORKFLOW DOES NOT PUBLISH AND CANNOT TRIGGER A PUBLISH. publish_action.yml
+# filters `on.push` by `branches: [main]`, and GitHub does not run a
+# `branches`-filtered push workflow for a tag ref — empirically confirmed by the
+# ten tags above, every one of which was pushed with no publish run appearing.
+# So creating a missing historical tag is safe: it runs this audit and nothing else.
+
+on:
+  push:
+    tags:
+      - "v*"
+  # So a historical tag can be audited on demand without pushing anything.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to audit (e.g. v0.15.104)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    name: Tag and tree declare the same version
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The audit walks first-parent from the previous reachable tag and reads
+          # pyproject.toml at each commit, so it needs real history AND the tag
+          # list. A shallow checkout would make `git describe` find no earlier tag
+          # and silently reduce rule 2 to a no-op.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Audit the release tag
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: node scripts/check-release-tag.mjs "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [0.15.105] - 2026-08-26
 
 ### Fixed
+- a release tag proves the tagged tree is the version it claims, and that nothing shipped untagged (#1882)
 - scrolling up during a streaming turn no longer snaps back to the bottom (#1879)
 - graph_connect reports live dynamic slot rewrites and safely bounds hostile disclosure values (#1876)
 - the pruned-retry disclosure says why the first post is not pre-pruned (#1881)

--- a/browser_tests/unit/release-tag-guard.test.mjs
+++ b/browser_tests/unit/release-tag-guard.test.mjs
@@ -40,8 +40,9 @@ const treeAt = (v) => ({
   panelJs: `const PANEL_VERSION = "${v}";\n`,
 });
 
-const noTags = () => false;
-const tagsFor = (...vs) => (v) => vs.includes(v);
+const noTags = () => null;
+/** version -> the commit its tag resolves to. */
+const tagsAt = (map) => (v) => map[v] ?? null;
 
 // ---------------------------------------------------------------------------
 // parsers
@@ -51,7 +52,7 @@ test("#1882 pyprojectVersion reads [project].version and ignores other tables", 
   const toml =
     '[build-system]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "0.15.97"\n\n[tool.comfy]\nversion = "1.2.3"\n';
   assert.equal(pyprojectVersion(toml), "0.15.97");
-  assert.equal(pyprojectVersion("[tool.comfy]\nversion = \"1.2.3\"\n"), null);
+  assert.equal(pyprojectVersion('[tool.comfy]\nversion = "1.2.3"\n'), null);
   assert.equal(pyprojectVersion(null), null);
 });
 
@@ -72,8 +73,10 @@ test("#1882 a coherent release passes", () => {
   const violations = auditTag({
     tag: "v0.15.104",
     treeAtTag: treeAt("0.15.104"),
-    range: [{ sha: "aaaaaaaa1", subject: "chore: release v0.15.104", version: "0.15.104", parentVersion: "0.15.103" }],
-    hasTagFor: tagsFor("0.15.103"),
+    range: [
+      { sha: "aaaaaaaa1", subject: "chore: release v0.15.104", version: "0.15.104", parentVersion: "0.15.103" },
+    ],
+    tagTargetFor: tagsAt({ "0.15.103": "zzzzzzzz9" }),
   });
   assert.deepEqual(violations, []);
 });
@@ -84,12 +87,9 @@ test("#1882 the v0.15.90 shape is caught: tag says .90, tree still declares 0.15
   // asymmetry is why all three witnesses are compared and not just two.
   const violations = auditTag({
     tag: "v0.15.90",
-    treeAtTag: {
-      ...treeAt("0.15.85"),
-      packageJson: JSON.stringify({ version: "0.15.90" }),
-    },
+    treeAtTag: { ...treeAt("0.15.85"), packageJson: JSON.stringify({ version: "0.15.90" }) },
     range: [],
-    hasTagFor: noTags,
+    tagTargetFor: noTags,
   });
   assert.equal(violations.length, 2, violations.join("\n"));
   assert.ok(violations.some((v) => v.includes("pyproject.toml declares 0.15.85")));
@@ -102,7 +102,7 @@ test("#1882 an unreadable version witness is a violation, not a silent pass", ()
     tag: "v0.15.104",
     treeAtTag: { ...treeAt("0.15.104"), panelJs: "// PANEL_VERSION constant removed\n" },
     range: [],
-    hasTagFor: noTags,
+    tagTargetFor: noTags,
   });
   assert.equal(violations.length, 1);
   assert.match(violations[0], /could not read a version from PANEL_VERSION/);
@@ -113,7 +113,7 @@ test("#1882 a non-release tag is reported rather than silently audited as cohere
     tag: "nightly",
     treeAtTag: treeAt("0.15.104"),
     range: [],
-    hasTagFor: noTags,
+    tagTargetFor: noTags,
   });
   assert.equal(violations.length, 1);
   assert.match(violations[0], /not a v<major>\.<minor>\.<patch> release tag/);
@@ -130,17 +130,51 @@ test("#1882 the v0.15.98 shape is caught: 0.15.97 shipped in the range with no t
     range: [
       { sha: "1111111111", subject: "chore: release v0.15.98", version: "0.15.98", parentVersion: "0.15.97" },
       { sha: "2222222222", subject: "fix: something", version: "0.15.97", parentVersion: "0.15.97" },
-      { sha: "7b477d5500", subject: "Merge pull request #1826 from artokun/release/0.15.97", version: "0.15.97", parentVersion: "0.15.85" },
+      {
+        sha: "7b477d5500",
+        subject: "Merge pull request #1826 from artokun/release/0.15.97",
+        version: "0.15.97",
+        parentVersion: "0.15.85",
+      },
     ],
-    hasTagFor: tagsFor("0.15.96"),
+    tagTargetFor: tagsAt({ "0.15.96": "9999999999" }),
   });
   assert.equal(violations.length, 1, violations.join("\n"));
-  assert.match(violations[0], /^0\.15\.97 was published by 7b477d55 /);
+  assert.match(violations[0], /^0\.15\.97 was cut by 7b477d55 /);
   assert.match(violations[0], /no v0\.15\.97 tag exists/);
   // The remedy has to be in the message: the reason this sat unfixed is that
   // pushing the tag was believed to re-publish to the Registry.
   assert.match(violations[0], /git tag -a v0\.15\.97 7b477d55/);
-  assert.match(violations[0], /does not re-trigger the publish workflow/);
+  assert.match(violations[0], /cannot re-trigger the publish workflow/);
+  // ...and the message must NOT prescribe tagging unconditionally, because a
+  // version that was cut but never shipped would then get a tag asserting it was.
+  assert.match(violations[0], /If it did not ship, do not tag it/);
+});
+
+test("#1882 a tag is credited only when it resolves to the commit that cut the version", () => {
+  // A tag is a movable label. Crediting v0.15.97 by NAME would let it sit on an
+  // unrelated commit while the commit that actually published 0.15.97 stayed
+  // untagged — the same confusion the guard exists to end.
+  const range = [
+    { sha: "1111111111", subject: "chore: release v0.15.98", version: "0.15.98", parentVersion: "0.15.97" },
+    { sha: "7b477d5500", subject: "chore: release v0.15.97", version: "0.15.97", parentVersion: "0.15.85" },
+  ];
+  const wrongTarget = auditTag({
+    tag: "v0.15.98",
+    treeAtTag: treeAt("0.15.98"),
+    range,
+    tagTargetFor: tagsAt({ "0.15.97": "deadbeef00" }),
+  });
+  assert.equal(wrongTarget.length, 1, wrongTarget.join("\n"));
+  assert.match(wrongTarget[0], /v0\.15\.97 exists but resolves to deadbeef, not the commit that cut 0\.15\.97/);
+
+  const rightTarget = auditTag({
+    tag: "v0.15.98",
+    treeAtTag: treeAt("0.15.98"),
+    range,
+    tagTargetFor: tagsAt({ "0.15.97": "7b477d5500" }),
+  });
+  assert.deepEqual(rightTarget, []);
 });
 
 test("#1882 the tag's own release commit is never reported as an untagged gap", () => {
@@ -149,8 +183,10 @@ test("#1882 the tag's own release commit is never reported as an untagged gap", 
   const violations = auditTag({
     tag: "v0.15.105",
     treeAtTag: treeAt("0.15.105"),
-    range: [{ sha: "abcabcabc", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" }],
-    hasTagFor: noTags,
+    range: [
+      { sha: "abcabcabc", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
+    ],
+    tagTargetFor: noTags,
   });
   assert.deepEqual(violations, []);
 });
@@ -163,22 +199,43 @@ test("#1882 a pyproject.toml edit that leaves the version alone is not a release
       { sha: "ddddddddd", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
       { sha: "eeeeeeeee", subject: "chore: widen a dependency pin", version: "0.15.104", parentVersion: "0.15.104" },
     ],
-    hasTagFor: noTags,
+    tagTargetFor: noTags,
   });
   assert.deepEqual(violations, []);
 });
 
-test("#1882 an already-tagged prior release in the range is fine", () => {
+// ---------------------------------------------------------------------------
+// fail closed — an unrunnable scan must never read as a clean one
+// ---------------------------------------------------------------------------
+
+test("#1882 unavailable history is a violation, not an empty range that passes", () => {
+  // The first draft turned every git failure into `range = []`, so a shallow
+  // clone or unfetched tags made rule 2 silently vacuous while the job still
+  // reported success — the same "guard that isn't a guard" shape as the stale
+  // pack-contents entry.
   const violations = auditTag({
-    tag: "v0.15.105",
-    treeAtTag: treeAt("0.15.105"),
-    range: [
-      { sha: "ffffffff1", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
-      { sha: "ffffffff2", subject: "chore: release v0.15.104", version: "0.15.104", parentVersion: "0.15.103" },
-    ],
-    hasTagFor: tagsFor("0.15.104"),
+    tag: "v0.15.98",
+    treeAtTag: treeAt("0.15.98"),
+    range: [],
+    tagTargetFor: noTags,
+    historyError: "this is a shallow clone, so the range cannot be walked",
   });
-  assert.deepEqual(violations, []);
+  assert.equal(violations.length, 1, violations.join("\n"));
+  assert.match(violations[0], /untagged-release scan could not run/);
+  assert.match(violations[0], /shallow clone/);
+});
+
+test("#1882 a history failure still reports the tree-vs-tag mismatch it could check", () => {
+  const violations = auditTag({
+    tag: "v0.15.90",
+    treeAtTag: treeAt("0.15.85"),
+    range: [],
+    tagTargetFor: noTags,
+    historyError: "no v* tags are visible",
+  });
+  assert.ok(violations.length >= 2, violations.join("\n"));
+  assert.ok(violations.some((v) => v.includes("pyproject.toml declares 0.15.85")));
+  assert.ok(violations.some((v) => v.includes("untagged-release scan could not run")));
 });
 
 // ---------------------------------------------------------------------------
@@ -189,9 +246,9 @@ test("#1882 the guard is wired to tag pushes and actually invokes the checker", 
   const wf = read(".github/workflows/release-tag-guard.yml");
   assert.match(wf, /node scripts\/check-release-tag\.mjs/, "the workflow must run the checker");
   assert.match(wf, /on:\s*\n\s*push:\s*\n\s*tags:\s*\n\s*- "v\*"/, "must trigger on v* tag pushes");
-  // fetch-depth: 0 is load-bearing, not hygiene. On a shallow checkout
-  // `git describe` finds no earlier tag, the range collapses, and rule 2
-  // degrades to a no-op that still reports success.
+  // fetch-depth: 0 is load-bearing, not hygiene. On a shallow checkout the range
+  // cannot be walked at all; the checker now reports that rather than passing,
+  // so a regression here turns every release red instead of silently vacuous.
   assert.match(wf, /fetch-depth: 0/, "rule 2 needs full history to walk the range");
   assert.match(wf, /fetch-tags: true/, "rule 2 needs the tag list to test against");
 });

--- a/browser_tests/unit/release-tag-guard.test.mjs
+++ b/browser_tests/unit/release-tag-guard.test.mjs
@@ -1,0 +1,243 @@
+/**
+ * #1882 — `git tag` is used as the "was this released?" operand and has been
+ * wrong in both directions.
+ *
+ *   * v0.15.86..v0.15.96 are tagged, and every one of those trees declares
+ *     version "0.15.85". publish_action.yml fires on `paths: [pyproject.toml]`,
+ *     so on tagged commits that never touched that file it never ran — ten
+ *     versions silently never shipped, with nothing in the Actions tab.
+ *   * 0.15.97 shipped to the Registry and has no tag at all, so two reporters
+ *     were told it "was never released".
+ *
+ * These lock the two rules in scripts/check-release-tag.mjs against the exact
+ * historical shapes, and — separately — lock the WIRING, because a guard that is
+ * correct but never invoked is the failure this issue is about. The last test
+ * covers a second instance of the same class the owner found in the same file:
+ * the pack-contents gate still listed web/js/vendor/a2ui-lit.bundle.js after
+ * #1865 deleted it, and a listed-but-missing path passes `check-ignore`
+ * trivially, so the entry read as coverage while asserting nothing.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  auditTag,
+  packageJsonVersion,
+  panelVersion,
+  pyprojectVersion,
+  versionOfTag,
+} from "../../scripts/check-release-tag.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const read = (rel) => readFileSync(join(root, rel), "utf8");
+
+const treeAt = (v) => ({
+  pyproject: `[project]\nname = "comfyui-mcp-panel"\nversion = "${v}"\n`,
+  packageJson: JSON.stringify({ name: "comfyui-mcp-panel", version: v }),
+  panelJs: `const PANEL_VERSION = "${v}";\n`,
+});
+
+const noTags = () => false;
+const tagsFor = (...vs) => (v) => vs.includes(v);
+
+// ---------------------------------------------------------------------------
+// parsers
+// ---------------------------------------------------------------------------
+
+test("#1882 pyprojectVersion reads [project].version and ignores other tables", () => {
+  const toml =
+    '[build-system]\nversion = "9.9.9"\n\n[project]\nname = "x"\nversion = "0.15.97"\n\n[tool.comfy]\nversion = "1.2.3"\n';
+  assert.equal(pyprojectVersion(toml), "0.15.97");
+  assert.equal(pyprojectVersion("[tool.comfy]\nversion = \"1.2.3\"\n"), null);
+  assert.equal(pyprojectVersion(null), null);
+});
+
+test("#1882 the other two version witnesses parse, and fail closed", () => {
+  assert.equal(packageJsonVersion('{"version":"0.15.97"}'), "0.15.97");
+  assert.equal(packageJsonVersion("not json"), null);
+  assert.equal(panelVersion('const PANEL_VERSION = "0.15.97";'), "0.15.97");
+  assert.equal(panelVersion("const PANEL_VERSION = 1;"), null);
+  assert.equal(versionOfTag("v0.15.97"), "0.15.97");
+  assert.equal(versionOfTag("release-0.15.97"), null);
+});
+
+// ---------------------------------------------------------------------------
+// rule 1 — the tagged tree declares the tag's own version
+// ---------------------------------------------------------------------------
+
+test("#1882 a coherent release passes", () => {
+  const violations = auditTag({
+    tag: "v0.15.104",
+    treeAtTag: treeAt("0.15.104"),
+    range: [{ sha: "aaaaaaaa1", subject: "chore: release v0.15.104", version: "0.15.104", parentVersion: "0.15.103" }],
+    hasTagFor: tagsFor("0.15.103"),
+  });
+  assert.deepEqual(violations, []);
+});
+
+test("#1882 the v0.15.90 shape is caught: tag says .90, tree still declares 0.15.85", () => {
+  // The real historical tree — set-version.mjs was never run, so pyproject and
+  // PANEL_VERSION are frozen, while package.json (bumped by npm) moved on. That
+  // asymmetry is why all three witnesses are compared and not just two.
+  const violations = auditTag({
+    tag: "v0.15.90",
+    treeAtTag: {
+      ...treeAt("0.15.85"),
+      packageJson: JSON.stringify({ version: "0.15.90" }),
+    },
+    range: [],
+    hasTagFor: noTags,
+  });
+  assert.equal(violations.length, 2, violations.join("\n"));
+  assert.ok(violations.some((v) => v.includes("pyproject.toml declares 0.15.85")));
+  assert.ok(violations.some((v) => v.includes("PANEL_VERSION declares 0.15.85")));
+  assert.ok(!violations.some((v) => v.includes("package.json declares")));
+});
+
+test("#1882 an unreadable version witness is a violation, not a silent pass", () => {
+  const violations = auditTag({
+    tag: "v0.15.104",
+    treeAtTag: { ...treeAt("0.15.104"), panelJs: "// PANEL_VERSION constant removed\n" },
+    range: [],
+    hasTagFor: noTags,
+  });
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /could not read a version from PANEL_VERSION/);
+});
+
+test("#1882 a non-release tag is reported rather than silently audited as coherent", () => {
+  const violations = auditTag({
+    tag: "nightly",
+    treeAtTag: treeAt("0.15.104"),
+    range: [],
+    hasTagFor: noTags,
+  });
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /not a v<major>\.<minor>\.<patch> release tag/);
+});
+
+// ---------------------------------------------------------------------------
+// rule 2 — nothing that shipped before this tag went untagged
+// ---------------------------------------------------------------------------
+
+test("#1882 the v0.15.98 shape is caught: 0.15.97 shipped in the range with no tag", () => {
+  const violations = auditTag({
+    tag: "v0.15.98",
+    treeAtTag: treeAt("0.15.98"),
+    range: [
+      { sha: "1111111111", subject: "chore: release v0.15.98", version: "0.15.98", parentVersion: "0.15.97" },
+      { sha: "2222222222", subject: "fix: something", version: "0.15.97", parentVersion: "0.15.97" },
+      { sha: "7b477d5500", subject: "Merge pull request #1826 from artokun/release/0.15.97", version: "0.15.97", parentVersion: "0.15.85" },
+    ],
+    hasTagFor: tagsFor("0.15.96"),
+  });
+  assert.equal(violations.length, 1, violations.join("\n"));
+  assert.match(violations[0], /^0\.15\.97 was published by 7b477d55 /);
+  assert.match(violations[0], /no v0\.15\.97 tag exists/);
+  // The remedy has to be in the message: the reason this sat unfixed is that
+  // pushing the tag was believed to re-publish to the Registry.
+  assert.match(violations[0], /git tag -a v0\.15\.97 7b477d55/);
+  assert.match(violations[0], /does not re-trigger the publish workflow/);
+});
+
+test("#1882 the tag's own release commit is never reported as an untagged gap", () => {
+  // At push time this tag legitimately has no *earlier* tag for its own version,
+  // and flagging it would make every single release red.
+  const violations = auditTag({
+    tag: "v0.15.105",
+    treeAtTag: treeAt("0.15.105"),
+    range: [{ sha: "abcabcabc", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" }],
+    hasTagFor: noTags,
+  });
+  assert.deepEqual(violations, []);
+});
+
+test("#1882 a pyproject.toml edit that leaves the version alone is not a release", () => {
+  const violations = auditTag({
+    tag: "v0.15.105",
+    treeAtTag: treeAt("0.15.105"),
+    range: [
+      { sha: "ddddddddd", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
+      { sha: "eeeeeeeee", subject: "chore: widen a dependency pin", version: "0.15.104", parentVersion: "0.15.104" },
+    ],
+    hasTagFor: noTags,
+  });
+  assert.deepEqual(violations, []);
+});
+
+test("#1882 an already-tagged prior release in the range is fine", () => {
+  const violations = auditTag({
+    tag: "v0.15.105",
+    treeAtTag: treeAt("0.15.105"),
+    range: [
+      { sha: "ffffffff1", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
+      { sha: "ffffffff2", subject: "chore: release v0.15.104", version: "0.15.104", parentVersion: "0.15.103" },
+    ],
+    hasTagFor: tagsFor("0.15.104"),
+  });
+  assert.deepEqual(violations, []);
+});
+
+// ---------------------------------------------------------------------------
+// wiring — a correct guard nobody invokes is the bug, not the fix
+// ---------------------------------------------------------------------------
+
+test("#1882 the guard is wired to tag pushes and actually invokes the checker", () => {
+  const wf = read(".github/workflows/release-tag-guard.yml");
+  assert.match(wf, /node scripts\/check-release-tag\.mjs/, "the workflow must run the checker");
+  assert.match(wf, /on:\s*\n\s*push:\s*\n\s*tags:\s*\n\s*- "v\*"/, "must trigger on v* tag pushes");
+  // fetch-depth: 0 is load-bearing, not hygiene. On a shallow checkout
+  // `git describe` finds no earlier tag, the range collapses, and rule 2
+  // degrades to a no-op that still reports success.
+  assert.match(wf, /fetch-depth: 0/, "rule 2 needs full history to walk the range");
+  assert.match(wf, /fetch-tags: true/, "rule 2 needs the tag list to test against");
+});
+
+test("#1882 the tag guard must not adopt a branch trigger — that is what would publish", () => {
+  // publish_action.yml is filtered by `branches: [main]`, which is exactly why a
+  // tag push cannot fire it. If this guard ever grew a push-to-main trigger it
+  // would run on release commits, where the tag does not exist yet.
+  const wf = read(".github/workflows/release-tag-guard.yml");
+  const onBlock = wf.slice(wf.indexOf("\non:"), wf.indexOf("permissions:"));
+  assert.ok(!/\bbranches:/.test(onBlock), "the tag guard must stay tag-triggered only");
+});
+
+test("#1882 publish_action.yml stays branches-filtered, so a tag push cannot republish", () => {
+  // The whole reason a missing historical tag can be created safely. If someone
+  // adds a `tags:` filter here, backfilling a tag would re-publish to the Registry.
+  const wf = read(".github/workflows/publish_action.yml");
+  const onBlock = wf.slice(wf.indexOf("\non:"), wf.indexOf("\njobs:"));
+  assert.match(onBlock, /branches:\s*\n\s*- main/);
+  assert.ok(!/\btags:/.test(onBlock), "publish must never trigger on a tag push");
+});
+
+// ---------------------------------------------------------------------------
+// the same class, second instance: a gate listing a file that no longer exists
+// ---------------------------------------------------------------------------
+
+test("#1882 every path in the pack-contents gate exists (a missing one is vacuous)", () => {
+  const files = [".github/workflows/ci.yml", ".github/workflows/publish_action.yml"];
+  let checked = 0;
+  for (const file of files) {
+    const src = read(file);
+    const block = /for f in \\\r?\n([\s\S]*?)\r?\n\s*; do/.exec(src);
+    assert.ok(block, `pack-contents file list not found in ${file}`);
+    const paths = block[1]
+      .split(/\r?\n/)
+      .map((l) => l.replace(/\\\s*$/, "").trim())
+      .filter(Boolean);
+    assert.ok(paths.length >= 4, `${file}: expected the runtime asset list, got ${paths.length} entries`);
+    for (const p of paths) {
+      assert.ok(
+        existsSync(join(root, p)),
+        `${file} asserts ${p} is not .comfyignore'd, but that file does not exist — ` +
+          `check-ignore passes trivially on a missing path, so the entry is coverage in name only (#1882)`,
+      );
+      checked += 1;
+    }
+  }
+  assert.ok(checked > 0);
+});

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -1,0 +1,238 @@
+/**
+ * Fail a release when the git tag and the version in the tree disagree — in
+ * EITHER direction.
+ *
+ *   node scripts/check-release-tag.mjs v0.15.105     # audit one tag
+ *   GITHUB_REF_NAME=v0.15.105 node scripts/check-release-tag.mjs
+ *
+ * WHY. "Was version X released?" is answered from `git tag`, and that operand
+ * has been wrong both ways on this repo (#1882):
+ *
+ *   tag exists, tree stale  → v0.15.86..v0.15.96 all declare version "0.15.85"
+ *                             in their own pyproject.toml. `publish_action.yml`
+ *                             fires on `paths: [pyproject.toml]`, so for the
+ *                             tagged commits that never touched that file the
+ *                             workflow NEVER RAN — no job, no red X, nothing in
+ *                             the Actions tab. Ten consecutive versions were
+ *                             silently never published, and `latest_version` on
+ *                             the Registry still reads 0.15.85.
+ *
+ *   tree shipped, no tag    → 0.15.97 is live on the Registry (created
+ *                             2026-08-26T03:01:45Z) from commit cd50f093
+ *                             "chore: release v0.15.97". There is no v0.15.97
+ *                             tag. Two reporters on #1859 and #1860 were told
+ *                             0.15.97 "was never released" because the tag list
+ *                             said so.
+ *
+ * WHY THE CHECK LIVES ON THE TAG PUSH AND NOT IN THE PUBLISH JOB. The publish
+ * job is the wrong place for the first failure mode, because the whole failure
+ * IS that the publish job did not execute. A guard inside a workflow that never
+ * runs is not a guard. The tag push is an event that did occur every one of
+ * those ten times.
+ *
+ * TWO RULES, and the second is what lets a tag-only trigger see the untagged
+ * direction at all:
+ *
+ *   1. TREE MATCHES TAG. At tag `v<X>`, pyproject.toml, package.json and the
+ *      panel's PANEL_VERSION constant must all read exactly `<X>`. All three,
+ *      because pyproject and PANEL_VERSION are written by the same script
+ *      (scripts/set-version.mjs) and therefore cannot disagree when that script
+ *      is simply never run — package.json is the independent witness. This
+ *      mirrors ci.yml's three-way gate but anchors it to the TAG, which ci.yml
+ *      cannot see.
+ *
+ *   2. NO PUBLISHED VERSION WAS SKIPPED. Walk first-parent from the previous
+ *      reachable tag to this one. Every commit in that range whose pyproject
+ *      version differs from its parent's is a commit that triggered a publish,
+ *      i.e. a version that shipped — so it must have a tag of its own. Pushing
+ *      v0.15.98 today would go red naming cd50f093 / 0.15.97.
+ *
+ *      This direction has no race. It only ever looks at versions that shipped
+ *      STRICTLY BEFORE the tag being pushed, so a tag pushed minutes after its
+ *      own release commit is never in its own scan. Asserting "a tag exists at
+ *      the SHA I am publishing" from inside the publish job would be racy for
+ *      exactly that reason, and would abort a legitimate release over a tag that
+ *      is seconds away.
+ *
+ *      It is also self-bounding: the range starts at the previous reachable tag,
+ *      so this never re-litigates the whole history and cannot become
+ *      permanently red over a historical gap nobody intends to backfill.
+ *
+ * PUSHING A TAG DOES NOT PUBLISH. `publish_action.yml` filters `on.push` by
+ * `branches: [main]`, and GitHub does not run a `branches`-filtered push
+ * workflow for a tag ref. So this guard can be added, and a missing historical
+ * tag can be created, without re-publishing anything to the Registry.
+ */
+import { execFileSync } from "node:child_process";
+
+/** `version = "0.15.97"` out of a pyproject.toml — the [project] table only. */
+export function pyprojectVersion(text) {
+  if (typeof text !== "string") return null;
+  // Split on table headers so a `version` under e.g. [tool.something] cannot win.
+  const project = text.split(/^\[/m).find((chunk) => chunk.startsWith("project]"));
+  if (!project) return null;
+  const m = /^\s*version\s*=\s*["']([^"']+)["']/m.exec(project);
+  return m ? m[1] : null;
+}
+
+export function packageJsonVersion(text) {
+  try {
+    const v = JSON.parse(text)?.version;
+    return typeof v === "string" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function panelVersion(text) {
+  if (typeof text !== "string") return null;
+  const m = /const PANEL_VERSION = "([^"]+)"/.exec(text);
+  return m ? m[1] : null;
+}
+
+/** `v0.15.97` -> `0.15.97`. Anything else -> null (not a release tag). */
+export function versionOfTag(tag) {
+  const m = /^v(\d+\.\d+\.\d+.*)$/.exec(String(tag ?? ""));
+  return m ? m[1] : null;
+}
+
+/**
+ * The pure core. Everything git-shaped is injected, so the rules are testable
+ * without fabricating a repository and can be exercised against the exact
+ * historical shapes from #1882.
+ *
+ * @param {object} o
+ * @param {string} o.tag  tag being audited, e.g. "v0.15.105"
+ * @param {{pyproject:string|null, packageJson:string|null, panelJs:string|null}} o.treeAtTag
+ * @param {Array<{sha:string, subject:string, version:string|null, parentVersion:string|null}>} o.range
+ *        first-parent commits from the previous reachable tag (exclusive) to the
+ *        tag (inclusive). Order is not used.
+ * @param {(version:string)=>boolean} o.hasTagFor  does a tag exist for this version?
+ * @returns {string[]} violations; empty means the release is coherent.
+ */
+export function auditTag({ tag, treeAtTag, range = [], hasTagFor }) {
+  const violations = [];
+  const expected = versionOfTag(tag);
+  if (!expected) {
+    return [`"${tag}" is not a v<major>.<minor>.<patch> release tag — nothing to audit.`];
+  }
+
+  // ---- Rule 1: the tree at the tag declares the tag's version, three ways.
+  const seen = {
+    "pyproject.toml": pyprojectVersion(treeAtTag?.pyproject),
+    "package.json": packageJsonVersion(treeAtTag?.packageJson),
+    PANEL_VERSION: panelVersion(treeAtTag?.panelJs),
+  };
+  for (const [where, got] of Object.entries(seen)) {
+    if (got === null) {
+      violations.push(`${tag}: could not read a version from ${where}.`);
+    } else if (got !== expected) {
+      violations.push(
+        `${tag}: ${where} declares ${got}, but the tag says ${expected}. The tagged ` +
+          `tree is not the version it claims to be — this is the v0.15.86..v0.15.96 ` +
+          `shape, where publish_action.yml never ran at all because pyproject.toml ` +
+          `never changed. Run "node scripts/set-version.mjs ${expected}" and re-tag.`,
+      );
+    }
+  }
+
+  // ---- Rule 2: nothing shipped between the previous tag and this one untagged.
+  for (const c of range) {
+    const v = c?.version;
+    if (!v || v === c.parentVersion) continue; // pyproject touched, version unchanged
+    if (v === expected) continue; // this tag's own release commit
+    if (hasTagFor(v)) continue;
+    const short = String(c.sha).slice(0, 8);
+    violations.push(
+      `${v} was published by ${short} ("${c.subject}") — that commit changed ` +
+        `pyproject.toml's version, which is what triggers publish_action.yml — but ` +
+        `no v${v} tag exists. The Registry has a release "git tag" cannot see ` +
+        `(#1882). Create it with: git tag -a v${v} ${short} -m "release v${v}" && ` +
+        `git push origin v${v} — a tag push does not re-trigger the publish workflow.`,
+    );
+  }
+
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// git-backed shell
+// ---------------------------------------------------------------------------
+
+const git = (...args) =>
+  execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+
+const showOrNull = (rev, path) => {
+  try {
+    return git("show", `${rev}:${path}`);
+  } catch {
+    return null;
+  }
+};
+
+export function collectFromGit(tag) {
+  const treeAtTag = {
+    pyproject: showOrNull(tag, "pyproject.toml"),
+    packageJson: showOrNull(tag, "package.json"),
+    panelJs: showOrNull(tag, "web/js/comfyui-mcp-panel.js"),
+  };
+
+  // Previous reachable tag. When tags are missing this walks further back, which
+  // is exactly what rule 2 needs: a gap widens the window that finds it.
+  let previousTag = null;
+  try {
+    previousTag = git("describe", "--tags", "--abbrev=0", "--match", "v*", `${tag}^`).trim();
+  } catch {
+    previousTag = null; // first tag in history, or no earlier tag fetched
+  }
+
+  const spec = previousTag ? `${previousTag}..${tag}` : tag;
+  let range = [];
+  try {
+    range = git("rev-list", "--first-parent", "--format=%H%x00%s", spec)
+      .split("\n")
+      .filter((l) => l && !l.startsWith("commit "))
+      .map((line) => {
+        const [sha, subject] = line.split("\0");
+        return {
+          sha,
+          subject: subject ?? "",
+          version: pyprojectVersion(showOrNull(sha, "pyproject.toml")),
+          parentVersion: pyprojectVersion(showOrNull(`${sha}^`, "pyproject.toml")),
+        };
+      });
+  } catch {
+    range = [];
+  }
+
+  const tags = new Set(
+    git("tag", "--list", "v*")
+      .split("\n")
+      .map((t) => t.trim())
+      .filter(Boolean),
+  );
+  return { treeAtTag, range, hasTagFor: (v) => tags.has(`v${v}`), previousTag };
+}
+
+const invokedDirectly =
+  typeof process.argv[1] === "string" &&
+  process.argv[1].replace(/\\/g, "/").endsWith("scripts/check-release-tag.mjs");
+
+if (invokedDirectly) {
+  const tag = (process.argv[2] || process.env.GITHUB_REF_NAME || "").trim();
+  if (!tag) {
+    console.error("usage: node scripts/check-release-tag.mjs <tag>   (or set GITHUB_REF_NAME)");
+    process.exit(2);
+  }
+  const { treeAtTag, range, hasTagFor, previousTag } = collectFromGit(tag);
+  const violations = auditTag({ tag, treeAtTag, range, hasTagFor });
+  console.error(
+    `auditing ${tag} against ${previousTag ?? "(no earlier tag)"} — ` +
+      `${range.length} first-parent commit(s) in range`,
+  );
+  for (const v of violations) console.log(`::error::${v}`);
+  if (!violations.length) {
+    console.log(`release ${tag} is coherent: tree, tag and prior releases all agree.`);
+  }
+  process.exit(violations.length ? 1 : 0);
+}

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -18,11 +18,10 @@
  *                             the Registry still reads 0.15.85.
  *
  *   tree shipped, no tag    → 0.15.97 is live on the Registry (created
- *                             2026-08-26T03:01:45Z) from commit cd50f093
- *                             "chore: release v0.15.97". There is no v0.15.97
- *                             tag. Two reporters on #1859 and #1860 were told
- *                             0.15.97 "was never released" because the tag list
- *                             said so.
+ *                             2026-08-26T03:01:45Z) from the merge of
+ *                             release/0.15.97. There is no v0.15.97 tag. Two
+ *                             reporters on #1859 and #1860 were told 0.15.97
+ *                             "was never released" because the tag list said so.
  *
  * WHY THE CHECK LIVES ON THE TAG PUSH AND NOT IN THE PUBLISH JOB. The publish
  * job is the wrong place for the first failure mode, because the whole failure
@@ -43,9 +42,12 @@
  *
  *   2. NO PUBLISHED VERSION WAS SKIPPED. Walk first-parent from the previous
  *      reachable tag to this one. Every commit in that range whose pyproject
- *      version differs from its parent's is a commit that triggered a publish,
- *      i.e. a version that shipped — so it must have a tag of its own. Pushing
- *      v0.15.98 today would go red naming cd50f093 / 0.15.97.
+ *      version differs from its parent's is a commit that shipped a version, so
+ *      it must carry a tag OF ITS OWN — the tag for `<v>` must resolve to THAT
+ *      COMMIT, not merely exist. A tag is a movable label; crediting one by name
+ *      alone would let `v0.15.97` sit on an unrelated commit while the commit
+ *      that actually published 0.15.97 stayed untagged, which is the very
+ *      confusion this guard exists to end.
  *
  *      This direction has no race. It only ever looks at versions that shipped
  *      STRICTLY BEFORE the tag being pushed, so a tag pushed minutes after its
@@ -58,10 +60,21 @@
  *      so this never re-litigates the whole history and cannot become
  *      permanently red over a historical gap nobody intends to backfill.
  *
- * PUSHING A TAG DOES NOT PUBLISH. `publish_action.yml` filters `on.push` by
- * `branches: [main]`, and GitHub does not run a `branches`-filtered push
- * workflow for a tag ref. So this guard can be added, and a missing historical
- * tag can be created, without re-publishing anything to the Registry.
+ * IT FAILS CLOSED. Every git lookup this needs can fail — a shallow clone, tags
+ * that were never fetched, an unreadable object. The first draft turned each of
+ * those into an empty range, which made the gap scan silently vacuous while the
+ * job still reported success. That is the identical shape as the stale
+ * pack-contents entry this issue also fixes, and it is worse in a guard than
+ * anywhere else: unavailable history is reported as a violation, never as a pass.
+ *
+ * WHAT A TAG PUSH DOES AND DOES NOT RUN. `publish_action.yml` filters `on.push`
+ * by `branches: [main]`, and GitHub does not run a `branches`-filtered push
+ * workflow for a tag ref — so pushing a tag, including a backfilled historical
+ * one, cannot re-publish to the Registry. Note the converse, which is easy to
+ * get backwards: GitHub loads workflow files from the ref the event carries, so
+ * a tag pushed at a commit that predates THIS file runs no guard either. A
+ * historical backfill is therefore safe but unaudited; audit it after the fact
+ * with the workflow's workflow_dispatch input, which runs this file from main.
  */
 import { execFileSync } from "node:child_process";
 
@@ -96,6 +109,8 @@ export function versionOfTag(tag) {
   return m ? m[1] : null;
 }
 
+const short = (sha) => String(sha ?? "").slice(0, 8);
+
 /**
  * The pure core. Everything git-shaped is injected, so the rules are testable
  * without fabricating a repository and can be exercised against the exact
@@ -107,10 +122,14 @@ export function versionOfTag(tag) {
  * @param {Array<{sha:string, subject:string, version:string|null, parentVersion:string|null}>} o.range
  *        first-parent commits from the previous reachable tag (exclusive) to the
  *        tag (inclusive). Order is not used.
- * @param {(version:string)=>boolean} o.hasTagFor  does a tag exist for this version?
+ * @param {(version:string)=>(string|null)} o.tagTargetFor
+ *        commit SHA that `v<version>` resolves to, or null when no such tag exists.
+ * @param {string|null} [o.historyError]
+ *        set when the range could not be established at all; reported as a
+ *        violation so an unrunnable gap scan can never read as a clean one.
  * @returns {string[]} violations; empty means the release is coherent.
  */
-export function auditTag({ tag, treeAtTag, range = [], hasTagFor }) {
+export function auditTag({ tag, treeAtTag, range = [], tagTargetFor, historyError = null }) {
   const violations = [];
   const expected = versionOfTag(tag);
   if (!expected) {
@@ -136,19 +155,42 @@ export function auditTag({ tag, treeAtTag, range = [], hasTagFor }) {
     }
   }
 
+  // ---- Rule 2 preflight: an unrunnable scan is a violation, never a pass.
+  if (historyError) {
+    violations.push(
+      `${tag}: the untagged-release scan could not run — ${historyError}. Refusing to ` +
+        `report this release as coherent on a check that did not execute (#1882).`,
+    );
+    return violations;
+  }
+
   // ---- Rule 2: nothing shipped between the previous tag and this one untagged.
   for (const c of range) {
     const v = c?.version;
     if (!v || v === c.parentVersion) continue; // pyproject touched, version unchanged
     if (v === expected) continue; // this tag's own release commit
-    if (hasTagFor(v)) continue;
-    const short = String(c.sha).slice(0, 8);
+    const target = typeof tagTargetFor === "function" ? tagTargetFor(v) : null;
+    if (target && target === c.sha) continue;
+
+    // A version bump reaching main is what triggers publish_action.yml. It is
+    // ALMOST always a version that shipped, but not certainly: the workflow runs
+    // once per push against the head commit, so if two bumps land in one push
+    // only the later one is published. Both readings are release-record defects
+    // worth a red build, and they have different remedies, so name both rather
+    // than prescribing a tag that would itself become a false "was released".
+    const why =
+      target === null
+        ? `no v${v} tag exists`
+        : `v${v} exists but resolves to ${short(target)}, not the commit that cut ${v}`;
     violations.push(
-      `${v} was published by ${short} ("${c.subject}") — that commit changed ` +
+      `${v} was cut by ${short(c.sha)} ("${c.subject}") — that commit changed ` +
         `pyproject.toml's version, which is what triggers publish_action.yml — but ` +
-        `no v${v} tag exists. The Registry has a release "git tag" cannot see ` +
-        `(#1882). Create it with: git tag -a v${v} ${short} -m "release v${v}" && ` +
-        `git push origin v${v} — a tag push does not re-trigger the publish workflow.`,
+        `${why}. Either it published and was never tagged (the 0.15.97 case in ` +
+        `#1882), or it never shipped because a later bump landed in the same push. ` +
+        `If it shipped: git tag -a v${v} ${short(c.sha)} -m "release v${v}" && ` +
+        `git push origin v${v} (a tag push cannot re-trigger the publish workflow). ` +
+        `If it did not ship, do not tag it — that would recreate the same bad ` +
+        `operand in the other direction.`,
     );
   }
 
@@ -177,41 +219,86 @@ export function collectFromGit(tag) {
     panelJs: showOrNull(tag, "web/js/comfyui-mcp-panel.js"),
   };
 
-  // Previous reachable tag. When tags are missing this walks further back, which
-  // is exactly what rule 2 needs: a gap widens the window that finds it.
+  // Fail closed from here down. Each of these can fail on a runner in a way that
+  // leaves the tree readable but the history unusable, and a gap scan over an
+  // empty range would report success while checking nothing.
+  let historyError = null;
   let previousTag = null;
-  try {
-    previousTag = git("describe", "--tags", "--abbrev=0", "--match", "v*", `${tag}^`).trim();
-  } catch {
-    previousTag = null; // first tag in history, or no earlier tag fetched
-  }
-
-  const spec = previousTag ? `${previousTag}..${tag}` : tag;
   let range = [];
+  const tagTargets = new Map();
+
   try {
-    range = git("rev-list", "--first-parent", "--format=%H%x00%s", spec)
-      .split("\n")
-      .filter((l) => l && !l.startsWith("commit "))
-      .map((line) => {
-        const [sha, subject] = line.split("\0");
-        return {
-          sha,
-          subject: subject ?? "",
-          version: pyprojectVersion(showOrNull(sha, "pyproject.toml")),
-          parentVersion: pyprojectVersion(showOrNull(`${sha}^`, "pyproject.toml")),
-        };
-      });
-  } catch {
-    range = [];
+    if (git("rev-parse", "--is-shallow-repository").trim() === "true") {
+      historyError =
+        "this is a shallow clone, so the range cannot be walked (checkout needs fetch-depth: 0)";
+    }
+  } catch (e) {
+    historyError = `git rev-parse --is-shallow-repository failed: ${e.message}`;
   }
 
-  const tags = new Set(
-    git("tag", "--list", "v*")
-      .split("\n")
-      .map((t) => t.trim())
-      .filter(Boolean),
-  );
-  return { treeAtTag, range, hasTagFor: (v) => tags.has(`v${v}`), previousTag };
+  if (!historyError) {
+    try {
+      // `%(*objectname)` is the peeled target and is non-empty only for annotated
+      // tags; lightweight tags report the commit in `%(objectname)`.
+      for (const line of git(
+        "for-each-ref",
+        "--format=%(refname:short)%00%(objectname)%00%(*objectname)",
+        "refs/tags/v*",
+      ).split("\n")) {
+        if (!line.trim()) continue;
+        const [name, objectname, peeled] = line.split("\0");
+        tagTargets.set(name.trim(), (peeled || objectname || "").trim());
+      }
+      if (tagTargets.size === 0) {
+        historyError =
+          "no v* tags are visible, so no prior release can be credited (checkout needs fetch-tags: true)";
+      }
+    } catch (e) {
+      historyError = `listing v* tags failed: ${e.message}`;
+    }
+  }
+
+  if (!historyError) {
+    // Previous reachable tag. When tags are missing this walks further back,
+    // which is exactly what rule 2 needs: a gap widens the window that finds it.
+    // Failure here is legitimate for the first tag in history, so it is NOT an
+    // error — the range simply starts at the root.
+    try {
+      previousTag = git("describe", "--tags", "--abbrev=0", "--match", "v*", `${tag}^`).trim();
+    } catch {
+      previousTag = null;
+    }
+
+    try {
+      range = git(
+        "rev-list",
+        "--first-parent",
+        "--format=%H%x00%s",
+        previousTag ? `${previousTag}..${tag}` : tag,
+      )
+        .split("\n")
+        .filter((l) => l && !l.startsWith("commit "))
+        .map((line) => {
+          const [sha, subject] = line.split("\0");
+          return {
+            sha,
+            subject: subject ?? "",
+            version: pyprojectVersion(showOrNull(sha, "pyproject.toml")),
+            parentVersion: pyprojectVersion(showOrNull(`${sha}^`, "pyproject.toml")),
+          };
+        });
+    } catch (e) {
+      historyError = `walking ${previousTag ?? "(root)"}..${tag} failed: ${e.message}`;
+    }
+  }
+
+  return {
+    treeAtTag,
+    range,
+    previousTag,
+    historyError,
+    tagTargetFor: (v) => tagTargets.get(`v${v}`) ?? null,
+  };
 }
 
 const invokedDirectly =
@@ -224,11 +311,12 @@ if (invokedDirectly) {
     console.error("usage: node scripts/check-release-tag.mjs <tag>   (or set GITHUB_REF_NAME)");
     process.exit(2);
   }
-  const { treeAtTag, range, hasTagFor, previousTag } = collectFromGit(tag);
-  const violations = auditTag({ tag, treeAtTag, range, hasTagFor });
+  const collected = collectFromGit(tag);
+  const violations = auditTag({ tag, ...collected });
   console.error(
-    `auditing ${tag} against ${previousTag ?? "(no earlier tag)"} — ` +
-      `${range.length} first-parent commit(s) in range`,
+    `auditing ${tag} against ${collected.previousTag ?? "(no earlier tag)"} — ` +
+      `${collected.range.length} first-parent commit(s) in range` +
+      (collected.historyError ? ` — HISTORY UNAVAILABLE: ${collected.historyError}` : ""),
   );
   for (const v of violations) console.log(`::error::${v}`);
   if (!violations.length) {


### PR DESCRIPTION
Fixes #1882.

Implements the fix you narrowed to in the 21:51Z comment — the assertion on the tag/release path, plus the stale pack-contents entry — and covers the untagged direction too, which a tag-push trigger can't reach on its own.

## The two operand failures

| | what happened |
|---|---|
| tag exists, tree stale | `v0.15.86`..`v0.15.96` are tagged; every one of those trees declares `version = "0.15.85"`. `publish_action.yml` fires on `paths: [pyproject.toml]`, so on tagged commits that never touched that file it **never ran** — no job, no red X. Ten versions silently never shipped. |
| tree shipped, no tag | `0.15.97` is live on the Registry from the merge of `release/0.15.97`, with no tag. Two reporters on #1859/#1860 were told it "was never released". |

## What this adds

**`.github/workflows/release-tag-guard.yml`** — `on: push: tags: ['v*']`, plus `workflow_dispatch` with a `tag` input so a historical tag can be audited without pushing anything. It runs **`scripts/check-release-tag.mjs`**: pure node + git, no install.

**Rule 1 — the tagged tree is the version it claims.** At `v<X>`, `pyproject.toml`, `package.json` and `PANEL_VERSION` must all read `<X>`. All three, for the reason `ci.yml` already spells out: pyproject and PANEL_VERSION are written by the same script, so they cannot disagree when that script is simply never run. This is `ci.yml`'s three-way gate anchored to the **tag**, which `ci.yml` cannot see.

**Rule 2 — nothing between the previous tag and this one went untagged.** Walk first-parent from the previous reachable tag; every commit whose pyproject version differs from its parent's cut a version, so it must carry a tag **that resolves to that commit**. This is what lets a tag-only trigger see the untagged direction.

Rule 2 is deliberately not in the publish job. Asserting "a tag exists at the SHA I am publishing" there would be **racy** — the tag is pushed after the release merge — and would abort legitimate releases. Rule 2 only looks at versions cut *strictly before* the tag being pushed, so a tag pushed minutes after its own release commit is never in its own scan. It is also self-bounding (range starts at the previous reachable tag), so it can't go permanently red over a historical gap nobody intends to backfill.

## One correction to the issue

> That single assertion catches every case seen here: the ten silent no-ops, and the untagged 0.15.97 from the opposite direction.

The tree-vs-tag assertion alone does **not** catch the untagged direction — 0.15.97 has no tag, so no tag push happens, so nothing fires. That's why rule 2 exists: it finds the gap on the **next** tag push. Pushing `v0.15.98` today goes red naming `7b477d55` / `0.15.97`.

## Also: `web/js/vendor/a2ui-lit.bundle.js`, and the class it belongs to

Dropped from the pack-contents gate in **both** `ci.yml` and `publish_action.yml` — you flagged it in `publish_action.yml`; the identical stale entry was in `ci.yml` too. #1865 deleted the file in 0.15.103.

Rather than just deleting the line, the loop now **fails on a listed-but-missing path**. `check-ignore` passes trivially on a path that doesn't exist, so a stale entry reads as coverage while asserting nothing — the same "guard that isn't a guard" shape as the rest of this issue.

## Review round 1 found three real defects in my first draft

The gate was right on all of them; each is fixed and mutation-verified.

1. **It failed open.** `collectFromGit` turned every git failure into an empty range, so a shallow clone or unfetched tags made rule 2 silently vacuous *while the job reported success* — the identical shape as the stale pack-contents entry this PR removes. Unavailable history is now a violation. Proved on a real `git clone --depth 1`: **exit 1 with the fix, exit 0 without it.**
2. **It credited a tag by name, not target.** `v0.15.97` sitting on an unrelated commit would have satisfied the guard while the commit that actually published 0.15.97 stayed untagged — the very confusion the guard exists to end. The tag must now resolve to the commit that cut the version. Verified this is strictly stronger with no false positives: every tag `v0.15.99`..`v0.15.105` already points exactly at its own version-bumping commit.
3. **It prescribed a tag unconditionally.** `publish_action.yml` runs once per push against the head commit, so if two bumps land in one push only the later one publishes — the earlier version was cut but never shipped, and tagging it would recreate the same bad operand in the other direction. The message now names both readings and both remedies. **It still blocks the release, deliberately:** a consumed-but-unshipped version is itself a release-record defect, and that's a judgement call worth your override if you disagree.

It also corrected a wrong claim in my prose: **GitHub loads workflow files from the ref the event carries**, so a tag pushed at a commit predating this file runs no guard. A historical backfill is still safe (publish is branch-filtered at that commit too) but it is *unaudited*; `workflow_dispatch` is how you audit one after the fact.

## Evidence

**Live audit against real history** (`node scripts/check-release-tag.mjs <tag>`):

```
v0.15.90   exit 1  pyproject.toml declares 0.15.85, but the tag says 0.15.90
                   PANEL_VERSION declares 0.15.85, but the tag says 0.15.90
v0.15.96   exit 1  (same)
v0.15.98   exit 1  0.15.97 was cut by 7b477d55 ("Merge pull request #1826
                   from artokun/release/0.15.97") ... but no v0.15.97 tag exists
v0.15.101  exit 0  coherent
v0.15.104  exit 0  coherent
v0.15.105  exit 0  coherent   <- released mid-PR; the guard passes the live cut
```

Red on exactly the two documented incidents, green on every healthy release including the one that landed while this branch was open.

**Mutation-verified** — each guard deleted, the named test watched go red, then restored. Baseline clean after every one.

| mutation | result |
|---|---|
| revert both workflows to `origin/main` (a2ui-lit entry back) | `every path in the pack-contents gate exists` FAILS |
| delete `release-tag-guard.yml` | both wiring tests FAIL |
| `fetch-depth: 0` → `1` | wiring test FAILS |
| rule 1 comparison → `false` | unit test FAILS **and** live `v0.15.90` audit drops to exit 0 |
| rule 2 `hasTagFor` → always-continue | unit test FAILS **and** live `v0.15.98` audit drops to exit 0 |
| fail-closed preflight → `false` | 2 unit tests FAIL **and** the real shallow clone drops to exit 0 |
| credit tag by name only (`target && target === c.sha` → `target`) | `a tag is credited only when it resolves to the commit that cut the version` FAILS |

16 tests in `browser_tests/unit/release-tag-guard.test.mjs`; full suite 7041 pass / 0 fail; `tsc --noEmit` clean.

## Where the load-bearing claims are — please push on these

1. **"A tag push does not trigger `publish_action.yml`."** Everything rests on this, including your option-2 backfill. Documented behaviour (`on.push` filtered by `branches` does not run for a tag ref) and empirically confirmed twice over: the ten tags `v0.15.86`..`v0.15.95` were all pushed with no publish run appearing, and every publish run in the Actions history is `event=push ref=main` — never a tag ref. A test pins `publish_action.yml` to `branches`-only, so adding a `tags:` filter later goes red.
2. **`fetch-depth: 0` is load-bearing, not hygiene.** On a shallow checkout the range cannot be walked at all. That used to pass silently; now it's a violation, demonstrated against a real depth-1 clone.
3. **Rule 2 keys on "pyproject version changed", not on commit subject.** That's the operand the publish trigger itself uses, so it can't drift from what actually publishes. It reports the **first-parent merge commit** (`7b477d55`) — the SHA that pushed to main and ran the publish — not `cd50f093` from the issue body, which is the branch-side commit with the same tree.
4. **The batched-push trade-off in item 3 above** is the one place I chose to keep a red build over a possible false alarm. Worth your call.
5. `github.event.inputs.tag || github.ref_name` rather than `inputs.tag` — the `inputs` context is only populated for `workflow_dispatch`/`workflow_call`; `github.event.inputs` is valid on every event.

## Deliberately not done

- **Not creating `v0.15.97`.** You said that needs a decision, not a quick fix, and it stays yours. It would not re-publish; it also would not run this guard (see the correction above), so audit it afterwards with `workflow_dispatch`.
- **No auto-tagging from the publish job.** It would close the untagged gap at the source, but needs `contents: write` on the release path and is a bigger change than this issue asked for. Worth a follow-up.
- **No Registry API call** (option 3). Rule 2 gets the same answer from git alone, with no token and no network in the guard.
- **No browser verification** — nothing here renders in the panel; the diff is `.github/`, `scripts/`, `browser_tests/unit/` and `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
