### PR TITLE
fix(1886): actually run the network-rule replica in CI, as a ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,23 @@ jobs:
           sys.exit(1 if bad else 0)
           PY
 
+      # The YARA step above covers SVG onload/onerror and process-spawn literals ONLY.
+      # It knows nothing about python_network_operations, the rule family the registry
+      # added on 2026-08-26 — which is exactly how fifteen consecutive releases shipped
+      # with this job GREEN while the registry flagged every one of them (#1854/#1886).
+      # scripts/check-registry-yara.mjs (added in #1874) does model that family; it had
+      # simply never been wired to anything, so it only ran when someone remembered.
+      #
+      # Wired as a RATCHET, not a hard zero. Three shipped files match today and cannot
+      # be cleared by refactoring: two match on third-party verbs (WebSocket, litegraph)
+      # that we do not own and cannot rename, and the third is a plain socket READ in the
+      # orchestrator probe — a liveness probe has to read the response. Allowing exactly
+      # today's count means this job goes RED the moment a FOURTH shipped file gains
+      # socket traffic, which is the regression actually worth catching. Lower the number
+      # whenever a finding is genuinely cleared; never raise it to make a build pass.
+      - name: Security scan (Comfy Registry parity — network rules)
+        run: node scripts/check-registry-yara.mjs --allow 3
+
       # The registry applies .comfyignore with gitignore semantics: a bare
       # `vendor/` matches a vendor dir at ANY depth, so the exclusion meant for
       # the root CI artefact also silently dropped web/js/vendor/ (the runtime


### PR DESCRIPTION
## The gap

#1874 added a replica that models `python_network_operations`. #1916 made it faithful. **Neither wired it to anything** — it ran only when someone remembered to type it.

Meanwhile the "Comfy Registry parity" step that *does* run covers only SVG `onload`/`onerror` and process-spawn literals. It knows nothing about the network rule family, which is exactly how **fifteen consecutive releases shipped with CI green while the registry flagged every one**. That's the defect #1886 names: the gate is confidently wrong, so each release adds to the backlog while reporting success.

## Wired as a ratchet, not a hard zero

Zero isn't currently reachable. Three shipped files match and none can be refactored away:

- `comfyui-mcp-panel.js` and `restart-tab-identity.js` match on **third-party verbs** (WebSocket, litegraph) we neither own nor can rename
- `__init__.py` matches on a plain socket **read** in the orchestrator probe — a liveness probe has to read the response

So `--allow 3` passes today and goes **red the moment a fourth shipped file gains socket traffic**, which is the regression actually worth catching. The number comes down as findings are genuinely cleared; it must never go up to make a build pass.

## Verified in both directions

Not assumed — a gate that only ever passes proves nothing:

```
node scripts/check-registry-yara.mjs --allow 3   ->  exit 0   (passes at today's baseline)
node scripts/check-registry-yara.mjs --allow 2   ->  exit 1   (fires — not a no-op)
```

`ci.yml` still parses as YAML.

## Note on what this does and doesn't do

This does **not** make the pack Active — that still needs the registry allow-list ([#180](https://github.com/Comfy-Org/registry-backend/issues/180) / [#208](https://github.com/Comfy-Org/registry-backend/issues/208)). What it does is stop the backlog growing silently, and guarantee the next person to add a socket call to a new file finds out in CI instead of from a flagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXS5Qys1hiK9aDdXJRJ6Y