### PR TITLE
fix(ci): block stale rendered changelog releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,14 +268,36 @@ jobs:
           # real failure — that set-version.mjs was not run AT ALL — because one script writes
           # both, so they cannot disagree. That is exactly how 0.15.86..0.15.96 shipped with
           # pyproject and PANEL_VERSION frozen at 0.15.85 while CI stayed green. Compare all
-          # three, so a release that skips set-version.mjs is a RED build.
+          # four, so a release that skips set-version.mjs or omits the rendered artefact
+          # is a RED build.
           pkg = json.load(open("package.json", encoding="utf-8")).get("version")
-          seen = {"package.json": pkg, "pyproject.toml": proj["version"], "PANEL_VERSION": m.group(1)}
+          try:
+              rendered = json.load(open("web/changelog.json", encoding="utf-8"))
+          except (OSError, ValueError) as error:
+              sys.exit(f"VERSION MISMATCH: web/changelog.json is unreadable — {error}")
+          releases = rendered.get("releases") if isinstance(rendered, dict) else None
+          rendered_version = (
+              releases[0].get("version")
+              if isinstance(releases, list)
+              and releases
+              and isinstance(releases[0], dict)
+              and isinstance(releases[0].get("version"), str)
+              else None
+          )
+          # web/changelog.json is the rendered artefact the panel actually ships and displays.
+          # Its newest record is a fourth witness: a release can leave all three version files
+          # coherent while still shipping notes that stop one version short (#1899).
+          seen = {
+              "package.json": pkg,
+              "pyproject.toml": proj["version"],
+              "PANEL_VERSION": m.group(1),
+              "web/changelog.json": rendered_version,
+          }
           if len(set(seen.values())) != 1:
               sys.exit(
                   "VERSION MISMATCH: "
                   + ", ".join(f"{k}={v}" for k, v in seen.items())
                   + f" — run `node scripts/set-version.mjs {pkg}`."
               )
-          print(f"pyproject OK: {proj['name']} {proj['version']} (package.json + JS PANEL_VERSION match)")
+          print(f"pyproject OK: {proj['name']} {proj['version']} (all four release version witnesses match)")
           PY

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -264,14 +264,36 @@ jobs:
           js = open("web/js/comfyui-mcp-panel.js", encoding="utf-8").read()
           m = re.search(r'const PANEL_VERSION = "([^"]+)"', js)
           assert m, "PANEL_VERSION constant not found in web/js/comfyui-mcp-panel.js"
-          # Three-way, for the reason spelled out in ci.yml: pyproject and PANEL_VERSION are
-          # written by the same script, so comparing just those two cannot detect that the
-          # script never ran. package.json is the independent witness.
+          # The three original witnesses have the reason spelled out in ci.yml: pyproject and
+          # PANEL_VERSION are written by the same script, so comparing just those two cannot
+          # detect that the script never ran. package.json is the independent witness, and the
+          # rendered changelog is the fourth witness because it is what the panel displays.
           pkg = json.load(open("package.json", encoding="utf-8")).get("version")
-          seen = {"package.json": pkg, "pyproject.toml": proj["version"], "PANEL_VERSION": m.group(1)}
+          try:
+              rendered = json.load(open("web/changelog.json", encoding="utf-8"))
+          except (OSError, ValueError) as error:
+              sys.exit(f"VERSION MISMATCH: web/changelog.json is unreadable — {error}")
+          releases = rendered.get("releases") if isinstance(rendered, dict) else None
+          rendered_version = (
+              releases[0].get("version")
+              if isinstance(releases, list)
+              and releases
+              and isinstance(releases[0], dict)
+              and isinstance(releases[0].get("version"), str)
+              else None
+          )
+          # web/changelog.json is the rendered artefact the panel actually ships and displays.
+          # Its newest record is a fourth witness: a release can leave all three version files
+          # coherent while still shipping notes that stop one version short (#1899).
+          seen = {
+              "package.json": pkg,
+              "pyproject.toml": proj["version"],
+              "PANEL_VERSION": m.group(1),
+              "web/changelog.json": rendered_version,
+          }
           if len(set(seen.values())) != 1:
               sys.exit("VERSION MISMATCH: " + ", ".join(f"{k}={v}" for k, v in seen.items()) + " — run scripts/set-version.mjs")
