### PR TITLE
fix(1882): the tag guard fails closed on an unreadable commit, and checks its own tag target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - a release tag proves the tagged tree is the version it claims, and that nothing shipped untagged (#1882)
-
+- the release tag guard fails closed on an unreadable commit, and checks its own tag target (#1882)
 
 ## [0.15.105] - 2026-08-26
 

--- a/browser_tests/unit/release-tag-guard.test.mjs
+++ b/browser_tests/unit/release-tag-guard.test.mjs
@@ -249,19 +249,22 @@ test("#1882 a commit whose version could not be read is reported, never skipped"
   assert.match(violations[0], /left unaudited/);
 });
 
-test("#1882 pyproject genuinely absent at a commit is not an error", () => {
-  // Pre-pyproject history is a legitimate "nothing was released here", and must
-  // stay distinguishable from "the file is there and unreadable".
-  const violations = auditTag({
-    tag: "v0.15.105",
-    treeAtTag: treeAt("0.15.105"),
-    range: [
-      { sha: "aaaaaaaa1", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
-      { sha: "bbbbbbbb2", subject: "docs: readme", version: null, parentVersion: null, versionError: null },
-    ],
-    tagTargetFor: tagsAt({ "0.15.105": "aaaaaaaa1" }),
-  });
-  assert.deepEqual(violations, []);
+test("#1882 versionAtRev reports unknown rather than returning a bare null", async () => {
+  // Exercises the git-backed reader against the real repository rather than
+  // injected data, because the fail-open bug lived in the reader, not the rules.
+  const { execFileSync } = await import("node:child_process");
+  const run = (args) => execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+
+  // A real commit: readable, and its version parses.
+  const head = run(["rev-parse", "HEAD"]);
+  const real = pyprojectVersion(run(["show", `${head}:pyproject.toml`]));
+  assert.match(real, /^\d+\.\d+\.\d+/);
+
+  // pyproject.toml has existed since the root commit, which is why the reader
+  // treats absence as unknown rather than as "this revision released nothing" —
+  // there is no revision in this repo where the quiet reading would be correct.
+  const rootCommit = run(["rev-list", "--max-parents=0", "HEAD"]).split("\n").pop().trim();
+  assert.notEqual(run(["ls-tree", "--name-only", rootCommit, "--", "pyproject.toml"]), "");
 });
 
 test("#1882 the tag being pushed is not exempt from the target check", () => {

--- a/browser_tests/unit/release-tag-guard.test.mjs
+++ b/browser_tests/unit/release-tag-guard.test.mjs
@@ -26,6 +26,7 @@ import { dirname, join } from "node:path";
 import {
   auditTag,
   collectFromGit,
+  firstParentAtRev,
   packageJsonVersion,
   panelVersion,
   pyprojectVersion,
@@ -308,6 +309,29 @@ test("#1882 a reader failure reaches auditTag as a violation through the real ra
     }),
     [],
   );
+});
+
+test("#1882 a failed historical parent lookup is a violation, never a root commit", () => {
+  // Keep the real collectFromGit -> versionAtRev walk, but make the underlying
+  // parent lookup fail through the production helper. The old rev-parse catch
+  // converted this exact failure into `hasParent = false`, which made the range
+  // look auditable and could let this release pass.
+  const failing = collectFromGit("v0.15.104", {
+    firstParentAt: (rev) =>
+      firstParentAtRev(rev, () => {
+        throw new Error(`simulated historical parent lookup failure for ${rev}`);
+      }),
+  });
+  assert.equal(failing.historyError, null, "the commit range itself must still walk");
+  assert.ok(failing.range.length > 0, "expected commits in v0.15.103..v0.15.104");
+  assert.ok(
+    failing.range.every((c) => /historical parent lookup .* failed/.test(c.versionError ?? "")),
+    "every historical parent lookup failure must be carried into the range entry",
+  );
+
+  const violations = auditTag({ tag: "v0.15.104", ...failing });
+  assert.ok(violations.length > 0, "a failed parent lookup must not audit as coherent");
+  assert.ok(violations.every((v) => /left unaudited/.test(v)));
 });
 
 test("#1882 the tag being pushed is not exempt from the target check", () => {

--- a/browser_tests/unit/release-tag-guard.test.mjs
+++ b/browser_tests/unit/release-tag-guard.test.mjs
@@ -19,9 +19,11 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 
 import {
   auditTag,
@@ -36,6 +38,49 @@ import {
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const read = (rel) => readFileSync(join(root, rel), "utf8");
+
+/**
+ * The hosted unit job intentionally uses a shallow checkout. Keep tests that
+ * exercise the git-backed collector independent of the panel repository's
+ * fetched tags by creating the smallest real history the collector needs.
+ * This still runs the production `git show`, `git describe`, `git rev-list`,
+ * and `git for-each-ref` calls; it only makes their inputs deterministic.
+ */
+function withReleaseHistory(callback) {
+  const fixture = mkdtempSync(join(tmpdir(), "panel-release-tag-guard-"));
+  const runGit = (...args) =>
+    execFileSync("git", args, { cwd: fixture, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+
+  const writeVersion = (version) => {
+    writeFileSync(
+      join(fixture, "pyproject.toml"),
+      `[project]\nname = "release-tag-guard-fixture"\nversion = "${version}"\n`,
+    );
+    writeFileSync(join(fixture, "package.json"), `${JSON.stringify({ version })}\n`);
+    mkdirSync(join(fixture, "web", "js"), { recursive: true });
+    writeFileSync(join(fixture, "web", "js", "comfyui-mcp-panel.js"), `const PANEL_VERSION = "${version}";\n`);
+  };
+
+  try {
+    runGit("init", "--initial-branch=main");
+    runGit("config", "user.email", "release-tag-guard-fixture@example.invalid");
+    runGit("config", "user.name", "release-tag-guard-fixture");
+
+    writeVersion("0.15.103");
+    runGit("add", ".");
+    runGit("commit", "-m", "chore: fixture release v0.15.103");
+    runGit("tag", "v0.15.103");
+
+    writeVersion("0.15.104");
+    runGit("add", ".");
+    runGit("commit", "-m", "chore: fixture release v0.15.104");
+    runGit("tag", "v0.15.104");
+
+    return callback(fixture);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+}
 
 const treeAt = (v) => ({
   pyproject: `[project]\nname = "comfyui-mcp-panel"\nversion = "${v}"\n`,
@@ -270,68 +315,67 @@ test("#1882 versionAtRev itself returns an error, never a bare null, on an unrea
 });
 
 test("#1882 a reader failure reaches auditTag as a violation through the real range walk", () => {
-  // End-to-end over real history: collectFromGit walks v0.15.104 for real and the
-  // injected reader fails on every commit, so the wiring — reader -> versionError
-  // -> auditTag -> violation — is exercised rather than assumed. With the real
-  // reader the same tag is clean, which is asserted second so a broken walk
-  // cannot make this test pass vacuously.
-  const failing = collectFromGit("v0.15.104", {
-    readVersionAt: (rev) => ({ version: null, error: `simulated unreadable blob at ${rev}` }),
-  });
-  assert.equal(failing.historyError, null, "the range itself must still walk");
-  assert.ok(failing.range.length > 0, "expected commits in v0.15.103..v0.15.104");
-  assert.ok(failing.range.every((c) => c.versionError), "every entry must carry the read failure");
+  withReleaseHistory((cwd) => {
+    // End-to-end over an isolated real history: collectFromGit walks
+    // v0.15.104 for real and the injected reader fails on every commit, so the
+    // wiring — reader -> versionError -> auditTag -> violation — is exercised
+    // rather than assumed. With the real reader the same tag is clean, which
+    // is asserted second so a broken walk cannot make this test pass vacuously.
+    const failing = collectFromGit("v0.15.104", {
+      cwd,
+      readVersionAt: (rev) => ({ version: null, error: `simulated unreadable blob at ${rev}` }),
+    });
+    assert.equal(failing.historyError, null, "the range itself must still walk");
+    assert.ok(failing.range.length > 0, "expected commits in v0.15.103..v0.15.104");
+    assert.ok(failing.range.every((c) => c.versionError), "every entry must carry the read failure");
 
-  const violations = auditTag({
-    tag: "v0.15.104",
-    treeAtTag: treeAt("0.15.104"),
-    range: failing.range,
-    tagTargetFor: failing.tagTargetFor,
-  });
-  assert.ok(violations.length > 0, "a range of unreadable commits must not audit as coherent");
-  assert.ok(violations.every((v) => /left unaudited/.test(v)));
-
-  const real = collectFromGit("v0.15.104");
-  assert.equal(real.historyError, null);
-  assert.deepEqual(
-    auditTag({
+    const violations = auditTag({
       tag: "v0.15.104",
-      treeAtTag: {
-        pyproject: readFileSync(join(root, "pyproject.toml"), "utf8").replace(
-          /^version = ".*"$/m,
-          'version = "0.15.104"',
-        ),
-        packageJson: JSON.stringify({ version: "0.15.104" }),
-        panelJs: 'const PANEL_VERSION = "0.15.104";',
-      },
-      range: real.range,
-      tagTargetFor: real.tagTargetFor,
-    }),
-    [],
-  );
+      treeAtTag: failing.treeAtTag,
+      range: failing.range,
+      tagTargetFor: failing.tagTargetFor,
+    });
+    assert.ok(violations.length > 0, "a range of unreadable commits must not audit as coherent");
+    assert.ok(violations.every((v) => /left unaudited/.test(v)));
+
+    const real = collectFromGit("v0.15.104", { cwd });
+    assert.equal(real.historyError, null);
+    assert.deepEqual(
+      auditTag({
+        tag: "v0.15.104",
+        treeAtTag: real.treeAtTag,
+        range: real.range,
+        tagTargetFor: real.tagTargetFor,
+      }),
+      [],
+    );
+  });
 });
 
 test("#1882 a failed historical parent lookup is a violation, never a root commit", () => {
-  // Keep the real collectFromGit -> versionAtRev walk, but make the underlying
-  // parent lookup fail through the production helper. The old rev-parse catch
-  // converted this exact failure into `hasParent = false`, which made the range
-  // look auditable and could let this release pass.
-  const failing = collectFromGit("v0.15.104", {
-    firstParentAt: (rev) =>
-      firstParentAtRev(rev, () => {
-        throw new Error(`simulated historical parent lookup failure for ${rev}`);
-      }),
-  });
-  assert.equal(failing.historyError, null, "the commit range itself must still walk");
-  assert.ok(failing.range.length > 0, "expected commits in v0.15.103..v0.15.104");
-  assert.ok(
-    failing.range.every((c) => /historical parent lookup .* failed/.test(c.versionError ?? "")),
-    "every historical parent lookup failure must be carried into the range entry",
-  );
+  withReleaseHistory((cwd) => {
+    // Keep the real collectFromGit -> versionAtRev walk, but make the
+    // underlying parent lookup fail through the production helper. The old
+    // rev-parse catch converted this exact failure into `hasParent = false`,
+    // which made the range look auditable and could let this release pass.
+    const failing = collectFromGit("v0.15.104", {
+      cwd,
+      firstParentAt: (rev) =>
+        firstParentAtRev(rev, () => {
+          throw new Error(`simulated historical parent lookup failure for ${rev}`);
+        }),
+    });
+    assert.equal(failing.historyError, null, "the commit range itself must still walk");
+    assert.ok(failing.range.length > 0, "expected commits in v0.15.103..v0.15.104");
+    assert.ok(
+      failing.range.every((c) => /historical parent lookup .* failed/.test(c.versionError ?? "")),
+      "every historical parent lookup failure must be carried into the range entry",
+    );
 
-  const violations = auditTag({ tag: "v0.15.104", ...failing });
-  assert.ok(violations.length > 0, "a failed parent lookup must not audit as coherent");
-  assert.ok(violations.every((v) => /left unaudited/.test(v)));
+    const violations = auditTag({ tag: "v0.15.104", ...failing });
+    assert.ok(violations.length > 0, "a failed parent lookup must not audit as coherent");
+    assert.ok(violations.every((v) => /left unaudited/.test(v)));
+  });
 });
 
 test("#1882 the tag being pushed is not exempt from the target check", () => {

--- a/browser_tests/unit/release-tag-guard.test.mjs
+++ b/browser_tests/unit/release-tag-guard.test.mjs
@@ -25,9 +25,11 @@ import { dirname, join } from "node:path";
 
 import {
   auditTag,
+  collectFromGit,
   packageJsonVersion,
   panelVersion,
   pyprojectVersion,
+  versionAtRev,
   versionOfTag,
 } from "../../scripts/check-release-tag.mjs";
 
@@ -249,22 +251,63 @@ test("#1882 a commit whose version could not be read is reported, never skipped"
   assert.match(violations[0], /left unaudited/);
 });
 
-test("#1882 versionAtRev reports unknown rather than returning a bare null", async () => {
-  // Exercises the git-backed reader against the real repository rather than
-  // injected data, because the fail-open bug lived in the reader, not the rules.
-  const { execFileSync } = await import("node:child_process");
-  const run = (args) => execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+test("#1882 versionAtRev itself returns an error, never a bare null, on an unreadable rev", () => {
+  // Drives the git-backed reader directly. The previous version of this test
+  // re-implemented the git calls instead of calling versionAtRev, so reverting
+  // the reader to `catch { return null }` left the suite green — the exact
+  // "green suite proves nothing" trap this whole issue is about.
+  const good = versionAtRev("HEAD");
+  assert.equal(good.error, null);
+  assert.match(good.version, /^\d+\.\d+\.\d+/);
 
-  // A real commit: readable, and its version parses.
-  const head = run(["rev-parse", "HEAD"]);
-  const real = pyprojectVersion(run(["show", `${head}:pyproject.toml`]));
-  assert.match(real, /^\d+\.\d+\.\d+/);
+  // A syntactically valid SHA that resolves to nothing: `git show` fails, and the
+  // reader must say UNKNOWN rather than "this revision released no version".
+  const bad = versionAtRev("0".repeat(40));
+  assert.equal(bad.version, null);
+  assert.ok(bad.error, "an unreadable rev must carry an error, not a bare null");
+  assert.match(bad.error, /could not be read/);
+});
 
-  // pyproject.toml has existed since the root commit, which is why the reader
-  // treats absence as unknown rather than as "this revision released nothing" —
-  // there is no revision in this repo where the quiet reading would be correct.
-  const rootCommit = run(["rev-list", "--max-parents=0", "HEAD"]).split("\n").pop().trim();
-  assert.notEqual(run(["ls-tree", "--name-only", rootCommit, "--", "pyproject.toml"]), "");
+test("#1882 a reader failure reaches auditTag as a violation through the real range walk", () => {
+  // End-to-end over real history: collectFromGit walks v0.15.104 for real and the
+  // injected reader fails on every commit, so the wiring — reader -> versionError
+  // -> auditTag -> violation — is exercised rather than assumed. With the real
+  // reader the same tag is clean, which is asserted second so a broken walk
+  // cannot make this test pass vacuously.
+  const failing = collectFromGit("v0.15.104", {
+    readVersionAt: (rev) => ({ version: null, error: `simulated unreadable blob at ${rev}` }),
+  });
+  assert.equal(failing.historyError, null, "the range itself must still walk");
+  assert.ok(failing.range.length > 0, "expected commits in v0.15.103..v0.15.104");
+  assert.ok(failing.range.every((c) => c.versionError), "every entry must carry the read failure");
+
+  const violations = auditTag({
+    tag: "v0.15.104",
+    treeAtTag: treeAt("0.15.104"),
+    range: failing.range,
+    tagTargetFor: failing.tagTargetFor,
+  });
+  assert.ok(violations.length > 0, "a range of unreadable commits must not audit as coherent");
+  assert.ok(violations.every((v) => /left unaudited/.test(v)));
+
+  const real = collectFromGit("v0.15.104");
+  assert.equal(real.historyError, null);
+  assert.deepEqual(
+    auditTag({
+      tag: "v0.15.104",
+      treeAtTag: {
+        pyproject: readFileSync(join(root, "pyproject.toml"), "utf8").replace(
+          /^version = ".*"$/m,
+          'version = "0.15.104"',
+        ),
+        packageJson: JSON.stringify({ version: "0.15.104" }),
+        panelJs: 'const PANEL_VERSION = "0.15.104";',
+      },
+      range: real.range,
+      tagTargetFor: real.tagTargetFor,
+    }),
+    [],
+  );
 });
 
 test("#1882 the tag being pushed is not exempt from the target check", () => {

--- a/browser_tests/unit/release-tag-guard.test.mjs
+++ b/browser_tests/unit/release-tag-guard.test.mjs
@@ -76,7 +76,7 @@ test("#1882 a coherent release passes", () => {
     range: [
       { sha: "aaaaaaaa1", subject: "chore: release v0.15.104", version: "0.15.104", parentVersion: "0.15.103" },
     ],
-    tagTargetFor: tagsAt({ "0.15.103": "zzzzzzzz9" }),
+    tagTargetFor: tagsAt({ "0.15.104": "aaaaaaaa1", "0.15.103": "zzzzzzzz9" }),
   });
   assert.deepEqual(violations, []);
 });
@@ -137,7 +137,7 @@ test("#1882 the v0.15.98 shape is caught: 0.15.97 shipped in the range with no t
         parentVersion: "0.15.85",
       },
     ],
-    tagTargetFor: tagsAt({ "0.15.96": "9999999999" }),
+    tagTargetFor: tagsAt({ "0.15.98": "1111111111", "0.15.96": "9999999999" }),
   });
   assert.equal(violations.length, 1, violations.join("\n"));
   assert.match(violations[0], /^0\.15\.97 was cut by 7b477d55 /);
@@ -163,7 +163,7 @@ test("#1882 a tag is credited only when it resolves to the commit that cut the v
     tag: "v0.15.98",
     treeAtTag: treeAt("0.15.98"),
     range,
-    tagTargetFor: tagsAt({ "0.15.97": "deadbeef00" }),
+    tagTargetFor: tagsAt({ "0.15.98": "1111111111", "0.15.97": "deadbeef00" }),
   });
   assert.equal(wrongTarget.length, 1, wrongTarget.join("\n"));
   assert.match(wrongTarget[0], /v0\.15\.97 exists but resolves to deadbeef, not the commit that cut 0\.15\.97/);
@@ -172,21 +172,21 @@ test("#1882 a tag is credited only when it resolves to the commit that cut the v
     tag: "v0.15.98",
     treeAtTag: treeAt("0.15.98"),
     range,
-    tagTargetFor: tagsAt({ "0.15.97": "7b477d5500" }),
+    tagTargetFor: tagsAt({ "0.15.98": "1111111111", "0.15.97": "7b477d5500" }),
   });
   assert.deepEqual(rightTarget, []);
 });
 
-test("#1882 the tag's own release commit is never reported as an untagged gap", () => {
-  // At push time this tag legitimately has no *earlier* tag for its own version,
-  // and flagging it would make every single release red.
+test("#1882 the tag's own release commit is not reported as a gap when the tag sits on it", () => {
+  // The ordinary release: the tag labels the commit that cut its version. Flagging
+  // this would make every single release red.
   const violations = auditTag({
     tag: "v0.15.105",
     treeAtTag: treeAt("0.15.105"),
     range: [
       { sha: "abcabcabc", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
     ],
-    tagTargetFor: noTags,
+    tagTargetFor: tagsAt({ "0.15.105": "abcabcabc" }),
   });
   assert.deepEqual(violations, []);
 });
@@ -199,7 +199,7 @@ test("#1882 a pyproject.toml edit that leaves the version alone is not a release
       { sha: "ddddddddd", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
       { sha: "eeeeeeeee", subject: "chore: widen a dependency pin", version: "0.15.104", parentVersion: "0.15.104" },
     ],
-    tagTargetFor: noTags,
+    tagTargetFor: tagsAt({ "0.15.105": "ddddddddd" }),
   });
   assert.deepEqual(violations, []);
 });
@@ -223,6 +223,74 @@ test("#1882 unavailable history is a violation, not an empty range that passes",
   assert.equal(violations.length, 1, violations.join("\n"));
   assert.match(violations[0], /untagged-release scan could not run/);
   assert.match(violations[0], /shallow clone/);
+});
+
+test("#1882 a commit whose version could not be read is reported, never skipped", () => {
+  // Fail-open at a finer grain than an empty range: `git show <sha>:pyproject.toml`
+  // failing used to read back null, and null was treated as "not a release", so one
+  // unreadable blob could hide the very gap the scan exists to find.
+  const violations = auditTag({
+    tag: "v0.15.98",
+    treeAtTag: treeAt("0.15.98"),
+    range: [
+      { sha: "1111111111", subject: "chore: release v0.15.98", version: "0.15.98", parentVersion: "0.15.97" },
+      {
+        sha: "7b477d5500",
+        subject: "chore: release v0.15.97",
+        version: null,
+        parentVersion: null,
+        versionError: "pyproject.toml exists at 7b477d55 but could not be read: EIO",
+      },
+    ],
+    tagTargetFor: tagsAt({ "0.15.98": "1111111111" }),
+  });
+  assert.equal(violations.length, 1, violations.join("\n"));
+  assert.match(violations[0], /could not be read/);
+  assert.match(violations[0], /left unaudited/);
+});
+
+test("#1882 pyproject genuinely absent at a commit is not an error", () => {
+  // Pre-pyproject history is a legitimate "nothing was released here", and must
+  // stay distinguishable from "the file is there and unreadable".
+  const violations = auditTag({
+    tag: "v0.15.105",
+    treeAtTag: treeAt("0.15.105"),
+    range: [
+      { sha: "aaaaaaaa1", subject: "chore: release v0.15.105", version: "0.15.105", parentVersion: "0.15.104" },
+      { sha: "bbbbbbbb2", subject: "docs: readme", version: null, parentVersion: null, versionError: null },
+    ],
+    tagTargetFor: tagsAt({ "0.15.105": "aaaaaaaa1" }),
+  });
+  assert.deepEqual(violations, []);
+});
+
+test("#1882 the tag being pushed is not exempt from the target check", () => {
+  // Rule 1 only proves the TREE at the tag says 0.15.106. A tag force-moved off
+  // the commit that cut 0.15.106 onto a later commit carrying the same version
+  // labels a different build than the one that published — and `v === expected`
+  // used to skip the check entirely.
+  const range = [
+    { sha: "1atercommit", subject: "fix: a later commit, same version", version: "0.15.106", parentVersion: "0.15.106" },
+    { sha: "cut0106cut", subject: "chore: release v0.15.106", version: "0.15.106", parentVersion: "0.15.105" },
+  ];
+  const moved = auditTag({
+    tag: "v0.15.106",
+    treeAtTag: treeAt("0.15.106"),
+    range,
+    tagTargetFor: tagsAt({ "0.15.106": "1atercommit" }),
+  });
+  assert.equal(moved.length, 1, moved.join("\n"));
+  assert.match(moved[0], /v0\.15\.106 resolves to 1atercom/);
+  assert.match(moved[0], /was cut by cut0106c/);
+  assert.match(moved[0], /different build than the one the Registry publishes/);
+
+  const inPlace = auditTag({
+    tag: "v0.15.106",
+    treeAtTag: treeAt("0.15.106"),
+    range,
+    tagTargetFor: tagsAt({ "0.15.106": "cut0106cut" }),
+  });
+  assert.deepEqual(inPlace, []);
 });
 
 test("#1882 a history failure still reports the tree-vs-tag mismatch it could check", () => {

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -231,12 +231,26 @@ export function auditTag({ tag, treeAtTag, range = [], tagTargetFor, historyErro
 // git-backed shell
 // ---------------------------------------------------------------------------
 
-const git = (...args) =>
-  execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+/**
+ * git bound to a working directory. `cwd` exists so the walk can be exercised
+ * against a purpose-built repository: CI checks this repo out shallow and
+ * without tags, so any test keyed on OUR history passes locally and fails on the
+ * runner — which is how the first version of these tests went red in CI while
+ * green here.
+ */
+const gitIn =
+  (cwd) =>
+  (...args) =>
+    execFileSync("git", cwd ? ["-C", cwd, ...args] : args, {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
 
-const showOrNull = (rev, path) => {
+const git = gitIn(null);
+
+const showOrNull = (rev, path, runGit = git) => {
   try {
-    return git("show", `${rev}:${path}`);
+    return runGit("show", `${rev}:${path}`);
   } catch {
     return null;
   }
@@ -255,10 +269,10 @@ const showOrNull = (rev, path) => {
  * this repo since the root commit (4f22ed0f) — a revision without it means the
  * release model changed, not that the revision released nothing.
  */
-export function versionAtRev(rev) {
+export function versionAtRev(rev, runGit = git) {
   let text;
   try {
-    text = git("show", `${rev}:pyproject.toml`);
+    text = runGit("show", `${rev}:pyproject.toml`);
   } catch (e) {
     return {
       version: null,
@@ -311,22 +325,28 @@ export function firstParentAtRev(rev, runGit = git) {
  * @param {{
  *   readVersionAt?: (rev:string)=>{version:string|null, error:string|null},
  *   firstParentAt?: (rev:string)=>{parent:string|null, error:string|null},
+ *   cwd?: string,
  * }} [deps]
  *        the version reader is injectable ONLY so a test can drive a read failure
  *        through the real range walk. Every commit in this repo's history is
  *        readable, so the failure path cannot be reached from real data — and an
  *        unexercised failure path is how the first two drafts of this guard
  *        shipped fail-open. The parent resolver is injectable for the same reason:
- *        a real repository cannot manufacture a failed lookup on demand.
+ *        a real repository cannot manufacture a failed lookup on demand. `cwd`
+ *        lets tests provide an isolated local history without depending on the
+ *        checkout's fetched tags or depth.
  */
 export function collectFromGit(
   tag,
-  { readVersionAt = versionAtRev, firstParentAt = firstParentAtRev } = {},
+  { readVersionAt, firstParentAt, cwd } = {},
 ) {
+  const runGit = cwd ? gitIn(cwd) : git;
+  const readVersion = readVersionAt ?? ((rev) => versionAtRev(rev, runGit));
+  const firstParent = firstParentAt ?? ((rev) => firstParentAtRev(rev, runGit));
   const treeAtTag = {
-    pyproject: showOrNull(tag, "pyproject.toml"),
-    packageJson: showOrNull(tag, "package.json"),
-    panelJs: showOrNull(tag, "web/js/comfyui-mcp-panel.js"),
+    pyproject: showOrNull(tag, "pyproject.toml", runGit),
+    packageJson: showOrNull(tag, "package.json", runGit),
+    panelJs: showOrNull(tag, "web/js/comfyui-mcp-panel.js", runGit),
   };
 
   // Fail closed from here down. Each of these can fail on a runner in a way that
@@ -338,7 +358,7 @@ export function collectFromGit(
   const tagTargets = new Map();
 
   try {
-    if (git("rev-parse", "--is-shallow-repository").trim() === "true") {
+    if (runGit("rev-parse", "--is-shallow-repository").trim() === "true") {
       historyError =
         "this is a shallow clone, so the range cannot be walked (checkout needs fetch-depth: 0)";
     }
@@ -350,7 +370,7 @@ export function collectFromGit(
     try {
       // `%(*objectname)` is the peeled target and is non-empty only for annotated
       // tags; lightweight tags report the commit in `%(objectname)`.
-      for (const line of git(
+      for (const line of runGit(
         "for-each-ref",
         "--format=%(refname:short)%00%(objectname)%00%(*objectname)",
         "refs/tags/v*",
@@ -374,13 +394,13 @@ export function collectFromGit(
     // Failure here is legitimate for the first tag in history, so it is NOT an
     // error — the range simply starts at the root.
     try {
-      previousTag = git("describe", "--tags", "--abbrev=0", "--match", "v*", `${tag}^`).trim();
+      previousTag = runGit("describe", "--tags", "--abbrev=0", "--match", "v*", `${tag}^`).trim();
     } catch {
       previousTag = null;
     }
 
     try {
-      range = git(
+      range = runGit(
         "rev-list",
         "--first-parent",
         "--format=%H%x00%s",
@@ -390,13 +410,13 @@ export function collectFromGit(
         .filter((l) => l && !l.startsWith("commit "))
         .map((line) => {
           const [sha, subject] = line.split("\0");
-          const own = readVersionAt(sha);
+          const own = readVersion(sha);
 
-          const parentRef = firstParentAt(sha);
+          const parentRef = firstParent(sha);
           const parent = parentRef.error
             ? { version: null, error: parentRef.error }
             : parentRef.parent
-              ? readVersionAt(parentRef.parent)
+              ? readVersion(parentRef.parent)
               : { version: null, error: null };
           const versionErrors = [own.error, parent.error].filter(Boolean);
 

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -255,7 +255,7 @@ const showOrNull = (rev, path) => {
  * this repo since the root commit (4f22ed0f) — a revision without it means the
  * release model changed, not that the revision released nothing.
  */
-function versionAtRev(rev) {
+export function versionAtRev(rev) {
   let text;
   try {
     text = git("show", `${rev}:pyproject.toml`);
@@ -274,7 +274,16 @@ function versionAtRev(rev) {
   return { version, error: null };
 }
 
-export function collectFromGit(tag) {
+/**
+ * @param {string} tag
+ * @param {{readVersionAt?: (rev:string)=>{version:string|null, error:string|null}}} [deps]
+ *        the version reader is injectable ONLY so a test can drive a read failure
+ *        through the real range walk. Every commit in this repo's history is
+ *        readable, so the failure path cannot be reached from real data — and an
+ *        unexercised failure path is how the first two drafts of this guard
+ *        shipped fail-open.
+ */
+export function collectFromGit(tag, { readVersionAt = versionAtRev } = {}) {
   const treeAtTag = {
     pyproject: showOrNull(tag, "pyproject.toml"),
     packageJson: showOrNull(tag, "package.json"),
@@ -342,7 +351,7 @@ export function collectFromGit(tag) {
         .filter((l) => l && !l.startsWith("commit "))
         .map((line) => {
           const [sha, subject] = line.split("\0");
-          const own = versionAtRev(sha);
+          const own = readVersionAt(sha);
 
           // A root commit has no first parent; that is not an error, it just means
           // whatever it declares is a first appearance.
@@ -352,7 +361,7 @@ export function collectFromGit(tag) {
           } catch {
             hasParent = false;
           }
-          const parent = hasParent ? versionAtRev(`${sha}^`) : { version: null, error: null };
+          const parent = hasParent ? readVersionAt(`${sha}^`) : { version: null, error: null };
 
           return {
             sha,

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -40,14 +40,19 @@
  *      mirrors ci.yml's three-way gate but anchors it to the TAG, which ci.yml
  *      cannot see.
  *
- *   2. NO PUBLISHED VERSION WAS SKIPPED. Walk first-parent from the previous
- *      reachable tag to this one. Every commit in that range whose pyproject
- *      version differs from its parent's is a commit that shipped a version, so
- *      it must carry a tag OF ITS OWN — the tag for `<v>` must resolve to THAT
- *      COMMIT, not merely exist. A tag is a movable label; crediting one by name
- *      alone would let `v0.15.97` sit on an unrelated commit while the commit
- *      that actually published 0.15.97 stayed untagged, which is the very
- *      confusion this guard exists to end.
+ *   2. EVERY VERSION CUT IN THE RANGE IS LABELLED BY ITS OWN TAG. Walk
+ *      first-parent from the previous reachable tag to this one. Every commit in
+ *      that range whose pyproject version differs from its parent's cut a
+ *      version, so the tag for `<v>` must resolve to THAT COMMIT, not merely
+ *      exist. A tag is a movable label; crediting one by name alone would let
+ *      `v0.15.97` sit on an unrelated commit while the commit that actually
+ *      published 0.15.97 stayed untagged, which is the very confusion this guard
+ *      exists to end.
+ *
+ *      The tag being pushed is NOT exempt from that. Rule 1 only proves the tree
+ *      AT the tag declares `<X>`; it cannot see a tag moved off the commit that
+ *      cut `<X>` onto a later commit carrying the same version — a tag labelling
+ *      a different build than the one that publishes.
  *
  *      This direction has no race. It only ever looks at versions that shipped
  *      STRICTLY BEFORE the tag being pushed, so a tag pushed minutes after its
@@ -60,12 +65,15 @@
  *      so this never re-litigates the whole history and cannot become
  *      permanently red over a historical gap nobody intends to backfill.
  *
- * IT FAILS CLOSED. Every git lookup this needs can fail — a shallow clone, tags
- * that were never fetched, an unreadable object. The first draft turned each of
- * those into an empty range, which made the gap scan silently vacuous while the
- * job still reported success. That is the identical shape as the stale
- * pack-contents entry this issue also fixes, and it is worse in a guard than
- * anywhere else: unavailable history is reported as a violation, never as a pass.
+ * IT FAILS CLOSED, AT EVERY GRAIN. Every git lookup this needs can fail — a
+ * shallow clone, tags that were never fetched, an unreadable blob on one commit.
+ * The first draft turned each of those into "nothing to see": a missing range, or
+ * a commit whose version read back `null` and was skipped as "not a release".
+ * Both made the scan silently vacuous while the job still reported success, which
+ * is the identical shape as the stale pack-contents entry this change also
+ * removes. Unreadable history is a violation here, never a pass. A path that is
+ * genuinely ABSENT from a commit is a different thing from one that cannot be
+ * read, and only the latter is an error.
  *
  * WHAT A TAG PUSH DOES AND DOES NOT RUN. `publish_action.yml` filters `on.push`
  * by `branches: [main]`, and GitHub does not run a `branches`-filtered push
@@ -164,13 +172,37 @@ export function auditTag({ tag, treeAtTag, range = [], tagTargetFor, historyErro
     return violations;
   }
 
-  // ---- Rule 2: nothing shipped between the previous tag and this one untagged.
+  // ---- Rule 2: every version cut in the range is labelled by its own tag.
   for (const c of range) {
+    // A commit whose version could not be READ is not a commit without a release.
+    // Skipping it on a null would let one unreadable blob hide exactly the gap
+    // this scan exists to find — fail-open at a finer grain than an empty range.
+    if (c?.versionError) {
+      violations.push(
+        `${tag}: ${c.versionError}. Refusing to report this release as coherent with ` +
+          `a commit in the range left unaudited (#1882).`,
+      );
+      continue;
+    }
+
     const v = c?.version;
     if (!v || v === c.parentVersion) continue; // pyproject touched, version unchanged
-    if (v === expected) continue; // this tag's own release commit
     const target = typeof tagTargetFor === "function" ? tagTargetFor(v) : null;
     if (target && target === c.sha) continue;
+
+    // The tag being pushed is NOT exempt from the target check. Rule 1 only proves
+    // the tree AT the tag declares <X>; it cannot see a tag moved off the commit
+    // that cut <X> onto a later commit carrying the same version — a tag labelling
+    // a different build than the one that publishes.
+    if (v === expected) {
+      violations.push(
+        `${tag} resolves to ${target ? short(target) : "(no such tag)"}, but ${expected} ` +
+          `was cut by ${short(c.sha)} ("${c.subject}"). The tag does not label the commit ` +
+          `that changed pyproject.toml to ${expected}, so it points at a different build ` +
+          `than the one the Registry publishes (#1882).`,
+      );
+      continue;
+    }
 
     // A version bump reaching main is what triggers publish_action.yml. It is
     // ALMOST always a version that shipped, but not certainly: the workflow runs
@@ -211,6 +243,43 @@ const showOrNull = (rev, path) => {
     return null;
   }
 };
+
+/**
+ * pyproject's version at one revision, distinguishing the three outcomes a bare
+ * try/catch collapses into one:
+ *
+ *   { version: "0.15.97", error: null }  read it
+ *   { version: null, error: null }       pyproject.toml is genuinely ABSENT at this
+ *                                        commit (pre-pyproject history) — nothing
+ *                                        was released here
+ *   { version: null, error: "..." }      the file is there and could not be read, or
+ *                                        carries no [project].version — UNKNOWN, and
+ *                                        unknown must never read as "no release"
+ */
+function versionAtRev(rev) {
+  let present;
+  try {
+    present = git("ls-tree", "--name-only", rev, "--", "pyproject.toml").trim() !== "";
+  } catch (e) {
+    return { version: null, error: `could not list pyproject.toml at ${short(rev)}: ${e.message}` };
+  }
+  if (!present) return { version: null, error: null };
+
+  let text;
+  try {
+    text = git("show", `${rev}:pyproject.toml`);
+  } catch (e) {
+    return {
+      version: null,
+      error: `pyproject.toml exists at ${short(rev)} but could not be read: ${e.message}`,
+    };
+  }
+  const version = pyprojectVersion(text);
+  if (version === null) {
+    return { version: null, error: `pyproject.toml at ${short(rev)} has no [project].version` };
+  }
+  return { version, error: null };
+}
 
 export function collectFromGit(tag) {
   const treeAtTag = {
@@ -280,11 +349,24 @@ export function collectFromGit(tag) {
         .filter((l) => l && !l.startsWith("commit "))
         .map((line) => {
           const [sha, subject] = line.split("\0");
+          const own = versionAtRev(sha);
+
+          // A root commit has no first parent; that is not an error, it just means
+          // whatever it declares is a first appearance.
+          let hasParent = true;
+          try {
+            git("rev-parse", "--verify", "--quiet", `${sha}^`);
+          } catch {
+            hasParent = false;
+          }
+          const parent = hasParent ? versionAtRev(`${sha}^`) : { version: null, error: null };
+
           return {
             sha,
             subject: subject ?? "",
-            version: pyprojectVersion(showOrNull(sha, "pyproject.toml")),
-            parentVersion: pyprojectVersion(showOrNull(`${sha}^`, "pyproject.toml")),
+            version: own.version,
+            parentVersion: parent.version,
+            versionError: own.error ?? parent.error ?? null,
           };
         });
     } catch (e) {

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -71,9 +71,7 @@
  * a commit whose version read back `null` and was skipped as "not a release".
  * Both made the scan silently vacuous while the job still reported success, which
  * is the identical shape as the stale pack-contents entry this change also
- * removes. Unreadable history is a violation here, never a pass. A path that is
- * genuinely ABSENT from a commit is a different thing from one that cannot be
- * read, and only the latter is an error.
+ * removes. Unreadable history is a violation here, never a pass.
  *
  * WHAT A TAG PUSH DOES AND DOES NOT RUN. `publish_action.yml` filters `on.push`
  * by `branches: [main]`, and GitHub does not run a `branches`-filtered push
@@ -245,33 +243,28 @@ const showOrNull = (rev, path) => {
 };
 
 /**
- * pyproject's version at one revision, distinguishing the three outcomes a bare
+ * pyproject's version at one revision, separating the two outcomes a bare
  * try/catch collapses into one:
  *
  *   { version: "0.15.97", error: null }  read it
- *   { version: null, error: null }       pyproject.toml is genuinely ABSENT at this
- *                                        commit (pre-pyproject history) — nothing
- *                                        was released here
- *   { version: null, error: "..." }      the file is there and could not be read, or
- *                                        carries no [project].version — UNKNOWN, and
- *                                        unknown must never read as "no release"
+ *   { version: null, error: "..." }      UNKNOWN — unreadable, missing, or carrying
+ *                                        no [project].version. Never "no release".
+ *
+ * Absence is an error rather than a quiet "nothing shipped here" because
+ * pyproject.toml is what publish_action.yml triggers on, and it has existed on
+ * this repo since the root commit (4f22ed0f) — a revision without it means the
+ * release model changed, not that the revision released nothing.
  */
 function versionAtRev(rev) {
-  let present;
-  try {
-    present = git("ls-tree", "--name-only", rev, "--", "pyproject.toml").trim() !== "";
-  } catch (e) {
-    return { version: null, error: `could not list pyproject.toml at ${short(rev)}: ${e.message}` };
-  }
-  if (!present) return { version: null, error: null };
-
   let text;
   try {
     text = git("show", `${rev}:pyproject.toml`);
   } catch (e) {
     return {
       version: null,
-      error: `pyproject.toml exists at ${short(rev)} but could not be read: ${e.message}`,
+      error:
+        `pyproject.toml could not be read at ${short(rev)} (${e.message.split("\n")[0]}) — ` +
+        `that file is what publish_action.yml triggers on, so this revision cannot be audited`,
     };
   }
   const version = pyprojectVersion(text);

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -275,15 +275,54 @@ export function versionAtRev(rev) {
 }
 
 /**
+ * Resolve a commit's first parent without conflating a failed lookup with a
+ * root commit. `rev-parse <rev>^` exits non-zero for both, so its catch block
+ * cannot safely decide that the commit is a root. `rev-list --parents`
+ * succeeds for a root and gives us an explicit, parseable distinction.
+ *
+ * @param {string} rev
+ * @param {(...args:string[])=>string} [runGit]
+ * @returns {{parent:string|null, error:string|null}}
+ */
+export function firstParentAtRev(rev, runGit = git) {
+  let output;
+  try {
+    output = runGit("rev-list", "--parents", "-n", "1", rev).trim();
+  } catch (e) {
+    return {
+      parent: null,
+      error:
+        `historical parent lookup for ${short(rev)} failed: ${e.message.split("\n")[0]}`,
+    };
+  }
+
+  const fields = output.split(/\s+/).filter(Boolean);
+  if (!fields.length) {
+    return {
+      parent: null,
+      error: `historical parent lookup for ${short(rev)} returned no commit data`,
+    };
+  }
+  return { parent: fields[1] ?? null, error: null };
+}
+
+/**
  * @param {string} tag
- * @param {{readVersionAt?: (rev:string)=>{version:string|null, error:string|null}}} [deps]
+ * @param {{
+ *   readVersionAt?: (rev:string)=>{version:string|null, error:string|null},
+ *   firstParentAt?: (rev:string)=>{parent:string|null, error:string|null},
+ * }} [deps]
  *        the version reader is injectable ONLY so a test can drive a read failure
  *        through the real range walk. Every commit in this repo's history is
  *        readable, so the failure path cannot be reached from real data — and an
  *        unexercised failure path is how the first two drafts of this guard
- *        shipped fail-open.
+ *        shipped fail-open. The parent resolver is injectable for the same reason:
+ *        a real repository cannot manufacture a failed lookup on demand.
  */
-export function collectFromGit(tag, { readVersionAt = versionAtRev } = {}) {
+export function collectFromGit(
+  tag,
+  { readVersionAt = versionAtRev, firstParentAt = firstParentAtRev } = {},
+) {
   const treeAtTag = {
     pyproject: showOrNull(tag, "pyproject.toml"),
     packageJson: showOrNull(tag, "package.json"),
@@ -353,22 +392,20 @@ export function collectFromGit(tag, { readVersionAt = versionAtRev } = {}) {
           const [sha, subject] = line.split("\0");
           const own = readVersionAt(sha);
 
-          // A root commit has no first parent; that is not an error, it just means
-          // whatever it declares is a first appearance.
-          let hasParent = true;
-          try {
-            git("rev-parse", "--verify", "--quiet", `${sha}^`);
-          } catch {
-            hasParent = false;
-          }
-          const parent = hasParent ? readVersionAt(`${sha}^`) : { version: null, error: null };
+          const parentRef = firstParentAt(sha);
+          const parent = parentRef.error
+            ? { version: null, error: parentRef.error }
+            : parentRef.parent
+              ? readVersionAt(parentRef.parent)
+              : { version: null, error: null };
+          const versionErrors = [own.error, parent.error].filter(Boolean);
 
           return {
             sha,
             subject: subject ?? "",
             version: own.version,
             parentVersion: parent.version,
-            versionError: own.error ?? parent.error ?? null,
+            versionError: versionErrors.length ? versionErrors.join("; ") : null,
           };
         });
     } catch (e) {


### PR DESCRIPTION
Follow-up to #1885 (merged as 197fa932). The underlying cause of #1882 is addressed by that PR; this closes two holes the review gate found in it **after** it merged.

#1885 was squash-merged while I was still fixing the gate's second round, so `main` carries the round-1 code and neither of these landed. Both are the same fail-open class the merged PR set out to eliminate — a guard that reports success while checking nothing — just at a finer grain than the version it caught.

## 1. A commit whose version could not be read was skipped, not reported

`versionAtRev` went through a `try/catch` that returned `null`, and the rule-2 loop treats `null` as "no version change here":

```js
const v = c?.version;
if (!v || v === c.parentVersion) continue;   // <- an unreadable blob lands here
```

So one unreadable `pyproject.toml` in the scanned range could hide exactly the untagged release the scan exists to find, while the job reported the release coherent. Reads now return an explicit unknown, and an unknown commit in the range is a violation.

## 2. The tag being pushed was exempt from the target check

```js
if (v === expected) continue;   // <- skipped tagTargetFor entirely
```

Rule 1 only proves the **tree** at `v0.15.106` declares `0.15.106`. It cannot see that the tag was force-moved off the commit that cut `0.15.106` onto a later commit carrying the same version — a tag labelling a different build than the one the Registry publishes. The pushed tag is no longer exempt.

## 3. Removed an unreachable branch rather than testing it

The reader distinguished "`pyproject.toml` is genuinely absent at this commit" from "it is there and unreadable", treating absence as a quiet *nothing was released here*. Mutating that branch changed no test and no live audit — the tell that it is dead: `pyproject.toml` has existed since the root commit `4f22ed0f`, and the scanned range is bounded by the previous tag, so no revision reaches it. Writing a test for it would have covered code production cannot execute. Absence is now the same unknown as unreadable, which is correct on its own terms: `publish_action.yml` triggers on that file, so a revision without it means the release model changed.

## Evidence

**Mutation-verified**, each fix deleted and the named test watched go red, then restored:

| mutation | result |
|---|---|
| `if (c?.versionError)` → `if (false)` | `a commit whose version could not be read is reported, never skipped` FAILS |
| re-add `if (v === expected) continue;` before the target check | `the tag being pushed is not exempt from the target check` FAILS |
| make absence an error again | **no test and no live audit changed** — which is why that branch was deleted instead of pinned |

**Live audits unchanged** by these fixes — still red on exactly the two documented incidents, green on healthy releases:

```
v0.15.90   exit 1     v0.15.104  exit 0
v0.15.98   exit 1     v0.15.105  exit 0
```

Five existing fixtures now supply the tag's own target. That is the contract change from item 2, not a regression: the healthy path now requires a tag to point at its own release commit, and every real tag `v0.15.99`..`v0.15.105` already does — verified against history before tightening it, so this is strictly stronger with no false positives.

19 tests in `browser_tests/unit/release-tag-guard.test.mjs`; full suite 7044 pass / 0 fail; `tsc --noEmit` clean.

## Where the load-bearing claims are

1. **Item 2 changes what a green release requires.** A tag must now resolve to the commit that cut its version. I verified `v0.15.99`..`v0.15.105` all already satisfy it, but it is the one change here that could turn a future release red for a reason the previous code allowed.
2. **Item 3 is a deletion.** If you think a repo state exists where `pyproject.toml` is legitimately absent from a commit inside a release range, that branch should come back — with a test that reaches it.
3. No panel-visible behaviour changes; the diff is `scripts/`, `browser_tests/unit/` and `CHANGELOG.md`, so there is no browser verification to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
