### PR TITLE
test(1891): verify full changelog artifact records

### DIFF
--- a/browser_tests/unit/changelog-integrity.test.mjs
+++ b/browser_tests/unit/changelog-integrity.test.mjs
@@ -15,6 +15,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { parseChangelog } from "../../scripts/gen-changelog-json.mjs";
 
 const MD = readFileSync(fileURLToPath(new URL("../../CHANGELOG.md", import.meta.url)), "utf8")
   .replace(/\r\n/g, "\n");
@@ -27,6 +28,14 @@ const MD = readFileSync(fileURLToPath(new URL("../../CHANGELOG.md", import.meta.
 const JSON_RELEASES = JSON.parse(
   readFileSync(fileURLToPath(new URL("../../web/changelog.json", import.meta.url)), "utf8"),
 ).releases;
+
+function assertArtifactMatches(markdown, message = "web/changelog.json is stale") {
+  assert.deepEqual(
+    JSON_RELEASES,
+    parseChangelog(markdown),
+    `${message} — re-run \`node scripts/gen-changelog-json.mjs\` after editing CHANGELOG.md`,
+  );
+}
 
 /** Every `## [x.y.z] - date` heading, in file order. */
 function versionHeadings(markdown = MD) {
@@ -141,15 +150,35 @@ test("changelog.json: no version appears twice in the rendered artefact", () => 
 });
 
 test("changelog.json: the rendered artefact matches CHANGELOG.md", () => {
-  // The two files drift only in one direction that matters — the markdown is repaired and the
-  // JSON is left stale, because the JSON is regenerated at release time rather than on the
-  // commit that repaired it. Compare the version LISTS, in order, so drift fails on the commit
-  // that introduces it instead of surviving until the next cut.
-  const fromMarkdown = versionHeadings().map((h) => h.version);
-  const fromJson = JSON_RELEASES.map((r) => r.version);
-  assert.deepEqual(
-    fromJson,
-    fromMarkdown,
-    "web/changelog.json is stale — re-run `node scripts/gen-changelog-json.mjs` after editing CHANGELOG.md",
+  // Compare every generated field, not only versions: the panel renders dates and section
+  // entries too, and a same-version edit must not survive as a stale shipped artefact.
+  assertArtifactMatches(MD);
+});
+
+test("changelog.json: a same-version date drift fails the sync assertion", () => {
+  const release = JSON_RELEASES[0];
+  const heading = `## [${release.version}] - ${release.date}`;
+  const fixture = MD.replace(heading, `## [${release.version}] - 2099-01-01`);
+
+  assert.notEqual(fixture, MD, "date-drift fixture did not change CHANGELOG.md");
+  assert.throws(() => assertArtifactMatches(fixture), /web\/changelog\.json is stale/);
+});
+
+test("changelog.json: same-version release content drift fails the sync assertion", () => {
+  const original = "- reconcile generated changelog sections and release-history guards (#1891, #1894)";
+  const fixture = MD.replace(original, "- stale release content drift fixture (#1891, #1894)");
+
+  assert.notEqual(fixture, MD, "content-drift fixture did not change CHANGELOG.md");
+  assert.throws(() => assertArtifactMatches(fixture), /web\/changelog\.json is stale/);
+});
+
+test("changelog.json: Unreleased content remains outside released records", () => {
+  const fixture = MD.replace(
+    "## [Unreleased]\n",
+    "## [Unreleased]\n\n### Fixed\n- unreleased-only fixture content\n",
   );
+
+  assert.notEqual(fixture, MD, "Unreleased fixture did not change CHANGELOG.md");
+  assert.deepEqual(parseChangelog(fixture), parseChangelog(MD));
+  assertArtifactMatches(fixture, "Unreleased content changed released records");
 });

--- a/browser_tests/unit/changelog-integrity.test.mjs
+++ b/browser_tests/unit/changelog-integrity.test.mjs
@@ -29,13 +29,36 @@ const JSON_RELEASES = JSON.parse(
   readFileSync(fileURLToPath(new URL("../../web/changelog.json", import.meta.url)), "utf8"),
 ).releases;
 
-function assertArtifactMatches(markdown, message = "web/changelog.json is stale") {
+function assertArtifactMatches(
+  markdown,
+  artifactReleases = JSON_RELEASES,
+  message = "web/changelog.json is stale",
+) {
   assert.deepEqual(
-    JSON_RELEASES,
+    artifactReleases,
     parseChangelog(markdown),
     `${message} — re-run \`node scripts/gen-changelog-json.mjs\` after editing CHANGELOG.md`,
   );
 }
+
+// Keep transform-level drift fixtures independent of the live changelog's prose and heading
+// layout. The shipped artifact below is the exact output generated from this small source; the
+// tests then mutate only one source property at a time and compare it to that unchanged output.
+const FIXTURE_CHANGELOG = [
+  "# Changelog",
+  "",
+  "## [9.8.7] - 2026-08-25",
+  "",
+  "### Fixed",
+  "",
+  "- released fixture entry.",
+  "",
+  "### Changed",
+  "",
+  "- second released fixture entry.",
+  "",
+].join("\n");
+const FIXTURE_ARTIFACT = parseChangelog(FIXTURE_CHANGELOG);
 
 /** Every `## [x.y.z] - date` heading, in file order. */
 function versionHeadings(markdown = MD) {
@@ -156,29 +179,47 @@ test("changelog.json: the rendered artefact matches CHANGELOG.md", () => {
 });
 
 test("changelog.json: a same-version date drift fails the sync assertion", () => {
-  const release = JSON_RELEASES[0];
-  const heading = `## [${release.version}] - ${release.date}`;
-  const fixture = MD.replace(heading, `## [${release.version}] - 2099-01-01`);
+  const fixture = FIXTURE_CHANGELOG.replace(
+    /^(## \[[^\]]+\] - )\S+$/m,
+    "$12099-01-01",
+  );
 
-  assert.notEqual(fixture, MD, "date-drift fixture did not change CHANGELOG.md");
-  assert.throws(() => assertArtifactMatches(fixture), /web\/changelog\.json is stale/);
+  assert.notEqual(fixture, FIXTURE_CHANGELOG, "date-drift fixture did not change CHANGELOG.md");
+  assert.throws(
+    () => assertArtifactMatches(fixture, FIXTURE_ARTIFACT),
+    /web\/changelog\.json is stale/,
+  );
 });
 
 test("changelog.json: same-version release content drift fails the sync assertion", () => {
-  const original = "- reconcile generated changelog sections and release-history guards (#1891, #1894)";
-  const fixture = MD.replace(original, "- stale release content drift fixture (#1891, #1894)");
+  const fixture = FIXTURE_CHANGELOG.replace(
+    "- released fixture entry.",
+    "- changed fixture entry.",
+  );
 
-  assert.notEqual(fixture, MD, "content-drift fixture did not change CHANGELOG.md");
-  assert.throws(() => assertArtifactMatches(fixture), /web\/changelog\.json is stale/);
+  assert.notEqual(fixture, FIXTURE_CHANGELOG, "content-drift fixture did not change CHANGELOG.md");
+  assert.throws(
+    () => assertArtifactMatches(fixture, FIXTURE_ARTIFACT),
+    /web\/changelog\.json is stale/,
+  );
 });
 
 test("changelog.json: Unreleased content remains outside released records", () => {
-  const fixture = MD.replace(
-    "## [Unreleased]\n",
-    "## [Unreleased]\n\n### Fixed\n- unreleased-only fixture content\n",
-  );
+  const fixture = [
+    "## [Unreleased]",
+    "",
+    "### Fixed",
+    "",
+    "- unreleased-only fixture content.",
+    "",
+    FIXTURE_CHANGELOG,
+  ].join("\n");
 
-  assert.notEqual(fixture, MD, "Unreleased fixture did not change CHANGELOG.md");
-  assert.deepEqual(parseChangelog(fixture), parseChangelog(MD));
-  assertArtifactMatches(fixture, "Unreleased content changed released records");
+  assert.notEqual(fixture, FIXTURE_CHANGELOG, "Unreleased fixture did not change CHANGELOG.md");
+  assert.deepEqual(parseChangelog(fixture), FIXTURE_ARTIFACT);
+  assertArtifactMatches(
+    fixture,
+    FIXTURE_ARTIFACT,
+    "Unreleased content changed released records",
+  );
 });


### PR DESCRIPTION
Follow-up to merged PR #1897. The regenerated web/changelog.json is preserved.

## What changed

- Compare the shipped release records against the production parseChangelog projection, including version, date, section names, and normalized emitted entry content.
- Add adversarial same-version date and release-content drift fixtures that must fail the sync assertion.
- Add an Unreleased-content fixture proving it remains excluded from released records.

## Validation

- node --test browser_tests/unit/changelog-integrity.test.mjs: 11 passed
- npm.cmd run test:unit: 7055 passed, 1 TODO
- npm.cmd run typecheck: passed
- npm.cmd run check:scope: passed
- npm.cmd run check:changelog: passed
- git diff --check: passed

No merge or release performed. No init.py, __init__.py, apps_routes.py, or py/apps_routes.py changes; no network operations added.