### PR TITLE
fix(1882): tag the published cut, and bound changelogs on chore: release

### DIFF
--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -8,6 +8,13 @@ on:
     paths:
       - "pyproject.toml"
 
+# After a successful Registry publish, --ensure --push writes the archival
+# `v<X>` tag. contents: write is that push; the job still cannot trigger a
+# second publish — GitHub does not run a branches-filtered workflow for a tag
+# ref, and GITHUB_TOKEN pushes do not re-fire workflows anyway (#1882).
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -373,3 +380,11 @@ jobs:
             echo "::warning::Registry publish with --changelog-file failed — retrying WITHOUT the changelog so the release still ships."
           fi
           comfy node publish --token "$REGISTRY_TOKEN"
+
+      # Inverse of release-tag-guard.yml: that workflow hangs off the tag push,
+      # so a publish that never gets a tag (0.15.97, 0.15.111–0.15.113) is
+      # silent. This runs because the publish ran. --ensure creates the
+      # annotated tag on the commit that cut the version when it is missing;
+      # --push is what makes the operand visible to `git tag` afterwards.
+      - name: Published version must have a git tag
+        run: node scripts/check-release-tag.mjs --published --ensure --push

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -29,12 +29,18 @@ on:
   push:
     tags:
       - "v*"
-  # So a historical tag can be audited on demand without pushing anything.
+  # A tag-push trigger cannot see a release that never got a tag. Audit HEAD's
+  # declared version daily so a published-but-untagged tree is a red build
+  # within a day rather than at the next tag (#1882).
+  schedule:
+    - cron: "17 6 * * *"
+  # So a historical tag — or HEAD's published version — can be audited on
+  # demand without pushing anything.
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to audit (e.g. v0.15.104)"
-        required: true
+        description: "Tag to audit (e.g. v0.15.104). Leave empty to audit HEAD's published version."
+        required: false
         type: string
 
 permissions:
@@ -55,11 +61,17 @@ jobs:
           fetch-tags: true
 
       - name: Audit the release tag
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '') }}
         env:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: node scripts/check-release-tag.mjs "$TAG"
 
       - name: Audit the tagged changelog
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '') }}
         env:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: node scripts/check-changelog.mjs "${TAG#v}" --ref "$TAG"
