### PR TITLE
fix(1919): a token COUNT is a generation control, not a credential

### DIFF
--- a/browser_tests/unit/widget-secret-redaction.test.mjs
+++ b/browser_tests/unit/widget-secret-redaction.test.mjs
@@ -105,3 +105,90 @@ test("#1729 preserves aliases and cycles within one redaction context", () => {
   assert.strictEqual(safe.left, safe.right, "same-context aliases remain aliases");
   assert.strictEqual(safe.cycle.self, safe.cycle, "same-context cycles remain finite and cyclic");
 });
+
+// ---------------------------------------------------------------------------
+// #1919 — a token COUNT is a generation control, not a credential.
+//
+// `max_tokens` normalizes to `max_tokens`, which the #1729 TOKEN name pattern matches
+// on its `_tokens` ending, so an ordinary numeric setting came back as [REDACTED] and
+// could not be inspected or validated.
+//
+// The relaxation is keyed on the NAME, not the value's type, and is an allow-list of
+// quantity qualifiers so it fails CLOSED. Both properties are pinned below, because
+// both are ways this fix could have gone wrong in the direction that leaks.
+// ---------------------------------------------------------------------------
+
+test("#1919 token COUNT widgets are visible, whatever type they hold", () => {
+  for (const name of [
+    "max_tokens",
+    "maxTokens",
+    "max_new_tokens",
+    "min_tokens",
+    "num_tokens",
+    "n_tokens",
+    "total_tokens",
+    "prompt_tokens",
+    "completion_tokens",
+    "context_tokens",
+    "budget_tokens",
+  ]) {
+    assert.equal(redactWidgetValue(name, 256), 256, `${name} (number) must stay visible`);
+    // The reported fix keyed on the value being numeric, which left this case redacted.
+    assert.equal(redactWidgetValue(name, "256"), "256", `${name} (string) must stay visible`);
+  }
+});
+
+test("#1919 FAILS CLOSED: an unqualified token name is still redacted", () => {
+  // The qualifier list is an allow-list. A token field it does not name stays secret --
+  // including one holding a bare number, which a type-based rule would have revealed.
+  for (const [name, value] of [
+    ["token", 12345],
+    ["token", "sk-abc"],
+    ["tokens", 100],
+    ["token_value", 5],
+    ["token_header", 7],
+    ["session_tokens", 42],
+  ]) {
+    assert.equal(
+      redactWidgetValue(name, value),
+      REDACTED_WIDGET_VALUE,
+      `${name} is not a counted quantity and must stay redacted`,
+    );
+  }
+});
+
+test("#1919 credential names are redacted no matter what qualifies them", () => {
+  // SENSITIVE_WIDGET_NAME_RE is tested FIRST and is never relaxed, so a qualifier that
+  // would otherwise read as a count cannot unlock a real credential.
+  for (const [name, value] of [
+    ["access_token", 12345],
+    ["refresh_token", 1],
+    ["auth_token", 999],
+    ["max_access_token", 5],
+    ["num_auth_tokens", 3],
+    // These match the COUNT allow-list AND the credential list at the same time
+    // (`max_token_...` satisfies `<qualifier>_token`). 1152 such names exist over this
+    // module`s own vocabulary. They are the ONLY thing that proves the credential check
+    // runs FIRST: with the two clauses swapped every one of them is revealed, and every
+    // other case in this file passes unchanged.
+    ["max_token_api_key", "s3cret"],
+    ["max_token_access_token", "s3cret"],
+    ["num_tokens_password", "s3cret"],
+    ["limit_token_client_secret", "s3cret"],
+    ["api_key", 42],
+    ["password", 1234],
+    ["client_secret", 7],
+  ]) {
+    assert.equal(
+      redactWidgetValue(name, value),
+      REDACTED_WIDGET_VALUE,
+      `${name} must stay redacted`,
+    );
+  }
+});
+
+test("#1919 ordinary widgets are untouched", () => {
+  assert.equal(redactWidgetValue("seed", 12345), 12345);
+  assert.equal(redactWidgetValue("steps", 20), 20);
+  assert.equal(redactWidgetValue("text", "a prompt about tokens"), "a prompt about tokens");
+});

--- a/web/js/lib/widget-secret-redaction.js
+++ b/web/js/lib/widget-secret-redaction.js
@@ -8,6 +8,23 @@ const SENSITIVE_WIDGET_NAME_RE =
   /(?:^|_)(?:credentials?|secret(?:_keys?)?|private_keys?|api_keys?|apikeys?|access_token|refresh_token|auth_token|authentication_token|authorization|bearer|password|passwd|client_secrets?)(?:_|$)/;
 const TOKEN_WIDGET_NAME_RE = /(?:^|_)tokens?(?:$|_(?:value|values|string|header|headers))/;
 
