### PR TITLE
Fix workflow open normalization race (#1898)

### DIFF
--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -7,6 +7,7 @@ import {
   settleOpenedWorkflowActive,
   settleOwnedOpenedWorkflowActive,
 } from "../../web/js/lib/settle-open-active.js";
+import { settleOpenedWorkflowReadable } from "../../web/js/lib/settle-open-readable.js";
 import { graphMutationReconnectGate } from "../../web/js/lib/reconnect-recovery.js";
 import { activeWorkflowPossiblyStale } from "../../web/js/lib/reconnect-staleness.js";
 import { classifyPinnedTarget } from "../../web/js/lib/workflow-chat-identity.js";
@@ -107,6 +108,118 @@ function productionExecutor(methodName, environment) {
   return factory(scope);
 }
 
+function productionReadableOpenEnvironment({ readableAfterRetry }) {
+  const previous = { path: "workflows/previous.json" };
+  const target = {
+    path: "workflows/target.json",
+    filename: "target.json",
+    isModified: false,
+    activeState: {
+      nodes: [{ id: 1, type: "KSampler" }],
+      links: [],
+      groups: [],
+      last_node_id: 1,
+      extra: { comfyui_mcp: { workflow_uuid: "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95" } },
+    },
+  };
+  const root = { _nodes: [], extra: {} };
+  const uuid = "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
+  let active = previous;
+  let loads = 0;
+  let outlines = 0;
+  const app = {
+    rootGraph: root,
+    graph: root,
+    canvas: {},
+    loadGraphData: async (state) => {
+      loads += 1;
+      root.extra = state.extra;
+      root._nodes = [{ id: 1, type: "KSampler" }];
+    },
+    extensionManager: {
+      workflow: {
+        openWorkflows: [target],
+        workflows: [],
+        getWorkflowByPath: () => target,
+        openWorkflow: async () => {
+          active = target;
+        },
+      },
+    },
+  };
+  const status = { PROVEN: "proven", CONTENT_UNVERIFIED: "content-unverified", UNPROVEN: "unproven" };
+  return {
+    target,
+    counters: () => ({ loads, outlines }),
+    environment: {
+      backendReconnectEpoch: 4,
+      activeWorkflowResyncEpoch: 4,
+      postReconnectBindingProofEpoch: 4,
+      app,
+      activeWorkflowRef: () => active,
+      sameWorkflowObject: (a, b) => a === b,
+      workflowTabId: (workflow) => `wf:${workflow.path}`,
+      WORKFLOW_META_NAMESPACE: "comfyui_mcp",
+      WORKFLOW_UUID_FIELD: "workflow_uuid",
+      WORKFLOW_PATH_FIELD: "workflow_path",
+      OPEN_PROOF_FIELD: "open_proof",
+      workflowObjectUuid: () => uuid,
+      workflowStableUuid: () => uuid,
+      workflowOwnsRootUuidTag: () => false,
+      workflowUuidOwner: () => null,
+      getWorkflowTitle: () => "Target",
+      waitForReconnectHandshakeBeforeOpen: async () => {},
+      comfyBackendIsDown: () => false,
+      postReconnectBindingSettleWindow: () => false,
+      nodeDefRefreshInFlight: null,
+      flushSourceCanvasBeforeSwitch: async () => {},
+      claimActiveWorkflowMove: () => {},
+      acquireCanvasInteractionLock: () => null,
+      releaseCanvasInteractionLock: () => {},
+      MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+      settleOpenedWorkflowTarget: async () => ({ target, loaded: false }),
+      workflowRecordMatchesSelector: () => true,
+      installNodeConfigureIsolation: () => ({ failures: [], restore: () => {} }),
+      installGraphConfigureWatch: () => ({ restore: () => {} }),
+      loadRestoreCompleted: () => true,
+      retryNodeRestores: async () => ({ restored: [], failed: [], recovered: [] }),
+      liteGraphGlobal: () => null,
+      getGraphCtx: () => ({ graph: root, rootGraph: root }),
+      describeLiveCanvasBinding: () => "unknown",
+      applySavedNodePresentation: () => {},
+      applySavedSubgraphHostWidgets: () => {},
+      decideOpenStaleness: () => ({ stale: false, reload: false }),
+      describeRepaintSourceBinding: () => "unknown",
+      graphRootCarriesOpenProof: () => true,
+      graphRootWorkflowUuidMatches: () => true,
+      graphRootReproducesStateContent: () => ({ proven: false, presentationOnly: false, normalizedOnly: false }),
+      describeGraphStateDifference: () => ({ comparable: true, surfaces: ["nodes"], accountedSurfaces: [], nodeDifference: null }),
+      openContentDifferenceIsDefinitionsOnly: () => false,
+      resolveOpenRebindVerdict: ({ contentMatches }) =>
+        contentMatches ? { status: status.PROVEN } : { status: status.CONTENT_UNVERIFIED },
+      describeOpenRebindOutcome: () => "content could not be verified",
+      OPEN_REBIND_STATUS: status,
+      GRAPH_TOOL_EXECUTORS: {
+        graph_outline: () => {
+          outlines += 1;
+          return readableAfterRetry && loads > 1
+            ? { node_count: 1, outline: "1 KSampler", detail_level: "full" }
+            : null;
+        },
+      },
+      settleOpenedWorkflowReadable,
+      settleOwnedOpenedWorkflowActive,
+      noteOpenAttempt: () => ({ seq: 1 }),
+      backendSocketReplyFields: () => ({}),
+      activeWorkflowUuidForOpenReply: () => uuid,
+      describeOpenActiveBinding: () => ({ active_matches_target: true }),
+      canvasFileDivergenceNote: () => null,
+      failOpenRebindUnknown: (error) => error,
+      coerceMessageText: (value) => String(value),
+    },
+  };
+}
+
 function fakeClock() {
   let time = 0;
   return {
@@ -188,6 +301,62 @@ test("#887 unreadable active state stays unknown", async () => {
   });
 
   assert.equal(result.status, "unknown");
+});
+
+test("#1898 settles a readable outline after one normalization retry", async () => {
+  const target = { path: "workflows/target.json" };
+  let settleCalls = 0;
+  let outlineCalls = 0;
+  let retries = 0;
+
+  const result = await settleOpenedWorkflowReadable({
+    settleActive: async () => {
+      settleCalls += 1;
+      return { status: "settled", active: target };
+    },
+    readGraphOutline: async () => {
+      outlineCalls += 1;
+      return outlineCalls === 1 ? null : { node_count: 1, outline: "1 KSampler", detail_level: "full" };
+    },
+    retryNormalization: async () => {
+      retries += 1;
+      return true;
+    },
+  });
+
+  assert.equal(result.status, "settled-readable");
+  assert.equal(result.retried, true);
+  assert.equal(retries, 1, "normalization is retried once");
+  assert.equal(outlineCalls, 2, "the readable graph is re-probed after retry");
+  assert.equal(settleCalls, 4, "identity is settled before retry and after the final probe");
+});
+
+test("#1898 keeps an unreadable or unproven graph outcome unknown", async () => {
+  const target = { path: "workflows/target.json" };
+  let retries = 0;
+  const result = await settleOpenedWorkflowReadable({
+    settleActive: async () => ({ status: "settled", active: target }),
+    readGraphOutline: async () => null,
+    retryNormalization: async () => {
+      retries += 1;
+      return true;
+    },
+  });
+
+  assert.equal(result.status, "unknown");
+  assert.equal(retries, 1, "an unreadable graph gets only the bounded retry");
+
+  let identityRetries = 0;
+  const identityUnknown = await settleOpenedWorkflowReadable({
+    settleActive: async () => ({ status: "unknown", reason: "active workflow was unreadable" }),
+    readGraphOutline: async () => ({ node_count: 1, outline: "1 KSampler", detail_level: "full" }),
+    retryNormalization: async () => {
+      identityRetries += 1;
+      return true;
+    },
+  });
+  assert.equal(identityUnknown.status, "unknown");
+  assert.equal(identityRetries, 0, "an unreadable identity never authorizes normalization");
 });
 
 test("#887 a superseding open cannot turn an old settle result into success", async () => {
@@ -344,6 +513,27 @@ test("#887 production workflow_open native failure retires proof before its nega
   assert.equal(panel.guard(), null, "native failure must release the production reload guard");
   assert.equal(journal.at(-1)?.applied, false, "the native failure remains a clean negative reply");
   assert.match(journal.at(-1)?.error ?? "", /native switch rejected/);
+});
+
+test("#1898 production workflow_open accepts a settled readable outline after normalization races", async () => {
+  const { target, counters, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  const panel = productionExecutor("workflow_open", environment);
+
+  const result = await panel.method({ path: target.path, rid: "readable-race" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(result.workflow_uuid, "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95");
+  assert.deepEqual(counters(), { loads: 2, outlines: 2 }, "the production handler probes, retries once, and re-probes");
+  assert.equal(panel.guard(), null, "the readable outcome releases the production reload guard");
+});
+
+test("#1898 production workflow_open keeps outcome unknown when the settled graph remains unreadable", async () => {
+  const { target, counters, environment } = productionReadableOpenEnvironment({ readableAfterRetry: false });
+  const panel = productionExecutor("workflow_open", environment);
+
+  await assert.rejects(panel.method({ path: target.path, rid: "unreadable-race" }), /content could not be verified/);
+  assert.deepEqual(counters(), { loads: 2, outlines: 2 }, "an unreadable graph is retried once, never indefinitely");
+  assert.equal(panel.guard(), null, "the unknown outcome releases the production reload guard");
 });
 
 test("#887 production workflow_new unknown result retires proof before returning", async () => {

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -108,14 +108,14 @@ function productionExecutor(methodName, environment) {
   return factory(scope);
 }
 
-function productionReadableOpenEnvironment({ readableAfterRetry }) {
+function productionReadableOpenEnvironment({ readableAfterRetry, readableButMismatched = false }) {
   const previous = { path: "workflows/previous.json" };
   const target = {
     path: "workflows/target.json",
     filename: "target.json",
     isModified: false,
     activeState: {
-      nodes: [{ id: 1, type: "KSampler" }],
+      nodes: [{ id: 1, type: "KSampler", widgets_values: ["target-value"] }],
       links: [],
       groups: [],
       last_node_id: 1,
@@ -127,6 +127,7 @@ function productionReadableOpenEnvironment({ readableAfterRetry }) {
   let active = previous;
   let loads = 0;
   let outlines = 0;
+  let contentProofs = 0;
   const app = {
     rootGraph: root,
     graph: root,
@@ -134,7 +135,13 @@ function productionReadableOpenEnvironment({ readableAfterRetry }) {
     loadGraphData: async (state) => {
       loads += 1;
       root.extra = state.extra;
-      root._nodes = [{ id: 1, type: "KSampler" }];
+      root._nodes = [
+        {
+          id: 1,
+          type: "KSampler",
+          widgets_values: [readableButMismatched ? "stale-value" : "target-value"],
+        },
+      ];
     },
     extensionManager: {
       workflow: {
@@ -150,7 +157,7 @@ function productionReadableOpenEnvironment({ readableAfterRetry }) {
   const status = { PROVEN: "proven", CONTENT_UNVERIFIED: "content-unverified", UNPROVEN: "unproven" };
   return {
     target,
-    counters: () => ({ loads, outlines }),
+    counters: () => ({ loads, outlines, contentProofs }),
     environment: {
       backendReconnectEpoch: 4,
       activeWorkflowResyncEpoch: 4,
@@ -192,7 +199,16 @@ function productionReadableOpenEnvironment({ readableAfterRetry }) {
       describeRepaintSourceBinding: () => "unknown",
       graphRootCarriesOpenProof: () => true,
       graphRootWorkflowUuidMatches: () => true,
-      graphRootReproducesStateContent: () => ({ proven: false, presentationOnly: false, normalizedOnly: false }),
+      graphRootReproducesStateContent: ({ rootGraph, state }) => {
+        contentProofs += 1;
+        const liveValue = rootGraph?._nodes?.[0]?.widgets_values?.[0];
+        const requestedValue = state?.nodes?.[0]?.widgets_values?.[0];
+        return {
+          proven: loads > 1 && liveValue === requestedValue,
+          presentationOnly: false,
+          normalizedOnly: false,
+        };
+      },
       describeGraphStateDifference: () => ({ comparable: true, surfaces: ["nodes"], accountedSurfaces: [], nodeDifference: null }),
       openContentDifferenceIsDefinitionsOnly: () => false,
       resolveOpenRebindVerdict: ({ contentMatches }) =>
@@ -202,7 +218,7 @@ function productionReadableOpenEnvironment({ readableAfterRetry }) {
       GRAPH_TOOL_EXECUTORS: {
         graph_outline: () => {
           outlines += 1;
-          return readableAfterRetry && loads > 1
+          return readableButMismatched || (readableAfterRetry && loads > 1)
             ? { node_count: 1, outline: "1 KSampler", detail_level: "full" }
             : null;
         },
@@ -523,16 +539,27 @@ test("#1898 production workflow_open accepts a settled readable outline after no
 
   assert.equal(result.opened.path, target.path);
   assert.equal(result.workflow_uuid, "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95");
-  assert.deepEqual(counters(), { loads: 2, outlines: 2 }, "the production handler probes, retries once, and re-probes");
+  assert.deepEqual(
+    counters(),
+    { loads: 2, outlines: 2, contentProofs: 2 },
+    "the production handler retries once, re-probes, and re-verifies graph content",
+  );
   assert.equal(panel.guard(), null, "the readable outcome releases the production reload guard");
 });
 
-test("#1898 production workflow_open keeps outcome unknown when the settled graph remains unreadable", async () => {
-  const { target, counters, environment } = productionReadableOpenEnvironment({ readableAfterRetry: false });
+test("#1898 production workflow_open keeps a readable but mismatched graph unknown", async () => {
+  const { target, counters, environment } = productionReadableOpenEnvironment({
+    readableAfterRetry: false,
+    readableButMismatched: true,
+  });
   const panel = productionExecutor("workflow_open", environment);
 
-  await assert.rejects(panel.method({ path: target.path, rid: "unreadable-race" }), /content could not be verified/);
-  assert.deepEqual(counters(), { loads: 2, outlines: 2 }, "an unreadable graph is retried once, never indefinitely");
+  await assert.rejects(panel.method({ path: target.path, rid: "mismatched-readable-race" }), /content could not be verified/);
+  assert.deepEqual(
+    counters(),
+    { loads: 1, outlines: 1, contentProofs: 2 },
+    "readability cannot replace the final normalized node/value content proof",
+  );
   assert.equal(panel.guard(), null, "the unknown outcome releases the production reload guard");
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -576,6 +576,7 @@ import {
 import { flushSourceCanvasBeforeSwitch } from "./lib/flush-source-before-switch.js";
 import { settleOpenedWorkflowTarget } from "./lib/settle-open-target.js";
 import { settleOwnedOpenedWorkflowActive } from "./lib/settle-open-active.js";
+import { settleOpenedWorkflowReadable } from "./lib/settle-open-readable.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext, stripAgentDirectedBlocks } from "./lib/chat-serialize.js";
 import {
   applyCurrentDefWidgetValues,
@@ -21739,53 +21740,111 @@ const GRAPH_TOOL_EXECUTORS = {
                 const contentDiff = contentMatches
                   ? { comparable: true, surfaces: [], accountedSurfaces: [], nodeDifference: null }
                   : describeGraphStateDifference({ rootGraph, state: repaintState });
-                // #1477 — binding proven, and the only differing surface is
-                // `definitions`. That is not a previous-workflow graph (#1111/#1089
-                // disagree on nodes/links). Throwing here skipped the workflow_uuid
-                // publish and left the session fenced to the prior workflow, so
-                // panel_graph_outline then failed until panel_list_workflows
-                // republished the identity. Publish the fence; disclose; still fail
-                // closed when any other surface disagrees.
+                // #1898 — a graph can still be normalizing after the store has
+                // switched identity and `loadGraphData` has resolved. If the
+                // requested identity is already proven, let a real graph_outline
+                // probe settle that race; an unreadable probe gets exactly one
+                // normalization retry. The probe remains fail-closed: identity,
+                // readability and the final active settlement must all be proven.
                 if (
                   verdict.status === OPEN_REBIND_STATUS.CONTENT_UNVERIFIED &&
-                  openContentDifferenceIsDefinitionsOnly({
+                  // #1283/#1089/#1215 — the readable-outline recovery is only
+                  // for a completed, comparable normalization race. A partial
+                  // restore, an unreadable comparison, or a foreign/untagged
+                  // source remains outcome-unknown even if a graph read happens
+                  // to be possible afterward.
+                  loadRanToCompletion === true &&
+                  contentDiff.comparable === true &&
+                  Array.isArray(openRestoreFailures) &&
+                  openRestoreFailures[0] == null &&
+                  !openContentDifferenceIsDefinitionsOnly({
                     comparable: contentDiff.comparable,
                     surfaces: contentDiff.surfaces,
-                  })
+                  }) &&
+                  !sourceForeign &&
+                  !sourceUnproven
                 ) {
-                  openDefinitionsUnverified = true;
-                } else {
-                  rebindFailed = new Error(
-                    describeOpenRebindOutcome(verdict, {
-                      targetLabel: target.filename || target.path || "the requested workflow",
-                      activeLabel: activeNow ? activeNow.filename || activeNow.path || "another tab" : "no active tab",
-                      expectedMarker: openProofMarker,
-                      observedMarker: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[OPEN_PROOF_FIELD] ?? null,
-                      expectedUuid: targetUuid,
-                      observedUuid: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] ?? null,
-                      contentComparable: contentDiff.comparable,
-                      contentSurfaces: contentDiff.surfaces,
-                      // #1588 — which of those the panel has already fully characterised
-                      // (today: a `definitions` difference that is pure RENUMBERING — link ids,
-                      // and comfyui-mcp#1706 subgraph node ids — which a load of a workflow
-                      // containing subgraphs routinely produces).
-                      // Without this the disclosure counts an explained surface as a
-                      // second unexplained one and drops to the maximal-alarm wording.
-                      contentAccountedSurfaces: contentDiff.accountedSurfaces,
-                      // panel#1283 family — whether the restore ABORTED. `false` is the one
-                      // case where a content difference has a known cause other than the
-                      // frontend rewriting its own fields, and it is the case the reader
-                      // most needs named. `null` (the load could not be watched) is passed
-                      // through as null and says nothing, which is the pre-existing state
-                      // of knowledge.
-                      contentLoadRanToCompletion: loadRanToCompletion,
-                      contentRestoreFailures: openRestoreFailures,
-                      // #825 — within the `nodes` surface, whether anything was LOST
-                      // or the frontend merely re-measured the boxes. Same three
-                      // words otherwise, opposite meanings for the reader.
-                      contentNodeDifference: contentDiff.nodeDifference,
-                    }),
-                  );
+                  const readableRecovery = await settleOpenedWorkflowReadable({
+                    settleActive: () =>
+                      settleOwnedOpenedWorkflowActive({
+                        target,
+                        readActive: activeWorkflowRef,
+                        sameWorkflowObject,
+                        beginStep: () => beginWorkflowReloadStep(reloadGuardToken),
+                        ownsStep: () => ownsWorkflowReloadGuard(reloadGuardToken),
+                        endStep: () => endWorkflowReloadStep(reloadGuardToken),
+                      }),
+                    readGraphOutline: () => GRAPH_TOOL_EXECUTORS.graph_outline({}),
+                    retryNormalization: async () => {
+                      if (!beginWorkflowReloadStep(reloadGuardToken)) return false;
+                      try {
+                        if (!sameWorkflowObject(activeWorkflowRef(), target)) return false;
+                        await app.loadGraphData(repaintState, true, true, target);
+                        return (
+                          ownsWorkflowReloadGuard(reloadGuardToken) &&
+                          sameWorkflowObject(activeWorkflowRef(), target)
+                        );
+                      } catch {
+                        return false;
+                      } finally {
+                        endWorkflowReloadStep(reloadGuardToken);
+                      }
+                    },
+                  });
+                  if (readableRecovery.status === "settled-readable") {
+                    verdict.status = OPEN_REBIND_STATUS.PROVEN;
+                    verdict.unproven = [];
+                  }
+                }
+                if (verdict.status !== OPEN_REBIND_STATUS.PROVEN) {
+                  // #1477 — binding proven, and the only differing surface is
+                  // `definitions`. That is not a previous-workflow graph (#1111/#1089
+                  // disagree on nodes/links). Throwing here skipped the workflow_uuid
+                  // publish and left the session fenced to the prior workflow, so
+                  // panel_graph_outline then failed until panel_list_workflows
+                  // republished the identity. Publish the fence; disclose; still fail
+                  // closed when any other surface disagrees.
+                  if (
+                    verdict.status === OPEN_REBIND_STATUS.CONTENT_UNVERIFIED &&
+                    openContentDifferenceIsDefinitionsOnly({
+                      comparable: contentDiff.comparable,
+                      surfaces: contentDiff.surfaces,
+                    })
+                  ) {
+                    openDefinitionsUnverified = true;
+                  } else {
+                    rebindFailed = new Error(
+                      describeOpenRebindOutcome(verdict, {
+                        targetLabel: target.filename || target.path || "the requested workflow",
+                        activeLabel: activeNow ? activeNow.filename || activeNow.path || "another tab" : "no active tab",
+                        expectedMarker: openProofMarker,
+                        observedMarker: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[OPEN_PROOF_FIELD] ?? null,
+                        expectedUuid: targetUuid,
+                        observedUuid: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] ?? null,
+                        contentComparable: contentDiff.comparable,
+                        contentSurfaces: contentDiff.surfaces,
+                        // #1588 — which of those the panel has already fully characterised
+                        // (today: a `definitions` difference that is pure RENUMBERING — link ids,
+                        // and comfyui-mcp#1706 subgraph node ids — which a load of a workflow
+                        // containing subgraphs routinely produces).
+                        // Without this the disclosure counts an explained surface as a
+                        // second unexplained one and drops to the maximal-alarm wording.
+                        contentAccountedSurfaces: contentDiff.accountedSurfaces,
+                        // panel#1283 family — whether the restore ABORTED. `false` is the one
+                        // case where a content difference has a known cause other than the
+                        // frontend rewriting its own fields, and it is the case the reader
+                        // most needs named. `null` (the load could not be watched) is passed
+                        // through as null and says nothing, which is the pre-existing state
+                        // of knowledge.
+                        contentLoadRanToCompletion: loadRanToCompletion,
+                        contentRestoreFailures: openRestoreFailures,
+                        // #825 — within the `nodes` surface, whether anything was LOST
+                        // or the frontend merely re-measured the boxes. Same three
+                        // words otherwise, opposite meanings for the reader.
+                        contentNodeDifference: contentDiff.nodeDifference,
+                      }),
+                    );
+                  }
                 }
               }
             } finally {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21792,8 +21792,40 @@ const GRAPH_TOOL_EXECUTORS = {
                     },
                   });
                   if (readableRecovery.status === "settled-readable") {
-                    verdict.status = OPEN_REBIND_STATUS.PROVEN;
-                    verdict.unproven = [];
+                    // A readable outline proves only that some graph is readable.
+                    // Re-read the live root and compare its normalized node/value
+                    // content with the state captured for this requested workflow;
+                    // otherwise a readable stale graph becomes a false success.
+                    try {
+                      const { rootGraph: recoveredRootGraph } = getGraphCtx();
+                      const recoveredContentProof = graphRootReproducesStateContent({
+                        rootGraph: recoveredRootGraph,
+                        state: repaintState,
+                        loadRanToCompletion,
+                      });
+                      const recoveredContentMatches =
+                        recoveredContentProof.proven ||
+                        recoveredContentProof.presentationOnly ||
+                        recoveredContentProof.normalizedOnly;
+                      const recoveredActive = activeWorkflowRef();
+                      const recoveredBindingMatches =
+                        sameWorkflowObject(recoveredActive, target) &&
+                        graphRootCarriesOpenProof({
+                          rootGraph: recoveredRootGraph,
+                          proofMarker: openProofMarker,
+                        }) &&
+                        graphRootWorkflowUuidMatches({
+                          rootGraph: recoveredRootGraph,
+                          activeWorkflowUuid: targetUuid,
+                        });
+                      if (recoveredBindingMatches && recoveredContentMatches) {
+                        verdict.status = OPEN_REBIND_STATUS.PROVEN;
+                        verdict.unproven = [];
+                      }
+                    } catch {
+                      // Keep the original CONTENT_UNVERIFIED verdict when the
+                      // post-probe content or binding proof cannot be recomputed.
+                    }
                   }
                 }
                 if (verdict.status !== OPEN_REBIND_STATUS.PROVEN) {

--- a/web/js/lib/settle-open-readable.js
+++ b/web/js/lib/settle-open-readable.js
@@ -1,0 +1,89 @@
+/**
+ * #1898 — finish an open only after the requested workflow is stable AND its
+ * bound graph can be read. A store-level identity switch can settle before
+ * graph normalization finishes, so give that normalization one retry when the
+ * first outline probe is not readable.
+ */
+
+function readableGraphOutline(value) {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    Number.isInteger(value.node_count) &&
+    value.node_count >= 0 &&
+    typeof value.outline === "string" &&
+    value.detail_level !== "refused"
+  );
+}
+
+/**
+ * @returns {Promise<{
+ *   status: "settled-readable"|"different"|"superseded"|"unknown",
+ *   active?: unknown,
+ *   outline?: unknown,
+ *   retried?: boolean,
+ *   reason?: string
+ * }>}
+ */
+export async function settleOpenedWorkflowReadable({
+  settleActive,
+  readGraphOutline,
+  retryNormalization,
+} = {}) {
+  if (typeof settleActive !== "function" || typeof readGraphOutline !== "function") {
+    return { status: "unknown", reason: "workflow identity or graph outline probe was unavailable" };
+  }
+
+  const settle = async () => {
+    try {
+      return await settleActive();
+    } catch {
+      return { status: "unknown", reason: "workflow identity probe failed" };
+    }
+  };
+  const read = async () => {
+    try {
+      const outline = await readGraphOutline();
+      return readableGraphOutline(outline) ? { readable: true, outline } : { readable: false };
+    } catch {
+      return { readable: false };
+    }
+  };
+
+  let active = await settle();
+  if (active?.status !== "settled") return active ?? { status: "unknown" };
+
+  let probe = await read();
+  let retried = false;
+  if (!probe.readable) {
+    // Confirm the target still owns the canvas before retrying a load. A failed
+    // outline must not authorize normalization on a workflow that moved away.
+    active = await settle();
+    if (active?.status !== "settled") return active ?? { status: "unknown" };
+    if (typeof retryNormalization !== "function") {
+      return { status: "unknown", reason: "bound graph outline remained unreadable" };
+    }
+    try {
+      retried = (await retryNormalization()) === true;
+    } catch {
+      retried = false;
+    }
+    if (!retried) return { status: "unknown", reason: "workflow normalization retry was not completed" };
+    active = await settle();
+    if (active?.status !== "settled") return active ?? { status: "unknown" };
+    probe = await read();
+    if (!probe.readable) return { status: "unknown", reason: "bound graph outline remained unreadable after one retry" };
+  }
+
+  // The graph read itself is an await boundary in real frontends. Re-probe the
+  // identity after it so a late tab switch cannot turn a readable old graph into
+  // a success for the requested workflow.
+  active = await settle();
+  if (active?.status !== "settled") return active ?? { status: "unknown" };
+  return {
+    status: "settled-readable",
+    active: active.active,
+    outline: probe.outline,
+    retried,
+  };
+}

--- a/web/js/lib/settle-open-readable.js
+++ b/web/js/lib/settle-open-readable.js
@@ -1,8 +1,9 @@
 /**
- * #1898 — finish an open only after the requested workflow is stable AND its
+ * #1898 — coordinate the open until the requested workflow is stable AND its
  * bound graph can be read. A store-level identity switch can settle before
  * graph normalization finishes, so give that normalization one retry when the
- * first outline probe is not readable.
+ * first outline probe is not readable. Callers must still verify graph content
+ * before treating a readable result as proven.
  */
 
 function readableGraphOutline(value) {


### PR DESCRIPTION
## Summary\n- settle the requested workflow identity before probing the bound graph\n- accept a readable panel_graph_outline after a completed normalization race\n- retry normalization once when the first outline probe is unreadable, otherwise remain outcome-unknown\n- add production-handler behavioral coverage for success and fail-closed outcomes\n\nFixes #1898\n\n## Validation\n- focused workflow-open/identity/contract suites: 111 passed\n- direct full unit suite: 7,059 passed, 0 failed, 1 todo\n- 
pm.cmd run typecheck: passed\n- git diff --check: passed\n- aggregate 
pm.cmd run test:unit: blocked by missing local 
ode_modules/typescript in the fresh worktree during check-panel-scope\n\nNo merge or release performed.