+
+      - name: Audit the published tree's version has a tag
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag == '') }}
+        run: node scripts/check-release-tag.mjs --published

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_set_widget no longer queues a second whole `/object_info` behind a timed-out `api.getNodeDefs()`, so the type-scoped fallback can use the remaining command time on a large install (#1739)
 - retain verified add-node schema across a timed-out refresh (#1709)
+- a Registry publish of version X leaves tag vX on the commit that cut it, and changelog generation recognises `chore: release vX.Y.Z` so an untagged previous cut still bounds the next entry (#1882)
 
 ## [0.15.115] - 2026-08-27
 

--- a/browser_tests/unit/changelog-base.test.mjs
+++ b/browser_tests/unit/changelog-base.test.mjs
@@ -158,3 +158,48 @@ test("#1191: release commits are excluded from the entry they announce", () => {
   // the releases that preceded them.
   assert.equal(isReleaseSubject("chore(release): 0.14.25 (#1182)"), true, "…so the parser skips it");
 });
+
+// ---------------------------------------------------------------------------
+// #1882 — the CURRENT cut shape is `chore: release v0.15.115`, and tags lag it.
+//
+// #1191 taught the predicate `chore(release):` and then the repo changed spelling
+// again. Every release from 0.15.97 through 0.15.115 uses `chore: release vX.Y.Z`,
+// which matched none of the three arms. Combined with missing tags (0.15.97,
+// 0.15.111–0.15.113), prevTag() cannot fall back to the release commit and bounds
+// at the previous tag — the next cut re-lists everything in between.
+// ---------------------------------------------------------------------------
+
+test("#1882: the CURRENT release shape is recognised — `chore: release vX.Y.Z`", () => {
+  for (const s of [
+    "chore: release v0.15.115 (#1945)",
+    "chore: release v0.15.114 (#1940)",
+    "chore: release v0.15.113 — first release at ZERO registry findings",
+    "chore: release v0.15.112 — bound panel search replies (#1908)",
+    "chore: release v0.15.111",
+    "chore: release 0.15.97",
+  ]) {
+    assert.equal(isReleaseSubject(s), true, JSON.stringify(s));
+  }
+});
+
+test("#1882: `chore: release` without a version is not a release boundary", () => {
+  for (const s of [
+    "chore: release notes for later",
+    "chore: release the kraken",
+    "chore: bump deps",
+    "fix: chore: release v0.15.115 is quoted in the body",
+  ]) {
+    assert.equal(isReleaseSubject(s), false, JSON.stringify(s));
+  }
+});
+
+test("#1882: a `chore: release` commit beats an older tagged `chore(release):` as the base", () => {
+  const sha = pickReleaseSha(
+    [
+      logLine("aaaaaaaa", "fix(1927): re-vendor the tool vocabulary (#1930)"),
+      logLine("bbbbbbbb", "chore: release v0.15.115 (#1945)"),
+      logLine("cccccccc", "chore(release): 0.14.28 (#1195)"),
+    ].join("\n"),
+  );
+  assert.equal(sha, "bbbbbbbb", "the newest release is the untagged chore: release commit");
+});

--- a/browser_tests/unit/changelog-release-guard.test.mjs
+++ b/browser_tests/unit/changelog-release-guard.test.mjs
@@ -176,6 +176,46 @@ test("#1891: release generation merges headings and issue/PR aliases", () => {
   }
 });
 
+test("#1882: changelog generation bounds at an untagged `chore: release` commit", () => {
+  // Tags lag this repo's cuts. If the generator only recognises `chore(release):` /
+  // `release:` / a bare version, prevTag() falls back to the previous TAG and the
+  // next cut re-lists everything since — the 0.15.111–0.15.113 shape in #1882.
+  const cwd = mkdtempSync(join(tmpdir(), "panel-changelog-untagged-"));
+  try {
+    git(cwd, "init", "-b", "main");
+    git(cwd, "config", "user.email", "test@example.invalid");
+    git(cwd, "config", "user.name", "Changelog Test");
+    writeFileSync(
+      cwd + "/CHANGELOG.md",
+      ["# Changelog", "", "## [Unreleased]", "", "## [1.0.0] - 2026-08-26", "", "### Fixed", "- initial fix (#90)", ""].join(
+        "\n",
+      ),
+      "utf8",
+    );
+    git(cwd, "add", "CHANGELOG.md");
+    git(cwd, "commit", "-m", "1.0.0 — initial release");
+    git(cwd, "tag", "v1.0.0");
+    git(cwd, "commit", "--allow-empty", "-m", "fix: shipped only in 1.1.0 (#201)");
+    git(cwd, "commit", "--allow-empty", "-m", "chore: release v1.1.0 (#202)");
+    git(cwd, "commit", "--allow-empty", "-m", "fix: shipped only in 1.2.0 (#203)");
+
+    execFileSync(process.execPath, [GENERATOR, "1.2.0"], {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, CHANGELOG_ROOT: cwd },
+    });
+    const generated = readFileSync(cwd + "/CHANGELOG.md", "utf8");
+    const section12 = generated.slice(generated.indexOf("## [1.2.0]"));
+    const nextRelease = section12.search(/\n## \[/);
+    const body12 = nextRelease >= 0 ? section12.slice(0, nextRelease) : section12;
+    assert.match(body12, /#203/, "the new cut must include its own commit");
+    assert.doesNotMatch(body12, /#201/, "an untagged previous release must still bound the range");
+    assert.doesNotMatch(body12, /#202/, "the previous release commit is not filed as a change");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("#1891: publish guard receives pyproject version before checking changelog", () => {
   const workflow = readFileSync(PUBLISH_WORKFLOW, "utf8");
   const versionStep = workflow.indexOf("id: release-version");

--- a/browser_tests/unit/release-tag-guard.test.mjs
+++ b/browser_tests/unit/release-tag-guard.test.mjs
@@ -26,8 +26,11 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  auditPublishedVersion,
   auditTag,
   collectFromGit,
+  collectPublishedFromGit,
+  ensurePublishedTag,
   firstParentAtRev,
   packageJsonVersion,
   panelVersion,
@@ -407,6 +410,112 @@ test("#1882 the tag being pushed is not exempt from the target check", () => {
   assert.deepEqual(inPlace, []);
 });
 
+test("#1882 a published version with no tag is a violation, not a later-tag problem", () => {
+  const violations = auditPublishedVersion({
+    version: "0.15.111",
+    cutSha: "48d655db00",
+    cutSubject: "chore: release v0.15.111",
+    tagTargetFor: noTags,
+  });
+  assert.equal(violations.length, 1, violations.join("\n"));
+  assert.match(violations[0], /^0\.15\.111 was cut by 48d655db /);
+  assert.match(violations[0], /no v0\.15\.111 tag exists/);
+  assert.match(violations[0], /git tag -a v0\.15\.111 48d655db/);
+  assert.match(violations[0], /cannot re-trigger the publish workflow/);
+});
+
+test("#1882 a published-version tag is credited only when it labels the cut", () => {
+  const cut = "86fee2f800";
+  const wrong = auditPublishedVersion({
+    version: "0.15.111",
+    cutSha: cut,
+    tagTargetFor: tagsAt({ "0.15.111": "deadbeef00" }),
+  });
+  assert.equal(wrong.length, 1, wrong.join("\n"));
+  assert.match(wrong[0], /v0\.15\.111 resolves to deadbeef/);
+  assert.match(wrong[0], /was cut by 86fee2f8/);
+
+  const right = auditPublishedVersion({
+    version: "0.15.111",
+    cutSha: cut,
+    tagTargetFor: tagsAt({ "0.15.111": cut }),
+  });
+  assert.deepEqual(right, []);
+});
+
+test("#1882 an unrunnable published-version scan is a violation, not a pass", () => {
+  const violations = auditPublishedVersion({
+    version: "0.15.115",
+    cutSha: "6d08afd900",
+    tagTargetFor: noTags,
+    historyError: "this is a shallow clone, so the range cannot be walked",
+  });
+  assert.equal(violations.length, 1, violations.join("\n"));
+  assert.match(violations[0], /tag check could not run/);
+  assert.match(violations[0], /shallow clone/);
+});
+
+test("#1882 collectPublishedFromGit walks back to the cut, not HEAD", () => {
+  withReleaseHistory((cwd) => {
+    writeFileSync(join(cwd, "note.txt"), "later same version\n");
+    execFileSync("git", ["-C", cwd, "add", "note.txt"]);
+    execFileSync("git", ["-C", cwd, "commit", "-m", "docs: a later commit at 0.15.104"]);
+    const head = execFileSync("git", ["-C", cwd, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    const cut = execFileSync("git", ["-C", cwd, "rev-parse", "v0.15.104^{commit}"], { encoding: "utf8" }).trim();
+    assert.notEqual(head, cut);
+
+    const collected = collectPublishedFromGit("HEAD", { cwd });
+    assert.equal(collected.historyError, null, collected.historyError);
+    assert.equal(collected.version, "0.15.104");
+    assert.equal(collected.cutSha, cut);
+    assert.deepEqual(auditPublishedVersion(collected), []);
+  });
+});
+
+test("#1882 collectPublishedFromGit reports the 0.15.111 shape: tree shipped, no tag", () => {
+  withReleaseHistory((cwd) => {
+    execFileSync("git", ["-C", cwd, "tag", "-d", "v0.15.104"]);
+    const collected = collectPublishedFromGit("HEAD", { cwd });
+    assert.equal(collected.historyError, null, collected.historyError);
+    assert.equal(collected.version, "0.15.104");
+    const violations = auditPublishedVersion(collected);
+    assert.equal(violations.length, 1, violations.join("\n"));
+    assert.match(violations[0], /no v0\.15\.104 tag exists/);
+  });
+});
+
+test("#1882 --ensure creates the missing tag on the commit that cut the version", () => {
+  withReleaseHistory((cwd) => {
+    execFileSync("git", ["-C", cwd, "tag", "-d", "v0.15.104"]);
+    const missing = collectPublishedFromGit("HEAD", { cwd });
+    const ensured = ensurePublishedTag(missing, { cwd });
+    assert.equal(ensured.error, null, ensured.error);
+    assert.equal(ensured.created, true);
+    assert.equal(ensured.pushed, false);
+
+    const after = collectPublishedFromGit("HEAD", { cwd });
+    assert.deepEqual(auditPublishedVersion(after), []);
+    const target = execFileSync("git", ["-C", cwd, "rev-parse", "v0.15.104^{commit}"], { encoding: "utf8" }).trim();
+    assert.equal(target, missing.cutSha);
+  });
+});
+
+test("#1882 --ensure will not move a tag that already points at a different commit", () => {
+  withReleaseHistory((cwd) => {
+    const cut = execFileSync("git", ["-C", cwd, "rev-parse", "v0.15.104^{commit}"], { encoding: "utf8" }).trim();
+    const other = execFileSync("git", ["-C", cwd, "rev-parse", "v0.15.103^{commit}"], { encoding: "utf8" }).trim();
+    execFileSync("git", ["-C", cwd, "tag", "-d", "v0.15.104"]);
+    execFileSync("git", ["-C", cwd, "tag", "v0.15.104", other]);
+    const collected = collectPublishedFromGit("HEAD", { cwd });
+    const ensured = ensurePublishedTag(collected, { cwd });
+    assert.equal(ensured.created, false);
+    assert.match(ensured.error ?? "", /Refusing to move a release tag/);
+    const still = execFileSync("git", ["-C", cwd, "rev-parse", "v0.15.104^{commit}"], { encoding: "utf8" }).trim();
+    assert.equal(still, other);
+    assert.notEqual(still, cut);
+  });
+});
+
 test("#1882 a history failure still reports the tree-vs-tag mismatch it could check", () => {
   const violations = auditTag({
     tag: "v0.15.90",
@@ -444,6 +553,12 @@ test("#1882 the tag guard must not adopt a branch trigger — that is what would
   assert.ok(!/\bbranches:/.test(onBlock), "the tag guard must stay tag-triggered only");
 });
 
+test("#1882 the tag guard also audits HEAD on a schedule, because no tag push may ever come", () => {
+  const wf = read(".github/workflows/release-tag-guard.yml");
+  assert.match(wf, /schedule:\s*\n\s*- cron:/, "a published-but-untagged tree must not wait for the next tag");
+  assert.match(wf, /node scripts\/check-release-tag\.mjs --published/, "the schedule must run the published-version check");
+});
+
 test("#1882 publish_action.yml stays branches-filtered, so a tag push cannot republish", () => {
   // The whole reason a missing historical tag can be created safely. If someone
   // adds a `tags:` filter here, backfilling a tag would re-publish to the Registry.
@@ -451,6 +566,18 @@ test("#1882 publish_action.yml stays branches-filtered, so a tag push cannot rep
   const onBlock = wf.slice(wf.indexOf("\non:"), wf.indexOf("\njobs:"));
   assert.match(onBlock, /branches:\s*\n\s*- main/);
   assert.ok(!/\btags:/.test(onBlock), "publish must never trigger on a tag push");
+});
+
+test("#1882 the publish job tags the cut AFTER a successful Registry publish", () => {
+  const wf = read(".github/workflows/publish_action.yml");
+  const publish = wf.indexOf("- name: Publish custom node");
+  const guard = wf.indexOf("scripts/check-release-tag.mjs --published");
+  assert.notEqual(publish, -1, "the publish step is missing");
+  assert.notEqual(guard, -1, "the published-version check is missing");
+  assert.ok(guard > publish, "tagging a version that failed to publish recreates the stale-tag operand");
+  assert.match(wf, /--ensure/, "the path must create the missing tag, not only complain");
+  assert.match(wf, /--push/, "a local tag is not the operand `git tag` on a clone sees");
+  assert.match(wf, /contents:\s*write/, "pushing the archival tag needs contents: write");
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -65,6 +65,22 @@
  *      so this never re-litigates the whole history and cannot become
  *      permanently red over a historical gap nobody intends to backfill.
  *
+ * THE TAG-PUSH TRIGGER CANNOT SEE A RELEASE THAT NEVER GOT A TAG. 0.15.111,
+ * 0.15.112 and 0.15.113 all reached the Registry after this file shipped, and
+ * none of them has a tag — there was no tag-push event, so nothing ran. Rule 2
+ * would have named them on the *next* tag push, but that is too late: the
+ * operand is already wrong, and a later tagged cut (v0.15.115) bounds at
+ * v0.15.114 and never looks back. The inverse trigger is the publish job,
+ * which DID run. After a successful Registry publish of `<X>`:
+ *
+ *   3. THE PUBLISHED VERSION IS LABELLED. Tag `v<X>` must exist and resolve to
+ *      the first-parent commit that cut `<X>`, not merely to HEAD (a later
+ *      same-version commit is not the release). `--ensure` creates that
+ *      annotated tag when it is missing so the path cannot ship a version and
+ *      leave it untagged; it will not move a tag that already points elsewhere.
+ *      `--published` is also what the scheduled run of release-tag-guard.yml
+ *      audits, so a gap is a red build within a day rather than at the next tag.
+ *
  * IT FAILS CLOSED, AT EVERY GRAIN. Every git lookup this needs can fail — a
  * shallow clone, tags that were never fetched, an unreadable blob on one commit.
  * The first draft turned each of those into "nothing to see": a missing range, or
@@ -227,6 +243,62 @@ export function auditTag({ tag, treeAtTag, range = [], tagTargetFor, historyErro
   return violations;
 }
 
+/**
+ * Rule 3. The tree's declared version must be labelled by a tag on the commit
+ * that cut it — independent of whether a later tag push ever happens.
+ *
+ * @param {object} o
+ * @param {string|null} o.version  pyproject version at the audited rev
+ * @param {string|null} o.cutSha   first-parent commit that changed pyproject to `version`
+ * @param {string} [o.cutSubject]
+ * @param {(version:string)=>(string|null)} o.tagTargetFor
+ * @param {string|null} [o.historyError]
+ * @returns {string[]}
+ */
+export function auditPublishedVersion({
+  version,
+  cutSha,
+  cutSubject = "",
+  tagTargetFor,
+  historyError = null,
+}) {
+  if (historyError) {
+    return [
+      `published version: the tag check could not run — ${historyError}. Refusing to ` +
+        `report this release as tagged on a check that did not execute (#1882).`,
+    ];
+  }
+  if (!version) {
+    return [`published version: could not read [project].version from the audited tree.`];
+  }
+  if (!cutSha) {
+    return [
+      `${version}: could not find the first-parent commit that cut this version, so the ` +
+        `tag cannot be checked against the build the Registry publishes (#1882).`,
+    ];
+  }
+
+  const target = typeof tagTargetFor === "function" ? tagTargetFor(version) : null;
+  const quoted = cutSubject ? ` ("${cutSubject}")` : "";
+  if (!target) {
+    return [
+      `${version} was cut by ${short(cutSha)}${quoted} and is what publish_action.yml ` +
+        `ships, but no v${version} tag exists. "Was this released?" answers from git ` +
+        `tag, so an untagged Registry publish is a silent wrong operand (#1882). ` +
+        `git tag -a v${version} ${short(cutSha)} -m "release v${version}" && ` +
+        `git push origin v${version} (a tag push cannot re-trigger the publish workflow).`,
+    ];
+  }
+  if (target !== cutSha) {
+    return [
+      `v${version} resolves to ${short(target)}, but ${version} was cut by ${short(cutSha)}${quoted}. ` +
+        `The tag does not label the commit that changed pyproject.toml to ${version}, so it ` +
+        `points at a different build than the one the Registry publishes (#1882).`,
+    ];
+  }
+  return [];
+}
+
 // ---------------------------------------------------------------------------
 // git-backed shell
 // ---------------------------------------------------------------------------
@@ -239,14 +311,83 @@ export function auditTag({ tag, treeAtTag, range = [], tagTargetFor, historyErro
  * green here.
  */
 const gitIn =
-  (cwd) =>
+  (cwd, extraEnv) =>
   (...args) =>
     execFileSync("git", cwd ? ["-C", cwd, ...args] : args, {
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
+      env: extraEnv ? { ...process.env, ...extraEnv } : process.env,
     });
 
 const git = gitIn(null);
+
+const TAG_IDENTITY_ENV = {
+  GIT_AUTHOR_NAME: "github-actions[bot]",
+  GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com",
+  GIT_COMMITTER_NAME: "github-actions[bot]",
+  GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com",
+};
+
+function shallowRepoError(runGit) {
+  try {
+    if (runGit("rev-parse", "--is-shallow-repository").trim() === "true") {
+      return "this is a shallow clone, so the range cannot be walked (checkout needs fetch-depth: 0)";
+    }
+  } catch (e) {
+    return `git rev-parse --is-shallow-repository failed: ${e.message}`;
+  }
+  return null;
+}
+
+function readVersionTagTargets(runGit) {
+  const tagTargets = new Map();
+  try {
+    for (const line of runGit(
+      "for-each-ref",
+      "--format=%(refname:short)%00%(objectname)%00%(*objectname)",
+      "refs/tags/v*",
+    ).split("\n")) {
+      if (!line.trim()) continue;
+      const [name, objectname, peeled] = line.split("\0");
+      tagTargets.set(name.trim(), (peeled || objectname || "").trim());
+    }
+    return { tagTargets, error: null };
+  } catch (e) {
+    return { tagTargets, error: `listing v* tags failed: ${e.message}` };
+  }
+}
+
+/**
+ * Walk first-parent from `startSha` until the parent's pyproject version differs.
+ * That commit is the cut — the SHA `publish_action.yml` actually shipped, and the
+ * only SHA a `v<version>` tag may label.
+ *
+ * @param {string} startSha
+ * @param {string} version
+ * @param {{
+ *   readVersion: (rev:string)=>{version:string|null, error:string|null},
+ *   firstParent: (rev:string)=>{parent:string|null, error:string|null},
+ * }} deps
+ * @returns {{cutSha:string|null, error:string|null}}
+ */
+export function findVersionCut(startSha, version, { readVersion, firstParent }) {
+  let cursor = startSha;
+  const seen = new Set();
+  while (cursor && !seen.has(cursor)) {
+    seen.add(cursor);
+    const parentRef = firstParent(cursor);
+    if (parentRef.error) return { cutSha: null, error: parentRef.error };
+    if (!parentRef.parent) return { cutSha: cursor, error: null };
+    const parent = readVersion(parentRef.parent);
+    if (parent.error) return { cutSha: null, error: parent.error };
+    if (parent.version !== version) return { cutSha: cursor, error: null };
+    cursor = parentRef.parent;
+  }
+  return {
+    cutSha: null,
+    error: `version-cut walk for ${short(startSha)} did not terminate`,
+  };
+}
 
 const showOrNull = (rev, path, runGit = git) => {
   try {
@@ -357,34 +498,20 @@ export function collectFromGit(
   let range = [];
   const tagTargets = new Map();
 
-  try {
-    if (runGit("rev-parse", "--is-shallow-repository").trim() === "true") {
-      historyError =
-        "this is a shallow clone, so the range cannot be walked (checkout needs fetch-depth: 0)";
-    }
-  } catch (e) {
-    historyError = `git rev-parse --is-shallow-repository failed: ${e.message}`;
-  }
+  historyError = shallowRepoError(runGit);
 
   if (!historyError) {
-    try {
-      // `%(*objectname)` is the peeled target and is non-empty only for annotated
-      // tags; lightweight tags report the commit in `%(objectname)`.
-      for (const line of runGit(
-        "for-each-ref",
-        "--format=%(refname:short)%00%(objectname)%00%(*objectname)",
-        "refs/tags/v*",
-      ).split("\n")) {
-        if (!line.trim()) continue;
-        const [name, objectname, peeled] = line.split("\0");
-        tagTargets.set(name.trim(), (peeled || objectname || "").trim());
-      }
+    // `%(*objectname)` is the peeled target and is non-empty only for annotated
+    // tags; lightweight tags report the commit in `%(objectname)`.
+    const listed = readVersionTagTargets(runGit);
+    if (listed.error) {
+      historyError = listed.error;
+    } else {
+      for (const [name, sha] of listed.tagTargets) tagTargets.set(name, sha);
       if (tagTargets.size === 0) {
         historyError =
           "no v* tags are visible, so no prior release can be credited (checkout needs fetch-tags: true)";
       }
-    } catch (e) {
-      historyError = `listing v* tags failed: ${e.message}`;
     }
   }
 
@@ -442,14 +569,166 @@ export function collectFromGit(
   };
 }
 
+/**
+ * Facts needed to audit (and optionally create) the tag for the version the
+ * tree at `rev` declares. `cwd` / injected readers exist for the same reason
+ * as collectFromGit: CI is a shallow checkout of THIS repo.
+ *
+ * @param {string} [rev]
+ * @param {{
+ *   readVersionAt?: (rev:string)=>{version:string|null, error:string|null},
+ *   firstParentAt?: (rev:string)=>{parent:string|null, error:string|null},
+ *   cwd?: string,
+ * }} [deps]
+ */
+export function collectPublishedFromGit(rev = "HEAD", { readVersionAt, firstParentAt, cwd } = {}) {
+  const runGit = cwd ? gitIn(cwd) : git;
+  const readVersion = readVersionAt ?? ((r) => versionAtRev(r, runGit));
+  const firstParent = firstParentAt ?? ((r) => firstParentAtRev(r, runGit));
+
+  let historyError = shallowRepoError(runGit);
+  let sha = null;
+  if (!historyError) {
+    try {
+      sha = runGit("rev-parse", "--verify", `${rev}^{commit}`).trim();
+    } catch (e) {
+      historyError = `could not resolve ${rev}: ${e.message.split("\n")[0]}`;
+    }
+  }
+
+  const own = sha && !historyError ? readVersion(sha) : { version: null, error: null };
+  if (!historyError && own.error) historyError = own.error;
+
+  let cutSha = null;
+  let cutSubject = "";
+  if (!historyError && sha && own.version) {
+    const cut = findVersionCut(sha, own.version, { readVersion, firstParent });
+    if (cut.error) historyError = cut.error;
+    else cutSha = cut.cutSha;
+  }
+  if (cutSha) {
+    try {
+      cutSubject = runGit("log", "-1", "--format=%s", cutSha).trim();
+    } catch {
+      cutSubject = "";
+    }
+  }
+
+  const listed = historyError ? { tagTargets: new Map(), error: null } : readVersionTagTargets(runGit);
+  if (!historyError && listed.error) historyError = listed.error;
+  const tagTargets = listed.tagTargets;
+
+  return {
+    version: own.version,
+    cutSha,
+    cutSubject,
+    historyError,
+    tagTargetFor: (v) => tagTargets.get(`v${v}`) ?? null,
+    cwd,
+  };
+}
+
+/**
+ * Create an annotated `v<version>` tag on the cut commit when none exists.
+ * Will not move a tag that already points at a different commit.
+ *
+ * @param {{version:string|null, cutSha:string|null, tagTargetFor?: Function, cwd?: string}} collected
+ * @param {{push?: boolean, cwd?: string}} [opts]
+ * @returns {{created:boolean, pushed:boolean, error:string|null}}
+ */
+export function ensurePublishedTag(collected, { push = false, cwd } = {}) {
+  const version = collected?.version;
+  const cutSha = collected?.cutSha;
+  if (!version || !cutSha) {
+    return { created: false, pushed: false, error: "cannot create a release tag without a version and a cut commit" };
+  }
+  const tag = `v${version}`;
+  const existing = typeof collected.tagTargetFor === "function" ? collected.tagTargetFor(version) : null;
+  if (existing) {
+    if (existing === cutSha) return { created: false, pushed: false, error: null };
+    return {
+      created: false,
+      pushed: false,
+      error:
+        `${tag} already exists at ${short(existing)}, not at ${short(cutSha)} that cut ${version}. ` +
+        `Refusing to move a release tag (#1882).`,
+    };
+  }
+
+  const dir = cwd ?? collected.cwd;
+  const tagGit = gitIn(dir, TAG_IDENTITY_ENV);
+  try {
+    tagGit("tag", "-a", tag, cutSha, "-m", `release ${tag}`);
+  } catch (e) {
+    return {
+      created: false,
+      pushed: false,
+      error: `failed to create ${tag} at ${short(cutSha)}: ${e.message.split("\n")[0]}`,
+    };
+  }
+  if (!push) return { created: true, pushed: false, error: null };
+  try {
+    tagGit("push", "origin", `refs/tags/${tag}`);
+  } catch (e) {
+    return {
+      created: true,
+      pushed: false,
+      error: `created ${tag} locally but pushing it failed: ${e.message.split("\n")[0]}`,
+    };
+  }
+  return { created: true, pushed: true, error: null };
+}
+
 const invokedDirectly =
   typeof process.argv[1] === "string" &&
   process.argv[1].replace(/\\/g, "/").endsWith("scripts/check-release-tag.mjs");
 
 if (invokedDirectly) {
-  const tag = (process.argv[2] || process.env.GITHUB_REF_NAME || "").trim();
+  const args = process.argv.slice(2);
+  const published = args.includes("--published");
+  const ensure = args.includes("--ensure");
+  const push = args.includes("--push");
+  const positional = args.filter((a) => !a.startsWith("--"));
+
+  if (published) {
+    const rev = (positional[0] || process.env.GITHUB_SHA || "HEAD").trim();
+    let collected = collectPublishedFromGit(rev);
+    if (ensure) {
+      const ensured = ensurePublishedTag(collected, { push });
+      if (ensured.error) {
+        console.log(`::error::${ensured.error}`);
+        process.exit(1);
+      }
+      if (ensured.created) {
+        console.error(
+          `created annotated tag v${collected.version} at ${short(collected.cutSha)}` +
+            (ensured.pushed ? " and pushed it" : " (not pushed)"),
+        );
+        collected = collectPublishedFromGit(rev, { cwd: collected.cwd });
+      }
+    }
+    const violations = auditPublishedVersion(collected);
+    console.error(
+      `auditing published ${collected.version ?? "(unknown version)"} cut by ` +
+        `${short(collected.cutSha) || "(unknown sha)"}` +
+        (collected.historyError ? ` — HISTORY UNAVAILABLE: ${collected.historyError}` : ""),
+    );
+    for (const v of violations) console.log(`::error::${v}`);
+    if (!violations.length) {
+      console.log(
+        `published ${collected.version} is tagged at ${short(collected.cutSha)} — ` +
+          `tree, cut and tag agree.`,
+      );
+    }
+    process.exit(violations.length ? 1 : 0);
+  }
+
+  const tag = (positional[0] || process.env.GITHUB_REF_NAME || "").trim();
   if (!tag) {
-    console.error("usage: node scripts/check-release-tag.mjs <tag>   (or set GITHUB_REF_NAME)");
+    console.error(
+      "usage: node scripts/check-release-tag.mjs <tag> | --published [--ensure] [--push] [rev]\n" +
+        "       (or set GITHUB_REF_NAME / GITHUB_SHA)",
+    );
     process.exit(2);
   }
   const collected = collectFromGit(tag);

--- a/scripts/lib/changelog-match.mjs
+++ b/scripts/lib/changelog-match.mjs
@@ -49,6 +49,14 @@ export const SEP = "\x1f";
  * Verified: 78 newly matched subjects, every one of them a `chore(release):`, and zero new
  * matches anywhere else in history.
  *
+ * #1882 — THE SHAPE THIS REPO CUTS TODAY is `chore: release v0.15.115 (#1945)`, not
+ * `chore(release):`. Measured on main at 0.15.115: every release from 0.15.97 through
+ * 0.15.115 uses that subject, and the three-arm predicate matched ZERO of them. Tags lag
+ * those cuts (0.15.97, 0.15.111, 0.15.112, 0.15.113 shipped with no tag), so `prevTag()`
+ * cannot fall back to the release commit and bounds at the previous TAG instead — the next
+ * cut then re-lists everything since. The arm is `chore: release <version>`, not a bare
+ * `^chore: release`, so `chore: release notes` and `chore: bump deps` stay ordinary commits.
+ *
  * Deliberately anchored at the start and followed by a non-digit, so ordinary commits that
  * merely CONTAIN a version — `docs(changelog): 0.11.75 said the wrong thing`, `feat:
  * support 1.2.3 style ids` — are not swallowed. That direction is the dangerous one: it
@@ -58,6 +66,7 @@ export const SEP = "\x1f";
 export const isReleaseSubject = (s) =>
   /^release:/i.test(String(s ?? "")) ||
   /^chore\(release\):\s*(?:[a-z0-9-]*panel\s+)?v?\d+\.\d+\.\d+([^0-9]|$)/i.test(String(s ?? "")) ||
+  /^chore:\s+release\s+v?\d+\.\d+\.\d+([^0-9]|$)/i.test(String(s ?? "")) ||
   /^v?\d+\.\d+\.\d+([^0-9]|$)/.test(String(s ?? ""));
 
 /**


### PR DESCRIPTION
Closes #1882.

The tag-push guard from #1885/#1887 is still the right check for "tag exists, tree is stale". It cannot see the mirror case: a Registry publish that never gets a tag. 0.15.111, 0.15.112 and 0.15.113 all shipped after that guard landed; no tag-push event occurred, so nothing ran. Rule 2 would have named them on the *next* tag push, but a later tagged cut (`v0.15.115`) bounds at `v0.15.114` and never looks back.

This is the inverse trigger: the event that *did* happen.

## After a successful Registry publish, the cut is tagged

`publish_action.yml` now runs `node scripts/check-release-tag.mjs --published --ensure --push` **after** `comfy node publish`.

- `--published` reads `[project].version` at `GITHUB_SHA`, walks first-parent to the commit that *cut* that version, and requires `v<X>` to resolve to that commit — not to HEAD (a later same-version commit is not the release).
- `--ensure` creates the annotated tag on the cut when it is missing. It will not move a tag that already points elsewhere.
- `--push` is what makes the operand visible to `git tag` on a clone. A tag push still cannot re-trigger this workflow (`branches: [main]` only; pinned by test). `GITHUB_TOKEN` pushes do not re-fire workflows either, which is why the audit runs in this same job.

`contents: write` is only for that archival tag.

## Daily backstop

`release-tag-guard.yml` still hangs off `v*` tag pushes (and must not grow a branch trigger — that would race the tag). It now also runs `--published` on a schedule, and on `workflow_dispatch` with an empty tag input, so a published-but-untagged HEAD is a red build within a day rather than at the next tag.

## Changelog matching no longer depends on the missing tag

`isReleaseSubject` did not recognise the shape this repo actually cuts today: `chore: release v0.15.115 (#1945)`. Combined with missing tags, `prevTag()` fell back to the previous tag and the next cut re-listed everything in between. The new arm is `chore: release <version>`, not a bare `^chore: release`.

## Deliberately not done

- Not creating `v0.15.97` / `v0.15.111` / `v0.15.112` / `v0.15.113`. Those stay the owner's call. Future publishes will tag themselves.
- No Registry API call. The operand is still git, now produced by the publish path instead of hoped for afterwards.

## Tests

Drive the shipped scripts (`check-release-tag.mjs`, `changelog-match.mjs` / `gen-changelog.mjs`) and the workflow wiring. `npm run test:unit`: 7109 pass / 0 fail / 1 pre-existing todo.
