### PR TITLE
fix(1891): reconcile generated changelog sections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     name: Lint pack (JS syntax + Python + pyproject)
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-node@v7
         with:
@@ -57,6 +60,8 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm run test:unit
+      - name: Changelog release guard
+        run: npm run check:changelog
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       # ---- Gate: never publish a broken pack to the Registry. -------------
       # web/js is served live and a broken save crashes the whole ComfyUI
@@ -21,6 +24,11 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+
+      - name: Changelog release guard
+        env:
+          RELEASE_REF: ${{ github.sha }}
+        run: node scripts/check-changelog.mjs --ref "$RELEASE_REF"
 
       - name: JS syntax check (web/js)
         shell: bash

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -25,10 +25,35 @@ jobs:
         with:
           node-version: 22
 
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Read authoritative release version
+        id: release-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          try:
+              version = tomllib.load(Path("pyproject.toml").open("rb"))["project"]["version"]
+          except (KeyError, TypeError):
+              raise SystemExit("pyproject.toml [project].version is required")
+          if not isinstance(version, str) or not version.strip():
+              raise SystemExit("pyproject.toml [project].version must be a non-empty string")
+          print(version)
+          PY
+          )"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Changelog release guard
         env:
           RELEASE_REF: ${{ github.sha }}
-        run: node scripts/check-changelog.mjs --ref "$RELEASE_REF"
+          RELEASE_VERSION: ${{ steps.release-version.outputs.version }}
+        run: node scripts/check-changelog.mjs "$RELEASE_VERSION" --ref "$RELEASE_REF"
 
       - name: JS syntax check (web/js)
         shell: bash
@@ -163,10 +188,6 @@ jobs:
       # absent — silently skipped its bundle assertions here while being mandatory in CI.
       # A publish path where a test quietly downgrades itself to a no-op is worse than one
       # that omits the test, because the summary still says it ran.
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.11"
-
       - name: Install comfyui_frontend_package (for the frontend-contract test)
         shell: bash
         run: |
@@ -253,23 +274,22 @@ jobs:
       # is the honest source. Same underlying gap as comfyui-mcp's GitHub
       # Release fix (mcp#1138); this is its Registry twin.
       #
+      # The authoritative version and its non-empty changelog section are required
+      # by the release guard above. This extraction remains fail-open only for the
+      # Registry's optional --changelog-file convenience.
       # THIS STEP CANNOT FAIL THE JOB, BY CONSTRUCTION. Release notes are a
       # nicety; the release itself is not. There is deliberately no `set -e`
       # and the step ends in `exit 0`, so every way this can go wrong — no
-      # python, no tomllib, a pyproject without `[project].version`, a missing
-      # or empty CHANGELOG section — lands in the same place: `path=` empty,
-      # and the publish step below ships with no changelog.
+      # an extraction failure — lands in the same place: `path=` empty, and the
+      # publish step below ships without optional changelog notes. A missing or
+      # empty current-version section cannot reach this step because the guard above
+      # already fails the job.
       #
-      # The previous shape had `set -euo pipefail` with the version read on a
-      # bare assignment. Only the `node scripts/changelog-section.mjs` call was
-      # fail-open (an `if` condition is exempt from errexit); a non-zero
-      # `python -c` would have aborted the job BEFORE the publish step ran, so
-      # a release could have been lost over notes it was not going to use.
       - name: Extract this version's changelog for the Registry
         id: changelog
         run: |
           set -uo pipefail
-          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])' 2>/dev/null || true)"
+          version="${{ steps.release-version.outputs.version }}"
           if [ -n "$version" ] && node scripts/changelog-section.mjs "$version" > registry-changelog.md; then
             echo "path=registry-changelog.md" >> "$GITHUB_OUTPUT"
             echo "changelog for $version ($(wc -c < registry-changelog.md) chars):"

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -31,23 +31,31 @@ jobs:
 
       - name: Read authoritative release version
         id: release-version
-        shell: bash
+        shell: python
         run: |
-          set -euo pipefail
-          version="$(python - <<'PY'
+          import os
+          import re
           import tomllib
           from pathlib import Path
 
+          semver = re.compile(
+              r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+              r"(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
+              r"(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?"
+              r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+          )
           try:
-              version = tomllib.load(Path("pyproject.toml").open("rb"))["project"]["version"]
+              with Path("pyproject.toml").open("rb") as pyproject:
+                  version = tomllib.load(pyproject)["project"]["version"]
           except (KeyError, TypeError):
               raise SystemExit("pyproject.toml [project].version is required")
-          if not isinstance(version, str) or not version.strip():
-              raise SystemExit("pyproject.toml [project].version must be a non-empty string")
-          print(version)
-          PY
-          )"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if not isinstance(version, str) or semver.fullmatch(version) is None:
+              raise SystemExit("pyproject.toml [project].version must be strict SemVer")
+          output = os.environ.get("GITHUB_OUTPUT")
+          if not output:
+              raise SystemExit("GITHUB_OUTPUT is required")
+          with Path(output).open("a", encoding="utf-8", newline="") as output_file:
+              output_file.write(f"version={version}\n")
 
       - name: Changelog release guard
         env:
@@ -280,16 +288,18 @@ jobs:
       # THIS STEP CANNOT FAIL THE JOB, BY CONSTRUCTION. Release notes are a
       # nicety; the release itself is not. There is deliberately no `set -e`
       # and the step ends in `exit 0`, so every way this can go wrong — no
-      # an extraction failure — lands in the same place: `path=` empty, and the
+      # an extraction failure lands in the same place: `path=` empty, and the
       # publish step below ships without optional changelog notes. A missing or
       # empty current-version section cannot reach this step because the guard above
       # already fails the job.
       #
       - name: Extract this version's changelog for the Registry
         id: changelog
+        env:
+          RELEASE_VERSION: ${{ steps.release-version.outputs.version }}
         run: |
           set -uo pipefail
-          version="${{ steps.release-version.outputs.version }}"
+          version="$RELEASE_VERSION"
           if [ -n "$version" ] && node scripts/changelog-section.mjs "$version" > registry-changelog.md; then
             echo "path=registry-changelog.md" >> "$GITHUB_OUTPUT"
             echo "changelog for $version ($(wc -c < registry-changelog.md) chars):"

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -58,3 +58,8 @@ jobs:
         env:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: node scripts/check-release-tag.mjs "$TAG"
+
+      - name: Audit the tagged changelog
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: node scripts/check-changelog.mjs "${TAG#v}" --ref "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4784,12 +4784,31 @@ _No user-facing changes._
 
 ## [0.4.1] - 2026-06-26
 
+Start the agent with a **Connect** button instead of auto-spawning it on load.
+The Comfy Registry's security scanner flagged 0.4.0 because the pack launched a
+subprocess (`npx … --panel-orchestrator`) at import time. Now nothing spawns
+until you explicitly click Connect — the registry-safe pattern — and the panel
+still auto-connects when a bridge is already running.
+
 ### Added
 
 - **`graph_set_node_mode`** — bypass / mute / activate a node on the live canvas
   (undo-able like every other edit), so the agent can enable a bypassed path (e.g. a
   pack's Ideogram-JSON prompt builder) instead of improvising. The graph read now
   surfaces each node's mode, so bypassed/muted nodes are visible. (#30)
+
+### Changed
+
+- **Connect button replaces import-time auto-spawn.** `__init__.py` no longer
+  starts the orchestrator when ComfyUI imports the pack. Instead it registers a
+  small local API on ComfyUI's own server (`/comfyui_mcp_panel/{status,connect,
+  disconnect}`), and the panel's **Connect** button starts the orchestrator on
+  demand — an explicit, authenticated, local action. On load the panel only
+  auto-connects if a bridge is *already* running (you started it, or another
+  tab did); otherwise it waits behind the Connect button. A **Disconnect**
+  button stops an orchestrator the pack started. `COMFYUI_MCP_NO_AUTOSPAWN=1`
+  now makes Connect report status without spawning; `COMFYUI_MCP_BRIDGE_PORT`
+  still overrides the port. Fixes the `NodeVersionStatusFlagged` 0.4.0 release.
 
 ### Fixed
 
@@ -4800,6 +4819,9 @@ _No user-facing changes._
   a preview's temp name as the output. Applies to images and videos. (#31)
 
 ## [0.4.0] - 2026-06-26
+
+The panel now drives itself: it auto-starts an autonomous background agent on
+your Claude subscription, so you just open ComfyUI and type.
 
 ### Added
 
@@ -4812,6 +4834,17 @@ _No user-facing changes._
   - **About** — ⭐ Star on GitHub. **API tokens** — secure CivitAI / HuggingFace
     buttons (stored by the orchestrator, never in ComfyUI settings).
   - The comfyui-mcp logo in the panel header.
+  - **Auto-start the panel orchestrator on load.** The pack launches
+    `npx -y comfyui-mcp --panel-orchestrator` when ComfyUI loads it — idempotent
+    (skips if the bridge port is already owned), auto-detects this ComfyUI's
+    `COMFYUI_URL`, and runs on your Claude **subscription** (no API key). The agent
+    is a background Claude Agent SDK session per tab that loads comfyui-mcp's
+    bundled skills (model expertise), so the only prerequisite is being signed in
+    to Claude (`claude` once). Opt out with `COMFYUI_MCP_NO_AUTOSPAWN=1`; override
+    the port with `COMFYUI_MCP_BRIDGE_PORT`. Requires comfyui-mcp ≥ 0.14.
+  - **Lifecycle beacon.** The pack passes its PID so the orchestrator shuts down
+    when ComfyUI exits — including crashes/hard-kills — with an `atexit` teardown
+    on clean shutdown too. No orphan left holding the bridge port.
 
 ### Fixed
 
@@ -4830,6 +4863,14 @@ _No user-facing changes._
   settings load; appliers are now gated until the panel is armed. (#22)
 - **Steady connection status** — no connecting↔disconnected flicker, with
   backend-aware patience for slow Codex cold starts. (#24)
+
+### Changed
+
+- **Connection UI reflects the orchestrator model.** The settings help text and
+  header no longer tell you to wire the MCP into your interactive session with
+  `--channels` (which would steal the bridge port from the orchestrator); they
+  now describe the autonomous background agent and the one-time
+  `npx -y comfyui-mcp --panel-orchestrator` fallback.
 
 ## [0.3.1] - 2026-06-25
 
@@ -4854,6 +4895,8 @@ _No user-facing changes._
   orchestrator fix).
 
 ## [0.3.0] - 2026-06-25
+
+The polished public release — now live on the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) and installable from ComfyUI-Manager.
 
 ### Added
 
@@ -4903,6 +4946,64 @@ _No user-facing changes._
   packs are local/free; for an ad-hoc or generated graph the agent classifies the
   runtime (local / api / mixed / unknown) and **asks before spending paid API
   credits** rather than silently using hosted API nodes.
+- **Registry banner & SEO listing.** Added a 21:9 brand banner
+  (`assets/banner.png`) so the registry/social card uses a custom image
+  instead of the generic OG fallback, and rewrote the pack description to
+  lead with the terms people actually search (Claude Code, MCP / Model
+  Context Protocol, AI agent, live graph editing).
+
+- **Capability-aware empty state.** The onboarding hero now reflects the
+  agent's full surface — build/edit the live graph, generate images **and
+  audio** (`generate_audio`, ACE Step 1.5 / Stable Audio 3), run the workflow
+  and read its errors, and find models on Civitai — with clickable example
+  prompts that prefill the composer. Requires comfyui-mcp ≥ 0.13.
+- **Native ComfyUI design system.** The panel is restyled on the same
+  PrimeVue semantic tokens (`--p-content-background`, `--p-form-field-*`,
+  `--p-primary-color`, border radii, Inter) the built-in sidebar panels use —
+  it tracks your ComfyUI theme automatically. Header with live status dot,
+  empty-state onboarding, animated message bubbles, auto-growing composer.
+- **Activity cards.** Every graph edit the agent makes renders as a human-
+  readable card in the chat feed — "➕ Added KSampler (id 26)",
+  "🔗 Connected 4.MODEL → 26.model", "🎚 Set steps = 30 (was 20)" — so you
+  can watch Claude work.
+- **Multi-tab support.** Each ComfyUI browser tab holds its own bridge
+  connection, identified by a per-tab session id plus the open workflow's
+  title. The agent sees every tab (`panel_status`), routes edits per tab,
+  and knows which tab you typed in. Requires comfyui-mcp ≥ 0.12.
+- **Markdown-lite agent bubbles** — `code` and **bold** rendering, safely.
+- **"Claude is working…" indicator.** Sending a message shows an animated
+  typing indicator immediately; incoming graph edits keep it alive (and bump
+  it below the newest activity card), the agent's reply retires it, and a
+  45-second quiet period swaps it for a hint explaining that the agent reads
+  panel messages by polling its inbox. (Claude Code doesn't stream its
+  internal reasoning to MCP servers — narration + activity cards + this
+  indicator are the feedback surface.)
+- **`graph_clear` command** — wipes every node in a single
+  `beforeChange`/`afterChange` pair, so one Ctrl+Z restores the whole graph.
+  Exposed as the `panel_clear` MCP tool (comfyui-mcp ≥ 0.12).
+- **Full programmatic graph & app control.** New executor commands (each
+  with a matching `panel_*` MCP tool): `graph_move_node`, `graph_canvas`
+  (fit / center-on-node / pan / zoom), `graph_run` (queue the open workflow,
+  surfacing frontend validation errors), `graph_get_errors` (last
+  `execution_error` event + `lastNodeErrors`), `workflow_save` (Ctrl+S
+  path) and `workflow_save_as` (duplicate to `workflows/<name>.json`).
+- **Subgraph-aware reads.** Executors target the graph you're *viewing*
+  (root or an opened subgraph); `graph_get_state` reports `viewing`, marks
+  subgraph nodes `is_subgraph` with an inner node count (boundary slots +
+  widgets only), and `graph_get_subgraph` drills inside on demand.
+- **Zed-style composer.** Rounded composer card with a context-window ring
+  (radial fill — wired to `agent_status` frames; data source pending host
+  support), model chip, attach button (uploads straight into ComfyUI's
+  `input/` folder and inserts an `@input:` mention), and voice dictation
+  via the browser's speech recognition.
+- **Slash commands & @ mentions.** `/new`, `/fit`, `/run`, `/errors`,
+  `/help` run locally with arrow-key + Enter completion; `@` autocompletes
+  the current workflow, graph nodes, subgraphs, and registered node types.
+  Outgoing messages stamp the workflow + opened subgraph so the agent has
+  the context without asking.
+- **Chat threads.** New-chat and history buttons in the header; threads
+  persist to localStorage (last 20) and replay verbatim, activity cards
+  included.
 
 ## [0.2.0] - 2026-06-19
 
@@ -4942,6 +5043,22 @@ _No user-facing changes._
   the message's own handler (not an array index), so a bounded-history eviction
   can't point a rollback at the wrong turn.
 - **Save-card** rendering fix.
+
+### Changed
+
+- **BREAKING: MCP-driven, no API keys.** Dropped the AI-SDK `/api/chat`
+  backend entirely. The panel is now a WebSocket client of
+  [comfyui-mcp](https://github.com/artokun/comfyui-mcp)'s `--channels`
+  bridge (`ws://127.0.0.1:9101`): **your own Claude Code session is the
+  agent**, subscription-billed, zero LLM API keys anywhere in the path.
+  Settings reduced to one field (bridge URL); SSE parser and bearer token
+  removed.
+
+### Fixed
+
+- `import { app } from "/scripts/app.js"` — `window.app` is no longer
+  assigned at extension-eval time on ComfyUI frontend 1.4x, so the v1
+  global-read pattern silently failed and the sidebar tab never registered.
 
 ## [0.1.3] - 2026-06-19
 
