### PR TITLE
docs: 0.15.105 does not contain the release tag guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- a release tag proves the tagged tree is the version it claims, and that nothing shipped untagged (#1882)
+
+
 ## [0.15.105] - 2026-08-26
 
 ### Fixed
-- a release tag proves the tagged tree is the version it claims, and that nothing shipped untagged (#1882)
 - scrolling up during a streaming turn no longer snaps back to the bottom (#1879)
 - graph_connect reports live dynamic slot rewrites and safely bounds hostile disclosure values (#1876)
 - the pruned-retry disclosure says why the first post is not pre-pruned (#1881)


### PR DESCRIPTION
0.15.105's changelog credits it with the release tag guard from #1885. **0.15.105 does not contain it**, and 0.15.105 is already published.

    v0.15.105  cb2ae481  22:05:24Z
    #1885      197fa932  22:36:45Z    (31 minutes after the tag)

    git merge-base --is-ancestor 197fa932 v0.15.105   ->   false

Moves the entry to `[Unreleased]`, where it ships in the next cut.

## Same root cause as the 0.52.134 case, inverted

On mcp, 0.52.134's notes claimed a fix that had already shipped in 0.52.133. Here, a published release claims a fix that has not shipped at all. Both come from placing an entry by **which section is newest in the file** rather than by **which release actually contains the commit**.

The check is one command, and it is the same one that now guards the tags themselves:

```
git merge-base --is-ancestor <fix-sha> v<version>
```

Worth noting the irony: the entry that landed in the wrong release is the tag guard whose whole purpose is stopping the tag/tree record from lying. The guard is right — it just cannot see the changelog.

## Verified

- `changelog-base` 9 pass / 0 fail
- `gen-changelog-json.mjs` regenerated; its YARA self-check passes
- local registry replica still **6** — no new finding
- the remaining five 0.15.105 entries are unchanged and all genuinely in that tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
