### PR TITLE
chore: release v0.15.108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.108] - 2026-08-26
+
+### Fixed
+- reconcile generated changelog sections and release-history guards (#1891, #1894)
+
 ## [0.15.107] - 2026-08-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.107",
+  "version": "0.15.108",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-agent-panel-e2e",
-      "version": "0.15.107",
+      "version": "0.15.108",
       "dependencies": {
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-agent-panel-e2e",
-  "version": "0.15.107",
+  "version": "0.15.108",
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.15.107"
+version = "0.15.108"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2801,7 +2801,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // could never catch the real failure, that set-version.mjs was not run at all,
 // since one script writes them together. That is how 0.15.86..0.15.96 shipped
 // still announcing 0.15.85.
-const PANEL_VERSION = "0.15.107";
+const PANEL_VERSION = "0.15.108";
 
 // #1269 — ONE panel bundle per page, arbitrated AT MODULE SCOPE, before either
 // copy's registration polling can run. Two installs of this pack (a git clone at


### PR DESCRIPTION
## Summary\n- bump panel package metadata to 0.15.108\n- record the merged #1894 changelog consistency and release-history guard fix\n\n## Validation\n- exact four-file release diff\n- hosted CI required before merge\n\nReleases the merged #1894 fix.