### PR TITLE
fix(2436): the oversized-node detail stub keeps is_subgraph, so wide nodes stay writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- keep `is_subgraph` on oversized-node detail stubs so wide root nodes stay writable (artokun/comfyui-mcp#2436)
+
 ## [0.15.114] - 2026-08-27
 
 ### Fixed

--- a/browser_tests/unit/detail-stub-is-subgraph.test.mjs
+++ b/browser_tests/unit/detail-stub-is-subgraph.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * artokun/comfyui-mcp#2436 — a node wide enough to degrade became UNWRITABLE.
+ *
+ * The `detail` projection emits an always-boolean `is_subgraph` on purpose. #2314's
+ * comment says why: "MCP must distinguish a definitive ordinary node from an older
+ * Panel whose detail projection cannot classify promotion. Positive-only emission made
+ * missing capability look like false."
+ *
+ * `fitDetailLine` then replaced an oversized row with a stub carrying only
+ * `{id, type, title}` — dropping exactly that boolean, and reintroducing the absence
+ * #2314 had removed, one layer further down.
+ *
+ * The orchestrator's `parseVerifiedQueriedNodeScope` requires
+ * `typeof is_subgraph === "boolean"` and treats anything else as INDETERMINATE. Its
+ * caller then falls through to `graph_get_subgraph`, whose non-definitive answer is
+ * refused by the promoted-write fence. Net effect: every ordinary `panel_set_widget`
+ * on a wide node (`KSampler (Efficient)` in the report) was refused, with a message
+ * about promoted containers, on a root node that is not one.
+ *
+ * Run with `node --test`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { fitDetailLine } from "../../web/js/lib/graph-read.js";
+
+/** A detail row too wide for the budget — the shape that triggers the degrade. */
+const wide = (isSubgraph) =>
+  JSON.stringify({
+    id: 43,
+    type: "KSampler (Efficient)",
+    title: "KSampler (Efficient)",
+    is_subgraph: isSubgraph,
+    widgets: { blob: "x".repeat(4000) },
+  });
+
+test("#2436 the degraded stub PRESERVES a false is_subgraph", () => {
+  const out = fitDetailLine(wide(false), { id: 43, type: "KSampler (Efficient)", is_subgraph: false }, 300);
+
+  assert.ok(out.length <= 300, "the stub must still respect max_chars");
+  const parsed = JSON.parse(out);
+  assert.equal(typeof parsed.is_subgraph, "boolean", "a boolean is what the classifier requires");
+  assert.equal(parsed.is_subgraph, false);
+  assert.ok(parsed.detail_omitted, "and it still says the detail was omitted");
+});
+
+test("#2436 a true is_subgraph survives too — the degrade must not flip it", () => {
+  const out = fitDetailLine(wide(true), { id: 7, type: "MySubgraph", is_subgraph: true }, 300);
+  assert.equal(JSON.parse(out).is_subgraph, true);
+});
+
+test("#2436 an ABSENT is_subgraph stays absent — never invented as false", () => {
+  // An older panel cannot classify. Emitting `false` here would be the #2314 defect
+  // exactly: making missing capability look like a definitive ordinary node, which
+  // would authorize a promoted write the panel never vouched for.
+  const out = fitDetailLine(wide(false), { id: 9, type: "Old" }, 300);
+  assert.equal(Object.prototype.hasOwnProperty.call(JSON.parse(out), "is_subgraph"), false);
+});
+
+test("#2436 a non-boolean is_subgraph is dropped rather than passed through", () => {
+  const out = fitDetailLine(wide(false), { id: 9, type: "Weird", is_subgraph: "false" }, 300);
+  assert.equal(Object.prototype.hasOwnProperty.call(JSON.parse(out), "is_subgraph"), false);
+});
+
+test("#2436 an unclipped line is returned untouched — no stub, no added field", () => {
+  const small = JSON.stringify({ id: 1, type: "KSampler", is_subgraph: false });
+  assert.equal(fitDetailLine(small, { id: 1, type: "KSampler", is_subgraph: false }, 10_000), small);
+});
+
+test("#2436 the absurdly-small-budget fallback is unchanged", () => {
+  // That path identifies the node and nothing else by design; adding a field there
+  // could push it back over a budget that is already too small for the normal stub.
+  const out = fitDetailLine(wide(false), { id: 43, type: "KSampler (Efficient)", is_subgraph: false }, 40);
+  assert.ok(out.length <= 60, "stays minimal");
+  assert.equal(JSON.parse(out).detail_omitted, "raise `max_chars`");
+});
+
+test("#2436 the stub still fits the budget with the extra field", () => {
+  // The whole point of the stub is the bound. A boolean costs ~18 chars; prove the
+  // guarantee holds across a range of budgets rather than at one convenient number.
+  for (const budget of [120, 200, 300, 500, 1000]) {
+    const out = fitDetailLine(wide(false), { id: 43, type: "KSampler (Efficient)", is_subgraph: false }, budget);
+    assert.ok(out.length <= budget, `budget ${budget}: got ${out.length}`);
+    JSON.parse(out); // and it is always valid JSON
+  }
+});
+
+// The library fix is inert unless the detail projection actually HANDS it the field.
+// Read with CRLF normalized: the panel tree is CRLF, so an anchor taken from `git show`
+// never matches the working file (panel#1880 lost four pins to exactly that).
+test("#2436 WIRING: the detail projection passes is_subgraph into the stub", () => {
+  const SRC = readFileSync(
+    new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const call = SRC.match(/line = fitDetailLine\([^;]*\);/);
+  assert.ok(call, "the fitDetailLine call site moved — re-anchor this pin");
+  assert.match(call[0], /is_subgraph: summary\.is_subgraph/);
+});

--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -106,6 +106,10 @@ const summarizeNode = (node) => ({
   type: node.type,
   title: node.title,
   widgets: Object.fromEntries((node.widgets ?? []).map((w) => [w.name, w.value])),
+  // Production summarizeNode also emits inputs/outputs; those are what push a
+  // fully-capped detail row past max_chars and into fitDetailLine (#2436).
+  ...(Array.isArray(node.inputs) && node.inputs.length ? { inputs: node.inputs } : {}),
+  ...(Array.isArray(node.outputs) && node.outputs.length ? { outputs: node.outputs } : {}),
 });
 
 const graphQuerySource = methodSource(source, "graph_query({");
@@ -189,6 +193,29 @@ test("#1681 shipped graph_query keeps default detail at 2048 and raises one expl
   assert.equal(raisedRow.widgets.text, graph._nodes[0].widgets[0].value);
   assert.equal(Object.keys(defaultRead).join(","), Object.keys(raisedRead).join(","), "reply shape is unchanged");
   assert.equal(Object.keys(defaultRow).join(","), Object.keys(raisedRow).join(","), "detail row shape is unchanged");
+});
+
+test("#2436 shipped graph_query keeps is_subgraph on an oversized-node stub", () => {
+  // High-fan-in slots are what capSummaryWidgets does not touch, so the fully-capped
+  // detail still overflows max_chars and fitDetailLine degrades the row. That stub
+  // used to drop is_subgraph, which made the node unwritable.
+  const wide = {
+    id: 43,
+    type: "KSampler (Efficient)",
+    title: "KSampler (Efficient)",
+    widgets: [{ name: "sampler_name", value: "euler" }],
+    inputs: Array.from({ length: 4000 }, (_, i) => ({ name: `in${i}`, type: "INT" })),
+    outputs: [],
+  };
+  graph._nodes.push(wide);
+  try {
+    const row = detailRows(query({ ids: [43], fields: "detail", max_chars: 300 }))[0];
+    assert.ok(row.detail_omitted, "the row must have degraded to the stub");
+    assert.equal(typeof row.is_subgraph, "boolean", "a boolean is what the classifier requires");
+    assert.equal(row.is_subgraph, false);
+  } finally {
+    graph._nodes.pop();
+  }
 });
 
 test("#2314 detail rows explicitly classify ordinary and promoted nodes", () => {

--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -112,7 +112,13 @@ test("#1681 only an explicit detail query can raise the per-widget cap", () => {
   assert.match(body, /fields === "detail" && Array\.isArray\(ids\) && ids\.length === 1/);
   assert.match(body, /clampDetailWidgetCap\(widget_max_chars\)/);
   assert.match(body, /capSummaryWidgets\(summarizeNode\(n\), detailWidgetCap, maxChars\)/);
-  assert.match(body, /fitDetailLine\(line, \{ id: summary\.id, type: summary\.type, title: summary\.title \}, maxChars\)/);
+  // artokun/comfyui-mcp#2436 — the stub now also carries `is_subgraph`, which is
+  // LOAD-BEARING: the orchestrator refuses an ordinary write on any node it cannot
+  // classify, so dropping it made every wide node unwritable. Pinned by the fields
+  // that MATTER rather than by the whole literal, which froze incidental field order
+  // and broke on a change that was correct.
+  assert.match(body, /fitDetailLine\(line, \{[^}]*\}, maxChars\)/);
+  assert.match(body, /fitDetailLine\(line, \{[^}]*is_subgraph: summary\.is_subgraph[^}]*\}/);
 });
 
 // The `groups`/`rails` riders sit OUTSIDE the max_chars accounting (#807 owns that fix).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14574,7 +14574,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // very many/large slots, which capSummaryWidgets doesn't touch), degrade the
         // protected line to a bounded valid-JSON stub so it's never dropped yet can't
         // flood — every rendered detail line ends up ≤ max_chars.
-        line = fitDetailLine(line, { id: summary.id, type: summary.type, title: summary.title }, maxChars);
+        line = fitDetailLine(line, { id: summary.id, type: summary.type, title: summary.title, is_subgraph: summary.is_subgraph }, maxChars);
       } else {
         // #607: flag link-driven widgets in the compact line too.
         const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -311,6 +311,15 @@ export function fitDetailLine(line, stub, maxChars) {
     id: clipF(stub?.id),
     type: clipF(stub?.type),
     ...(stub?.title != null ? { title: clipF(stub.title) } : {}),
+    // artokun/comfyui-mcp#2436 — a BOOLEAN classification survives the degrade.
+    // #2314 gave the detail projection an always-boolean `is_subgraph` precisely so a
+    // consumer could tell ordinary-node from cannot-classify. This stub then dropped it,
+    // reintroducing the same absence one layer down. The orchestrator requires
+    // `typeof is_subgraph === "boolean"` and treats anything else as INDETERMINATE, so a
+    // node wide enough to degrade became unwritable: every ordinary panel_set_widget on
+    // it was refused by the promoted-write fence (KSampler (Efficient) in the report).
+    // Costs ~18 chars, is bounded by construction, and cannot flood.
+    ...(typeof stub?.is_subgraph === "boolean" ? { is_subgraph: stub.is_subgraph } : {}),
   };
   const s = JSON.stringify({
     ...safe,


### PR DESCRIPTION
Closes artokun/comfyui-mcp#2436.

## Root cause, found in code — no reporter round-trip needed

A node whose fully-capped detail still exceeds `max_chars` is degraded to a bounded JSON stub:

```js
line = fitDetailLine(line, { id: summary.id, type: summary.type, title: summary.title }, maxChars);
```

`is_subgraph` is not in that stub. The orchestrator's `parseVerifiedQueriedNodeScope` requires

```ts
const isSubgraph = row.is_subgraph;
if (typeof isSubgraph !== "boolean") return null;   // INDETERMINATE
```

so the wide node cannot be classified. `preparePromotedWidgetWrite`'s #2394 fast path — "root + ordinary ⇒ allow" — never fires, execution falls through to `graph_get_subgraph`, and its non-definitive answer is refused by the promoted-write fence.

**Every ordinary `panel_set_widget` on a wide node was refused, with a message about promoted containers, on a root node that is not one.** `KSampler (Efficient)` in the report — many widgets, several long combo values, so it degrades.

## This is #2314's defect one layer down

#2314 gave the detail projection an always-boolean `is_subgraph` for exactly this reason. Its comment:

> MCP must distinguish a definitive ordinary node from an older Panel whose detail projection cannot classify promotion. **Positive-only emission made missing capability look like false.**

The stub then dropped the boolean, reintroducing the absence that fix had removed.

## Guarded, not passed through

An **absent** classification must stay absent. Emitting `false` for an older panel that genuinely cannot classify would authorize a promoted write the panel never vouched for — the #2314 defect pointing the other way. So the field is carried only when it is already a boolean, and a non-boolean is dropped. Both directions are pinned.

A boolean costs ~18 chars. The stub's whole purpose is the bound, so that guarantee is tested across five budgets (120–1000) rather than at one convenient number, and the absurdly-small-budget fallback is deliberately left untouched.

## The #1681 pin

`outline-coverage.test.mjs` asserted the stub's exact field literal, so this change failed it. That pin's stated purpose is that the final guard **runs** on the detail line; the field list was incidental specificity that froze order and broke on a correct change.

It now pins the call *and* the field that is load-bearing. **Verified tighter, not looser:** a mutation dropping `is_subgraph` from the call site still fails it.

## Evidence

| mutant | verdict |
|---|---|
| stub drops the field again (pre-fix) | killed — 2 failures |
| pass through unguarded (non-boolean leaks) | killed — 1 |
| caller stops passing it | killed — 1 (the wiring pin) |

**Suite:** 7081 tests, **7080 pass, 0 fail** (1 pre-existing todo). `check-tool-vocabulary` OK, `check-panel-scope` OK, `tsc --noEmit` exit 0.

## Not merged

Merge gate quota-blocked (codex resets Sep 1; Copilot exhausted). Verified and queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
