### PR TITLE
fix(panel): bound panel_search_nodes replies (#1908)

### DIFF
--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -92,7 +92,10 @@ function buildTransportsOverRejectingFetch(thrown) {
     "classifyManager404",
     "markManagerUnreachable",
     "managerFetchFailureMessage",
-    `${pick(src, /async function managerV2\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerV2")}
+    "MANAGER_FETCH_TIMEOUT_MS",
+    "AbortSignal",
+    `${pick(src, /function anyAbortSignal\(signals\) \{[\s\S]*?\n\}/, "anyAbortSignal")}
+${pick(src, /async function managerV2\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerV2")}
 ${pick(src, /async function managerCall\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerCall")}
 return { managerV2, managerCall };`,
   );
@@ -105,6 +108,8 @@ return { managerV2, managerCall };`,
     classifyManager404,
     ManagerInstall.markManagerUnreachable,
     (route, err) => `Manager ${route} could not be delivered: ${err?.message}`,
+    15000,
+    AbortSignal,
   );
 }
 
@@ -157,7 +162,11 @@ test("managerV2/managerCall tag a 404 as managerRouteMissing, never the no-respo
     // recognises it without reading the (translated) message. Real implementation,
     // same as classifyManager404.
     "markManagerUnreachable",
-    `${pick(src, /async function managerV2\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerV2")}
+    "managerFetchFailureMessage",
+    "MANAGER_FETCH_TIMEOUT_MS",
+    "AbortSignal",
+    `${pick(src, /function anyAbortSignal\(signals\) \{[\s\S]*?\n\}/, "anyAbortSignal")}
+${pick(src, /async function managerV2\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerV2")}
 ${pick(src, /async function managerCall\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerCall")}
 return { managerV2, managerCall };`,
   );
@@ -169,6 +178,9 @@ return { managerV2, managerCall };`,
       { fetchApi: async () => res },
       classifyManager404,
       ManagerInstall.markManagerUnreachable,
+      (route, err) => `Manager ${route} could not be delivered: ${err?.message}`,
+      15000,
+      AbortSignal,
     );
     for (const call of [mv2, mcall]) {
       const err = await call("manager/queue/status").then(
@@ -206,6 +218,10 @@ return { managerV2, managerCall };`,
     const { managerV2: mv2, managerCall: mcall } = factory(
       { fetchApi: async () => secRes },
       classifyManager404,
+      ManagerInstall.markManagerUnreachable,
+      (route, err) => `Manager ${route} could not be delivered: ${err?.message}`,
+      15000,
+      AbortSignal,
     );
     for (const call of [mv2, mcall]) {
       const err = await call("manager/queue/install").then(
@@ -229,7 +245,14 @@ return { managerV2, managerCall };`,
         throw new Error("stream already consumed");
       },
     };
-    const { managerV2: mv2 } = factory({ fetchApi: async () => brokenBody }, classifyManager404);
+    const { managerV2: mv2 } = factory(
+      { fetchApi: async () => brokenBody },
+      classifyManager404,
+      ManagerInstall.markManagerUnreachable,
+      (route, err) => `Manager ${route} could not be delivered: ${err?.message}`,
+      15000,
+      AbortSignal,
+    );
     const err = await mv2("manager/queue/status").then(
       () => null,
       (e) => e,

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -1644,9 +1644,19 @@ test("#1908 the production nodes_search handler answers a stalled Manager inside
   const abortError = () => Object.assign(new Error("Manager request aborted"), { name: "AbortError" });
   const managerGet = async (_route, { signal } = {}) =>
     new Promise((_, reject) => {
-      const abort = () => reject(abortError());
+      // AbortSignal.timeout() uses an unref'd timer in Node. Keep this mock's
+      // worker alive with a short ref'd fallback, but clear it as soon as the
+      // production budget signal aborts so the test does not leave a timer
+      // behind. This fallback is only for event-loop liveness; the normal
+      // assertion still exercises the handler's 25ms AbortSignal timeout.
+      let fallbackTimer;
+      const abort = () => {
+        clearTimeout(fallbackTimer);
+        reject(abortError());
+      };
       if (signal?.aborted) return abort();
       signal?.addEventListener("abort", abort, { once: true });
+      fallbackTimer = setTimeout(abort, 250);
     });
   const managerCall = async () => {
     managerCallUsed = true;

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -1647,8 +1647,9 @@ test("#1908 the production nodes_search handler answers a stalled Manager inside
       // AbortSignal.timeout() uses an unref'd timer in Node. Keep this mock's
       // worker alive with a short ref'd fallback, but clear it as soon as the
       // production budget signal aborts so the test does not leave a timer
-      // behind. This fallback is only for event-loop liveness; the normal
-      // assertion still exercises the handler's 25ms AbortSignal timeout.
+      // behind. If the production budget is not wired, fail with a DISTINCT
+      // non-abort error; otherwise a generic AbortError-to-timeout conversion
+      // could make this test pass without the internal budget firing.
       let fallbackTimer;
       const abort = () => {
         clearTimeout(fallbackTimer);
@@ -1656,7 +1657,10 @@ test("#1908 the production nodes_search handler answers a stalled Manager inside
       };
       if (signal?.aborted) return abort();
       signal?.addEventListener("abort", abort, { once: true });
-      fallbackTimer = setTimeout(abort, 250);
+      fallbackTimer = setTimeout(
+        () => reject(new Error("test fallback fired before the internal budget")),
+        250,
+      );
     });
   const managerCall = async () => {
     managerCallUsed = true;
@@ -1704,6 +1708,73 @@ test("#1908 searchNodesVia forwards one caller signal through the legacy fallbac
   assert.equal(receivedSignal, controller.signal);
   assert.equal(result.count, 1);
   assert.equal(result.results[0].title, "ComfyUI-RMBG");
+});
+
+test("#1908 caller cancellation rejects instead of becoming the internal timeout result", async () => {
+  const controller = new AbortController();
+  const abortError = () =>
+    Object.assign(new Error("caller stopped the node search"), { name: "AbortError" });
+  const managerGet = async (_route, { signal } = {}) =>
+    new Promise((_, reject) => {
+      const abort = () => reject(signal?.reason ?? abortError());
+      if (signal?.aborted) return abort();
+      signal?.addEventListener("abort", abort, { once: true });
+    });
+  const managerCall = async () => {
+    throw new Error("legacy fallback must not run after caller cancellation");
+  };
+
+  const pending = searchNodesVia(managerGet, managerCall, {
+    query: "caller-cancelled",
+    signal: controller.signal,
+    timeoutMs: 25,
+  });
+  controller.abort(abortError());
+
+  await assert.rejects(
+    pending,
+    (err) => {
+      assert.equal(err.name, "AbortError");
+      assert.match(err.message, /caller stopped/);
+      assert.equal(err.managerSearchTimedOut, undefined);
+      return true;
+    },
+    "caller cancellation must remain a rejection",
+  );
+});
+
+test("#1908 caller cancellation through /object_info fallback rejects instead of timing out", async () => {
+  const controller = new AbortController();
+  const abortError = () =>
+    Object.assign(new Error("caller stopped the installed-node fallback"), { name: "AbortError" });
+  const unreachable = async () => {
+    throw UNREACHABLE;
+  };
+  const objectInfoGet = async ({ signal } = {}) =>
+    new Promise((_, reject) => {
+      const abort = () => reject(signal?.reason ?? abortError());
+      if (signal?.aborted) return abort();
+      signal?.addEventListener("abort", abort, { once: true });
+    });
+
+  const pending = searchNodesVia(unreachable, unreachable, {
+    query: "caller-cancelled-installed-fallback",
+    objectInfoGet,
+    signal: controller.signal,
+    timeoutMs: 25,
+  });
+  controller.abort(abortError());
+
+  await assert.rejects(
+    pending,
+    (err) => {
+      assert.equal(err.name, "AbortError");
+      assert.match(err.message, /installed-node fallback/);
+      assert.equal(err.managerSearchTimedOut, undefined);
+      return true;
+    },
+    "caller cancellation must remain a rejection through object_info",
+  );
 });
 
 test("parseNodeMappings handles array + map shapes and caps the limit", () => {

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -1603,6 +1603,99 @@ test("#251/#255 a non-unreachable error from the absolute fallback also propagat
   );
 });
 
+// ---------------------------------------------------------------------------
+// #1908 — nodes_search is a canvas-independent read, but its reply still has
+// to travel through the panel tab that received the command. The production
+// handler therefore gives the complete Manager probe/fallback ladder one
+// budget below the bridge's 20s read deadline and passes its AbortSignal down
+// to every request. A stalled Manager must become a structured answer, not a
+// misleading "bound canvas tab did not reply" timeout.
+// ---------------------------------------------------------------------------
+
+function loadNodesSearchHandler({ budgetMs, managerGet, managerCall, fetchObjectInfo }) {
+  const panelPath = fileURLToPath(
+    new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+  );
+  const src = readFileSync(panelPath, "utf8");
+  const fnMatch = src.match(/async nodes_search\(\{ query, limit \}\) \{[\s\S]*?\n  \},/);
+  assert.ok(fnMatch, "could not locate the production nodes_search handler");
+  const body = fnMatch[0].replace(/,\s*$/, "");
+  const factory = new Function(
+    "searchNodesVia",
+    "managerGet",
+    "managerCall",
+    "fetchObjectInfo",
+    "AbortSignal",
+    "NODES_SEARCH_COMMAND_BUDGET_MS",
+    `const handler = { ${body} }; return handler.nodes_search;`,
+  );
+  return factory(
+    searchNodesVia,
+    managerGet,
+    managerCall,
+    fetchObjectInfo,
+    AbortSignal,
+    budgetMs,
+  );
+}
+
+test("#1908 the production nodes_search handler answers a stalled Manager inside the bridge window", async () => {
+  let managerCallUsed = false;
+  const abortError = () => Object.assign(new Error("Manager request aborted"), { name: "AbortError" });
+  const managerGet = async (_route, { signal } = {}) =>
+    new Promise((_, reject) => {
+      const abort = () => reject(abortError());
+      if (signal?.aborted) return abort();
+      signal?.addEventListener("abort", abort, { once: true });
+    });
+  const managerCall = async () => {
+    managerCallUsed = true;
+    throw new Error("legacy fallback must not run after the search budget aborts");
+  };
+  const nodesSearch = loadNodesSearchHandler({
+    budgetMs: 25,
+    managerGet,
+    managerCall,
+    fetchObjectInfo: async () => {
+      throw new Error("object_info fallback must not run after the search budget aborts");
+    },
+  });
+
+  const started = Date.now();
+  const result = await nodesSearch({ query: "MiniMaxH3UnifiedToVideo" });
+  const elapsed = Date.now() - started;
+
+  assert.ok(elapsed < 1000, `stalled search must settle promptly, took ${elapsed} ms`);
+  assert.equal(managerCallUsed, false, "an exhausted search budget must not start another route");
+  assert.equal(result.supported, false);
+  assert.equal(result.managerReachable, false);
+  assert.equal(result.query, "MiniMaxH3UnifiedToVideo");
+  assert.match(result.reason, /timed out/i);
+  assert.match(result.message, /No canvas workflow was changed/i);
+  assert.match(result.message, /Retry/i);
+});
+
+test("#1908 searchNodesVia forwards one caller signal through the legacy fallback", async () => {
+  const controller = new AbortController();
+  let receivedSignal;
+  const managerGet = async () => {
+    throw UNREACHABLE;
+  };
+  const managerCall = async (_route, { signal } = {}) => {
+    receivedSignal = signal;
+    return GETMAPPINGS_MAP;
+  };
+  const result = await searchNodesVia(managerGet, managerCall, {
+    query: "BiRefNet",
+    signal: controller.signal,
+    timeoutMs: 15000,
+  });
+
+  assert.equal(receivedSignal, controller.signal);
+  assert.equal(result.count, 1);
+  assert.equal(result.results[0].title, "ComfyUI-RMBG");
+});
+
 test("parseNodeMappings handles array + map shapes and caps the limit", () => {
   const arr = [
     { id: "a/one", title: "One", description: "first" },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -25364,11 +25364,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // ComfyUI's /object_info (#426) so a legacy/disabled Manager still returns
     // usable, already-installed matches; on a miss it returns the structured
     // {supported:false,…} capability result.
-    const signal = AbortSignal.timeout(NODES_SEARCH_COMMAND_BUDGET_MS);
+    const budgetSignal = AbortSignal.timeout(NODES_SEARCH_COMMAND_BUDGET_MS);
     return searchNodesVia(managerGet, managerCall, {
       query,
       limit,
-      signal,
+      budgetSignal,
       timeoutMs: NODES_SEARCH_COMMAND_BUDGET_MS,
       objectInfoGet: fetchObjectInfo,
     });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7958,7 +7958,10 @@ async function managerV2(route, { method = "GET", body, signal } = {}) {
   try {
     res = await api.fetchApi(`/v2/${route}`, {
       method,
-      ...(signal ? { signal } : {}),
+      // #1908 — keep every Manager request inside both its per-fetch cap and
+      // the caller's overall search budget. Otherwise a legacy fallback can
+      // outlive the bridge reply window while the panel handler is awaiting it.
+      signal: anyAbortSignal([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal]),
       ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
     });
   } catch (err) {
@@ -8037,7 +8040,10 @@ async function managerCall(route, { method = "GET", body, signal } = {}) {
   try {
     res = await api.fetchApi(`/${route}`, {
       method,
-      ...(signal ? { signal } : {}),
+      // #1908 — the absolute legacy retry needs the same bounded transport as
+      // the dialect-routed request; a missing signal here can leave nodes_search
+      // waiting after the panel bridge has given up.
+      signal: anyAbortSignal([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal]),
       ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
     });
   } catch (err) {
@@ -8162,6 +8168,11 @@ async function reProbeManagerDialect({ signal } = {}) {
  *  never hang the install path (codex round 2 #5 — probes, install, start,
  *  status, list are ALL bounded). */
 const MANAGER_FETCH_TIMEOUT_MS = 15000;
+
+// #1908 — the bridge's default read reply window is 20s. Settle nodes_search
+// before that deadline even when Manager does not answer, leaving room for the
+// structured result to travel back over the same socket.
+const NODES_SEARCH_COMMAND_BUDGET_MS = 15000;
 
 /** #671 — ONE budget for the WHOLE nodes_install command (dialect detect →
  *  submit → queue/start → verify). The orchestrator relays nodes_install with a
@@ -8349,10 +8360,10 @@ async function resolveManagerUpdateTarget(requestedId) {
  *  for nodes_list when Manager is unreachable. Bounded by the shared Manager
  *  timeout; throws on any non-ok / parse failure (the Via fallbacks swallow it
  *  and degrade). */
-async function fetchObjectInfo() {
+async function fetchObjectInfo({ signal } = {}) {
   const res = await api.fetchApi("/object_info", {
     method: "GET",
-    signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
+    signal: anyAbortSignal([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal]),
   });
   if (!res || !res.ok) throw new Error(`/object_info HTTP ${res ? res.status : "no response"}`);
   const txt = await res.text();
@@ -25337,6 +25348,12 @@ const GRAPH_TOOL_EXECUTORS = {
 
   // --- Custom-node management via the BUILT-IN ComfyUI Manager (/v2 API) ----
   async nodes_search({ query, limit }) {
+    // #1908: Manager search is a canvas-independent read, but its reply still
+    // travels through the browser tab that received this command. Bound the
+    // complete probe/fallback ladder below the bridge's 20s read deadline so a
+    // missing Manager response becomes an actionable result instead of a
+    // misleading "bound canvas tab did not reply" timeout.
+    //
     // #251/#255: degrade gracefully against an unreachable / legacy Manager
     // instead of surfacing a raw throw that blocks the whole install-discovery
     // flow. searchNodesVia tries the dialect-routed GET, retries the ABSOLUTE
@@ -25347,7 +25364,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // ComfyUI's /object_info (#426) so a legacy/disabled Manager still returns
     // usable, already-installed matches; on a miss it returns the structured
     // {supported:false,…} capability result.
-    return searchNodesVia(managerGet, managerCall, { query, limit, objectInfoGet: fetchObjectInfo });
+    const signal = AbortSignal.timeout(NODES_SEARCH_COMMAND_BUDGET_MS);
+    return searchNodesVia(managerGet, managerCall, {
+      query,
+      limit,
+      signal,
+      timeoutMs: NODES_SEARCH_COMMAND_BUDGET_MS,
+      objectInfoGet: fetchObjectInfo,
+    });
   },
 
   async nodes_list(args = {}) {

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -801,14 +801,26 @@ export function parseObjectInfoSearch(objectInfo, query, limit) {
  * (the panel wires the live /object_info fetch) so this stays unit-testable, and
  * NEVER throws — any /object_info failure degrades to managerUnavailableResult.
  */
-export async function objectInfoSearchFallback(objectInfoGet, query, limit, err) {
+export async function objectInfoSearchFallback(
+  objectInfoGet,
+  query,
+  limit,
+  err,
+  signal,
+  timeoutMs,
+) {
+  if (managerSearchWasAborted(signal, err)) return managerSearchTimedOutResult(query, timeoutMs);
   if (typeof objectInfoGet !== "function") return managerUnavailableResult(query, err);
   let info;
   try {
-    info = await objectInfoGet();
-  } catch {
+    info = await objectInfoGet(signal ? { signal } : undefined);
+  } catch (fallbackErr) {
+    if (managerSearchWasAborted(signal, fallbackErr)) {
+      return managerSearchTimedOutResult(query, timeoutMs);
+    }
     return managerUnavailableResult(query, err);
   }
+  if (signal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
   const parsed = parseObjectInfoSearch(info, query, limit);
   if (!parsed.count) return managerUnavailableResult(query, err);
   const result = {
@@ -840,6 +852,7 @@ export async function objectInfoSearchFallback(objectInfoGet, query, limit, err)
  * result the caller can branch on. Issues #251/#255.
  */
 export function managerUnavailableResult(query, err) {
+  const timedOut = err?.managerSearchTimedOut === true;
   return {
     supported: false,
     managerReachable: false,
@@ -847,13 +860,36 @@ export function managerUnavailableResult(query, err) {
     results: [],
     query: query == null ? "" : String(query),
     reason: String(err?.message ?? err ?? "ComfyUI-Manager not reachable"),
-    message:
-      "Node-registry search is unavailable: the built-in ComfyUI-Manager could not " +
-      "be reached on this ComfyUI (it may be disabled, or a legacy/partial Manager " +
-      "build without the search endpoint). Enable the built-in Manager to search the " +
-      "registry, or continue with the nodes already installed — inspect them with " +
-      "panel_list_nodes and the current graph with panel_query_graph.",
+    message: timedOut
+      ? "Node-registry search timed out before ComfyUI-Manager replied. No canvas " +
+        "workflow was changed. Retry the search; if the Manager remains slow or " +
+        "unresponsive, enable/check the built-in Manager and continue with nodes " +
+        "already installed via panel_list_nodes or the current graph via " +
+        "panel_query_graph."
+      : "Node-registry search is unavailable: the built-in ComfyUI-Manager could not " +
+        "be reached on this ComfyUI (it may be disabled, or a legacy/partial Manager " +
+        "build without the search endpoint). Enable the built-in Manager to search the " +
+        "registry, or continue with the nodes already installed — inspect them with " +
+        "panel_list_nodes and the current graph with panel_query_graph.",
   };
+}
+
+/** #1908 — Manager search is a canvas-independent read, but its command still
+ * returns through the browser tab that received it. Treat an aborted Manager
+ * request as a bounded, actionable result instead of allowing the relay to
+ * report that the bound canvas tab never replied. */
+function managerSearchTimedOutResult(query, timeoutMs) {
+  const err = new Error(
+    `ComfyUI-Manager node search timed out after ${timeoutMs ?? 15000} ms; no reply arrived.`,
+  );
+  err.managerSearchTimedOut = true;
+  return managerUnavailableResult(query, err);
+}
+
+function managerSearchWasAborted(signal, err) {
+  return Boolean(
+    signal?.aborted || err?.name === "AbortError" || err?.name === "TimeoutError",
+  );
 }
 
 /**
@@ -988,22 +1024,30 @@ export function emptyCatalogueResult(query) {
 export async function searchNodesVia(
   managerGet,
   managerCall,
-  { query, limit, objectInfoGet } = {},
+  { query, limit, objectInfoGet, signal, timeoutMs } = {},
 ) {
   const route = "customnode/getmappings?mode=cache";
+  const requestOptions = signal ? { signal } : undefined;
   let data;
   try {
-    data = await managerGet(route);
+    data = await managerGet(route, requestOptions);
   } catch (err) {
+    if (managerSearchWasAborted(signal, err)) {
+      return managerSearchTimedOutResult(query, timeoutMs);
+    }
     if (!isManagerUnreachable(err)) throw err;
     try {
-      data = await managerCall(route);
+      data = await managerCall(route, requestOptions);
     } catch (err2) {
+      if (managerSearchWasAborted(signal, err2)) {
+        return managerSearchTimedOutResult(query, timeoutMs);
+      }
       if (isManagerUnreachable(err2))
-        return objectInfoSearchFallback(objectInfoGet, query, limit, err2);
+        return objectInfoSearchFallback(objectInfoGet, query, limit, err2, signal, timeoutMs);
       throw err2;
     }
   }
+  if (signal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
   const parsed = parseNodeMappings(data, query, limit);
   // #808 — an EMPTY catalogue is not a no-match, and only this branch can tell the
   // caller so. Checked on `catalogue_size` (packs the payload carried) rather than

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -806,21 +806,27 @@ export async function objectInfoSearchFallback(
   query,
   limit,
   err,
-  signal,
+  requestSignal,
   timeoutMs,
+  budgetSignal,
+  callerSignal,
 ) {
-  if (managerSearchWasAborted(signal, err)) return managerSearchTimedOutResult(query, timeoutMs);
+  const effectiveCallerSignal = callerSignal ?? (budgetSignal ? undefined : requestSignal);
+  throwIfManagerSearchCallerAborted(effectiveCallerSignal);
+  if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
+  if (isAbortLikeError(err)) throw err;
   if (typeof objectInfoGet !== "function") return managerUnavailableResult(query, err);
   let info;
   try {
-    info = await objectInfoGet(signal ? { signal } : undefined);
+    info = await objectInfoGet(requestSignal ? { signal: requestSignal } : undefined);
   } catch (fallbackErr) {
-    if (managerSearchWasAborted(signal, fallbackErr)) {
-      return managerSearchTimedOutResult(query, timeoutMs);
-    }
+    throwIfManagerSearchCallerAborted(effectiveCallerSignal);
+    if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
+    if (isAbortLikeError(fallbackErr)) throw fallbackErr;
     return managerUnavailableResult(query, err);
   }
-  if (signal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
+  throwIfManagerSearchCallerAborted(effectiveCallerSignal);
+  if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
   const parsed = parseObjectInfoSearch(info, query, limit);
   if (!parsed.count) return managerUnavailableResult(query, err);
   const result = {
@@ -875,9 +881,10 @@ export function managerUnavailableResult(query, err) {
 }
 
 /** #1908 — Manager search is a canvas-independent read, but its command still
- * returns through the browser tab that received it. Treat an aborted Manager
- * request as a bounded, actionable result instead of allowing the relay to
- * report that the bound canvas tab never replied. */
+ * returns through the browser tab that received it. Only the explicit internal
+ * budget is converted into a bounded, actionable result. Caller cancellation
+ * remains an AbortError so callers can stop the operation without it looking like
+ * a successful, structured Manager timeout. */
 function managerSearchTimedOutResult(query, timeoutMs) {
   const err = new Error(
     `ComfyUI-Manager node search timed out after ${timeoutMs ?? 15000} ms; no reply arrived.`,
@@ -886,10 +893,40 @@ function managerSearchTimedOutResult(query, timeoutMs) {
   return managerUnavailableResult(query, err);
 }
 
-function managerSearchWasAborted(signal, err) {
-  return Boolean(
-    signal?.aborted || err?.name === "AbortError" || err?.name === "TimeoutError",
-  );
+function isAbortLikeError(err) {
+  return err?.name === "AbortError" || err?.name === "TimeoutError";
+}
+
+function managerSearchAbortError() {
+  return Object.assign(new Error("The Manager node search was cancelled"), {
+    name: "AbortError",
+  });
+}
+
+function throwIfManagerSearchCallerAborted(signal) {
+  if (signal?.aborted) throw signal.reason ?? managerSearchAbortError();
+}
+
+/** Compose the caller's cancellation with the internal budget for transport, while
+ * keeping the two source signals separate for result classification. */
+function managerSearchRequestSignal(callerSignal, budgetSignal) {
+  if (!callerSignal) return budgetSignal;
+  if (!budgetSignal) return callerSignal;
+  if (typeof AbortSignal !== "undefined" && typeof AbortSignal.any === "function") {
+    return AbortSignal.any([callerSignal, budgetSignal]);
+  }
+  const controller = new AbortController();
+  const forward = (source) => {
+    if (source.aborted) {
+      controller.abort(source.reason);
+      return true;
+    }
+    source.addEventListener("abort", () => controller.abort(source.reason), { once: true });
+    return false;
+  };
+  if (forward(callerSignal)) return controller.signal;
+  forward(budgetSignal);
+  return controller.signal;
 }
 
 /**
@@ -1024,30 +1061,42 @@ export function emptyCatalogueResult(query) {
 export async function searchNodesVia(
   managerGet,
   managerCall,
-  { query, limit, objectInfoGet, signal, timeoutMs } = {},
+  { query, limit, objectInfoGet, signal, budgetSignal, timeoutMs } = {},
 ) {
   const route = "customnode/getmappings?mode=cache";
-  const requestOptions = signal ? { signal } : undefined;
+  const requestSignal = managerSearchRequestSignal(signal, budgetSignal);
+  const requestOptions = requestSignal ? { signal: requestSignal } : undefined;
+  throwIfManagerSearchCallerAborted(signal);
   let data;
   try {
     data = await managerGet(route, requestOptions);
   } catch (err) {
-    if (managerSearchWasAborted(signal, err)) {
-      return managerSearchTimedOutResult(query, timeoutMs);
-    }
+    throwIfManagerSearchCallerAborted(signal);
+    if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
+    if (isAbortLikeError(err)) throw err;
     if (!isManagerUnreachable(err)) throw err;
     try {
       data = await managerCall(route, requestOptions);
     } catch (err2) {
-      if (managerSearchWasAborted(signal, err2)) {
-        return managerSearchTimedOutResult(query, timeoutMs);
-      }
+      throwIfManagerSearchCallerAborted(signal);
+      if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
+      if (isAbortLikeError(err2)) throw err2;
       if (isManagerUnreachable(err2))
-        return objectInfoSearchFallback(objectInfoGet, query, limit, err2, signal, timeoutMs);
+        return objectInfoSearchFallback(
+          objectInfoGet,
+          query,
+          limit,
+          err2,
+          requestSignal,
+          timeoutMs,
+          budgetSignal,
+          signal,
+        );
       throw err2;
     }
   }
-  if (signal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
+  throwIfManagerSearchCallerAborted(signal);
+  if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
   const parsed = parseNodeMappings(data, query, limit);
   // #808 — an EMPTY catalogue is not a no-match, and only this branch can tell the
   // caller so. Checked on `catalogue_size` (packs the payload carried) rather than


### PR DESCRIPTION
## Summary

- Bound the complete panel_search_nodes Manager probe/fallback ladder to 15 seconds, below the bridge's 20-second read-reply window.
- Composed the caller budget with each Manager and object_info request timeout.
- Return an actionable structured timeout result explaining that no canvas workflow was changed and how to retry/inspect installed nodes.
- Added production-handler and legacy-fallback signal regression coverage.

Fixes #1908

## Validation

- npm.cmd run test:unit — 7,070 passed, 1 todo
- npm.cmd run typecheck — passed
- node --check web/js/lib/manager-install.js — passed
- node --check web/js/comfyui-mcp-panel.js — passed
- git diff --check — passed

No changes to init.py or apps_routes.py. Not merged; awaiting independent review.