@@ -5005,137 +5122,6 @@ _No user-facing changes._
 - **Smooth animated zoom-to-fit** after the agent makes structural edits.
 - **Programmatic save** (no Save/Rename dialog) and a persistent **"working"**
   indicator with cycling status words.
-
-## [0.4.1] - 2026-06-17
-
-Start the agent with a **Connect** button instead of auto-spawning it on load.
-The Comfy Registry's security scanner flagged 0.4.0 because the pack launched a
-subprocess (`npx … --panel-orchestrator`) at import time. Now nothing spawns
-until you explicitly click Connect — the registry-safe pattern — and the panel
-still auto-connects when a bridge is already running.
-
-### Changed
-
-- **Connect button replaces import-time auto-spawn.** `__init__.py` no longer
-  starts the orchestrator when ComfyUI imports the pack. Instead it registers a
-  small local API on ComfyUI's own server (`/comfyui_mcp_panel/{status,connect,
-  disconnect}`), and the panel's **Connect** button starts the orchestrator on
-  demand — an explicit, authenticated, local action. On load the panel only
-  auto-connects if a bridge is *already* running (you started it, or another
-  tab did); otherwise it waits behind the Connect button. A **Disconnect**
-  button stops an orchestrator the pack started. `COMFYUI_MCP_NO_AUTOSPAWN=1`
-  now makes Connect report status without spawning; `COMFYUI_MCP_BRIDGE_PORT`
-  still overrides the port. Fixes the `NodeVersionStatusFlagged` 0.4.0 release.
-
-## [0.4.0] - 2026-06-17
-
-The panel now drives itself: it auto-starts an autonomous background agent on
-your Claude subscription, so you just open ComfyUI and type.
-
-### Added
-
-- **Auto-start the panel orchestrator on load.** The pack launches
-  `npx -y comfyui-mcp --panel-orchestrator` when ComfyUI loads it — idempotent
-  (skips if the bridge port is already owned), auto-detects this ComfyUI's
-  `COMFYUI_URL`, and runs on your Claude **subscription** (no API key). The agent
-  is a background Claude Agent SDK session per tab that loads comfyui-mcp's
-  bundled skills (model expertise), so the only prerequisite is being signed in
-  to Claude (`claude` once). Opt out with `COMFYUI_MCP_NO_AUTOSPAWN=1`; override
-  the port with `COMFYUI_MCP_BRIDGE_PORT`. Requires comfyui-mcp ≥ 0.14.
-- **Lifecycle beacon.** The pack passes its PID so the orchestrator shuts down
-  when ComfyUI exits — including crashes/hard-kills — with an `atexit` teardown
-  on clean shutdown too. No orphan left holding the bridge port.
-
-### Changed
-
-- **Connection UI reflects the orchestrator model.** The settings help text and
-  header no longer tell you to wire the MCP into your interactive session with
-  `--channels` (which would steal the bridge port from the orchestrator); they
-  now describe the autonomous background agent and the one-time
-  `npx -y comfyui-mcp --panel-orchestrator` fallback.
-
-## [0.3.0] - 2026-06-16
-
-The polished public release — now live on the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) and installable from ComfyUI-Manager.
-
-### Added
-
-- **Registry banner & SEO listing.** Added a 21:9 brand banner
-  (`assets/banner.png`) so the registry/social card uses a custom image
-  instead of the generic OG fallback, and rewrote the pack description to
-  lead with the terms people actually search (Claude Code, MCP / Model
-  Context Protocol, AI agent, live graph editing).
-
-- **Capability-aware empty state.** The onboarding hero now reflects the
-  agent's full surface — build/edit the live graph, generate images **and
-  audio** (`generate_audio`, ACE Step 1.5 / Stable Audio 3), run the workflow
-  and read its errors, and find models on Civitai — with clickable example
-  prompts that prefill the composer. Requires comfyui-mcp ≥ 0.13.
-- **Native ComfyUI design system.** The panel is restyled on the same
-  PrimeVue semantic tokens (`--p-content-background`, `--p-form-field-*`,
-  `--p-primary-color`, border radii, Inter) the built-in sidebar panels use —
-  it tracks your ComfyUI theme automatically. Header with live status dot,
-  empty-state onboarding, animated message bubbles, auto-growing composer.
-- **Activity cards.** Every graph edit the agent makes renders as a human-
-  readable card in the chat feed — "➕ Added KSampler (id 26)",
-  "🔗 Connected 4.MODEL → 26.model", "🎚 Set steps = 30 (was 20)" — so you
-  can watch Claude work.
-- **Multi-tab support.** Each ComfyUI browser tab holds its own bridge
-  connection, identified by a per-tab session id plus the open workflow's
-  title. The agent sees every tab (`panel_status`), routes edits per tab,
-  and knows which tab you typed in. Requires comfyui-mcp ≥ 0.12.
-- **Markdown-lite agent bubbles** — `code` and **bold** rendering, safely.
-- **"Claude is working…" indicator.** Sending a message shows an animated
-  typing indicator immediately; incoming graph edits keep it alive (and bump
-  it below the newest activity card), the agent's reply retires it, and a
-  45-second quiet period swaps it for a hint explaining that the agent reads
-  panel messages by polling its inbox. (Claude Code doesn't stream its
-  internal reasoning to MCP servers — narration + activity cards + this
-  indicator are the feedback surface.)
-- **`graph_clear` command** — wipes every node in a single
-  `beforeChange`/`afterChange` pair, so one Ctrl+Z restores the whole graph.
-  Exposed as the `panel_clear` MCP tool (comfyui-mcp ≥ 0.12).
-- **Full programmatic graph & app control.** New executor commands (each
-  with a matching `panel_*` MCP tool): `graph_move_node`, `graph_canvas`
-  (fit / center-on-node / pan / zoom), `graph_run` (queue the open workflow,
-  surfacing frontend validation errors), `graph_get_errors` (last
-  `execution_error` event + `lastNodeErrors`), `workflow_save` (Ctrl+S
-  path) and `workflow_save_as` (duplicate to `workflows/<name>.json`).
-- **Subgraph-aware reads.** Executors target the graph you're *viewing*
-  (root or an opened subgraph); `graph_get_state` reports `viewing`, marks
-  subgraph nodes `is_subgraph` with an inner node count (boundary slots +
-  widgets only), and `graph_get_subgraph` drills inside on demand.
-- **Zed-style composer.** Rounded composer card with a context-window ring
-  (radial fill — wired to `agent_status` frames; data source pending host
-  support), model chip, attach button (uploads straight into ComfyUI's
-  `input/` folder and inserts an `@input:` mention), and voice dictation
-  via the browser's speech recognition.
-- **Slash commands & @ mentions.** `/new`, `/fit`, `/run`, `/errors`,
-  `/help` run locally with arrow-key + Enter completion; `@` autocompletes
-  the current workflow, graph nodes, subgraphs, and registered node types.
-  Outgoing messages stamp the workflow + opened subgraph so the agent has
-  the context without asking.
-- **Chat threads.** New-chat and history buttons in the header; threads
-  persist to localStorage (last 20) and replay verbatim, activity cards
-  included.
-
-## [0.2.0] - 2026-06-12
-
-### Changed
-
-- **BREAKING: MCP-driven, no API keys.** Dropped the AI-SDK `/api/chat`
-  backend entirely. The panel is now a WebSocket client of
-  [comfyui-mcp](https://github.com/artokun/comfyui-mcp)'s `--channels`
-  bridge (`ws://127.0.0.1:9101`): **your own Claude Code session is the
-  agent**, subscription-billed, zero LLM API keys anywhere in the path.
-  Settings reduced to one field (bridge URL); SSE parser and bearer token
-  removed.
-
-### Fixed
-
-- `import { app } from "/scripts/app.js"` — `window.app` is no longer
-  assigned at extension-eval time on ComfyUI frontend 1.4x, so the v1
-  global-read pattern silently failed and the sidebar tab never registered.
 
 ## [0.1.0] - 2026-06-12
 

