### PR TITLE
fix(1938): normalise duplicate boundary link ids so unpack_subgraph can run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - keep `is_subgraph` on oversized-node detail stubs so wide root nodes stay writable (artokun/comfyui-mcp#2436)
+- panel_unpack_subgraph no longer crashes when a subgraph rail serialises the same link id twice (#1938)
 
 ## [0.15.114] - 2026-08-27
 

--- a/browser_tests/unit/unpack-duplicate-linkids.test.mjs
+++ b/browser_tests/unit/unpack-duplicate-linkids.test.mjs
@@ -10,75 +10,300 @@
  * The #405 rollback caught it, so no graph was ever corrupted — the operation simply
  * could not run on that workflow at all.
  *
- * A link id resolves to ONE record with one origin and one target, so two entries
- * carrying the same id cannot be distinct edges. Deduping is therefore
- * semantics-preserving, and the panel never writes `linkIds` (only reads them), so this
- * normalises data that arrives malformed rather than masking our own mutation.
+ * These tests run the REAL shipped `graph_unpack_subgraph`, extracted from
+ * web/js/comfyui-mcp-panel.js and given LiteGraph-shaped doubles whose
+ * `unpackSubgraph` reproduces that crash. Deleting the dedupe from the panel source
+ * (not merely from a helper) fails them: the mock throws, the handler rolls back, and
+ * the call never returns a success.
  *
  * Run with `node --test`.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
-const SRC = readFileSync(
-  new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+import {
+  snapshotExternalLinks,
+  verifyExternalLinks,
+} from "../../web/js/lib/unpack-link-verify.js";
+import {
+  materializePromotedValues,
+  materializedValuesNote,
+  findDivergentPromotedValues,
+} from "../../web/js/lib/unpack-promoted-values.js";
+import { resolveLoadGraphArgs } from "../../web/js/lib/session-rebind.js";
+
+const panelSrc = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
   "utf8",
 ).replace(/\r\n/g, "\n");
 
-/** graph_unpack_subgraph's body only, so a match elsewhere cannot stand in for it. */
-const BODY = (() => {
-  const start = SRC.indexOf("async graph_unpack_subgraph({ node_id })");
-  assert.ok(start > 0, "graph_unpack_subgraph not found — re-anchor this pin");
-  const end = SRC.indexOf("\n  graph_", start + 10);
-  assert.ok(end > start, "could not bound the handler body");
-  return SRC.slice(start, end);
-})();
+/** The method source between its signature line and the first `  },` line. */
+function sliceMethod(signature) {
+  const lines = panelSrc.split("\n");
+  const start = lines.findIndex((l) => l === signature);
+  assert.ok(start >= 0, `could not locate "${signature}" in the panel source`);
+  const end = lines.findIndex((l, i) => i > start && l === "  },");
+  assert.ok(end > start, `could not locate the end of "${signature}"`);
+  return lines.slice(start, end + 1).join("\n");
+}
 
-test("#1938 the dedupe runs, and covers BOTH input and output rails", () => {
-  assert.match(BODY, /\[node\.subgraph\?\.inputs, node\.subgraph\?\.outputs\]/);
-  assert.match(BODY, /new Set\(slot\.linkIds\)/);
+const unpackSrc = sliceMethod("  async graph_unpack_subgraph({ node_id }) {");
+
+function resolveNode(graph, id) {
+  const n = graph.getNodeById(id);
+  if (!n) throw new Error(`No node with id ${id}`);
+  return n;
+}
+
+/**
+ * The frontend crash: walk every boundary `linkIds` entry, read `target_id` off the
+ * stored record, then delete the record. A duplicate id is undefined on the second
+ * visit — exactly `Cannot read properties of undefined (reading 'target_id')`.
+ */
+function visitBoundaryLinks(node) {
+  const store = node.subgraph._links;
+  for (const slots of [node.subgraph?.inputs, node.subgraph?.outputs]) {
+    for (const slot of slots ?? []) {
+      for (const linkId of slot.linkIds ?? []) {
+        const rec = store.get(linkId);
+        void rec.target_id;
+        store.delete(linkId);
+      }
+    }
+  }
+}
+
+function mkGraph() {
+  const map = new Map();
+  const graph = {
+    _links: map,
+    links: map,
+    _nodes: [],
+    dirty: 0,
+    unpackCalls: 0,
+    getNodeById: (id) => graph._nodes.find((n) => String(n.id) === String(id)) ?? null,
+    serialize: () => ({ nodes: graph._nodes.map((n) => ({ id: n.id })) }),
+    setDirtyCanvas() {
+      graph.dirty += 1;
+    },
+  };
+  return graph;
+}
+
+function addLink(store, id, origin_id, origin_slot, target_id, target_slot) {
+  store.set(id, { id, origin_id, origin_slot, target_id, target_slot });
+}
+
+/** Reporter's shape: IMAGE output rail serialises 1883 twice. No parent-graph wires. */
+function duplicateOutputRailGraph() {
+  const graph = mkGraph();
+  const interior = new Map();
+  addLink(interior, 1883, -20, 0, 10, 0);
+  const imageOut = { name: "IMAGE", type: "IMAGE", linkIds: [1883, 1883] };
+  const node = {
+    id: 1277,
+    type: "SubgraphNode",
+    inputs: [],
+    outputs: [{ name: "IMAGE", links: [] }],
+    subgraph: {
+      inputs: [],
+      outputs: [imageOut],
+      _links: interior,
+      _nodes: [{ id: 10, inputs: [{ name: "IMAGE", link: 1883 }], outputs: [] }],
+    },
+  };
+  graph._nodes.push(node);
+  graph.unpackSubgraph = function (n) {
+    this.unpackCalls += 1;
+    visitBoundaryLinks(n);
+    this.unpackedNodeId = n.id;
+  };
+  return { graph, node, imageOut };
+}
+
+/**
+ * Inbound fan-out with a duplicated interior consumer id. After a correct unpack there
+ * is ONE live parent-graph link (the duplicate was never a second edge). A snapshot
+ * taken over the duplicates would expect two consumers and refuse a correct unpack.
+ */
+function duplicateInboundRailGraph() {
+  const graph = mkGraph();
+  const source = {
+    id: 131,
+    outputs: [{ name: "IMAGE", links: [50] }],
+    inputs: [],
+  };
+  const interior = new Map();
+  addLink(interior, 1883, -10, 0, 10, 0);
+  const imageIn = { name: "IMAGE", type: "IMAGE", linkIds: [1883, 1883] };
+  const node = {
+    id: 1277,
+    type: "SubgraphNode",
+    inputs: [{ name: "IMAGE", link: 50 }],
+    outputs: [],
+    subgraph: {
+      inputs: [imageIn],
+      outputs: [],
+      _links: interior,
+      _nodes: [{ id: 10, inputs: [{ name: "IMAGE", link: 1883 }], outputs: [] }],
+    },
+  };
+  graph._nodes.push(source, node);
+  addLink(graph._links, 50, 131, 0, 1277, 0);
+  graph.unpackSubgraph = function (n) {
+    this.unpackCalls += 1;
+    visitBoundaryLinks(n);
+    const inner = { id: 10, inputs: [{ name: "IMAGE", link: 60 }], outputs: [] };
+    this._nodes = this._nodes.filter((x) => x !== n).concat(inner);
+    this._links.delete(50);
+    addLink(this._links, 60, 131, 0, 10, 0);
+    source.outputs[0].links = [60];
+  };
+  return { graph, node, imageIn, source };
+}
+
+function buildUnpack(graph, { app, canvas, rootGraph, methodSrc = unpackSrc } = {}) {
+  const factory = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "findDivergentPromotedValues",
+    "resolvePromotedInnerTarget",
+    "sourceForSubgraphInput",
+    "materializePromotedValues",
+    "resolveLoadGraphArgs",
+    "snapshotExternalLinks",
+    "verifyExternalLinks",
+    "materializedValuesNote",
+    `return ({
+${methodSrc}
+}).graph_unpack_subgraph;`,
+  );
+  return factory(
+    () => ({
+      graph,
+      canvas: canvas ?? { setDirty() {} },
+      app: app ?? {
+        loadGraphData: async () => {
+          graph.rolledBack = true;
+        },
+      },
+      rootGraph: rootGraph ?? graph,
+    }),
+    resolveNode,
+    findDivergentPromotedValues,
+    () => ({ promoted: false }),
+    () => null,
+    materializePromotedValues,
+    resolveLoadGraphArgs,
+    snapshotExternalLinks,
+    verifyExternalLinks,
+    materializedValuesNote,
+  );
+}
+
+test("#1938 the frontend-shaped unpack crashes on the reporter's duplicate link id", () => {
+  const { node } = duplicateOutputRailGraph();
+  assert.throws(() => visitBoundaryLinks(node), {
+    name: "TypeError",
+    message: /Cannot read properties of undefined \(reading 'target_id'\)/,
+  });
 });
 
-test("#1938 it runs BEFORE the #1665 external-link snapshot", () => {
-  // A snapshot taken over the duplicates would expect a consumer count the unpack can
-  // never produce, so the verification and the mutation must see the same state.
-  const dedupeAt = BODY.indexOf("new Set(slot.linkIds)");
-  const snapshotAt = BODY.indexOf("snapshotExternalLinks(graph, node)");
-  assert.ok(dedupeAt > 0 && snapshotAt > 0, "both landmarks must exist");
+test("#1938 the shipped unpack_subgraph runs on that same duplicate and does not crash", async () => {
+  const { graph, node, imageOut } = duplicateOutputRailGraph();
+  const unpack = buildUnpack(graph);
+  const res = await unpack({ node_id: 1277 });
+  assert.equal(graph.unpackCalls, 1, "the frontend unpack ran");
+  assert.equal(graph.unpackedNodeId, 1277);
+  assert.deepEqual(imageOut.linkIds, [1883], "only the repeat is removed");
+  assert.equal(res.unpacked.node_id, 1277);
+  assert.equal(node.subgraph._links.has(1883), false, "the single real edge was visited once");
+});
+
+test("#1938 duplicate INPUT-rail ids are normalised too, and the unpack still runs", async () => {
+  const { graph, imageIn } = duplicateInboundRailGraph();
+  const unpack = buildUnpack(graph);
+  const res = await unpack({ node_id: 1277 });
+  assert.equal(graph.unpackCalls, 1);
+  assert.deepEqual(imageIn.linkIds, [1883]);
+  assert.equal(res.unpacked.node_id, 1277);
+  assert.equal(res.unpacked.external_links_verified, 1, "the one real inbound edge survived");
+});
+
+test("#1938 a snapshot taken over the duplicates would refuse a correct unpack", () => {
+  // Why the dedupe must precede snapshotExternalLinks, not just the unpack: #1665
+  // derives an expected interior-consumer count from these arrays.
+  const { graph, node } = duplicateInboundRailGraph();
+  const snapDup = snapshotExternalLinks(graph, node);
+  assert.equal(snapDup.links[0].consumers, 2, "duplicates inflate the expected count");
+  node.subgraph.inputs[0].linkIds = [1883];
+  const snapDeduped = snapshotExternalLinks(graph, node);
+  assert.equal(snapDeduped.links[0].consumers, 1, "one id is one edge");
+});
+
+test("#1938 a slot that cannot contain a duplicate keeps its array identity", async () => {
+  const graph = mkGraph();
+  const empty = [];
+  const one = [1883];
+  const unique = [1884, 1885];
+  const interior = new Map();
+  addLink(interior, 1883, -20, 0, 10, 0);
+  addLink(interior, 1884, -20, 1, 11, 0);
+  addLink(interior, 1885, -20, 2, 12, 0);
+  const slots = [
+    { name: "A", linkIds: empty },
+    { name: "B", linkIds: one },
+    { name: "C", linkIds: unique },
+  ];
+  const node = {
+    id: 1277,
+    type: "SubgraphNode",
+    inputs: [],
+    outputs: slots.map((s) => ({ name: s.name, links: [] })),
+    subgraph: { inputs: [], outputs: slots, _links: interior, _nodes: [] },
+  };
+  graph._nodes.push(node);
+  graph.unpackSubgraph = function (n) {
+    this.unpackCalls += 1;
+    visitBoundaryLinks(n);
+  };
+  const unpack = buildUnpack(graph);
+  await unpack({ node_id: 1277 });
+  assert.equal(slots[0].linkIds, empty);
+  assert.equal(slots[1].linkIds, one);
+  assert.equal(slots[2].linkIds, unique);
+  assert.equal(graph.unpackCalls, 1);
+});
+
+test("#1938 stripping the dedupe from the shipped body makes the reporter fixture crash", async () => {
+  const start = unpackSrc.indexOf("for (const slots of [node.subgraph?.inputs, node.subgraph?.outputs])");
+  const end = unpackSrc.indexOf("const externalLinks = snapshotExternalLinks");
+  assert.ok(start > 0 && end > start, "could not cut the dedupe loop out of the shipped body");
+  const stripped = unpackSrc.slice(0, start) + unpackSrc.slice(end);
+  assert.equal(stripped.includes("new Set(slot.linkIds)"), false);
+
+  const { graph } = duplicateOutputRailGraph();
+  const unpack = buildUnpack(graph, { methodSrc: stripped });
+  await assert.rejects(
+    () => unpack({ node_id: 1277 }),
+    /Cannot read properties of undefined \(reading 'target_id'\)/,
+  );
+  assert.equal(graph.unpackCalls, 1, "the frontend unpack was reached");
+  assert.equal(graph.rolledBack, true, "the #405 rollback still caught the throw");
+});
+
+test("#1938 the shipped method still owns the dedupe, before snapshot and unpack", () => {
+  // Placement pins. The inbound consumer-count test is the behavioural proof; these
+  // fail if the loop is moved after the snapshot or dropped from this handler.
+  assert.match(unpackSrc, /\[node\.subgraph\?\.inputs, node\.subgraph\?\.outputs\]/);
+  assert.match(unpackSrc, /new Set\(slot\.linkIds\)/);
+  const dedupeAt = unpackSrc.indexOf("new Set(slot.linkIds)");
+  const snapshotAt = unpackSrc.indexOf("snapshotExternalLinks(graph, node)");
+  const unpackAt = unpackSrc.indexOf("graph.unpackSubgraph(node");
+  assert.ok(dedupeAt > 0 && snapshotAt > 0 && unpackAt > 0);
   assert.ok(dedupeAt < snapshotAt, "dedupe must precede the snapshot");
-});
-
-test("#1938 and BEFORE the unpack itself", () => {
-  const dedupeAt = BODY.indexOf("new Set(slot.linkIds)");
-  const unpackAt = BODY.indexOf("graph.unpackSubgraph(node");
-  assert.ok(unpackAt > 0, "the unpack call moved — re-anchor this pin");
   assert.ok(dedupeAt < unpackAt, "dedupe must precede the unpack");
-});
-
-test("#1938 a slot with fewer than two ids is left alone", () => {
-  // Cheap guard against a rewrite that reassigns every slot: touching arrays that
-  // cannot contain a duplicate is pure churn on a hot path.
-  assert.match(BODY, /slot\.linkIds\.length < 2\) continue/);
-});
-
-test("#1938 the array is only reassigned when something actually changed", () => {
-  // Assigning an identical copy would defeat any identity-based change detection the
-  // frontend keeps on these arrays.
-  assert.match(BODY, /deduped\.length !== slot\.linkIds\.length/);
-});
-
-test("#1938 the #405 rollback is still the outer safety net", () => {
-  // The dedupe makes the crash not happen; it does not replace the guarantee that a
-  // throw leaves the workflow exactly as it was.
-  assert.match(BODY, /graph\.unpackSubgraph\(node[\s\S]{0,400}?\} catch \(err\)/);
-});
-
-// The semantic claim the fix rests on, stated as an executable check rather than prose:
-// deduping a list of link ids cannot drop an edge, because an id identifies an edge.
-test("#1938 dedupe preserves the SET of edges, only the multiplicity", () => {
-  const withDup = [1883, 1884, 1883];
-  const deduped = [...new Set(withDup)];
-  assert.deepEqual(new Set(deduped), new Set(withDup), "no edge is lost");
-  assert.equal(deduped.length, 2, "only the repeat is removed");
+  assert.match(unpackSrc, /graph\.unpackSubgraph\(node[\s\S]{0,400}?\} catch \(err\)/);
 });

--- a/browser_tests/unit/unpack-duplicate-linkids.test.mjs
+++ b/browser_tests/unit/unpack-duplicate-linkids.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * #1938 — panel_unpack_subgraph crashed on duplicate boundary link ids.
+ *
+ * The bundled anima-inpaint subgraph serialises link id 1883 twice on one IMAGE output
+ * rail. ComfyUI frontend's `unpackSubgraph` removes the link on its first visit and then
+ * dereferences the now-missing record on the duplicate:
+ *
+ *     Cannot read properties of undefined (reading 'target_id')
+ *
+ * The #405 rollback caught it, so no graph was ever corrupted — the operation simply
+ * could not run on that workflow at all.
+ *
+ * A link id resolves to ONE record with one origin and one target, so two entries
+ * carrying the same id cannot be distinct edges. Deduping is therefore
+ * semantics-preserving, and the panel never writes `linkIds` (only reads them), so this
+ * normalises data that arrives malformed rather than masking our own mutation.
+ *
+ * Run with `node --test`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(
+  new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+/** graph_unpack_subgraph's body only, so a match elsewhere cannot stand in for it. */
+const BODY = (() => {
+  const start = SRC.indexOf("async graph_unpack_subgraph({ node_id })");
+  assert.ok(start > 0, "graph_unpack_subgraph not found — re-anchor this pin");
+  const end = SRC.indexOf("\n  graph_", start + 10);
+  assert.ok(end > start, "could not bound the handler body");
+  return SRC.slice(start, end);
+})();
+
+test("#1938 the dedupe runs, and covers BOTH input and output rails", () => {
+  assert.match(BODY, /\[node\.subgraph\?\.inputs, node\.subgraph\?\.outputs\]/);
+  assert.match(BODY, /new Set\(slot\.linkIds\)/);
+});
+
+test("#1938 it runs BEFORE the #1665 external-link snapshot", () => {
+  // A snapshot taken over the duplicates would expect a consumer count the unpack can
+  // never produce, so the verification and the mutation must see the same state.
+  const dedupeAt = BODY.indexOf("new Set(slot.linkIds)");
+  const snapshotAt = BODY.indexOf("snapshotExternalLinks(graph, node)");
+  assert.ok(dedupeAt > 0 && snapshotAt > 0, "both landmarks must exist");
+  assert.ok(dedupeAt < snapshotAt, "dedupe must precede the snapshot");
+});
+
+test("#1938 and BEFORE the unpack itself", () => {
+  const dedupeAt = BODY.indexOf("new Set(slot.linkIds)");
+  const unpackAt = BODY.indexOf("graph.unpackSubgraph(node");
+  assert.ok(unpackAt > 0, "the unpack call moved — re-anchor this pin");
+  assert.ok(dedupeAt < unpackAt, "dedupe must precede the unpack");
+});
+
+test("#1938 a slot with fewer than two ids is left alone", () => {
+  // Cheap guard against a rewrite that reassigns every slot: touching arrays that
+  // cannot contain a duplicate is pure churn on a hot path.
+  assert.match(BODY, /slot\.linkIds\.length < 2\) continue/);
+});
+
+test("#1938 the array is only reassigned when something actually changed", () => {
+  // Assigning an identical copy would defeat any identity-based change detection the
+  // frontend keeps on these arrays.
+  assert.match(BODY, /deduped\.length !== slot\.linkIds\.length/);
+});
+
+test("#1938 the #405 rollback is still the outer safety net", () => {
+  // The dedupe makes the crash not happen; it does not replace the guarantee that a
+  // throw leaves the workflow exactly as it was.
+  assert.match(BODY, /graph\.unpackSubgraph\(node[\s\S]{0,400}?\} catch \(err\)/);
+});
+
+// The semantic claim the fix rests on, stated as an executable check rather than prose:
+// deduping a list of link ids cannot drop an edge, because an id identifies an edge.
+test("#1938 dedupe preserves the SET of edges, only the multiplicity", () => {
+  const withDup = [1883, 1884, 1883];
+  const deduped = [...new Set(withDup)];
+  assert.deepEqual(new Set(deduped), new Set(withDup), "no edge is lost");
+  assert.equal(deduped.length, 2, "only the repeat is removed");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23546,6 +23546,29 @@ const GRAPH_TOOL_EXECUTORS = {
     // verified afterwards instead of trusted. litegraph's unpackSubgraph silently
     // drops links whose targets are widget-converted or dynamic inputs and leaves
     // one-sided ghosts behind; a bare success over that is silent graph corruption.
+    // artokun/comfyui-mcp-panel#1938 — NORMALISE duplicate boundary link ids before
+    // anything reads them. The bundled anima-inpaint subgraph serialises link id 1883
+    // twice on one IMAGE output rail; the frontend's unpackSubgraph removes the link on
+    // its first visit and then dereferences the now-missing record on the duplicate,
+    // throwing "Cannot read properties of undefined (reading 'target_id')". The #405
+    // rollback below caught it, so the graph was never corrupted — the operation simply
+    // could not run at all on that workflow.
+    //
+    // Semantics-preserving by construction: a link id resolves to ONE record with one
+    // origin and one target, so two entries carrying the same id cannot be distinct
+    // edges. The panel never writes linkIds (it only reads them), so this normalises
+    // data that arrives already malformed rather than papering over our own mutation.
+    //
+    // Placed BEFORE snapshotExternalLinks so the #1665 verification and the unpack see
+    // the same state — a snapshot taken over the duplicates would expect a consumer
+    // count the unpack can never produce.
+    for (const slots of [node.subgraph?.inputs, node.subgraph?.outputs]) {
+      for (const slot of slots ?? []) {
+        if (!Array.isArray(slot?.linkIds) || slot.linkIds.length < 2) continue;
+        const deduped = [...new Set(slot.linkIds)];
+        if (deduped.length !== slot.linkIds.length) slot.linkIds = deduped;
+      }
+    }
     const externalLinks = snapshotExternalLinks(graph, node);
     try {
       graph.unpackSubgraph(node, { skipMissingNodes: true });


### PR DESCRIPTION
Closes #1938.

## The crash

The bundled anima-inpaint subgraph serialises link id `1883` **twice** on one IMAGE output rail. The frontend's `unpackSubgraph` removes the link on its first visit, then dereferences the now-missing record on the duplicate:

    Cannot read properties of undefined (reading 'target_id')

The #405 rollback caught it, so no graph was ever corrupted — the operation simply could not run on that workflow at all.

## Why deduping is safe, not a paper-over

**By construction.** A link id resolves to ONE record with one origin and one target, so two entries carrying the same id cannot be distinct edges. Deduping removes a repeat, never an edge — pinned as an executable check rather than left as prose.

**Not our bug being masked.** The panel never *writes* `linkIds` anywhere; every reference in the tree is a read. So this normalises data that arrives already malformed rather than hiding a mutation of ours.

## The placement matters, and it is not just "before the unpack"

The reporter's patch put the dedupe immediately before `graph.unpackSubgraph`. It has to go **before `snapshotExternalLinks`** as well, which runs first:

```js
// One rail link can FAN OUT to several interior consumers; the unpack should
// recreate one live link per consumer in place of the single rail link, so the
// post-check compares counts, not mere existence.
let consumers = 1;
if (railSlot && Array.isArray(railSlot.linkIds)) consumers = railSlot.linkIds.length;
```

That #1665 verification derives an expected interior-consumer count from these very arrays. A snapshot taken over the duplicates would expect a count the unpack can never produce — so a *correct* unpack would then fail verification. Both orderings are pinned.

## Smaller detail

Reassigns only when the length actually changed. A slot that cannot contain a duplicate is left untouched, so any identity-based change detection the frontend keeps on these arrays is not disturbed by an identical copy.

## Evidence

7 pins green; the mutant (dedupe removed) kills 2 of them.

**Suite:** 7080 tests, **7079 pass, 0 fail** (1 pre-existing todo). `check-tool-vocabulary` OK, `check-panel-scope` OK, `tsc --noEmit` exit 0.

Credit to the reporter, who diagnosed this precisely and had the patch applied locally; the snapshot-ordering and the length guard are what this adds.

## Not merged

Merge gate quota-blocked (codex resets Sep 1; Copilot exhausted). Verified and queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVc7bsTMaAKtnFTWFJUafp