-          print(f"publishing {proj['name']} {proj['version']} (package.json + JS PANEL_VERSION match)")
+          print(f"publishing {proj['name']} {proj['version']} (all four release version witnesses match)")
           PY
       # --------------------------------------------------------------------
 

--- a/browser_tests/unit/release-version-gate.test.mjs
+++ b/browser_tests/unit/release-version-gate.test.mjs
@@ -1,0 +1,68 @@
+// #1899 — execute the version gate embedded in each authoritative workflow against both
+// a coherent release and the stale rendered changelog that previously shipped.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const WORKFLOWS = [
+  join(ROOT, ".github", "workflows", "ci.yml"),
+  join(ROOT, ".github", "workflows", "publish_action.yml"),
+];
+const VERSION = "1.2.3";
+
+function versionGate(workflowPath) {
+  const workflow = readFileSync(workflowPath, "utf8");
+  const start = workflow.indexOf("- name: pyproject.toml is valid + has registry fields + JS version matches");
+  assert.notEqual(start, -1, `${workflowPath}: version gate step is missing`);
+  const end = workflow.indexOf("\n      - name:", start + 1);
+  const step = workflow.slice(start, end === -1 ? workflow.length : end);
+  const match = /python - <<'PY'\r?\n([\s\S]*?)\r?\n\s*PY/.exec(step);
+  assert.ok(match, `${workflowPath}: could not extract the production Python gate`);
+  // YAML removes the ten-space block indentation before the runner executes this heredoc.
+  return match[1]
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^ {10}/, ""))
+    .join("\n");
+}
+
+function runGate(workflowPath, renderedVersion) {
+  const cwd = mkdtempSync(join(tmpdir(), "panel-release-version-gate-"));
+  try {
+    mkdirSync(join(cwd, "web", "js"), { recursive: true });
+    writeFileSync(
+      join(cwd, "pyproject.toml"),
+      `[project]\nname = "comfyui-agent-panel"\nversion = "${VERSION}"\ndescription = "fixture"\nlicense = { file = "LICENSE" }\n\n[tool.comfy]\nPublisherId = "artokun"\n`,
+    );
+    writeFileSync(join(cwd, "package.json"), JSON.stringify({ version: VERSION }));
+    writeFileSync(join(cwd, "LICENSE"), "fixture\n");
+    writeFileSync(join(cwd, "web", "changelog.json"), JSON.stringify({ releases: [{ version: renderedVersion }] }));
+    writeFileSync(join(cwd, "web", "js", "comfyui-mcp-panel.js"), `const PANEL_VERSION = "${VERSION}";\n`);
+    const result = spawnSync("python", ["-c", versionGate(workflowPath)], {
+      cwd,
+      encoding: "utf8",
+    });
+    return result;
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+for (const workflowPath of WORKFLOWS) {
+  test(`${workflowPath}: matching rendered changelog passes the actual version gate`, () => {
+    const result = runGate(workflowPath, VERSION);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /all four release version witnesses match/);
+  });
+
+  test(`${workflowPath}: stale rendered changelog fails and names the artefact`, () => {
+    const result = runGate(workflowPath, "1.2.2");
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /VERSION MISMATCH/);
+    assert.match(result.stderr, /web\/changelog\.json=1\.2\.2/);
+  });
+}


### PR DESCRIPTION
## Summary

- Extend the existing CI and Registry publish version gates with the newest `web/changelog.json` release version.
- Fail closed and name the rendered artifact when it is unreadable, missing, or stale.
- Execute both production workflow gates against matching and one-version-behind fixtures.

Closes #1899

## Validation

- `npm.cmd run test:unit` — 7,059 passed, 1 existing todo
- `npm.cmd run typecheck`
- `npm.cmd run check:scope`
- `npm.cmd run check:changelog`
- `node --check` — 225 web/js files
- `git diff --check`