### PR TITLE
fix(#1639): reject stale canvas capture after tab switch

### DIFF
--- a/browser_tests/unit/flush-source-before-switch.test.mjs
+++ b/browser_tests/unit/flush-source-before-switch.test.mjs
@@ -308,8 +308,8 @@ test("#1295: the #1215 TARGET capture gate still skips an untagged switch — th
   const flushAt = SRC.indexOf("await flushSourceCanvasBeforeSwitch({");
   assert.ok(flushAt < gateAt, "source flush is BEFORE the switch; target capture is AFTER");
   const gate = SRC.slice(gateAt, SRC.indexOf("await target.changeTracker?.checkState?.()", gateAt));
-  assert.match(gate, /captureBinding === "bound"/);
-  assert.match(gate, /captureBinding !== "foreign" && !pointerMovedThisOpen/);
+  assert.match(gate, /!pointerMovedThisOpen/);
+  assert.match(gate, /captureBinding !== "foreign"/);
   assert.doesNotMatch(
     gate,
     /if \(captureBinding !== "foreign"\)/,

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -80,6 +80,8 @@ function balancedFrom(src, marker, openAt = null) {
   throw new Error(`unterminated block: ${marker}`);
 }
 
+const PINIA_STORE_HELPER_SOURCE = balancedFrom(SRC, "function getPiniaStore(id)");
+
 // Execute a shipped executor body with the shipped reload guard and proof helper.
 // The frontend-facing services are supplied by each lifecycle test, but the operation
 // and its ownership/generation implementation are not re-created in the test.
@@ -94,7 +96,7 @@ function productionExecutor(methodName, environment) {
   );
   const factory = new Function(
     "sandbox",
-    `with (sandbox) {\n${RELOAD_GUARD_SOURCE[0]}\n${methodSource}\n` +
+    `with (sandbox) {\n${RELOAD_GUARD_SOURCE[0]}\n${PINIA_STORE_HELPER_SOURCE}\n${methodSource}\n` +
       `return { method: ${methodName}, guard: () => activeWorkflowReloadGuard(), ` +
       `proofs: () => ({ active: activeWorkflowResyncEpoch, post: postReconnectBindingProofEpoch }) };\n}`,
   );
@@ -233,6 +235,15 @@ function productionReadableOpenEnvironment({ readableAfterRetry, readableButMism
       failOpenRebindUnknown: (error) => error,
       coerceMessageText: (value) => String(value),
     },
+  };
+}
+
+function workflowPiniaDocument(workflowStore) {
+  return {
+    getElementById: () => ({
+      __vue_app__: { config: { globalProperties: { $pinia: { _s: new Map([["workflow", workflowStore]]) } } } },
+    }),
+    querySelector: () => null,
   };
 }
 
@@ -561,6 +572,426 @@ test("#1898 production workflow_open keeps a readable but mismatched graph unkno
     "readability cannot replace the final normalized node/value content proof",
   );
   assert.equal(panel.guard(), null, "the unknown outcome releases the production reload guard");
+});
+
+test("#1639 production workflow_open does not capture a stale previous canvas into a bare target tab", async () => {
+  const uuid = "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
+  const previous = { path: "workflows/previous.json" };
+  const previousState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: ["previous-value"] }],
+    links: [],
+    groups: [],
+    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+  };
+  const targetState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: ["target-value"] }],
+    links: [],
+    groups: [],
+    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+  };
+  let active = previous;
+  let captured = 0;
+  let loadedValue;
+  const root = {
+    _nodes: [{ id: 1, type: "KSampler", widgets_values: ["previous-value"] }],
+    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+  };
+  const target = {
+    path: "workflows/target.json",
+    filename: "target.json",
+    isModified: false,
+    changeTracker: {
+      activeState: structuredClone(targetState),
+      checkState() {
+        captured += 1;
+        this.activeState = structuredClone(previousState);
+      },
+    },
+  };
+  const app = {
+    rootGraph: root,
+    graph: root,
+    canvas: { graph: root },
+    loadGraphData: async (state) => {
+      loadedValue = state?.nodes?.[0]?.widgets_values?.[0];
+      root.extra = state.extra;
+      root._nodes = state.nodes.map((node) => ({ ...node }));
+    },
+    extensionManager: {
+      workflow: {
+        openWorkflows: [target],
+        workflows: [],
+        getWorkflowByPath: () => target,
+        openWorkflow: async () => {
+          active = target;
+        },
+      },
+    },
+  };
+  const status = { PROVEN: "proven", CONTENT_UNVERIFIED: "content-unverified", UNPROVEN: "unproven" };
+  const panel = productionExecutor("workflow_open", {
+    backendReconnectEpoch: 4,
+    activeWorkflowResyncEpoch: 4,
+    postReconnectBindingProofEpoch: 4,
+    app,
+    activeWorkflowRef: () => active,
+    sameWorkflowObject: (a, b) => a === b,
+    workflowTabId: (workflow) => `wf:${workflow.path}`,
+    WORKFLOW_META_NAMESPACE: "comfyui_mcp",
+    WORKFLOW_UUID_FIELD: "workflow_uuid",
+    WORKFLOW_PATH_FIELD: "workflow_path",
+    OPEN_PROOF_FIELD: "open_proof",
+    workflowObjectUuid: () => uuid,
+    workflowStableUuid: () => uuid,
+    workflowOwnsRootUuidTag: () => false,
+    workflowUuidOwner: () => null,
+    getWorkflowTitle: () => "Target",
+    waitForReconnectHandshakeBeforeOpen: async () => {},
+    comfyBackendIsDown: () => false,
+    postReconnectBindingSettleWindow: () => false,
+    nodeDefRefreshInFlight: null,
+    flushSourceCanvasBeforeSwitch: async () => {},
+    claimActiveWorkflowMove: () => {},
+    acquireCanvasInteractionLock: () => null,
+    releaseCanvasInteractionLock: () => {},
+    MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+    settleOpenedWorkflowTarget: async () => ({ target, loaded: false }),
+    workflowRecordMatchesSelector: () => true,
+    installNodeConfigureIsolation: () => ({ failures: [], restore: () => {} }),
+    installGraphConfigureWatch: () => ({ restore: () => {} }),
+    loadRestoreCompleted: () => true,
+    retryNodeRestores: async () => ({ restored: [], failed: [], recovered: [] }),
+    liteGraphGlobal: () => null,
+    getGraphCtx: () => ({ graph: root, rootGraph: root }),
+    // This is the regression input: a stale root UUID is not proof that the visible
+    // canvas belongs to the target, but the old capture gate treated it as enough.
+    describeLiveCanvasBinding: () => "bound",
+    applySavedNodePresentation: () => {},
+    applySavedSubgraphHostWidgets: () => {},
+    decideOpenStaleness: () => ({ stale: false, reload: false }),
+    describeRepaintSourceBinding: () => "unknown",
+    graphRootCarriesOpenProof: () => true,
+    graphRootWorkflowUuidMatches: () => true,
+    graphRootReproducesStateContent: ({ rootGraph, state }) => ({
+      proven: rootGraph?._nodes?.[0]?.widgets_values?.[0] === state?.nodes?.[0]?.widgets_values?.[0],
+      presentationOnly: false,
+      normalizedOnly: false,
+    }),
+    describeGraphStateDifference: () => ({ comparable: true, surfaces: ["nodes"], accountedSurfaces: [], nodeDifference: null }),
+    openContentDifferenceIsDefinitionsOnly: () => false,
+    resolveOpenRebindVerdict: ({ contentMatches }) =>
+      contentMatches ? { status: status.PROVEN } : { status: status.CONTENT_UNVERIFIED },
+    describeOpenRebindOutcome: () => "content could not be verified",
+    OPEN_REBIND_STATUS: status,
+    GRAPH_TOOL_EXECUTORS: { graph_outline: () => ({ node_count: 1, outline: "1 KSampler", detail_level: "full" }) },
+    settleOpenedWorkflowReadable,
+    settleOwnedOpenedWorkflowActive,
+    noteOpenAttempt: () => ({ seq: 1 }),
+    backendSocketReplyFields: () => ({}),
+    activeWorkflowUuidForOpenReply: () => uuid,
+    describeOpenActiveBinding: () => ({ active_matches_target: true }),
+    canvasFileDivergenceNote: () => null,
+    failOpenRebindUnknown: (error) => error,
+    coerceMessageText: (value) => String(value),
+  });
+
+  const result = await panel.method({ path: "target.json", rid: "bare-stale-canvas" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(loadedValue, "target-value", "the production repaint must use the target state, not the previous canvas");
+  assert.equal(captured, 0, "a moved active pointer is not proof that the stale visible root belongs to the target");
+  assert.equal(panel.guard(), null, "the production open releases its reload guard");
+});
+
+test("#1639 production workflow_open remembers switch-away-and-back during an early await", async () => {
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  const other = { path: "workflows/other.json" };
+  let active = target;
+  let captures = 0;
+  const subscribers = [];
+  const notifyStoreMutation = () => {
+    for (const subscriber of [...subscribers]) subscriber();
+  };
+  const workflowStore = {
+    $subscribe: (subscriber) => {
+      subscribers.push(subscriber);
+      return () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  };
+  target.changeTracker = {
+    activeState: target.activeState,
+    checkState() {
+      captures += 1;
+    },
+  };
+  environment.document = workflowPiniaDocument(workflowStore);
+  environment.activeWorkflowRef = () => active;
+  environment.describeLiveCanvasBinding = () => "bound";
+  environment.flushSourceCanvasBeforeSwitch = async () => {};
+  environment.waitForReconnectHandshakeBeforeOpen = async () => {
+    // This is before the reload guard and native open. The endpoint is restored
+    // before the await returns, so only the operation-local epoch can remember it.
+    active = other;
+    notifyStoreMutation();
+    await Promise.resolve();
+    active = target;
+    notifyStoreMutation();
+  };
+  environment.app.extensionManager.workflow.openWorkflow = async () => {
+    active = target;
+  };
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "early-switch-away-back" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(captures, 0, "an early switch excursion invalidates the endpoint-only proof");
+  assert.equal(subscribers.length, 0, "the synchronous pointer watch is cleaned up after the open");
+  assert.equal(panel.guard(), null, "the production open releases its reload guard");
+  assert.equal(active, target);
+});
+
+test("#1639 production workflow_open rejects a one-way external switch during source flush", async () => {
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  let active = environment.activeWorkflowRef();
+  let captures = 0;
+  const subscribers = [];
+  const notifyStoreMutation = () => {
+    for (const subscriber of [...subscribers]) subscriber();
+  };
+  const workflowStore = {
+    $subscribe: (subscriber) => {
+      subscribers.push(subscriber);
+      return () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  };
+  target.changeTracker = {
+    activeState: target.activeState,
+    checkState() {
+      captures += 1;
+    },
+  };
+  environment.document = workflowPiniaDocument(workflowStore);
+  environment.activeWorkflowRef = () => active;
+  environment.describeLiveCanvasBinding = () => "bound";
+  environment.flushSourceCanvasBeforeSwitch = async () => {
+    // The flush runs before the command stakes its native-move claim. This external
+    // one-way move must never authorize a later bound capture.
+    active = target;
+    notifyStoreMutation();
+    await Promise.resolve();
+  };
+  environment.app.extensionManager.workflow.openWorkflow = async () => {
+    active = target;
+  };
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "flush-one-way-switch" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(captures, 0, "a pre-native external move cannot authorize bound capture");
+  assert.equal(subscribers.length, 0, "the synchronous pointer watch is cleaned up after the open");
+  assert.equal(panel.guard(), null, "the production open releases its reload guard");
+  assert.equal(active, target);
+});
+
+test("#1639 production workflow_open preserves proven-bound capture after a legitimate tab move", async () => {
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  const previous = { path: "workflows/previous.json" };
+  let active = previous;
+  let captures = 0;
+  const subscribers = [];
+  const workflowStore = {
+    $subscribe: (subscriber) => {
+      subscribers.push(subscriber);
+      return () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  };
+  target.changeTracker = {
+    activeState: target.activeState,
+    checkState() {
+      captures += 1;
+    },
+  };
+  environment.document = workflowPiniaDocument(workflowStore);
+  environment.activeWorkflowRef = () => active;
+  environment.describeLiveCanvasBinding = () => "bound";
+  environment.app.extensionManager.workflow.openWorkflow = async () => {
+    active = target;
+  };
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "proven-bound-capture" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(captures, 1, "a proven-bound canvas still captures node-written values after a tab move");
+  assert.equal(subscribers.length, 0, "the synchronous pointer watch is cleaned up after the open");
+  assert.equal(panel.guard(), null, "the production open releases its reload guard");
+});
+
+test("#1639 production workflow_open remembers a switch-away-and-back during an awaited open step", async () => {
+  const uuid = "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
+  const previous = { path: "workflows/previous.json" };
+  const targetState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: ["target-value"] }],
+    links: [],
+    groups: [],
+    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+  };
+  const previousState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: ["previous-value"] }],
+    links: [],
+    groups: [],
+    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+  };
+  let captures = 0;
+  const target = {
+    path: "workflows/target.json",
+    filename: "target.json",
+    isModified: false,
+    changeTracker: {
+      activeState: structuredClone(targetState),
+      checkState() {
+        captures += 1;
+        this.activeState = structuredClone(previousState);
+      },
+    },
+  };
+  let active = target;
+  let loadedValue;
+  const subscribers = [];
+  const notifyStoreMutation = () => {
+    for (const subscriber of [...subscribers]) subscriber();
+  };
+  const workflowPiniaStore = {
+    $subscribe: (subscriber) => {
+      subscribers.push(subscriber);
+      return () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  };
+  const document = {
+    getElementById: () => ({
+      __vue_app__: { config: { globalProperties: { $pinia: { _s: new Map([["workflow", workflowPiniaStore]]) } } } },
+    }),
+    querySelector: () => null,
+  };
+  const root = {
+    _nodes: [{ id: 1, type: "KSampler", widgets_values: ["previous-value"] }],
+    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+  };
+  const app = {
+    rootGraph: root,
+    graph: root,
+    canvas: { graph: root },
+    loadGraphData: async (state) => {
+      loadedValue = state?.nodes?.[0]?.widgets_values?.[0];
+      root.extra = state.extra;
+      root._nodes = state.nodes.map((node) => ({ ...node }));
+    },
+    extensionManager: {
+      workflow: {
+        openWorkflows: [target],
+        workflows: [],
+        getWorkflowByPath: () => target,
+        openWorkflow: async () => {
+          notifyStoreMutation();
+        },
+      },
+    },
+  };
+  const status = { PROVEN: "proven", CONTENT_UNVERIFIED: "content-unverified", UNPROVEN: "unproven" };
+  const panel = productionExecutor("workflow_open", {
+    backendReconnectEpoch: 4,
+    activeWorkflowResyncEpoch: 4,
+    postReconnectBindingProofEpoch: 4,
+    app,
+    document,
+    activeWorkflowRef: () => active,
+    sameWorkflowObject: (a, b) => a === b,
+    workflowTabId: (workflow) => `wf:${workflow.path}`,
+    WORKFLOW_META_NAMESPACE: "comfyui_mcp",
+    WORKFLOW_UUID_FIELD: "workflow_uuid",
+    WORKFLOW_PATH_FIELD: "workflow_path",
+    OPEN_PROOF_FIELD: "open_proof",
+    workflowObjectUuid: () => uuid,
+    workflowStableUuid: () => uuid,
+    workflowOwnsRootUuidTag: () => false,
+    workflowUuidOwner: () => null,
+    getWorkflowTitle: () => "Target",
+    waitForReconnectHandshakeBeforeOpen: async () => {},
+    comfyBackendIsDown: () => false,
+    postReconnectBindingSettleWindow: () => false,
+    nodeDefRefreshInFlight: null,
+    flushSourceCanvasBeforeSwitch: async () => {},
+    claimActiveWorkflowMove: () => {},
+    acquireCanvasInteractionLock: () => null,
+    releaseCanvasInteractionLock: () => {},
+    MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+    settleOpenedWorkflowTarget: async () => {
+      // The target was active at the operation's start, so the endpoint comparison
+      // remains equal. The epoch must still remember this complete excursion.
+      active = previous;
+      notifyStoreMutation();
+      active = target;
+      notifyStoreMutation();
+      await Promise.resolve();
+      return { target, loaded: false };
+    },
+    workflowRecordMatchesSelector: () => true,
+    installNodeConfigureIsolation: () => ({ failures: [], restore: () => {} }),
+    installGraphConfigureWatch: () => ({ restore: () => {} }),
+    loadRestoreCompleted: () => true,
+    retryNodeRestores: async () => ({ restored: [], failed: [], recovered: [] }),
+    liteGraphGlobal: () => null,
+    getGraphCtx: () => ({ graph: root, rootGraph: root }),
+    describeLiveCanvasBinding: () => "bound",
+    applySavedNodePresentation: () => {},
+    applySavedSubgraphHostWidgets: () => {},
+    decideOpenStaleness: () => ({ stale: false, reload: false }),
+    describeRepaintSourceBinding: () => "unknown",
+    graphRootCarriesOpenProof: () => true,
+    graphRootWorkflowUuidMatches: () => true,
+    graphRootReproducesStateContent: ({ rootGraph, state }) => ({
+      proven: rootGraph?._nodes?.[0]?.widgets_values?.[0] === state?.nodes?.[0]?.widgets_values?.[0],
+      presentationOnly: false,
+      normalizedOnly: false,
+    }),
+    describeGraphStateDifference: () => ({ comparable: true, surfaces: ["nodes"], accountedSurfaces: [], nodeDifference: null }),
+    openContentDifferenceIsDefinitionsOnly: () => false,
+    resolveOpenRebindVerdict: ({ contentMatches }) =>
+      contentMatches ? { status: status.PROVEN } : { status: status.CONTENT_UNVERIFIED },
+    describeOpenRebindOutcome: () => "content could not be verified",
+    OPEN_REBIND_STATUS: status,
+    GRAPH_TOOL_EXECUTORS: { graph_outline: () => ({ node_count: 1, outline: "1 KSampler", detail_level: "full" }) },
+    settleOpenedWorkflowReadable,
+    settleOwnedOpenedWorkflowActive,
+    noteOpenAttempt: () => ({ seq: 1 }),
+    backendSocketReplyFields: () => ({}),
+    activeWorkflowUuidForOpenReply: () => uuid,
+    describeOpenActiveBinding: () => ({ active_matches_target: true }),
+    canvasFileDivergenceNote: () => null,
+    failOpenRebindUnknown: (error) => error,
+    coerceMessageText: (value) => String(value),
+  });
+
+  const result = await panel.method({ path: "target.json", rid: "switch-away-back" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(loadedValue, "target-value", "the repaint still uses the target state");
+  assert.equal(captures, 0, "an intervening switch invalidates the endpoint-only capture proof");
+  assert.equal(panel.guard(), null, "the production open releases its reload guard");
 });
 
 test("#887 production workflow_new unknown result retires proof before returning", async () => {

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -1140,11 +1140,10 @@ test("#1215: an untagged root admits the capture only in the already-current cas
   assert.notEqual(captureAt, -1);
   const gate = src.slice(gateAt, captureAt);
   assert.match(gate, /pointerMovedThisOpen = !sameWorkflowObject\(activeBefore, target\)/);
-  // "bound" captures outright — the #604/#708 divergence's node-written values
-  // ride on it — and a proven-foreign root still skips. "unknown" no longer
-  // suffices on its own: the pointer must NOT have moved.
-  assert.match(gate, /captureBinding === "bound"/);
-  assert.match(gate, /captureBinding !== "foreign" && !pointerMovedThisOpen/);
+  // A capture is allowed only when the active pointer did not move. A stale root
+  // carrying the target UUID is not independent canvas proof after a tab switch.
+  assert.match(gate, /!pointerMovedThisOpen/);
+  assert.match(gate, /captureBinding !== "foreign"/);
   assert.doesNotMatch(
     gate,
     /if \(captureBinding !== "foreign"\)/,

--- a/browser_tests/unit/settle-open-target.test.mjs
+++ b/browser_tests/unit/settle-open-target.test.mjs
@@ -547,8 +547,8 @@ test("#1575: a state just read off DISK is not overwritten by the still-mounted 
     "capturing the closed tab's canvas over the freshly-loaded file is the #1215 poison",
   );
   // #1295's own pins must survive this change.
-  assert.match(gate, /captureBinding === "bound"/);
-  assert.match(gate, /captureBinding !== "foreign" && !pointerMovedThisOpen/);
+  assert.match(gate, /!pointerMovedThisOpen/);
+  assert.match(gate, /captureBinding !== "foreign"/);
 });
 
 test("#1575: a repaired open DISCLOSES that the canvas is the on-disk copy", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20836,6 +20836,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // #433 TOCTOU: snapshot the reconnect epoch BEFORE the async open (see
     // workflow_new) so a reconnect landing mid-operation is not masked by our stamp.
     const openedForEpoch = backendReconnectEpoch;
+    let target = null;
     // #402 — journal the FAILURE side too. Every early throw below is a real "this open
     // did NOT apply" fact, and a caller whose reply was lost mid-command needs that
     // negative just as much as the positive: without it the only remaining evidence is
@@ -20887,7 +20888,72 @@ const GRAPH_TOOL_EXECUTORS = {
         all.find((w) => workflowRecordMatchesSelector(w, path))
       );
     };
-    let target = find();
+    // #1639 — install the synchronous pointer watch BEFORE any await in this open.
+    // A switch away and back during workflow-list refresh, the disk probe, or the
+    // reconnect handshake must remain visible to the later canvas-capture gate.
+    const activeBefore = activeWorkflowRef();
+    let activePointerEpoch = 0;
+    let activePointerLast = activeBefore;
+    const activePointerHistory = [];
+    let activePointerWatchStop = null;
+    let activePointerWatchAvailable = false;
+    const observeActivePointer = () => {
+      let current;
+      try {
+        current = activeWorkflowRef();
+      } catch {
+        activePointerEpoch += 1;
+        activePointerLast = null;
+        activePointerHistory.push(null);
+        return;
+      }
+      let unchanged = false;
+      try {
+        unchanged = sameWorkflowObject(current, activePointerLast) === true;
+      } catch {
+        unchanged = false;
+      }
+      if (!unchanged) {
+        activePointerEpoch += 1;
+        activePointerLast = current;
+        activePointerHistory.push(current);
+      }
+    };
+    const stopActivePointerWatch = () => {
+      const stop = activePointerWatchStop;
+      activePointerWatchStop = null;
+      activePointerWatchAvailable = false;
+      if (typeof stop === "function") {
+        try {
+          stop();
+        } catch {
+          // Subscription cleanup is best-effort; the open's other guards remain owner-checked.
+        }
+      }
+    };
+    try {
+      // The workflow service is a Pinia store, but it is also the strict
+      // frontend-contract surface. Reach Pinia through the panel's supported
+      // store lookup so `$subscribe` is not mistaken for a workflow-service
+      // member by the contract scanner.
+      const workflowPiniaStore = getPiniaStore("workflow");
+      if (typeof workflowPiniaStore?.$subscribe === "function") {
+        const stop = workflowPiniaStore.$subscribe(observeActivePointer, { detached: true, flush: "sync" });
+        if (typeof stop === "function") {
+          activePointerWatchStop = stop;
+          activePointerWatchAvailable = true;
+        }
+      }
+    } catch {
+      // Older workflow stores may not expose a usable synchronous subscription.
+    }
+    // The outer try/finally below covers failed lookup, refresh, probe, handshake,
+    // lock acquisition, and every later return. The watch must never outlive this open.
+    let activePointerEpochAtOpen = null;
+    let activePointerOpenTransitionProven = false;
+    try {
+    try {
+      target = find();
     // The frontend's workflow list is CACHED, so a just-saved/staged file (e.g. a
     // downloaded example) won't appear until the store re-reads the workflows dir.
     // If the first search misses, REFRESH the store and search again so a freshly
@@ -21050,6 +21116,13 @@ const GRAPH_TOOL_EXECUTORS = {
         return true;
       },
     });
+    } catch (err) {
+      // The reload guard below owns the normal-operation cleanup. Before it is
+      // acquired, however, lookup/probe/handshake failures still have to retire
+      // this operation's pointer subscription before they escape.
+      stopActivePointerWatch();
+      throw failOpen(err);
+    }
     // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
     // never re-read from disk. If the .json changed on disk out-of-band the canvas
     // would silently keep the pre-edit graph and this open would report a bland
@@ -21072,13 +21145,6 @@ const GRAPH_TOOL_EXECUTORS = {
     // That erased signal is what would authorize the destructive re-read to
     // discard the user's work.
     const wasDirty = !!target.isModified;
-    // #1215 — WHO was active before this open moves the pointer, snapshotted now:
-    // `s.openWorkflow(target)` below changes the answer. The #874 canvas capture's
-    // own precondition is "the mounted canvas is the target's", and on an UNTAGGED
-    // root — where describeLiveCanvasBinding can only answer "unknown" — whether
-    // the pointer just moved is the only evidence left bearing on that. Consumed
-    // by the capture gate below.
-    const activeBefore = activeWorkflowRef();
     // Bound to a local whose name does NOT end in "s": the #268 frontend-contract scanner
     // captures members off the workflow-service alias `s` with an unanchored `s\.` pattern,
     // so `canvas.<member>` would be misread as a new workflow-SERVICE dependency. This is a
@@ -21182,6 +21248,8 @@ const GRAPH_TOOL_EXECUTORS = {
         // captureCanvasIntoTracker no-ops on a non-active tracker, so this has to
         // happen BEFORE openWorkflow moves the pointer. Best-effort: a failed
         // flush must not block the switch.
+        const pointerTransitionsBeforeNativeOpen = activePointerHistory.length;
+        const activePointerEpochBeforeSourceFlush = activePointerEpoch;
         await flushSourceCanvasBeforeSwitch({
           source: activeBefore,
           target,
@@ -21189,11 +21257,32 @@ const GRAPH_TOOL_EXECUTORS = {
           describeLiveCanvasBinding,
           captureCanvasIntoTracker,
         });
+        // The source flush is awaited and can yield to an external tab switch. Its
+        // transition must not be mistaken for the native move below: the native move
+        // claim is deliberately made only after this proof point. A switch away and
+        // back is caught too, because the synchronous Pinia watcher advances the epoch
+        // for every identity transition.
+        const sourceFlushPointerStable =
+          activePointerWatchAvailable && activePointerEpoch === activePointerEpochBeforeSourceFlush;
         // #968 — claim this move BEFORE it happens, so the observer attributes it to this
         // command rather than reporting it as a move nobody made. A claim that is never
         // followed by a move is discarded by the next observation.
         claimActiveWorkflowMove(MOVE_CAUSES.OPEN_EXECUTOR, `workflow_open ${workflowTabId(target) || ""}`.trim());
         await s.openWorkflow(target);
+        // The native open may legitimately move the pointer from the workflow that
+        // was active at entry to `target`. Treat exactly that one transition as the
+        // command's expected move; every transition observed before or beyond it is
+        // an intervening switch and must invalidate even a bound-root capture.
+        observeActivePointer();
+        const nativeOpenHistory = activePointerHistory.slice(pointerTransitionsBeforeNativeOpen);
+        activePointerOpenTransitionProven =
+          sourceFlushPointerStable &&
+          pointerTransitionsBeforeNativeOpen === 0 &&
+          (nativeOpenHistory.length === 0
+            ? sameWorkflowObject(activeBefore, target) === true
+            : nativeOpenHistory.length === 1 &&
+              sameWorkflowObject(nativeOpenHistory[0], target) === true);
+        activePointerEpochAtOpen = activePointerEpoch;
       } catch (err) {
         // The native switch itself failed — nothing was applied. Recorded, then rethrown
         // through failOpen below (outside the freeze) so the negative is journaled.
@@ -21416,15 +21505,41 @@ const GRAPH_TOOL_EXECUTORS = {
           // reporting a bland success.
           const captureBinding = describeLiveCanvasBinding(target);
           pointerMovedThisOpen = !sameWorkflowObject(activeBefore, target);
+          observeActivePointer();
+          let activeAtCapture = null;
+          try {
+            activeAtCapture = activeWorkflowRef();
+          } catch {
+            activeAtCapture = null;
+          }
+          let activeIdentityAtCapture = false;
+          try {
+            activeIdentityAtCapture = sameWorkflowObject(activeAtCapture, target) === true;
+          } catch {
+            activeIdentityAtCapture = false;
+          }
+          const activePointerProof =
+            activePointerWatchAvailable &&
+            activePointerOpenTransitionProven &&
+            activePointerEpochAtOpen !== null &&
+            activePointerEpoch === activePointerEpochAtOpen &&
+            activeIdentityAtCapture;
+          const captureSourceProof =
+            captureBinding === "bound" || (captureBinding !== "foreign" && !pointerMovedThisOpen);
           if (
             // #1575 — a state THIS command just read off disk is authoritative, and the
             // canvas mounted behind it is whatever the closed tab left there. Serializing
             // that over the fresh state is the #1215/#968 poisoning through a new entry
             // point, and it can preserve nothing: nothing has run against a just-loaded
             // tracker, so it holds no node-written values (#874) for the capture to save.
+            // A moved active pointer is the same uncertainty even when the stale root
+            // carries this target's UUID: that tag is not independent canvas proof. Use
+            // the target tracker's own state after a tab switch and fail closed on the
+            // unproven capture rather than turning the previous canvas into this tab's
+            // state (#1639).
             openSettled?.loaded !== true &&
-            (captureBinding === "bound" ||
-              (captureBinding !== "foreign" && !pointerMovedThisOpen))
+            activePointerProof &&
+            captureSourceProof
           ) {
             try {
               // AWAITED (codex). A frontend whose tracker captures asynchronously would
@@ -22218,6 +22333,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // a frozen graph or the tab refusing every command. The canvas lock is owner-checked:
       // if a concurrent section still holds it, this release leaves it alone and the last
       // holder reopens the canvas.
+      stopActivePointerWatch();
       releaseWorkflowReloadGuard(reloadGuardToken);
       releaseCanvasInteractionLock(priorInteraction, canvasView);
     }
@@ -22580,6 +22696,11 @@ const GRAPH_TOOL_EXECUTORS = {
           }
         : {}),
     };
+    } finally {
+      // Covers every early return and every failure, including the lookup/probe
+      // section before the reload guard is acquired.
+      stopActivePointerWatch();
+    }
   },
 
   // #1299 — apply an out-of-band saved workflow onto the ACTIVE canvas, and


### PR DESCRIPTION
Refs #1639\n\n## Summary\n- Do not run the target changeTracker checkState capture after the active workflow pointer moved during workflow_open, even when a stale visible root carries the target UUID and is described as bound.\n- This prevents the previous tab's graph state from poisoning the target tab; the operation now uses the target tracker state and fails closed on unproven capture.\n- Add a production workflow_open behavioral test through the shipped bundle path, plus update the source-contract checks.\n- No graph read/render code was changed; existing render/read semantics remain intact.\n\n## Validation\n- Full unit suite: 7,064 passed, 1 todo.\n- Typecheck and scope checks: green.\n- Focused production-path #1639 tests: green.\n- Diff checks: green.\n- Based on origin/main df9a5b0; no MCP #2402/#2404/#2405 code is in this repository.