### PR TITLE
fix(1739): stop starving the type-scoped schema after a hung getNodeDefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget no longer queues a second whole `/object_info` behind a timed-out `api.getNodeDefs()`, so the type-scoped fallback can use the remaining command time on a large install (#1739)
+
 ## [0.15.115] - 2026-08-27
 
 ### Fixed

--- a/browser_tests/unit/object-info-abandoned-request.test.mjs
+++ b/browser_tests/unit/object-info-abandoned-request.test.mjs
@@ -329,6 +329,31 @@ test("#1739 both whole-map routes still report SILENCE, so the scoped read stays
   );
 });
 
+test("#1739 a timed-out client read does not enqueue a redundant second whole-map read", async () => {
+  const clock = makeVirtualClock();
+  const backend = singleLaneComfyUI(clock);
+  const result = await drive(
+    clock,
+    fetchWholeObjectInfo({
+      getNodeDefs: () => backend.getNodeDefs(),
+      fetchApi: (route, init) => backend.fetchApi(route, init),
+      deadlineMs: OBJECT_INFO_DEADLINE_MS,
+      timers: clock.timers,
+      now: clock.now,
+      skipHttpAfterClientNoAnswer: true,
+    }),
+  );
+
+  assert.equal(result.defs, null, "the unanswered whole-map read still fails closed");
+  assert.deepEqual(
+    result.outcomes.map((o) => o.kind),
+    [TRANSPORT_OUTCOME.NO_ANSWER],
+    "only the client read ran; the type-scoped caller gets the next request slot",
+  );
+  assert.deepEqual(backend.dropped, [], "no second whole-map request was queued and then abandoned");
+  assert.deepEqual(backend.served, ["/object_info"]);
+});
+
 test("#1739 an AbortError from the cancelled route never escapes the oracle", async () => {
   // The oracle documents that every failure path returns `defs: null`, and two callers await
   // it with no catch of their own. Cancelling introduces a NEW rejection into that path.
@@ -405,4 +430,9 @@ test("#1739 the PANEL forwards the init at every whole-map wiring, or the cancel
   );
   const forwarded = src.split(forwards).length - 1;
   assert.ok(forwarded >= 5, `expected every oracle/scoped wiring to forward the init, found ${forwarded}`);
+  assert.match(
+    src,
+    /fetchWholeObjectInfo\(\{[\s\S]*?skipHttpAfterClientNoAnswer:\s*true[\s\S]*?\}\);/,
+    "set_widget must not queue the raw whole-map fallback after its client read timed out",
+  );
 });

--- a/browser_tests/unit/object-info-probe-budget.test.mjs
+++ b/browser_tests/unit/object-info-probe-budget.test.mjs
@@ -55,7 +55,7 @@ test("#1734 production wiring selects from the page origin and keeps command bou
     PANEL_SRC,
     /const OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS = objectInfoSnapshotProbeDeadline\(pageComfyOrigin\(\)\);/,
   );
