### PR TITLE
fix(1709): retain verified add-node schema across a timed-out refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_set_widget no longer queues a second whole `/object_info` behind a timed-out `api.getNodeDefs()`, so the type-scoped fallback can use the remaining command time on a large install (#1739)
+- retain verified add-node schema across a timed-out refresh (#1709)
 
 ## [0.15.115] - 2026-08-27
 

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -803,10 +803,10 @@ test("#1709: a direct schema response crossing refresh cannot authorize a later 
   await directStarted.promise;
 
   // This is the same state transition registerComfyNodeDefs performs at refresh start:
-  // old whole-schema membership and verified per-class proof are both retired before the
-  // refresh fetch is allowed to establish new authority.
-  snapshot.clear();
-  built.verifiedNodeDefCache.clear();
+  // old whole-schema membership and verified per-class proof are fenced, not destroyed,
+  // so an in-flight probe cannot authorize after the refresh has begun.
+  snapshot.beginReplacement();
+  built.verifiedNodeDefCache.beginReplacement();
   const afterRefreshGeneration = built.verifiedNodeDefCache.generation();
   assert.ok(afterRefreshGeneration > beforeRefreshGeneration);
 
@@ -817,7 +817,7 @@ test("#1709: a direct schema response crossing refresh cannot authorize a later 
     "the old direct response cannot authorize after refresh; the timeout fallback refuses",
   );
   assert.equal(comfy.graph._nodes.length, 1, "the stale response did not mutate the graph");
-  assert.equal(snapshot.peek().held, false, "the old whole-schema snapshot stayed retired");
+  assert.equal(snapshot.isReplacementPending(), true, "the old whole-schema snapshot stayed fenced");
   assert.equal(
     built.verifiedNodeDefCache.get("ExistingNode", {
       epoch: 0,
@@ -825,7 +825,7 @@ test("#1709: a direct schema response crossing refresh cannot authorize a later 
       generation: afterRefreshGeneration,
     }),
     undefined,
-    "the old direct response did not repopulate verified proof",
+    "the old direct response did not repopulate verified proof while replacement is pending",
   );
   assert.deepEqual(
     calls,
@@ -916,6 +916,181 @@ test("#2249: an empty refresh response retires the old whole snapshot instead of
     null,
     "a later silent probe cannot resurrect a type absent from the empty replacement",
   );
+});
+
+test("#1709: timeout-starved repeated add fails without proof and reuses verified schema after a failed refresh", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  comfy.app.registerNodesFromDefs(defs);
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  const objectInfoCache = createObjectInfoCache();
+  assert.equal(
+    snapshot.record(defs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
+    true,
+  );
+
+  const calls = [];
+  let unavailable = false;
+  const api = {
+    async fetchApi(route) {
+      calls.push(route);
+      if (unavailable) return { status: 503, json: async () => ({}) };
+      const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+      return {
+        status: 200,
+        json: async () =>
+          Object.prototype.hasOwnProperty.call(defs, classType) ? { [classType]: defs[classType] } : {},
+      };
+    },
+    async getNodeDefs() {
+      calls.push("/object_info");
+      if (unavailable) return NODE_DEFS_NO_ANSWER;
+      return defs;
+    },
+  };
+
+  const built = realGraphAddNode({
+    comfy,
+    overrides: {
+      api,
+      objectInfoCache,
+      objectInfoSnapshot: snapshot,
+      verifiedNodeDefCache,
+      objectInfoHistory: { wasTypeEverDefined: () => true },
+    },
+  });
+
+  unavailable = true;
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "ExistingNode" }),
+    /cannot verify node type|object_info is unavailable|Refusing to add/i,
+    "a timeout-starved first add of a never-verified class still fails closed",
+  );
+  assert.equal(comfy.graph._nodes.length, 0, "the never-verified timeout add did not mutate the graph");
+
+  unavailable = false;
+  const first = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(first.added.type, "ExistingNode");
+  const proofGeneration = verifiedNodeDefCache.generation();
+  assert.ok(
+    verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: proofGeneration,
+    }),
+    "the first production add established reusable proof",
+  );
+
+  const register = realRegisterComfyNodeDefs({
+    app: comfy.app,
+    api: {
+      async getNodeDefs() {
+        return NODE_DEFS_NO_ANSWER;
+      },
+      async fetchApi() {
+        return { ok: false, status: 503, json: async () => ({}) };
+      },
+    },
+    objectInfoCache,
+    objectInfoSnapshot: snapshot,
+    verifiedNodeDefCache,
+  });
+  const verdict = await register(undefined, { runBudgetMs: 100 });
+  assert.equal(verdict.refreshed, false, "the timeout-starved refresh does not claim freshness");
+  assert.equal(verifiedNodeDefCache.isReplacementPending(), false, "the failed refresh settles the proof fence");
+  assert.ok(
+    verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: verifiedNodeDefCache.generation(),
+    }),
+    "verified proof survives a refresh that never obtained a whole map",
+  );
+
+  unavailable = true;
+  const reused = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(reused.added.type, "ExistingNode", "the later silent add reuses the verified schema");
+  assert.equal(comfy.graph._nodes.length, 2);
+
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    /cannot verify node type|object_info is unavailable|Refusing to add/i,
+    "a never-verified class still fails closed after the same silent probes",
+  );
+  assert.equal(comfy.graph._nodes.length, 2, "the never-verified timeout add still did not mutate the graph");
+});
+
+test("#1709: a successful whole refresh retires verified add-node proof before a later timeout", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  comfy.app.registerNodesFromDefs(defs);
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  const objectInfoCache = createObjectInfoCache();
+  const api = {
+    async fetchApi(route) {
+      if (route.startsWith("/object_info/")) {
+        const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+        return {
+          status: 200,
+          json: async () =>
+            Object.prototype.hasOwnProperty.call(defs, classType) ? { [classType]: defs[classType] } : {},
+        };
+      }
+      return { status: 503, json: async () => ({}) };
+    },
+    async getNodeDefs() {
+      return defs;
+    },
+  };
+  const built = realGraphAddNode({
+    comfy,
+    overrides: {
+      api,
+      objectInfoCache,
+      objectInfoSnapshot: snapshot,
+      verifiedNodeDefCache,
+      objectInfoHistory: { wasTypeEverDefined: () => true },
+    },
+  });
+  const first = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(first.added.type, "ExistingNode");
+
+  comfy.app.refreshComboInNodes = async () => {};
+  const register = realRegisterComfyNodeDefs({
+    app: comfy.app,
+    api,
+    objectInfoCache,
+    objectInfoSnapshot: snapshot,
+    verifiedNodeDefCache,
+  });
+  const verdict = await register(undefined, { runBudgetMs: 1000 });
+  assert.equal(verdict.refreshed, true, "the current whole map still refreshes");
+  assert.equal(
+    verifiedNodeDefCache.get("ExistingNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: verifiedNodeDefCache.generation(),
+    }),
+    undefined,
+    "an authoritative whole refresh retires per-class proof",
+  );
+
+  api.getNodeDefs = async () => NODE_DEFS_NO_ANSWER;
+  api.fetchApi = async () => ({ status: 503, json: async () => ({}) });
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "ExistingNode" }),
+    /cannot verify node type|object_info is unavailable|Refusing to add/i,
+    "a later timeout cannot reuse proof retired by the successful refresh",
+  );
+  assert.equal(comfy.graph._nodes.length, 1, "the refused timeout fallback did not add a node");
 });
 
 test("#1709: graph_add_node replaces the old whole cache and snapshot on a changed response", async () => {

--- a/browser_tests/unit/verified-node-def-cache.test.mjs
+++ b/browser_tests/unit/verified-node-def-cache.test.mjs
@@ -32,6 +32,61 @@ test("#1709 reuses only a verified class on the same backend and graph binding",
   );
 });
 