+// #1919 — a token COUNT is a generation control, not a credential. `max_tokens` matches
+// TOKEN_WIDGET_NAME_RE above (`_tokens` at end of name), so an ordinary numeric setting
+// came back as [REDACTED] and could not be inspected or validated. Same for maxTokens,
+// min_tokens, num_tokens, n_tokens and max_new_tokens.
+//
+// This is an ALLOW-LIST of quantity qualifiers, so it fails CLOSED: a token field whose
+// qualifier is not listed here stays redacted. The reported fix keyed on the VALUE being
+// numeric instead, which fails OPEN — a credential named exactly `token` holding a number
+// would have been revealed — and it also left `max_tokens: "256"` redacted, since a
+// string is not a number. Deciding by NAME fixes both directions: what makes `max_tokens`
+// safe is that it counts tokens, which is true whatever type the widget stores it as.
+//
+// SENSITIVE_WIDGET_NAME_RE is unaffected and still matches first, so `access_token`,
+// `refresh_token` and `auth_token` are redacted no matter what precedes them.
+const TOKEN_COUNT_WIDGET_NAME_RE =
+  /(?:^|_)(?:max|min|num|n|total|count|limit|budget|new|target|input|output|prompt|completion|context|response|remaining|used)_(?:new_)?tokens?(?:$|_)/;
+
 // Value-based coverage is intentionally limited to formats that are useful to catch
 // without treating arbitrary prose as a credential. The field-name checks above cover
 // provider-specific API-key widgets; these patterns catch an unhelpfully named field.
@@ -25,7 +42,11 @@ function normalizeWidgetName(name) {
 
 function isSensitiveName(name) {
   const normalized = normalizeWidgetName(name);
-  return SENSITIVE_WIDGET_NAME_RE.test(normalized) || TOKEN_WIDGET_NAME_RE.test(normalized);
+  // Checked first and never relaxed: these names are credentials whatever qualifies them.
+  if (SENSITIVE_WIDGET_NAME_RE.test(normalized)) return true;
+  if (!TOKEN_WIDGET_NAME_RE.test(normalized)) return false;
+  // #1919 — a counted quantity of tokens is not a token.
+  return !TOKEN_COUNT_WIDGET_NAME_RE.test(normalized);
 }
 
 function isPlainObject(value) {


### PR DESCRIPTION
Closes #1919.

## The bug, and it is wider than reported

`max_tokens` normalizes to `max_tokens`, which #1729's `TOKEN_WIDGET_NAME_RE` matches on its `_tokens` ending. Measured on `main` before changing anything:

    max_tokens        256    -> REDACTED
    maxTokens         256    -> REDACTED
    min_tokens        8      -> REDACTED
    num_tokens        4      -> REDACTED
    n_tokens          4      -> REDACTED
    seed              12345  -> 12345      (control)

## Why not the reported fix

The report keys on the **value** being numeric. That fails in the direction that matters:

- **fails OPEN** — a credential named exactly `token` holding a number would be revealed;
- and it does not fix `max_tokens: "256"`, because a string is not a number.

This keys on the **name**, through an allow-list of quantity qualifiers, so it fails **closed**: a token field whose qualifier is not listed stays redacted. What makes `max_tokens` safe is that it counts tokens — true whatever type the widget stores it as.

After:

| widget | before | after |
|---|---|---|
| `max_tokens` = `256` | REDACTED | `256` |
| `max_tokens` = `"256"` | REDACTED | `"256"` |
| `max_new_tokens` = `512` | REDACTED | `512` |
| `token` = `12345` | REDACTED | **REDACTED** |
| `tokens` = `100` | REDACTED | **REDACTED** |
| `session_tokens` = `42` | REDACTED | **REDACTED** |
| `access_token` = `12345` | REDACTED | **REDACTED** |

`SENSITIVE_WIDGET_NAME_RE` is untouched and still tested first.

## The part I got wrong first, and how it surfaced

That ordering is load-bearing, and **my first version of these tests did not prove it**. Swapping the two clauses passed all ten — because the cases I had picked (`max_access_token`, `num_auth_tokens`) match the credential list but *not* the count list, so the order could not matter for them. A passing suite, a surviving mutant, and a real leak behind it.

An exhaustive search over this module's own vocabulary (70,643 names, 1–3 segments) found **1152 names matching BOTH** patterns — `max_token_api_key`, `num_tokens_password`, `limit_token_client_secret`. Every one is revealed under the swap. Four are now pinned, and they are the only cases in the file that can see the ordering at all.

## Mutation results

| mutant | verdict |
|---|---|
| no count relaxation (pre-fix) | killed (1 of 10) |
| relax every token name (fail-open) | killed (3 of 10) |
| **clause swap — count checked before credentials** | **killed (1 of 10)** — survived before the 1152-name finding |
| drop `max` from the qualifiers | killed (1 of 10) |
| loosen the anchor so `session_tokens` leaks | killed (3 of 10) |

Controls survive each.

**Suite:** 7077 tests, **7076 pass, 0 fail** (1 pre-existing todo). `check-tool-vocabulary` OK, `check-panel-scope` OK, `tsc --noEmit` exit 0.

## Not merged

The merge gate has been returning `INDETERMINATE — codex account quota exhausted` board-wide; Copilot is quota-exhausted too. Verified directly and queued. This one relaxes a redaction control, so it deserves the independent read more than most — I would rather it wait for the gate than land on my own verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