-  assert.match(PANEL_SRC, /const SET_WIDGET_COMMAND_BUDGET_MS = 25000;/);
+  assert.match(PANEL_SRC, /const SET_WIDGET_COMMAND_BUDGET_MS = 80000;/);
   assert.match(
     PANEL_SRC,
     /deadlineMs: budget\.bounded\([\s\S]*?OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS/,

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -918,10 +918,10 @@ test("#1582 SHIPPED: the reported case — a held snapshot shortens hung probes"
   const defs = await o.getFreshObjectInfo();
   assert.ok(defs && Object.prototype.hasOwnProperty.call(defs, "H3Keyframes"), "the edit is no longer refused");
   assert.equal(clientCalls, 1, "the client route is still probed so an answered error can refuse");
-  assert.equal(httpCalls, 1, "the raw route is still probed so the fallback transport can answer");
+  assert.equal(httpCalls, 0, "the redundant raw whole-map request does not queue behind the hung client request");
   assert.deepEqual(deadlines, [2000], "the reusable snapshot caps the serial oracle before the 15s stall");
   assert.match(o.readNote(), /did not answer/);
-  assert.equal(o.readFailures().length, 2, "the fallback still discloses both silent routes");
+  assert.equal(o.readFailures().length, 1, "the refusal names only the route that actually ran");
 });
 
 test("#1734 SHIPPED set_widget: a remote high-latency schema gets the larger bounded probe", async () => {
@@ -1062,14 +1062,14 @@ test("#1582 SHIPPED: a second ordinary read does not re-wait on probes that alre
   });
   assert.ok(await o.getFreshObjectInfo(), "the first write still discovers silence");
   assert.equal(clientCalls, 1);
-  assert.equal(httpCalls, 1);
+  assert.equal(httpCalls, 0);
 
   const started = performance.now();
   const defs = await o.getFreshObjectInfo();
   const elapsed = performance.now() - started;
   assert.ok(defs && Object.prototype.hasOwnProperty.call(defs, "H3Keyframes"), "the second write is still authorized");
   assert.equal(clientCalls, 1, "getNodeDefs is not contacted again");
-  assert.equal(httpCalls, 1, "GET /object_info is not contacted again");
+  assert.equal(httpCalls, 0, "GET /object_info is never queued behind the hung client request");
   assert.ok(elapsed < 50, `second read stalled ${elapsed}ms on probes that were already silent`);
   assert.match(o.readNote(), /#1582/);
 });
@@ -1189,8 +1189,8 @@ test("#1223 SHIPPED: the ineligibility reason is NOT counted as a transport rout
   // defect (a refusal asserting something that did not happen).
   const o = buildShippedOracle({ api: hungApi, snapshot: createObjectInfoSnapshot(), epoch: 5 });
   assert.equal(await o.getFreshObjectInfo(), null);
-  assert.equal(o.readFailures().length, 2, "two transports were tried");
-  assert.match(objectInfoOracleFailureNote(o.readFailures()), /Tried 2 routes/);
+  assert.equal(o.readFailures().length, 1, "only the client transport was tried");
+  assert.match(objectInfoOracleFailureNote(o.readFailures()), /Tried one route/);
   assert.match(o.readIneligibility(), /no whole \/object_info has been observed/i);
 });
 

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -581,7 +581,7 @@ test("#1560/#2249: the panel wires scoped authority after a non-definitive whole
   assert.match(src, /if \(!scopedReadLicensed\) \{/, "an authoritative whole answer is never overruled");
   assert.match(src, /let scopedReadLicensed = false;/, "and it licenses nothing until a read establishes it");
   assert.match(src, /fetchTypeScopedObjectInfo\(types, \{/, "the panel calls the type-scoped reader");
-  assert.match(src, /deadlineMs: budget\.bounded\(SCOPED_OBJECT_INFO_DEADLINE_MS\)/, "bounded by what the command has left");
+  assert.match(src, /deadlineMs: budget\.remaining\(\)/, "the scoped check gets the command's entire remaining time");
   assert.match(src, /const scopedGeneration = verifiedNodeDefCache\.generation\(\)/, "fences the scoped request at issuance");
   assert.match(src, /scopedGeneration !== verifiedNodeDefCache\.generation\(\)/, "rejects a scoped answer after schema invalidation");
   assert.match(src, /setWidgetSchemaProvenance = \(\) => "scoped"/, "the reply is told which route answered");

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -1197,8 +1197,8 @@ test("#1709: a definitive per-class absence retires cached whole proof before gr
 //    can catch the constants drifting.
 // ---------------------------------------------------------------------------
 
-test("#1413 the shipped budget mirrors add_node's against the same 30s relay window", () => {
-  assert.equal(SET_WIDGET_COMMAND_BUDGET_MS, 25000, "25s budget + 5s slack against the 30s relay");
+test("#1413 the shipped budget uses the enlarged schema-command relay window", () => {
+  assert.equal(SET_WIDGET_COMMAND_BUDGET_MS, 80000, "80s budget + 10s slack against the 90s relay");
   assert.ok(
     SET_WIDGET_POST_REFRESH_RESERVE_MS > 0 && SET_WIDGET_POST_REFRESH_RESERVE_MS < SET_WIDGET_COMMAND_BUDGET_MS,
     "a reserve that is nothing protects nothing; one that is everything refuses everything",
@@ -1232,7 +1232,7 @@ test("#1418 the seed wait and the oracle read are capped by the command budget",
   );
   assert.match(
     body,
-    /deadlineMs:\s*budget\.bounded\([\s\S]{0,260}OBJECT_INFO_DEADLINE_MS/,
+    /fetchWholeObjectInfo\(\{[\s\S]*?deadlineMs:\s*budget\.bounded\([\s\S]*?OBJECT_INFO_DEADLINE_MS/,
     "the flat 20000ms oracle deadline is capped by what the command has left",
   );
   assert.match(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -343,7 +343,7 @@ import {
   snapshotAuthorizationNote,
   noBackendAnswerEstablished,
 } from "./lib/object-info-snapshot.js";
-import { fetchTypeScopedObjectInfo, SCOPED_OBJECT_INFO_DEADLINE_MS } from "./lib/scoped-object-info.js";
+import { fetchTypeScopedObjectInfo } from "./lib/scoped-object-info.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
@@ -12914,24 +12914,21 @@ function widenSocketProofBudget(deadlineMs) {
  * #1413 — `graph_set_widget`'s whole-command deadline, taken on the handler's first line.
  *
  * The fourth instance of the defect #1192 fixed for `graph_add_node` and #1404/#1409 for
- * `refresh_nodes`: a wait relayed inside the orchestrator's 30,000 ms window
- * (`OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` in comfyui-mcp's panel-tools.ts — the same relay
- * constant add_node is measured against) that never took a command budget. Here it is the
- * stale-combo recovery's `refreshComfyNodeDefs()` fallback: a plain join of a run someone
- * else started, under a deadline this command never stated. One run is ~14.5 s of wall
- * clock (NODE_DEFS_RUN_BUDGET_MS deliberately stops its clock across
- * registerNodesFromDefs/reapplyDefsToLiveNodes), and the recovery is reached only AFTER
- * the authorization /object_info has already spent part of the window — so an unbounded
- * join can outlive the relay even with every other step on the path bounded, and the
- * reply is then the bare `did not reply to "graph_set_widget" within 30000 ms` that names
- * nothing, instead of the worded, retryable refusal below.
+ * `refresh_nodes`: a wait relayed inside the orchestrator's schema-command window
+ * (`OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` in comfyui-mcp's panel-tools.ts) that never took a
+ * command budget. Here it is the stale-combo recovery's `refreshComfyNodeDefs()` fallback:
+ * a plain join of a run someone else started, under a deadline this command never stated.
+ * One run is ~14.5 s of wall clock (NODE_DEFS_RUN_BUDGET_MS deliberately stops its clock
+ * across registerNodesFromDefs/reapplyDefsToLiveNodes), and the recovery is reached only
+ * AFTER the authorization /object_info has already spent part of the window — so an
+ * unbounded join can outlive the relay even with every other step on the path bounded, and
+ * the reply is then the bare `did not reply to "graph_set_widget"` that names nothing,
+ * instead of the worded, retryable refusal below.
  *
- * 25,000 ms, mirroring ADD_NODE_COMMAND_BUDGET_MS against the same 30,000 ms window for
- * the same reason: 5,000 ms of slack for composing the reply, serialising it, and the
- * websocket hop. Mirrored rather than derived for the same reason too — the relay
- * constant lives in the OTHER repo, and a derived copy here could not be kept true.
+ * 80,000 ms leaves 10,000 ms against the schema command's 90,000 ms relay for composing
+ * the reply, serialising it, and the websocket hop.
  */
-const SET_WIDGET_COMMAND_BUDGET_MS = 25000;
+const SET_WIDGET_COMMAND_BUDGET_MS = 80000;
 
 /**
  * #1565 — `graph_run` was the one mutating command on this list with NO command budget at
@@ -17358,6 +17355,7 @@ const GRAPH_TOOL_EXECUTORS = {
                   ? OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS
                   : OBJECT_INFO_DEADLINE_MS,
               ),
+              skipHttpAfterClientNoAnswer: true,
             });
           },
           { stamp: () => backendReconnectEpoch },
@@ -17502,10 +17500,9 @@ const GRAPH_TOOL_EXECUTORS = {
       //      class unanswered; the exact type-scoped route may establish it. An
       //      answered-unusable or thrown route remains refused, and an unwired or
       //      never-attempted oracle licenses nothing.
-      //   2. WHAT THE COMMAND HAS LEFT. The whole-map attempt has already spent most of the
-      //      budget by the time this runs (measured on the reported shape: 15,015 ms of a 20s
-      //      oracle deadline), so this takes `budget.bounded` like every other step and
-      //      cannot push the reply past the bridge's own timeout.
+      //   2. WHAT THE COMMAND HAS LEFT. The timed-out client request cannot be cancelled and
+      //      still owns ComfyUI's request lane, so this narrow check needs the full remainder
+      //      instead of another fixed cap.
       //
       // NEVER recorded into the #1223 snapshot — object-info-snapshot.js requires an explicit
       // `whole: true` claim precisely so a per-class payload cannot make every OTHER type read
@@ -17530,7 +17527,7 @@ const GRAPH_TOOL_EXECUTORS = {
         const scopedGeneration = verifiedNodeDefCache.generation();
         const scoped = await fetchTypeScopedObjectInfo(types, {
           fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
-          deadlineMs: budget.bounded(SCOPED_OBJECT_INFO_DEADLINE_MS),
+          deadlineMs: budget.remaining(),
         });
         // The per-class route is authoritative only for the backend connection that
         // answered it. A reconnect, schema invalidation, or a down socket during this await

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -444,6 +444,12 @@ export async function fetchWholeObjectInfo({
   timers,
   // MONOTONIC BY DEFAULT, and that is the whole reason a clock is admissible here again.
   now,
+  // #1739/#1920 — `graph_set_widget`'s next fallback is type-scoped, not another whole map.
+  // A silent `api.getNodeDefs()` already occupies ComfyUI's single event loop (there is no
+  // `await` in `get_object_info`), and that call takes no AbortSignal, so a second
+  // GET /object_info queued behind it cannot answer and can only starve `/object_info/<Type>`.
+  // Other callers still try both whole-schema transports: they have no narrower fallback.
+  skipHttpAfterClientNoAnswer = false,
 } = {}) {
   // WHY THIS READS `performance.now()` AND NOT `Date.now()`.
   //
@@ -636,6 +642,7 @@ export async function fetchWholeObjectInfo({
   // and a tag list that silently omits an attempt would license the snapshot fallback on
   // evidence that route never gave.
   const outcomes = [];
+  let clientDidNotAnswer = false;
   // The route is passed, never DERIVED FROM THE SENTENCE. Sniffing the prose for a prefix
   // is the very coupling the tags exist to remove — it would re-break the moment a message
   // is reworded, which is a thing this file's history shows happening.
@@ -670,6 +677,7 @@ export async function fetchWholeObjectInfo({
         TRANSPORT_OUTCOME.NO_ANSWER,
         `api.getNodeDefs() did not answer within its ${Math.round(clientMs)}ms share of the ${budget}ms budget`,
       );
+      clientDidNotAnswer = true;
     } else if (kind === "threw") {
       record("client", TRANSPORT_OUTCOME.THREW, describeFailure("api.getNodeDefs() threw", outcome.err));
     } else {
@@ -705,6 +713,12 @@ export async function fetchWholeObjectInfo({
     // route that was never asked. Tagging an absent client as though it had answered would
     // make "no transport is wired" read as evidence the backend responded (#1223).
     record("client", TRANSPORT_OUTCOME.NOT_ATTEMPTED, "api.getNodeDefs is not a function on this frontend");
+  }
+
+  // The set-widget path has a narrower fallback. Do not queue the same whole-map request
+  // behind the uncancellable client request and starve that type-scoped check.
+  if (clientDidNotAnswer && skipHttpAfterClientNoAnswer) {
+    return { [CACHE_OUTCOME]: true, defs: null, failures, outcomes };
   }
 
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the


### PR DESCRIPTION
Fixes #1739

## Why this is still open

#1741 cancelled the abandoned raw `GET /object_info` after the oracle stopped waiting on it. That stopped the *starvation* of `/object_info/<Type>` by a second whole-map computation the panel had queued.

It did not close the issue. Recurrence on 0.15.111: `panel_set_widget` still refused because `api.getNodeDefs()` is uncancellable and occupies ComfyUI's single aiohttp loop for ~16s on a large install. The type-scoped fallback still had a 5s cap, which expires before that loop is free.

The 25s `SET_WIDGET_COMMAND_BUDGET_MS` was leaving ~65s unused: `panel_set_widget` dispatches at `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` = **90,000 ms**, not 30,000.

## The change

1. **Opt-in `skipHttpAfterClientNoAnswer`**, enabled only on `graph_set_widget`. After a silent `api.getNodeDefs()`, do not enqueue a second whole-map HTTP. That request cannot answer (it starts behind an identical document that is still running) and can only starve the type-scoped route. Other callers still try both whole-schema transports.
2. **Scoped fallback uses `budget.remaining()`.** The hung client call still owns the event loop for several more seconds; the command remainder can wait it out, then `/object_info/<Type>` answers in ~1ms.
3. **`SET_WIDGET_COMMAND_BUDGET_MS` 25,000 → 80,000.** 10s slack against the 90s schema relay, so 16s whole-map + 8s seed wait fits with margin.

## Evidence

Timeout/schema files: **136/136 pass**, including a new pin that `skipHttpAfterClientNoAnswer` issues no second whole-map, and a call-site pin that `graph_set_widget` actually sets the flag.

`npm run test:unit`: **7097 pass, 0 fail, 1 todo** (`check-panel-scope` OK, i18n, tool-vocabulary). `npx tsc --noEmit` clean.

## Deliberately not done

- Raising `OBJECT_INFO_DEADLINE_MS` itself. The working path is type-scoped, not a 16s whole map on every write.
- Trying `/object_info/<Type>` first. A scoped map cannot populate #1223's snapshot or `wasTypeEverDefined`.
- `panel_refresh_nodes` on a 52MB install still needs a whole map that lands.