+test("#1709 a failed replacement restores fenced proof, and a successful one drops it", () => {
+  const cache = createVerifiedNodeDefCache();
+  const binding = context();
+  const def = { input: { required: { seed: ["INT", {}] } } };
+  const generation = cache.generation();
+
+  assert.equal(cache.set("VRAM_Debug", def, { epoch: 0, context: binding, generation }), true);
+  cache.beginReplacement();
+  assert.equal(cache.isReplacementPending(), true);
+  assert.ok(cache.generation() > generation, "replacement advances the write fence");
+  assert.equal(
+    cache.get("VRAM_Debug", { epoch: 0, context: binding, generation: cache.generation() }),
+    undefined,
+    "proof cannot authorize while the replacement is unresolved",
+  );
+  assert.equal(
+    cache.set("Other", { input: { required: {} } }, { epoch: 0, context: binding, generation: cache.generation() }),
+    false,
+    "an in-flight writer cannot repopulate proof during replacement",
+  );
+
+  assert.equal(cache.retainAfterReplacementFailure({ epoch: 0, socketDown: false }), true);
+  assert.equal(cache.isReplacementPending(), false);
+  assert.equal(
+    cache.get("VRAM_Debug", { epoch: 0, context: binding, generation: cache.generation() }),
+    def,
+    "a silent replacement restores the previously verified class",
+  );
+
+  cache.beginReplacement();
+  cache.acceptReplacement();
+  assert.equal(cache.isReplacementPending(), false);
+  assert.equal(
+    cache.get("VRAM_Debug", { epoch: 0, context: binding, generation: cache.generation() }),
+    undefined,
+    "an authoritative whole map retires per-class proof",
+  );
+});
+
+test("#1709 a down socket during replacement discards proof instead of restoring it", () => {
+  const cache = createVerifiedNodeDefCache();
+  const binding = context();
+  const generation = cache.generation();
+  assert.equal(
+    cache.set("VRAM_Debug", { input: { required: {} } }, { epoch: 3, context: binding, generation }),
+    true,
+  );
+  cache.beginReplacement();
+  assert.equal(cache.retainAfterReplacementFailure({ epoch: 3, socketDown: true }), false);
+  assert.equal(
+    cache.get("VRAM_Debug", { epoch: 3, context: binding, generation: cache.generation() }),
+    undefined,
+  );
+});
+
 test("#1709 invalidating a class removes its reuse proof, and invalid inputs never enter", () => {
   const cache = createVerifiedNodeDefCache();
   const binding = context();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1681,7 +1681,15 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // run has conclusively failed. Reconnect handlers still clear it outright because a new
   // backend process is the one event that can change the type set.
   objectInfoSnapshot.beginReplacement?.();
-  if (typeof verifiedNodeDefCache !== "undefined") verifiedNodeDefCache.clear();
+  // #1709 — fence verified per-class proofs the same way. A timeout here is not evidence
+  // the type set moved; destroying them at refresh start turned a busy /object_info into a
+  // #458 refusal of a class this session already added on this connection. Generation still
+  // advances, so an in-flight probe cannot reuse or repopulate under the new fence.
+  if (typeof verifiedNodeDefCache?.beginReplacement === "function") {
+    verifiedNodeDefCache.beginReplacement();
+  } else if (typeof verifiedNodeDefCache !== "undefined") {
+    verifiedNodeDefCache.clear();
+  }
   // #1223 — the epoch this run STARTED on, captured before any fetch. The recording below
   // is refused if a reconnect lands while the fetch is in flight, so a pre-restart schema
   // can never be filed under post-restart provenance.
@@ -2098,6 +2106,9 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
       // `{}` or an unreadable object is an authoritative non-schema response for this
       // refresh, not a failed replacement that can resurrect the prior membership map.
       if (!snapshotRecorded) objectInfoSnapshot.clear();
+      // The new whole map is authority for every class. Drop per-class proofs without
+      // advancing generation again — this run is still current.
+      verifiedNodeDefCache.acceptReplacement?.();
     }
     // #1275 — snapshot the live graph BEFORE the first mutating phase. Everything
     // from here to the combo phase calls into frontend and extension code
@@ -2389,6 +2400,20 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
       objectInfoSnapshot.isReplacementPending?.() === true
     ) {
       objectInfoSnapshot.retainAfterReplacementFailure({
+        epoch: backendReconnectEpoch,
+        generation: verifiedNodeDefCache.generation(),
+        socketDown: comfyBackendSocketDown,
+      });
+    }
+    // #1709 — a timeout-starved refresh is not an authoritative type-set change. Restore
+    // per-class proofs so a later add of a class this session already verified can reuse
+    // them after both live routes go silent. A successful whole answer already called
+    // acceptReplacement, so this only runs when the replacement never landed.
+    if (
+      typeof verifiedNodeDefCache?.retainAfterReplacementFailure === "function" &&
+      verifiedNodeDefCache.isReplacementPending?.() === true
+    ) {
+      verifiedNodeDefCache.retainAfterReplacementFailure({
         epoch: backendReconnectEpoch,
         generation: verifiedNodeDefCache.generation(),
         socketDown: comfyBackendSocketDown,

--- a/web/js/lib/verified-node-def-cache.js
+++ b/web/js/lib/verified-node-def-cache.js
@@ -2,9 +2,15 @@
 //
 // This is deliberately narrower than the whole /object_info cache: it stores one detached
 // class definition, and only for the exact backend epoch and graph/workflow binding that
-// performed the verified add. A reconnect, schema refresh, tab switch, or graph switch can
-// therefore never authorize an add from an old entry. Callers still clear it when a schema
-// refresh or backend outage is observed; the identity checks are the last line of defense.
+// performed the verified add. A reconnect, an authoritative whole-schema answer, a tab
+// switch, or a graph switch can therefore never authorize an add from an old entry.
+//
+// A same-connection refresh that NEVER ANSWERS is not one of those events. Destroying the
+// proofs at refresh start turned a busy /object_info (panel_refresh_nodes returning
+// refreshed:false) into a #458 refusal of a class this session already added on this
+// connection. beginReplacement fences reuse while the replacement is unresolved;
+// retainAfterReplacementFailure restores it when the live routes were silent;
+// acceptReplacement drops the proofs only once a current whole map actually landed.
 
 function usableContext(context) {
   return !!(
@@ -32,14 +38,25 @@ function usableEpoch(epoch) {
 export function createVerifiedNodeDefCache() {
   const entries = new Map();
   let generation = 0;
+  let replacementPending = false;
+
+  function dropEntries() {
+    entries.clear();
+    replacementPending = false;
+  }
 
   return {
     generation() {
       return generation;
     },
 
+    isReplacementPending() {
+      return replacementPending;
+    },
+
     get(classType, { epoch, context, generation: expectedGeneration } = {}) {
       if (
+        replacementPending ||
         typeof classType !== "string" ||
         !usableEpoch(epoch) ||
         !usableContext(context) ||
@@ -54,6 +71,7 @@ export function createVerifiedNodeDefCache() {
 
     set(classType, def, { epoch, context, generation: expectedGeneration } = {}) {
       if (
+        replacementPending ||
         typeof classType !== "string" ||
         !classType ||
         !def ||
@@ -78,6 +96,34 @@ export function createVerifiedNodeDefCache() {
       return true;
     },
 
+    // Fence reuse without destroying proofs. Generation advances so an in-flight probe
+    // issued before this refresh cannot file or reuse under the new generation; the
+    // entries stay so a silent replacement can restore them.
+    beginReplacement() {
+      generation += 1;
+      replacementPending = true;
+    },
+
+    // An authoritative current whole map landed. Proofs are superseded; do not bump
+    // generation again — the refresh that observed this answer is still current.
+    acceptReplacement() {
+      dropEntries();
+    },
+
+    // The replacement never answered. Re-enable remaining proofs whose epoch still
+    // matches. A down socket or unreadable epoch discards them instead.
+    retainAfterReplacementFailure({ epoch: currentEpoch, socketDown = false } = {}) {
+      replacementPending = false;
+      if (socketDown || !usableEpoch(currentEpoch)) {
+        entries.clear();
+        return false;
+      }
+      for (const [classType, entry] of entries) {
+        if (entry.epoch !== currentEpoch) entries.delete(classType);
+      }
+      return entries.size > 0;
+    },
+
     // An authoritative absence or any schema/backend invalidation drops the type. The
     // class key is global because an observed backend absence is not workflow-specific.
     // Advance the generation even when the requested entry is already absent: an in-flight
@@ -90,7 +136,7 @@ export function createVerifiedNodeDefCache() {
 
     clear() {
       generation += 1;
-      entries.clear();
+      dropEntries();
     },
   };
 }


### PR DESCRIPTION
## Why

#1709 shipped in 0.15.70: after `panel_add_node` verifies a class, a later add of the same class can reuse that detached definition when `/object_info` times out.

The recurrence on 0.15.111: `panel_refresh_nodes` exhausted the fixed `/object_info` budget, returned `refreshed:false`, and **cleared** the verified proofs at the start of `registerComfyNodeDefs`. A subsequent `panel_add_node` of a class already verified on this connection then refused with #458 even though the backend socket and live graph were healthy.

A timeout is not evidence the type set moved. Destroying those proofs turned a busy schema fetch into a fail-closed add of a class this session already constructed.

## Change

Fence verified per-class proofs the same way #2249 already fences the whole-schema snapshot:

- `beginReplacement()` at refresh start advances the generation fence without dropping entries
- `retainAfterReplacementFailure()` restores them when both live routes were silent
- `acceptReplacement()` drops them only once a current whole map actually lands
- reconnect / authoritative empty / per-class absence still fail closed

Never-verified classes still refuse on timeout.

## Tests

`browser_tests/unit` drives the shipped `graph_add_node` and `registerComfyNodeDefs` bodies:

- timeout-starved first add of a never-verified class fails closed
- first add establishes proof, failed refresh keeps it, silent repeated add reuses it
- successful whole refresh retires proof, later timeout cannot reuse it

Related suite: 334 passed, 0 failed. Log: `tests-panel-1709.log`.

Closes #1709