--- a/browser_tests/unit/changelog-integrity.test.mjs
+++ b/browser_tests/unit/changelog-integrity.test.mjs
@@ -20,61 +20,59 @@ const MD = readFileSync(fileURLToPath(new URL("../../CHANGELOG.md", import.meta.
   .replace(/\r\n/g, "\n");
 
 /** Every `## [x.y.z] - date` heading, in file order. */
-function versionHeadings() {
-  return [...MD.matchAll(/^## \[(\d+\.\d+\.\d+)\](?:\s*-\s*(\S+))?/gm)].map((m) => ({
+function versionHeadings(markdown = MD) {
+  return [...markdown.matchAll(/^## \[(\d+\.\d+\.\d+)\](?:\s*-\s*(\S+))?/gm)].map((m) => ({
     version: m[1],
     date: m[2] ?? null,
-    line: MD.slice(0, m.index).split("\n").length,
+    line: markdown.slice(0, m.index).split("\n").length,
   }));
 }
 
-/**
- * Versions that legitimately appear twice, and are NOT the bug this file exists to catch.
- *
- * These four are version-number COLLISIONS, not duplications: each pair holds genuinely
- * DIFFERENT release notes. `0.4.1 - 2026-06-26` announces `graph_set_node_mode`; the second
- * `0.4.1 - 2026-06-17` announces the Connect button that replaced auto-spawn after the
- * Registry's scanner flagged 0.4.0. Two real releases reused one number, early in the
- * project's life.
- *
- * They are deliberately NOT merged. Merging would assert that one release shipped both sets
- * of changes, which is false — the same fabrication #1203 had to undo when a repair invented
- * content. Renumbering would rewrite published history. So they are recorded as fact here,
- * and the assertion below still fails on any NEW duplicate.
- *
- * The list is asserted to be EXHAUSTIVE against the file, so it cannot quietly rot into a
- * blanket exemption: an entry that stops colliding must be removed from it.
- */
-const KNOWN_VERSION_COLLISIONS = ["0.4.1", "0.4.0", "0.3.0", "0.2.0"];
+function duplicateVersions(markdown) {
+  const seen = new Set();
+  const duplicates = [];
+  for (const heading of versionHeadings(markdown)) {
+    if (seen.has(heading.version)) duplicates.push(heading.version);
+    else seen.add(heading.version);
+  }
+  return duplicates;
+}
 
 test("CHANGELOG: no version appears twice", () => {
   // The 0.14.31/32/33 regression. Both headings for a version arrived in the SAME release
   // commit, so the generator's "already has a [x.y.z] section — nothing to do" guard never
   // fired: it defends against a second INVOCATION, not against one run emitting two sections.
-  const seen = new Map();
-  const dupes = [];
-  for (const h of versionHeadings()) {
-    if (seen.has(h.version)) {
-      dupes.push({
-        version: h.version,
-        where: `lines ${seen.get(h.version).line} and ${h.line} ` +
-          `(dates ${seen.get(h.version).date} / ${h.date})`,
-      });
-    } else {
-      seen.set(h.version, h);
-    }
-  }
-  const unexpected = dupes.filter((d) => !KNOWN_VERSION_COLLISIONS.includes(d.version));
+  const dupes = duplicateVersions(MD);
   assert.deepEqual(
-    unexpected.map((d) => `${d.version} at ${d.where}`),
+    dupes,
     [],
     "duplicate version sections — one release must not write two",
   );
-  // The exemption list may not outlive what it exempts. Without this, a future repair that
-  // fixes a collision leaves a permanent hole the next regression can hide in.
-  const stillColliding = dupes.map((d) => d.version);
-  const stale = KNOWN_VERSION_COLLISIONS.filter((v) => !stillColliding.includes(v));
-  assert.deepEqual(stale, [], `KNOWN_VERSION_COLLISIONS lists versions that no longer collide: ${stale.join(", ")}`);
+});
+
+test("CHANGELOG: a newly introduced duplicate top-level section still fails", () => {
+  const fixture = `${MD.trimEnd()}\n\n## [0.15.107] - 2099-01-01\n\n### Fixed\n\n- duplicate fixture\n`;
+  assert.deepEqual(duplicateVersions(fixture), ["0.15.107"]);
+});
+
+test("CHANGELOG: merged legacy sections retain both note sets", () => {
+  const bodyFor = (version) => {
+    const heading = `## [${version}]`;
+    const start = MD.indexOf(heading);
+    const end = MD.indexOf("\n## ", start + heading.length);
+    return MD.slice(start, end === -1 ? MD.length : end);
+  };
+  const markers = [
+    ["0.4.1", "graph_set_node_mode", "Connect button replaces import-time auto-spawn"],
+    ["0.4.0", "Application Settings page", "Auto-start the panel orchestrator on load"],
+    ["0.3.0", "Provider switcher in the model selector", "Registry banner & SEO listing"],
+    ["0.2.0", "Rewind & rollback (#44)", "BREAKING: MCP-driven, no API keys"],
+  ];
+  for (const [version, newerNote, legacyNote] of markers) {
+    const body = bodyFor(version);
+    assert.ok(body.includes(newerNote), `${version} lost newer note: ${newerNote}`);
+    assert.ok(body.includes(legacyNote), `${version} lost legacy note: ${legacyNote}`);
+  }
 });
 
 test("CHANGELOG: no version section is empty", () => {
@@ -116,12 +114,5 @@ test("CHANGELOG: versions run newest-first, with no ordering breaks", () => {
   for (let i = 1; i < vs.length; i++) {
     if (cmp(vs[i - 1], vs[i]) < 0) breaks.push(`${vs[i - 1]} precedes ${vs[i]}`);
   }
-  // The ONE known break is where the second, older history block begins — the same block
-  // that holds the collisions above. Recorded rather than repaired for the same reason:
-  // reordering it would interleave two histories that were never one.
-  const KNOWN_BREAK = "0.1.3 precedes 0.4.1";
-  const unexpected = breaks.filter((b) => b !== KNOWN_BREAK);
-  assert.deepEqual(unexpected, [], `ordering breaks:\n  ${unexpected.join("\n  ")}`);
-  assert.ok(breaks.includes(KNOWN_BREAK), "the known ordering break is gone — remove KNOWN_BREAK");
-  assert.equal(breaks.length, 1, `expected exactly one known break, saw ${breaks.length}`);
+  assert.deepEqual(breaks, [], `ordering breaks:\n  ${breaks.join("\n  ")}`);
 });

--- a/browser_tests/unit/changelog-release-guard.test.mjs
+++ b/browser_tests/unit/changelog-release-guard.test.mjs
@@ -1,0 +1,99 @@
+// #1891 — exercise the actual release generator and the guard against a small
+// repository history, rather than testing a copy of either production path.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GENERATOR = join(HERE, "..", "..", "scripts", "gen-changelog.mjs");
+const GUARD = join(HERE, "..", "..", "scripts", "check-changelog.mjs");
+
+function git(cwd, ...args) {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+}
+
+function runGuard(cwd, ref = "v1.1.0") {
+  return spawnSync(process.execPath, [GUARD, "1.1.0", "--ref", ref], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, CHANGELOG_ROOT: cwd },
+  });
+}
+
+test("#1891: release generation merges headings and issue/PR aliases", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "panel-changelog-"));
+  try {
+    git(cwd, "init", "-b", "main");
+    git(cwd, "config", "user.email", "test@example.invalid");
+    git(cwd, "config", "user.name", "Changelog Test");
+    writeFileSync(cwd + "/CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n", "utf8");
+    git(cwd, "add", "CHANGELOG.md");
+    git(cwd, "commit", "-m", "0.1.0 — initial release");
+    git(cwd, "tag", "v1.0.0");
+
+    git(cwd, "commit", "--allow-empty", "-m", "fix(100): one change, issue spelling (#101)");
+    git(cwd, "commit", "--allow-empty", "-m", "fix: an independent fix (#102)");
+    writeFileSync(
+      cwd + "/CHANGELOG.md",
+      [
+        "# Changelog",
+        "",
+        "## [Unreleased]",
+        "",
+        "### Fixed",
+        "- hand-written issue spelling (#100)",
+        "",
+        "### Fixed",
+        "- hand-written PR spelling (#101)",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    execFileSync(process.execPath, [GENERATOR, "1.1.0"], {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, CHANGELOG_ROOT: cwd },
+    });
+    const generated = readFileSync(cwd + "/CHANGELOG.md", "utf8");
+    assert.equal((generated.match(/^### Fixed$/gm) ?? []).length, 1);
+    assert.equal((generated.match(/#100/g) ?? []).length, 1);
+    assert.equal((generated.match(/#101/g) ?? []).length, 0);
+    assert.equal((generated.match(/#102/g) ?? []).length, 1);
+
+    git(cwd, "add", "CHANGELOG.md");
+    git(cwd, "commit", "-m", "1.1.0 — release");
+    git(cwd, "tag", "v1.1.0");
+    const healthy = runGuard(cwd);
+    assert.equal(healthy.status, 0, healthy.stderr);
+
+    const olderTree = runGuard(cwd, "v1.0.0");
+    assert.notEqual(olderTree.status, 0);
+    assert.match(olderTree.stderr, /no merge candidate is an ancestor/);
+
+    writeFileSync(
+      cwd + "/CHANGELOG.md",
+      generated.replace("- an independent fix (#102)", "- duplicate alias (#101)\n- an independent fix (#102)"),
+      "utf8",
+    );
+    const duplicateAlias = runGuard(cwd);
+    assert.notEqual(duplicateAlias.status, 0);
+    assert.match(duplicateAlias.stderr, /repeats issue\/PR identity/);
+
+    writeFileSync(cwd + "/CHANGELOG.md", generated.replace("### Fixed\n", "### Fixed\n\n### Fixed\n"), "utf8");
+    const duplicateHeading = runGuard(cwd);
+    assert.notEqual(duplicateHeading.status, 0);
+    assert.match(duplicateHeading.stderr, /repeats heading/);
+
+    writeFileSync(cwd + "/CHANGELOG.md", generated.replace("#102", "#999"), "utf8");
+    const unreachableEntry = runGuard(cwd);
+    assert.notEqual(unreachableEntry.status, 0);
+    assert.match(unreachableEntry.stderr, /no reachable commit subject/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/browser_tests/unit/changelog-release-guard.test.mjs
+++ b/browser_tests/unit/changelog-release-guard.test.mjs
@@ -3,7 +3,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -46,6 +46,7 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
         "",
         "### Fixed",
         "- initial fix (#90)",
+        "- second fix (#91)",
         "",
       ].join("\n"),
       "utf8",
@@ -53,7 +54,13 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     git(cwd, "add", "CHANGELOG.md");
     git(cwd, "commit", "-m", "0.1.0 — initial release");
     git(cwd, "commit", "--allow-empty", "-m", "fix: initial fix (#90)");
+    git(cwd, "commit", "--allow-empty", "-m", "fix: second fix (#91)");
     git(cwd, "tag", "v1.0.0");
+
+    // A future branch must not feed alias discovery for an older audited tag.
+    git(cwd, "checkout", "-b", "future");
+    git(cwd, "commit", "--allow-empty", "-m", "fix(90): unrelated future alias (#91)");
+    git(cwd, "checkout", "main");
 
     git(cwd, "commit", "--allow-empty", "-m", "fix(100): one change, issue spelling (#101)");
     git(cwd, "commit", "--allow-empty", "-m", "fix: an independent fix (#102)");
@@ -99,6 +106,14 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     const inferredHistoricalTag = runGuard(cwd, null, "v1.0.0");
     assert.equal(inferredHistoricalTag.status, 0, inferredHistoricalTag.stderr);
 
+    for (const malformed of ["1.1", "1.1.0; touch pwned", "1.1.0\ninjected"]) {
+      const result = runGuard(cwd, malformed, "v1.0.0");
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /invalid release version/);
+      assert.doesNotMatch(result.stderr, /has no \[/);
+    }
+    assert.equal(existsSync(join(cwd, "pwned")), false);
+
     // Passing a version explicitly makes a missing current-version section fatal;
     // inference from another section must not let a publish proceed.
     const missingVersion = runGuard(cwd, "1.1.0", "v1.0.0");
@@ -139,10 +154,19 @@ test("#1891: publish guard receives pyproject version before checking changelog"
   const workflow = readFileSync(PUBLISH_WORKFLOW, "utf8");
   const versionStep = workflow.indexOf("id: release-version");
   const guardStep = workflow.indexOf('node scripts/check-changelog.mjs "$RELEASE_VERSION" --ref "$RELEASE_REF"');
+  const versionValidation = workflow.indexOf("semver.fullmatch(version) is None");
+  const outputWrite = workflow.indexOf('Path(output).open("a", encoding="utf-8", newline="")');
   assert.notEqual(versionStep, -1);
   assert.notEqual(guardStep, -1);
+  assert.notEqual(versionValidation, -1);
+  assert.notEqual(outputWrite, -1);
   assert.ok(versionStep < guardStep);
+  assert.ok(versionValidation < outputWrite);
   assert.ok(guardStep < workflow.indexOf("- name: Publish custom node"));
-  assert.match(workflow, /tomllib\.load\(Path\("pyproject\.toml"\)\.open\("rb"\)\)/);
+  assert.match(workflow, /shell: python/);
+  assert.match(workflow, /re\.compile\(/);
   assert.match(workflow, /RELEASE_VERSION: \$\{\{ steps\.release-version\.outputs\.version \}\}/);
+  assert.match(workflow, /version="\$RELEASE_VERSION"/);
+  assert.doesNotMatch(workflow, /version="\$\{\{ steps\.release-version\.outputs\.version \}\}"/);
+  assert.doesNotMatch(workflow, /echo "version=\$version"/);
 });

--- a/browser_tests/unit/changelog-release-guard.test.mjs
+++ b/browser_tests/unit/changelog-release-guard.test.mjs
@@ -17,10 +17,11 @@ function git(cwd, ...args) {
   return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
 }
 
-function runGuard(cwd, version = "1.1.0", ref = "v1.1.0") {
+function runGuard(cwd, version = "1.1.0", ref = "v1.1.0", extraArgs = []) {
   const args = [GUARD];
   if (version) args.push(version);
   if (ref) args.push("--ref", ref);
+  args.push(...extraArgs);
   return spawnSync(process.execPath, args, {
     cwd,
     encoding: "utf8",
@@ -107,7 +108,7 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     writeFileSync(cwd + "/CHANGELOG.md", generated, "utf8");
     const candidate = generated.replace("[1.1.0]", "[1.2.0]");
     writeFileSync(cwd + "/CHANGELOG.md", candidate, "utf8");
-    const workingTree = runGuard(cwd, "1.2.0", null);
+    const workingTree = runGuard(cwd, "1.2.0", null, ["--working-tree"]);
     assert.equal(workingTree.status, 0, workingTree.stderr);
     writeFileSync(cwd + "/CHANGELOG.md", generated, "utf8");
 
@@ -116,17 +117,17 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
       generated.replace("- an independent fix (#102)", "- duplicate alias (#101)\n- an independent fix (#102)"),
       "utf8",
     );
-    const duplicateAlias = runGuard(cwd, "1.1.0", null);
+    const duplicateAlias = runGuard(cwd, "1.1.0", null, ["--working-tree"]);
     assert.notEqual(duplicateAlias.status, 0);
     assert.match(duplicateAlias.stderr, /repeats issue\/PR identity/);
 
     writeFileSync(cwd + "/CHANGELOG.md", generated.replace("### Fixed\n", "### Fixed\n\n### Fixed\n"), "utf8");
-    const duplicateHeading = runGuard(cwd, "1.1.0", null);
+    const duplicateHeading = runGuard(cwd, "1.1.0", null, ["--working-tree"]);
     assert.notEqual(duplicateHeading.status, 0);
     assert.match(duplicateHeading.stderr, /repeats heading/);
 
     writeFileSync(cwd + "/CHANGELOG.md", generated.replace("#102", "#999"), "utf8");
-    const unreachableEntry = runGuard(cwd, "1.1.0", null);
+    const unreachableEntry = runGuard(cwd, "1.1.0", null, ["--working-tree"]);
     assert.notEqual(unreachableEntry.status, 0);
     assert.match(unreachableEntry.stderr, /no reachable commit subject/);
   } finally {

--- a/browser_tests/unit/changelog-release-guard.test.mjs
+++ b/browser_tests/unit/changelog-release-guard.test.mjs
@@ -11,13 +11,17 @@ import { dirname, join } from "node:path";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const GENERATOR = join(HERE, "..", "..", "scripts", "gen-changelog.mjs");
 const GUARD = join(HERE, "..", "..", "scripts", "check-changelog.mjs");
+const PUBLISH_WORKFLOW = join(HERE, "..", "..", ".github", "workflows", "publish_action.yml");
 
 function git(cwd, ...args) {
   return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
 }
 
-function runGuard(cwd, ref = "v1.1.0") {
-  return spawnSync(process.execPath, [GUARD, "1.1.0", "--ref", ref], {
+function runGuard(cwd, version = "1.1.0", ref = "v1.1.0") {
+  const args = [GUARD];
+  if (version) args.push(version);
+  if (ref) args.push("--ref", ref);
+  return spawnSync(process.execPath, args, {
     cwd,
     encoding: "utf8",
     env: { ...process.env, CHANGELOG_ROOT: cwd },
@@ -30,9 +34,24 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     git(cwd, "init", "-b", "main");
     git(cwd, "config", "user.email", "test@example.invalid");
     git(cwd, "config", "user.name", "Changelog Test");
-    writeFileSync(cwd + "/CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n", "utf8");
+    writeFileSync(
+      cwd + "/CHANGELOG.md",
+      [
+        "# Changelog",
+        "",
+        "## [Unreleased]",
+        "",
+        "## [1.0.0] - 2026-08-26",
+        "",
+        "### Fixed",
+        "- initial fix (#90)",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
     git(cwd, "add", "CHANGELOG.md");
     git(cwd, "commit", "-m", "0.1.0 — initial release");
+    git(cwd, "commit", "--allow-empty", "-m", "fix: initial fix (#90)");
     git(cwd, "tag", "v1.0.0");
 
     git(cwd, "commit", "--allow-empty", "-m", "fix(100): one change, issue spelling (#101)");
@@ -71,29 +90,58 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     const healthy = runGuard(cwd);
     assert.equal(healthy.status, 0, healthy.stderr);
 
-    const olderTree = runGuard(cwd, "v1.0.0");
-    assert.notEqual(olderTree.status, 0);
-    assert.match(olderTree.stderr, /no merge candidate is an ancestor/);
+    // Explicit refs must supply the audited file too. Remove the checkout's
+    // current file, then audit the intact historical tag; the tag's blob must win.
+    rmSync(cwd + "/CHANGELOG.md");
+    const historicalTag = runGuard(cwd, "1.0.0", "v1.0.0");
+    assert.equal(historicalTag.status, 0, historicalTag.stderr);
+    const inferredHistoricalTag = runGuard(cwd, null, "v1.0.0");
+    assert.equal(inferredHistoricalTag.status, 0, inferredHistoricalTag.stderr);
+
+    // Passing a version explicitly makes a missing current-version section fatal;
+    // inference from another section must not let a publish proceed.
+    const missingVersion = runGuard(cwd, "1.1.0", "v1.0.0");
+    assert.notEqual(missingVersion.status, 0);
+    assert.match(missingVersion.stderr, /has no \[1\.1\.0\] release section/);
+
+    writeFileSync(cwd + "/CHANGELOG.md", generated, "utf8");
+    const candidate = generated.replace("[1.1.0]", "[1.2.0]");
+    writeFileSync(cwd + "/CHANGELOG.md", candidate, "utf8");
+    const workingTree = runGuard(cwd, "1.2.0", null);
+    assert.equal(workingTree.status, 0, workingTree.stderr);
+    writeFileSync(cwd + "/CHANGELOG.md", generated, "utf8");
 
     writeFileSync(
       cwd + "/CHANGELOG.md",
       generated.replace("- an independent fix (#102)", "- duplicate alias (#101)\n- an independent fix (#102)"),
       "utf8",
     );
-    const duplicateAlias = runGuard(cwd);
+    const duplicateAlias = runGuard(cwd, "1.1.0", null);
     assert.notEqual(duplicateAlias.status, 0);
     assert.match(duplicateAlias.stderr, /repeats issue\/PR identity/);
 
     writeFileSync(cwd + "/CHANGELOG.md", generated.replace("### Fixed\n", "### Fixed\n\n### Fixed\n"), "utf8");
-    const duplicateHeading = runGuard(cwd);
+    const duplicateHeading = runGuard(cwd, "1.1.0", null);
     assert.notEqual(duplicateHeading.status, 0);
     assert.match(duplicateHeading.stderr, /repeats heading/);
 
     writeFileSync(cwd + "/CHANGELOG.md", generated.replace("#102", "#999"), "utf8");
-    const unreachableEntry = runGuard(cwd);
+    const unreachableEntry = runGuard(cwd, "1.1.0", null);
     assert.notEqual(unreachableEntry.status, 0);
     assert.match(unreachableEntry.stderr, /no reachable commit subject/);
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }
+});
+
+test("#1891: publish guard receives pyproject version before checking changelog", () => {
+  const workflow = readFileSync(PUBLISH_WORKFLOW, "utf8");
+  const versionStep = workflow.indexOf("id: release-version");
+  const guardStep = workflow.indexOf('node scripts/check-changelog.mjs "$RELEASE_VERSION" --ref "$RELEASE_REF"');
+  assert.notEqual(versionStep, -1);
+  assert.notEqual(guardStep, -1);
+  assert.ok(versionStep < guardStep);
+  assert.ok(guardStep < workflow.indexOf("- name: Publish custom node"));
+  assert.match(workflow, /tomllib\.load\(Path\("pyproject\.toml"\)\.open\("rb"\)\)/);
+  assert.match(workflow, /RELEASE_VERSION: \$\{\{ steps\.release-version\.outputs\.version \}\}/);
 });

--- a/browser_tests/unit/changelog-release-guard.test.mjs
+++ b/browser_tests/unit/changelog-release-guard.test.mjs
@@ -57,13 +57,16 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     git(cwd, "commit", "--allow-empty", "-m", "fix: second fix (#91)");
     git(cwd, "tag", "v1.0.0");
 
-    // A future branch must not feed alias discovery for an older audited tag.
+    // A future branch must not feed alias discovery for the current release either. Its
+    // #200/#103 spelling is intentionally related to a current PR so an unscoped `git
+    // log --all` would incorrectly deduplicate the current change.
     git(cwd, "checkout", "-b", "future");
-    git(cwd, "commit", "--allow-empty", "-m", "fix(90): unrelated future alias (#91)");
+    git(cwd, "commit", "--allow-empty", "-m", "fix(200): unrelated future alias (#103)");
     git(cwd, "checkout", "main");
 
     git(cwd, "commit", "--allow-empty", "-m", "fix(100): one change, issue spelling (#101)");
-    git(cwd, "commit", "--allow-empty", "-m", "fix: an independent fix (#102)");
+    git(cwd, "commit", "--allow-empty", "-m", "fix: a supporting fix (#102)");
+    git(cwd, "commit", "--allow-empty", "-m", "fix: an independent fix (#103)");
     writeFileSync(
       cwd + "/CHANGELOG.md",
       [
@@ -76,6 +79,7 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
         "",
         "### Fixed",
         "- hand-written PR spelling (#101)",
+        "- hand-written future issue (#200) (#102)",
         "",
       ].join("\n"),
       "utf8",
@@ -91,6 +95,8 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     assert.equal((generated.match(/#100/g) ?? []).length, 1);
     assert.equal((generated.match(/#101/g) ?? []).length, 0);
     assert.equal((generated.match(/#102/g) ?? []).length, 1);
+    assert.equal((generated.match(/#103/g) ?? []).length, 1);
+    assert.equal((generated.match(/#200/g) ?? []).length, 1);
 
     git(cwd, "add", "CHANGELOG.md");
     git(cwd, "commit", "-m", "1.1.0 — release");
@@ -106,7 +112,7 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     const inferredHistoricalTag = runGuard(cwd, null, "v1.0.0");
     assert.equal(inferredHistoricalTag.status, 0, inferredHistoricalTag.stderr);
 
-    for (const malformed of ["1.1", "1.1.0; touch pwned", "1.1.0\ninjected"]) {
+    for (const malformed of ["1.1", "1.1.0; touch pwned", "1.1.0\ninjected", "--bad-version"]) {
       const result = runGuard(cwd, malformed, "v1.0.0");
       assert.notEqual(result.status, 0);
       assert.match(result.stderr, /invalid release version/);
@@ -129,7 +135,7 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
 
     writeFileSync(
       cwd + "/CHANGELOG.md",
-      generated.replace("- an independent fix (#102)", "- duplicate alias (#101)\n- an independent fix (#102)"),
+      generated.replace("- an independent fix (#103)", "- duplicate alias (#101)\n- an independent fix (#103)"),
       "utf8",
     );
     const duplicateAlias = runGuard(cwd, "1.1.0", null, ["--working-tree"]);
@@ -140,6 +146,26 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
     const duplicateHeading = runGuard(cwd, "1.1.0", null, ["--working-tree"]);
     assert.notEqual(duplicateHeading.status, 0);
     assert.match(duplicateHeading.stderr, /repeats heading/);
+
+    const releaseIndex = generated.indexOf("## [1.1.0]");
+    const releaseBlock = generated.slice(releaseIndex).trimEnd();
+    writeFileSync(
+      cwd + "/CHANGELOG.md",
+      `${generated.slice(0, releaseIndex)}${releaseBlock}\n\n${releaseBlock}\n`,
+      "utf8",
+    );
+    const duplicateRelease = runGuard(cwd, "1.1.0", null, ["--working-tree"]);
+    assert.notEqual(duplicateRelease.status, 0);
+    assert.match(duplicateRelease.stderr, /repeats \[1\.1\.0\] release section/);
+
+    writeFileSync(
+      cwd + "/CHANGELOG.md",
+      ["# Changelog", "", "## [Unreleased]", "", "## [1.1.0] - 2026-08-26", ""].join("\n"),
+      "utf8",
+    );
+    const emptyRelease = runGuard(cwd, "1.1.0", null, ["--working-tree"]);
+    assert.notEqual(emptyRelease.status, 0);
+    assert.match(emptyRelease.stderr, /\[1\.1\.0\] release section is empty/);
 
     writeFileSync(cwd + "/CHANGELOG.md", generated.replace("#102", "#999"), "utf8");
     const unreachableEntry = runGuard(cwd, "1.1.0", null, ["--working-tree"]);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test:unit": "node scripts/i18n-check.mjs && node scripts/i18n-render-check.mjs && node scripts/check-tool-vocabulary.mjs && node scripts/check-panel-scope.mjs && node --test browser_tests/unit/*.test.mjs",
     "check:scope": "node scripts/check-panel-scope.mjs",
+    "check:changelog": "node scripts/check-changelog.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:list": "playwright test --list",

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Check the release section that is about to ship.
+ *
+ *   node scripts/check-changelog.mjs [version] [--ref v0.15.108]
+ *
+ * The release generator is deliberately allowed to start from hand-written
+ * notes, but the resulting section has one mechanical source of truth: the
+ * tree that the release ref can actually reach. This guard catches malformed
+ * sections before they become the pack's user-visible changelog.
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { canonicalReference, commitReferences, referenceAliases, referenceNumbers } from "./lib/changelog-refs.mjs";
+
+const SCRIPT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const ROOT = resolve(process.env.CHANGELOG_ROOT || SCRIPT_ROOT);
+const CHANGELOG = join(ROOT, "CHANGELOG.md");
+
+const args = process.argv.slice(2);
+const refIndex = args.indexOf("--ref");
+const explicitRef = refIndex >= 0 ? args[refIndex + 1] : null;
+const versionArg = args.find((arg) => /^v?\d+\.\d+\.\d+(?:[-+].+)?$/.test(arg));
+
+const git = (...gitArgs) =>
+  execFileSync("git", ["-C", ROOT, ...gitArgs], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+
+export function parseReleaseSections(markdown) {
+  const lines = String(markdown ?? "").replace(/\r\n/g, "\n").split("\n");
+  const releases = [];
+  let current = null;
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = /^##\s+\[([^\]]+)\](?:\s*-\s*(\S+))?/.exec(lines[index]);
+    if (match) {
+      if (current) current.lines = lines.slice(current.start + 1, index);
+      current = {
+        version: match[1].trim(),
+        date: match[2] ?? null,
+        start: index,
+        lines: [],
+      };
+      releases.push(current);
+    }
+  }
+  if (current) current.lines = lines.slice(current.start + 1);
+  return releases;
+}
+
+export function parseReleaseBody(lines) {
+  const headings = [];
+  const entries = [];
+  let section = null;
+  let entry = null;
+
+  const flush = () => {
+    if (entry) {
+      entries.push({ ...entry, text: entry.lines.join("\n").trim() });
+      entry = null;
+    }
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const heading = /^(#{3,6})\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      flush();
+      section = {
+        level: heading[1].length,
+        text: heading[2],
+        line: index + 1,
+      };
+      headings.push(section);
+      continue;
+    }
+    const bullet = /^[-*]\s+/.test(line);
+    if (bullet) {
+      flush();
+      entry = {
+        section,
+        line: index + 1,
+        lines: [line.replace(/^[-*]\s+/, "")],
+      };
+      continue;
+    }
+    if (entry && (line.trim() === "" || /^\s+\S/.test(line))) {
+      entry.lines.push(line.trim());
+    } else if (entry) {
+      flush();
+    }
+  }
+  flush();
+  return { headings, entries };
+}
+
+export function parseCommitSubjects(output) {
+  return String(output ?? "")
+    .split("\x1e")
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const separator = record.indexOf("\x1f");
+      const sha = separator >= 0 ? record.slice(0, separator) : "";
+      const subject = separator >= 0 ? record.slice(separator + 1) : record;
+      return { sha, subject, refs: commitReferences(subject) };
+    });
+}
+
+function releaseVersion(version) {
+  return String(version ?? "").replace(/^v/, "");
+}
+
+function targetRefFor(version, requestedRef) {
+  if (requestedRef) return requestedRef;
+  const tag = `v${releaseVersion(version)}`;
+  try {
+    git("rev-parse", "--verify", `${tag}^{commit}`);
+    return tag;
+  } catch {
+    // set-version runs before the new tag exists; HEAD is the candidate tree.
+    return "HEAD";
+  }
+}
+
+function allCommits() {
+  return parseCommitSubjects(git("log", "--all", "--format=%H%x1f%s%x1e"));
+}
+
+export function auditReleaseSection({ markdown, version, commits, targetRef, isAncestor }) {
+  const normalizedVersion = releaseVersion(version);
+  const section = parseReleaseSections(markdown).find((item) => item.version === normalizedVersion);
+  if (!section) return [`CHANGELOG.md has no [${normalizedVersion}] release section.`];
+
+  const { headings, entries } = parseReleaseBody(section.lines);
+  const violations = [];
+
+  const seenHeadings = new Map();
+  for (const heading of headings) {
+    const key = `${heading.level}:${heading.text.toLowerCase()}`;
+    if (seenHeadings.has(key)) {
+      violations.push(
+        `[${normalizedVersion}] repeats heading "${heading.text}" at lines ` +
+          `${seenHeadings.get(key)} and ${section.start + heading.line}. Merge the sections.`,
+      );
+    } else {
+      seenHeadings.set(key, section.start + heading.line);
+    }
+  }
+
+  const aliases = referenceAliases(commits);
+  const seenReferences = new Map();
+  for (const item of entries) {
+    const refs = referenceNumbers(item.text);
+    const keys = [...new Set(refs.map((ref) => canonicalReference(ref, aliases)))];
+    for (const key of keys) {
+      if (seenReferences.has(key)) {
+        violations.push(
+          `[${normalizedVersion}] repeats issue/PR identity #${key} at lines ` +
+            `${seenReferences.get(key)} and ${section.start + item.line}.`,
+        );
+      } else {
+        seenReferences.set(key, section.start + item.line);
+      }
+    }
+  }
+
+  const byRef = new Map();
+  for (const commit of commits) {
+    for (const ref of commit.refs) {
+      if (!byRef.has(ref)) byRef.set(ref, []);
+      byRef.get(ref).push(commit);
+    }
+  }
+  for (const item of entries) {
+    const refs = referenceNumbers(item.text);
+    if (!refs.length) continue; // Legacy prose without a PR cannot be ancestry-checked.
+    const pr = refs[refs.length - 1];
+    const candidates = byRef.get(pr) ?? [];
+    if (!candidates.length) {
+      violations.push(
+        `[${normalizedVersion}] entry at line ${section.start + item.line} names PR #${pr}, ` +
+          `but no reachable commit subject carries that PR reference.`,
+      );
+      continue;
+    }
+    const commit = candidates.find((candidate) => isAncestor(candidate.sha, targetRef));
+    if (!commit) {
+      violations.push(
+        `[${normalizedVersion}] entry at line ${section.start + item.line} names PR #${pr}, ` +
+          `but no merge candidate is an ancestor of ${targetRef}.`,
+      );
+    }
+  }
+  return violations;
+}
+
+export function checkChangelog({ markdown, version, commits, targetRef, isAncestor }) {
+  return auditReleaseSection({ markdown, version, commits, targetRef, isAncestor });
+}
+
+function main() {
+  const markdown = readFileSync(CHANGELOG, "utf8");
+  const version = releaseVersion(
+    versionArg || parseReleaseSections(markdown).find((section) => /^\d+\.\d+\.\d+(?:[-+].+)?$/.test(section.version))?.version,
+  );
+  if (!version) {
+    console.error("usage: node scripts/check-changelog.mjs [version] [--ref <git-ref>]");
+    process.exit(2);
+  }
+  const targetRef = targetRefFor(version, explicitRef);
+  let commits;
+  try {
+    git("rev-parse", "--verify", `${targetRef}^{commit}`);
+    commits = allCommits();
+  } catch (error) {
+    console.error(`changelog: could not read ${targetRef}: ${error.message.split("\n")[0]}`);
+    process.exit(1);
+  }
+  const violations = checkChangelog({
+    markdown,
+    version,
+    commits,
+    targetRef,
+    isAncestor: (sha, ref) => {
+      try {
+        git("merge-base", "--is-ancestor", sha, ref);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+  if (violations.length) {
+    for (const violation of violations) console.error(`changelog: ERROR — ${violation}`);
+    process.exit(1);
+  }
+  console.log(`changelog: [${version}] is structurally unique and reachable from ${targetRef}`);
+}
+
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (invokedDirectly) main();

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -24,7 +24,8 @@ const refIndex = args.indexOf("--ref");
 const explicitRef = refIndex >= 0 ? args[refIndex + 1] : null;
 const workingTree = args.includes("--working-tree");
 const versionArg = args.find(
-  (arg, index) => (refIndex < 0 || index !== refIndex + 1) && /^v?\d+\.\d+\.\d+(?:[-+].+)?$/.test(arg),
+  (arg, index) =>
+    (refIndex < 0 || index !== refIndex + 1) && arg !== "--working-tree" && !arg.startsWith("--"),
 );
 
 const git = (...gitArgs) =>
@@ -114,8 +115,17 @@ export function parseCommitSubjects(output) {
     });
 }
 
+const semverIdentifier = "(?:0|[1-9]\\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)";
+const strictSemver = new RegExp(
+  `^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-${semverIdentifier}(?:\\.${semverIdentifier})*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$`,
+);
+
 function releaseVersion(version) {
   return String(version ?? "").replace(/^v/, "");
+}
+
+function isStrictSemver(version) {
+  return strictSemver.test(releaseVersion(version));
 }
 
 function targetRefFor(version, requestedRef) {
@@ -130,8 +140,9 @@ function targetRefFor(version, requestedRef) {
   }
 }
 
-function allCommits() {
-  return parseCommitSubjects(git("log", "--all", "--format=%H%x1f%s%x1e"));
+function commitsAtRef(ref) {
+  const commit = git("rev-parse", "--verify", `${ref}^{commit}`);
+  return parseCommitSubjects(git("log", "--format=%H%x1f%s%x1e", commit));
 }
 
 function changelogAtRef(ref) {
@@ -213,6 +224,10 @@ export function checkChangelog({ markdown, version, commits, targetRef, isAncest
 function main() {
   let markdown;
   let targetRef = explicitRef;
+  if (refIndex >= 0 && !explicitRef) {
+    console.error("changelog: --ref requires a Git commit ref");
+    process.exit(2);
+  }
   if (explicitRef) {
     try {
       git("rev-parse", "--verify", `${explicitRef}^{commit}`);
@@ -229,9 +244,18 @@ function main() {
   } else {
     markdown = readFileSync(CHANGELOG, "utf8");
   }
-  const version = releaseVersion(
-    versionArg || parseReleaseSections(markdown).find((section) => /^\d+\.\d+\.\d+(?:[-+].+)?$/.test(section.version))?.version,
-  );
+  let version;
+  if (versionArg !== undefined) {
+    version = releaseVersion(versionArg);
+    if (!isStrictSemver(version)) {
+      console.error(`changelog: invalid release version "${versionArg}"; expected strict SemVer`);
+      process.exit(2);
+    }
+  } else {
+    version = releaseVersion(
+      parseReleaseSections(markdown).find((section) => isStrictSemver(section.version))?.version,
+    );
+  }
   if (!version) {
     console.error("usage: node scripts/check-changelog.mjs [version] [--ref <git-ref>] [--working-tree]");
     process.exit(2);
@@ -243,7 +267,7 @@ function main() {
     console.error(`changelog: could not read ${targetRef}: ${error.message.split("\n")[0]}`);
     process.exit(1);
   }
-  const commits = allCommits();
+  const commits = commitsAtRef(targetRef);
   const violations = checkChangelog({
     markdown,
     version,

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -2,7 +2,7 @@
 /**
  * Check the release section that is about to ship.
  *
- *   node scripts/check-changelog.mjs [version] [--ref v0.15.108]
+ *   node scripts/check-changelog.mjs [version] [--ref v0.15.108] [--working-tree]
  *
  * The release generator is deliberately allowed to start from hand-written
  * notes, but the resulting section has one mechanical source of truth: the
@@ -22,6 +22,7 @@ const CHANGELOG = join(ROOT, "CHANGELOG.md");
 const args = process.argv.slice(2);
 const refIndex = args.indexOf("--ref");
 const explicitRef = refIndex >= 0 ? args[refIndex + 1] : null;
+const workingTree = args.includes("--working-tree");
 const versionArg = args.find(
   (arg, index) => (refIndex < 0 || index !== refIndex + 1) && /^v?\d+\.\d+\.\d+(?:[-+].+)?$/.test(arg),
 );
@@ -232,10 +233,10 @@ function main() {
     versionArg || parseReleaseSections(markdown).find((section) => /^\d+\.\d+\.\d+(?:[-+].+)?$/.test(section.version))?.version,
   );
   if (!version) {
-    console.error("usage: node scripts/check-changelog.mjs [version] [--ref <git-ref>]");
+    console.error("usage: node scripts/check-changelog.mjs [version] [--ref <git-ref>] [--working-tree]");
     process.exit(2);
   }
-  targetRef ||= targetRefFor(version, null);
+  targetRef ||= workingTree ? "HEAD" : targetRefFor(version, null);
   try {
     git("rev-parse", "--verify", `${targetRef}^{commit}`);
   } catch (error) {

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -21,12 +21,16 @@ const CHANGELOG = join(ROOT, "CHANGELOG.md");
 
 const args = process.argv.slice(2);
 const refIndex = args.indexOf("--ref");
-const explicitRef = refIndex >= 0 ? args[refIndex + 1] : null;
+const refValueIndex = refIndex >= 0 ? refIndex + 1 : -1;
+const explicitRef = refIndex >= 0 ? args[refValueIndex] : null;
 const workingTree = args.includes("--working-tree");
-const versionArg = args.find(
-  (arg, index) =>
-    (refIndex < 0 || index !== refIndex + 1) && arg !== "--working-tree" && !arg.startsWith("--"),
+// Remove only the two supported control flags before selecting the optional version. Keep
+// option-shaped values in the candidate list so `--bad-version` is rejected as an invalid
+// version instead of being ignored and causing a different changelog section to be inferred.
+const versionArgs = args.filter(
+  (arg, index) => index !== refIndex && index !== refValueIndex && arg !== "--working-tree",
 );
+const versionArg = versionArgs.length === 1 ? versionArgs[0] : undefined;
 
 const git = (...gitArgs) =>
   execFileSync("git", ["-C", ROOT, ...gitArgs], {
@@ -151,11 +155,31 @@ function changelogAtRef(ref) {
 
 export function auditReleaseSection({ markdown, version, commits, targetRef, isAncestor }) {
   const normalizedVersion = releaseVersion(version);
-  const section = parseReleaseSections(markdown).find((item) => item.version === normalizedVersion);
-  if (!section) return [`CHANGELOG.md has no [${normalizedVersion}] release section.`];
+  const sections = parseReleaseSections(markdown);
+  const violations = [];
+  const seenReleaseSections = new Map();
+  for (const item of sections) {
+    const itemVersion = releaseVersion(item.version);
+    if (!isStrictSemver(itemVersion)) continue;
+    const line = item.start + 1;
+    if (seenReleaseSections.has(itemVersion)) {
+      violations.push(
+        `CHANGELOG.md repeats [${itemVersion}] release section at lines ` +
+          `${seenReleaseSections.get(itemVersion)} and ${line}. Keep one top-level section.`,
+      );
+    } else {
+      seenReleaseSections.set(itemVersion, line);
+    }
+    if (!item.lines.some((lineText) => lineText.trim())) {
+      violations.push(`CHANGELOG.md [${itemVersion}] release section is empty.`);
+    }
+  }
+
+  const section = sections.find((item) => releaseVersion(item.version) === normalizedVersion);
+  if (!section) return [...violations, `CHANGELOG.md has no [${normalizedVersion}] release section.`];
+  if (!section.lines.some((lineText) => lineText.trim())) return violations;
 
   const { headings, entries } = parseReleaseBody(section.lines);
-  const violations = [];
 
   const seenHeadings = new Map();
   for (const heading of headings) {
@@ -224,6 +248,10 @@ export function checkChangelog({ markdown, version, commits, targetRef, isAncest
 function main() {
   let markdown;
   let targetRef = explicitRef;
+  if (versionArgs.length > 1) {
+    console.error("changelog: expected at most one release version argument");
+    process.exit(2);
+  }
   if (refIndex >= 0 && !explicitRef) {
     console.error("changelog: --ref requires a Git commit ref");
     process.exit(2);

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -22,7 +22,9 @@ const CHANGELOG = join(ROOT, "CHANGELOG.md");
 const args = process.argv.slice(2);
 const refIndex = args.indexOf("--ref");
 const explicitRef = refIndex >= 0 ? args[refIndex + 1] : null;
-const versionArg = args.find((arg) => /^v?\d+\.\d+\.\d+(?:[-+].+)?$/.test(arg));
+const versionArg = args.find(
+  (arg, index) => (refIndex < 0 || index !== refIndex + 1) && /^v?\d+\.\d+\.\d+(?:[-+].+)?$/.test(arg),
+);
 
 const git = (...gitArgs) =>
   execFileSync("git", ["-C", ROOT, ...gitArgs], {
@@ -131,6 +133,10 @@ function allCommits() {
   return parseCommitSubjects(git("log", "--all", "--format=%H%x1f%s%x1e"));
 }
 
+function changelogAtRef(ref) {
+  return git("show", `${ref}:CHANGELOG.md`);
+}
+
 export function auditReleaseSection({ markdown, version, commits, targetRef, isAncestor }) {
   const normalizedVersion = releaseVersion(version);
   const section = parseReleaseSections(markdown).find((item) => item.version === normalizedVersion);
@@ -204,7 +210,24 @@ export function checkChangelog({ markdown, version, commits, targetRef, isAncest
 }
 
 function main() {
-  const markdown = readFileSync(CHANGELOG, "utf8");
+  let markdown;
+  let targetRef = explicitRef;
+  if (explicitRef) {
+    try {
+      git("rev-parse", "--verify", `${explicitRef}^{commit}`);
+    } catch (error) {
+      console.error(`changelog: could not read ${explicitRef}: ${error.message.split("\n")[0]}`);
+      process.exit(1);
+    }
+    try {
+      markdown = changelogAtRef(explicitRef);
+    } catch (error) {
+      console.error(`changelog: could not read CHANGELOG.md at ${explicitRef}: ${error.message.split("\n")[0]}`);
+      process.exit(1);
+    }
+  } else {
+    markdown = readFileSync(CHANGELOG, "utf8");
+  }
   const version = releaseVersion(
     versionArg || parseReleaseSections(markdown).find((section) => /^\d+\.\d+\.\d+(?:[-+].+)?$/.test(section.version))?.version,
   );
@@ -212,15 +235,14 @@ function main() {
     console.error("usage: node scripts/check-changelog.mjs [version] [--ref <git-ref>]");
     process.exit(2);
   }
-  const targetRef = targetRefFor(version, explicitRef);
-  let commits;
+  targetRef ||= targetRefFor(version, null);
   try {
     git("rev-parse", "--verify", `${targetRef}^{commit}`);
-    commits = allCommits();
   } catch (error) {
     console.error(`changelog: could not read ${targetRef}: ${error.message.split("\n")[0]}`);
     process.exit(1);
   }
+  const commits = allCommits();
   const violations = checkChangelog({
     markdown,
     version,

--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -4,10 +4,11 @@
 //   node scripts/gen-changelog.mjs <version>
 //
 // It stamps a dated section for <version> at the top of CHANGELOG.md by:
-//   1. Promoting whatever you hand-wrote under "## [Unreleased]" VERBATIM
-//      (your highlights — the rich prose we care about), then
+//   1. Promoting whatever you hand-wrote under "## [Unreleased]" (your
+//      highlights — the rich prose we care about), merging repeated headings
+//      and issue/PR aliases, then
 //   2. Appending anything in the git history since the last tag that your
-//      highlights didn't already mention (deduped by PR number), grouped into
+//      highlights didn't already mention (deduped by issue/PR identity), grouped into
 //      COMPONENT sections (MCP / RunPod image) and Keep-a-Changelog buckets
 //      (Added / Fixed / Changed) from the conventional-commit type.
 //   3. Resetting "## [Unreleased]" to an empty stub.
@@ -21,10 +22,18 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { isReleaseSubject, pickReleaseSha } from "./lib/changelog-match.mjs";
+import {
+  ambiguousReferences,
+  canonicalReference,
+  commitReferences,
+  coveredByReferences,
+  referenceAliases,
+  referenceNumbers,
+} from "./lib/changelog-refs.mjs";
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const ROOT = resolve(process.env.CHANGELOG_ROOT || join(dirname(fileURLToPath(import.meta.url)), ".."));
 const CHANGELOG = join(ROOT, "CHANGELOG.md");
 
 // ── Repo config ─────────────────────────────────────────────────────────────
@@ -195,21 +204,18 @@ function parseCommits(range) {
   for (const subject of raw.split("\n")) {
     if (isReleaseSubject(subject)) continue; // release commits describe themselves
     const m = subject.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
-    // The LAST `(#N)`, not the first: GitHub appends the PR reference at the end of a
-    // squash subject, so anything earlier is an ISSUE the author cited. Both shapes occur —
-    // `fix(#584): … (#596)` puts the issue in the scope, and
-    // `fix(panel): … (#291) (#633)` puts it inline — and taking the first match attributes
-    // the entry to the issue. That also breaks the dedupe against hand-written highlights,
-    // which is keyed on the PR number, so a hand-written entry would be duplicated by the
-    // auto-generated one instead of suppressed.
+    // GitHub appends the PR reference at the end of a squash subject, while an earlier
+    // reference is often the tracked issue: `fix(1882): ... (#1885)`. Keep both references so
+    // the release generator can treat them as one identity when reconciling hand-written notes.
+    const refs = commitReferences(subject);
     const prIn = (s) => {
-      const all = [...s.matchAll(/\(#(\d+)\)/g)];
-      return all.length ? all[all.length - 1][1] : null;
+      const all = referenceNumbers(s);
+      return all.length ? all[all.length - 1] : null;
     };
     if (!m) {
       const pr = prIn(subject);
       if (pr) {
-        out.push({ type: "", scope: "", desc: subject.trim(), section: "Changed", pr });
+        out.push({ type: "", scope: "", desc: subject.trim(), section: "Changed", pr, refs });
       } else {
         skipped.push(subject); // a local commit with no PR; a squash supersedes it
       }
@@ -224,7 +230,7 @@ function parseCommits(range) {
       skipped.push(subject);
       continue;
     }
-    out.push({ type, scope: scope || "", desc: desc.trim(), section, pr });
+    out.push({ type, scope: scope || "", desc: desc.trim(), section, pr, refs });
   }
   if (skipped.length) {
     process.stderr.write(
@@ -236,14 +242,23 @@ function parseCommits(range) {
   return out;
 }
 
+function allHistoryReferences() {
+  const raw = git("log --all --no-merges --pretty=format:%s");
+  return raw
+    ? raw.split("\n").map((subject) => ({ subject, refs: commitReferences(subject) }))
+    : [];
+}
+
 function componentOf(scope) {
   return (COMPONENTS.find((c) => c.match(scope)) || COMPONENTS[COMPONENTS.length - 1]).name;
 }
 
 /** Build the auto-generated component/section body for commits not already
- *  covered by the hand-written highlights (deduped by PR number). */
-function autoBody(commits, coveredPRs) {
-  const fresh = commits.filter((c) => !(c.pr && coveredPRs.has(c.pr)));
+ *  covered by the hand-written highlights (deduped by issue/PR identity). */
+function autoBody(commits, coveredRefs, identityCommits = commits) {
+  const aliases = referenceAliases(identityCommits);
+  const ambiguous = ambiguousReferences(identityCommits);
+  const fresh = commits.filter((c) => !coveredByReferences(c.refs, coveredRefs, aliases, ambiguous));
   if (fresh.length === 0) return "";
   // component -> section -> bullets[]
   const byComp = new Map();
@@ -269,6 +284,90 @@ function autoBody(commits, coveredPRs) {
     }
   }
   return lines.join("\n").trimEnd();
+}
+
+/**
+ * Reconcile the two inputs to a release body before writing it. In particular,
+ * append-generated `### Fixed` content belongs under the hand-written heading,
+ * not in a second heading beside it. The same identity map removes an issue
+ * spelling and its PR spelling as duplicate bullets.
+ */
+function normalizeBody(body, aliases) {
+  const blocks = [];
+  let current = { heading: null, lines: [] };
+  const flush = () => {
+    if (current.heading || current.lines.some((line) => line.trim())) blocks.push(current);
+    current = { heading: null, lines: [] };
+  };
+  for (const line of String(body ?? "").split("\n")) {
+    if (/^#{3,6}\s+/.test(line)) {
+      flush();
+      current = { heading: line.trimEnd(), lines: [] };
+    } else {
+      current.lines.push(line);
+    }
+  }
+  flush();
+
+  const merged = [];
+  const byHeading = new Map();
+  for (const block of blocks) {
+    if (!block.heading) {
+      merged.push(block);
+      continue;
+    }
+    const key = block.heading.toLowerCase();
+    const existing = byHeading.get(key);
+    if (!existing) {
+      byHeading.set(key, block);
+      merged.push(block);
+    } else {
+      while (existing.lines.at(-1) === "") existing.lines.pop();
+      const incoming = [...block.lines];
+      while (incoming[0] === "") incoming.shift();
+      if (existing.lines.length && incoming.length) existing.lines.push("");
+      existing.lines.push(...incoming);
+    }
+  }
+
+  const seen = new Set();
+  const dedupeBullets = (lines) => {
+    const out = [];
+    let item = null;
+    const flushItem = () => {
+      if (!item) return;
+      const refs = referenceNumbers(item.join("\n"));
+      const keys = refs.length
+        ? [...new Set(refs.map((ref) => canonicalReference(ref, aliases)))]
+        : [`text:${item.join(" ").replace(/\s+/g, " ").trim()}`];
+      if (!refs.length || !keys.some((key) => seen.has(key))) {
+        out.push(...item);
+        keys.forEach((key) => seen.add(key));
+      }
+      item = null;
+    };
+    for (const line of lines) {
+      if (/^[-*]\s+/.test(line)) {
+        flushItem();
+        item = [line];
+      } else if (item && (line.trim() === "" || /^\s+\S/.test(line))) {
+        item.push(line);
+      } else {
+        flushItem();
+        out.push(line);
+      }
+    }
+    flushItem();
+    return out;
+  };
+
+  return merged
+    .map((block) => ({ ...block, lines: dedupeBullets(block.lines) }))
+    .map((block) => [block.heading, ...block.lines].filter((line, index) => index === 0 || line !== undefined))
+    .flat()
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 /**
@@ -303,37 +402,19 @@ const EOL = rawMd.includes("\r\n") ? "\r\n" : "\n";
 const writeChangelog = (s) => writeFileSync(CHANGELOG, EOL === "\r\n" ? s.replace(/\n/g, "\r\n") : s);
 
 /** Build a dated entry string for `ver` from commits in `range`, folding in any
- *  hand-written highlights (deduped by PR). */
+ *  hand-written highlights (deduped by issue/PR identity). */
 function buildEntry(ver, range, highlights = "") {
-  // BARE `#N` ONLY, deliberately — this set is compared against PANEL PR numbers.
-  //
-  // A first attempt at #1219 widened this to `/\((?:[\w.-]+)?#(\d+)\)/g` so it would also see
-  // `(comfyui-mcp#1478)`, on the theory that upstream-first descriptions were failing to
-  // suppress their commits. That is wrong twice over. The two ids are different numbers in
-  // different namespaces — panel PR #1211 and mcp issue #1478 name the same change — so
-  // capturing the upstream number cannot match anything here. And it would be actively
-  // dangerous: an upstream issue number that happens to equal an unrelated panel PR number
-  // would suppress that PR's commit from the auto body, silently dropping shipped work.
-  //
-  // Cross-namespace dedupe is not solvable by number, and NOTHING here replaces it. An
-  // earlier version of this comment pointed at "the post-write assertion at the bottom of
-  // this file" — an assertion that was removed in the same change as unreachable, so the
-  // comment claimed a protection that did not exist.
-  //
-  // Stated accurately: a highlight citing `comfyui-mcp#1478` and a commit carrying panel PR
-  // `#1211` for the same change will BOTH be listed, as two bullets in one section.
-  // `changelog-integrity.test.mjs` catches duplicate version HEADINGS; it does not compare
-  // bullet text, so this particular redundancy is unguarded and is caught only by a human
-  // reading the release notes. That is a smaller problem than the duplicate sections this
-  // issue was about — a reader sees one release saying a thing twice, not two releases — and
-  // fixing it needs an identifier map the repo does not have.
-  const covered = new Set([...highlights.matchAll(/\(#(\d+)\)/g)].map((m) => m[1]));
+  const covered = new Set(referenceNumbers(highlights));
   const commits = parseCommits(range);
-  const auto = autoBody(commits, covered);
+  const identityCommits = [...commits, ...allHistoryReferences()];
+  const auto = autoBody(commits, covered, identityCommits);
   const parts = [`## [${ver}] - ${today()}`, ""];
-  if (highlights) parts.push(highlights, "");
-  if (auto) parts.push(auto, "");
-  if (!highlights && !auto) parts.push("_No user-facing changes._", "");
+  const body = normalizeBody(
+    [highlights, auto].filter(Boolean).join("\n\n"),
+    referenceAliases(identityCommits),
+  );
+  if (body) parts.push(body, "");
+  if (!body) parts.push("_No user-facing changes._", "");
   return { text: parts.join("\n").trimEnd(), commits };
 }
 
@@ -392,11 +473,15 @@ if (!version) {
   // [Unreleased] without stamping a version — keeps the changelog warm between
   // releases (e.g. after a runpod:release). Idempotent: items already present
   // (by PR number or exact text) are not re-added.
-  const covered = new Set([...highlights.matchAll(/\(#(\d+)\)/g)].map((m) => m[1]));
-  const commits = parseCommits(`${prevTag()}..HEAD`).filter(
-    (c) => !(c.pr && covered.has(c.pr)) && !highlights.includes(c.desc),
+  const covered = new Set(referenceNumbers(highlights));
+  const candidates = parseCommits(`${prevTag()}..HEAD`);
+  const identityCommits = [...candidates, ...allHistoryReferences()];
+  const aliases = referenceAliases(identityCommits);
+  const ambiguous = ambiguousReferences(identityCommits);
+  const commits = candidates.filter(
+    (c) => !coveredByReferences(c.refs, covered, aliases, ambiguous) && !highlights.includes(c.desc),
   );
-  const auto = autoBody(commits, new Set());
+  const auto = autoBody(commits, new Set(), identityCommits);
   if (!auto) {
     console.log("changelog: [Unreleased] already covers every commit since " + prevTag());
     process.exit(0);

--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -242,13 +242,6 @@ function parseCommits(range) {
   return out;
 }
 
-function allHistoryReferences() {
-  const raw = git("log --all --no-merges --pretty=format:%s");
-  return raw
-    ? raw.split("\n").map((subject) => ({ subject, refs: commitReferences(subject) }))
-    : [];
-}
-
 function componentOf(scope) {
   return (COMPONENTS.find((c) => c.match(scope)) || COMPONENTS[COMPONENTS.length - 1]).name;
 }
@@ -406,7 +399,10 @@ const writeChangelog = (s) => writeFileSync(CHANGELOG, EOL === "\r\n" ? s.replac
 function buildEntry(ver, range, highlights = "") {
   const covered = new Set(referenceNumbers(highlights));
   const commits = parseCommits(range);
-  const identityCommits = [...commits, ...allHistoryReferences()];
+  // Alias identity is release-local: commits reachable through this range are the only
+  // evidence that two references belong to this release. Looking at --all lets an
+  // unmerged/future branch suppress a real entry or deduplicate unrelated notes.
+  const identityCommits = commits;
   const auto = autoBody(commits, covered, identityCommits);
   const parts = [`## [${ver}] - ${today()}`, ""];
   const body = normalizeBody(
@@ -475,7 +471,9 @@ if (!version) {
   // (by PR number or exact text) are not re-added.
   const covered = new Set(referenceNumbers(highlights));
   const candidates = parseCommits(`${prevTag()}..HEAD`);
-  const identityCommits = [...candidates, ...allHistoryReferences()];
+  // Refresh mode has the same scope as a release: only commits since the previous tag
+  // can establish issue/PR aliases for the current [Unreleased] notes.
+  const identityCommits = candidates;
   const aliases = referenceAliases(identityCommits);
   const ambiguous = ambiguousReferences(identityCommits);
   const commits = candidates.filter(

--- a/scripts/lib/changelog-refs.mjs
+++ b/scripts/lib/changelog-refs.mjs
@@ -1,0 +1,102 @@
+/**
+ * Reference identity helpers shared by the release generator and its guard.
+ *
+ * A squash subject commonly names the tracked issue in its scope and the PR
+ * that merged it at the end, for example `fix(1882): ... (#1885)`. Those are
+ * two spellings of one shipped change, not two changelog entries.
+ */
+
+export function referenceNumbers(text) {
+  return [...String(text ?? "").matchAll(/\(#(\d+)\)/g)].map((m) => m[1]);
+}
+
+/** References in a conventional commit subject, including numeric issue scopes. */
+export function commitReferences(subject) {
+  const text = String(subject ?? "");
+  const refs = referenceNumbers(text);
+  const match = /^(?:\w+)(?:\(([^)]+)\))?(?:!)?:\s*/.exec(text);
+  if (match && /^#?\d+$/.test(match[1] ?? "")) refs.unshift((match[1] ?? "").replace(/^#/, ""));
+  return [...new Set(refs)];
+}
+
+/**
+ * Build equivalence classes for issue/PR references that occur together in a
+ * commit subject. An issue is only linked when it has one PR in the supplied
+ * history; an umbrella issue used by several follow-up PRs stays distinct so
+ * deduplication cannot hide legitimate fixes.
+ */
+export function referenceAliases(commits) {
+  const candidates = new Map();
+  for (const commit of commits ?? []) {
+    const refs = commit?.refs ?? commitReferences(commit?.subject);
+    if (refs.length < 2) continue;
+    const pr = refs.at(-1);
+    for (const issue of refs.slice(0, -1)) {
+      if (issue === pr) continue;
+      if (!candidates.has(issue)) candidates.set(issue, new Set());
+      candidates.get(issue).add(pr);
+    }
+  }
+
+  const parent = new Map();
+
+  const ensure = (ref) => {
+    if (!parent.has(ref)) parent.set(ref, ref);
+  };
+  const find = (ref) => {
+    ensure(ref);
+    let root = ref;
+    while (parent.get(root) !== root) root = parent.get(root);
+    while (parent.get(ref) !== ref) {
+      const next = parent.get(ref);
+      parent.set(ref, root);
+      ref = next;
+    }
+    return root;
+  };
+  const union = (a, b) => {
+    const left = find(a);
+    const right = find(b);
+    if (left !== right) parent.set(right, left);
+  };
+
+  for (const [issue, prs] of candidates) {
+    if (prs.size !== 1) continue;
+    const [pr] = prs;
+    ensure(issue);
+    ensure(pr);
+    union(issue, pr);
+  }
+
+  const aliases = new Map();
+  for (const ref of parent.keys()) aliases.set(ref, find(ref));
+  return aliases;
+}
+
+export function ambiguousReferences(commits) {
+  const candidates = new Map();
+  for (const commit of commits ?? []) {
+    const refs = commit?.refs ?? commitReferences(commit?.subject);
+    if (refs.length < 2) continue;
+    const pr = refs.at(-1);
+    for (const issue of refs.slice(0, -1)) {
+      if (issue === pr) continue;
+      if (!candidates.has(issue)) candidates.set(issue, new Set());
+      candidates.get(issue).add(pr);
+    }
+  }
+  return new Set([...candidates].filter(([, prs]) => prs.size > 1).map(([issue]) => issue));
+}
+
+export function canonicalReference(ref, aliases = new Map()) {
+  return aliases.get(ref) ?? ref;
+}
+
+export function coveredByReferences(refs, covered, aliases = new Map(), ambiguous = new Set()) {
+  const coveredKeys = new Set(
+    [...covered].filter((ref) => !ambiguous.has(ref)).map((ref) => canonicalReference(ref, aliases)),
+  );
+  return refs.some(
+    (ref) => !ambiguous.has(ref) && coveredKeys.has(canonicalReference(ref, aliases)),
+  );
+}

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -62,7 +62,7 @@ try {
 // duplicate issue/PR identities, or notes for unreachable changes fail here.
 execFileSync(
   "node",
-  [join(root, "scripts", "check-changelog.mjs"), version],
+  [join(root, "scripts", "check-changelog.mjs"), version, "--working-tree"],
   { stdio: "inherit" },
 );
 

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -62,7 +62,7 @@ try {
 // duplicate issue/PR identities, or notes for unreachable changes fail here.
 execFileSync(
   "node",
-  [join(root, "scripts", "check-changelog.mjs"), version, "--ref", "HEAD"],
+  [join(root, "scripts", "check-changelog.mjs"), version],
   { stdio: "inherit" },
 );
 

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -21,7 +21,11 @@ import { dirname, join } from "node:path";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const version = process.argv[2];
-if (!version || !/^\d+\.\d+\.\d+([-.].+)?$/.test(version)) {
+const semverIdentifier = "(?:0|[1-9]\\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)";
+const strictSemver = new RegExp(
+  `^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-${semverIdentifier}(?:\\.${semverIdentifier})*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$`,
+);
+if (!version || !strictSemver.test(version)) {
   console.error(`usage: node scripts/set-version.mjs <version>  (got: ${version ?? "nothing"})`);
   process.exit(1);
 }

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -48,13 +48,23 @@ writeFileSync(jsPath, js2);
 console.log(`set version ${version} in pyproject.toml + PANEL_VERSION (web/js/comfyui-mcp-panel.js)`);
 
 // Stamp the changelog for this version (hybrid: keeps hand-written [Unreleased]
-// highlights, appends commits since the last release, deduped by PR). Best-effort
-// — a bump must not fail because the changelog gen hiccuped.
+// highlights, appends commits since the last release, and reconciles issue/PR
+// aliases). Generation remains best-effort for the initial write, but the
+// release guard below must pass before a version bump can proceed.
 try {
   execFileSync("node", [join(root, "scripts", "gen-changelog.mjs"), version], { stdio: "inherit" });
 } catch (err) {
   console.warn(`changelog generation skipped: ${err instanceof Error ? err.message : String(err)}`);
 }
+
+// #1891 — the generated section is the release record. Check it against the
+// candidate tree before deriving the shipped JSON, so duplicate headings,
+// duplicate issue/PR identities, or notes for unreachable changes fail here.
+execFileSync(
+  "node",
+  [join(root, "scripts", "check-changelog.mjs"), version, "--ref", "HEAD"],
+  { stdio: "inherit" },
+);
 
 // #758 — the panel-readable copy, OUTSIDE that catch on purpose.
 //


### PR DESCRIPTION
## Summary
- reconcile hand-written `[Unreleased]` notes with generated release sections
- merge repeated headings and deduplicate unambiguous issue/PR aliases
- add a fail-closed changelog ancestry/shape guard to release tooling, CI, publish, and tag audit paths
- keep umbrella issues with multiple follow-up PRs distinct

Closes #1891

## Validation
- `npm.cmd run typecheck`
- `npm.cmd run test:unit` (7048 tests: 7047 passed, 1 todo)
- `npm.cmd run check:scope`
- `npm.cmd run check:changelog`
- production generator + guard isolated Git fixture
- Node syntax checks and `git diff --check`

No `__init__.py` or `apps_routes.py` changes.