### PR TITLE
fix(1911): do not skip live-canvas capture silently when $subscribe is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_set_widget no longer queues a second whole `/object_info` behind a timed-out `api.getNodeDefs()`, so the type-scoped fallback can use the remaining command time on a large install (#1739)
 - retain verified add-node schema across a timed-out refresh (#1709)
 - a Registry publish of version X leaves tag vX on the commit that cut it, and changelog generation recognises `chore: release vX.Y.Z` so an untagged previous cut still bounds the next entry (#1882)
+- live-canvas capture no longer skips silently when Pinia `$subscribe` is missing (#1911)
 
 ## [0.15.115] - 2026-08-27
 

--- a/browser_tests/unit/live-canvas-capture-gate.test.mjs
+++ b/browser_tests/unit/live-canvas-capture-gate.test.mjs
@@ -1,0 +1,259 @@
+// #1911 — live-canvas capture must not skip silently when Pinia `$subscribe`
+// cannot be installed.
+//
+// THE REPORT. `activePointerProof` begins with `activePointerWatchAvailable &&`.
+// That flag is true only when `getPiniaStore("workflow")?.$subscribe` returns a
+// stop handle. On a frontend where any of those miss, TARGET `checkState()` is
+// skipped with no other branch — the same value as "the watcher saw a move".
+// #1215's remaining recurrence: SOURCE widget values survive onto the new canvas
+// because nothing flushed or disclosed.
+//
+// THE FIX. A shipped helper either installs the watch on the workflow service
+// itself (it IS the Pinia store) or, if that also fails, captures already-current
+// via the pre-watch proof / skips a switch capture and DISCLOSES. SOURCE flush
+// stays ungated — that is the #1295 inverse of #1215 and must not be weakened.
+//
+// These tests drive the SHIPPED helper, then pin that `workflow_open` actually
+// calls it. `$subscribe` absent + silent skip fails them.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  decideLiveCanvasCapture,
+  installActivePointerWatch,
+  POINTER_WATCH_UNAVAILABLE_NOTICE,
+} from "../../web/js/lib/live-canvas-capture-gate.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function piniaStore() {
+  const subscribers = [];
+  return {
+    subscribers,
+    $subscribe(observer) {
+      subscribers.push(observer);
+      return () => {
+        const index = subscribers.indexOf(observer);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour of the shipped helper
+// ---------------------------------------------------------------------------
+
+test("#1911: watch available + pointer proof + source proof captures and stays quiet", () => {
+  const decision = decideLiveCanvasCapture({
+    watchAvailable: true,
+    openLoaded: false,
+    captureSourceProof: true,
+    pointerProof: true,
+    pointerMovedThisOpen: true,
+  });
+  assert.equal(decision.capture, true);
+  assert.equal(decision.disclose, false);
+  assert.equal(decision.reason, "pointer-proof");
+  assert.equal(decision.notice, undefined);
+});
+
+test("#1911: watch available + unproven pointer skips capture without pretending the watch is missing", () => {
+  const decision = decideLiveCanvasCapture({
+    watchAvailable: true,
+    captureSourceProof: true,
+    pointerProof: false,
+    pointerMovedThisOpen: true,
+  });
+  assert.equal(decision.capture, false);
+  assert.equal(decision.disclose, false);
+  assert.equal(decision.reason, "unproven-pointer");
+});
+
+test("#1911: $subscribe absent + tab switch does NOT capture TARGET (that is the #1215 poison) and DISCLOSES", () => {
+  const decision = decideLiveCanvasCapture({
+    watchAvailable: false,
+    captureSourceProof: true, // "bound" after a move — the #1639 hole if trusted
+    pointerProof: false,
+    pointerMovedThisOpen: true,
+  });
+  assert.equal(decision.capture, false, "a switch without a watcher must not write SOURCE's canvas into TARGET");
+  assert.equal(decision.disclose, true, "silent skip is the bug");
+  assert.equal(decision.reason, "watch-unavailable-switch");
+  assert.equal(decision.notice, POINTER_WATCH_UNAVAILABLE_NOTICE);
+  assert.match(decision.notice, /\$subscribe/);
+  assert.match(decision.notice, /panel_graph_outline/);
+  assert.match(decision.notice, /panel_load_workflow/);
+  assert.match(decision.notice, /REPLACES the canvas/);
+});
+
+test("#1911: $subscribe absent + already-current still captures via the pre-watch proof, and names the gap", () => {
+  const decision = decideLiveCanvasCapture({
+    watchAvailable: false,
+    captureSourceProof: true,
+    pointerProof: false,
+    pointerMovedThisOpen: false,
+  });
+  assert.equal(decision.capture, true, "already-current is the #874 proof this path used before the watcher");
+  assert.equal(decision.disclose, true);
+  assert.equal(decision.reason, "watch-unavailable-already-current");
+  assert.equal(decision.notice, POINTER_WATCH_UNAVAILABLE_NOTICE);
+});
+
+test("#1911: $subscribe absent + already-current + foreign source does not capture", () => {
+  const decision = decideLiveCanvasCapture({
+    watchAvailable: false,
+    captureSourceProof: false,
+    pointerProof: false,
+    pointerMovedThisOpen: false,
+  });
+  assert.equal(decision.capture, false);
+  assert.equal(decision.disclose, true);
+  assert.equal(decision.reason, "watch-unavailable-unproven-source");
+});
+
+test("#1911: a just-loaded disk state is never overwritten, watch or not", () => {
+  const watched = decideLiveCanvasCapture({
+    watchAvailable: true,
+    openLoaded: true,
+    captureSourceProof: true,
+    pointerProof: true,
+    pointerMovedThisOpen: false,
+  });
+  assert.equal(watched.capture, false);
+  assert.equal(watched.disclose, false);
+  assert.equal(watched.reason, "loaded-from-disk");
+
+  const unwatched = decideLiveCanvasCapture({
+    watchAvailable: false,
+    openLoaded: true,
+    captureSourceProof: true,
+    pointerProof: false,
+    pointerMovedThisOpen: true,
+  });
+  assert.equal(unwatched.capture, false);
+  assert.equal(unwatched.disclose, true);
+  assert.equal(unwatched.reason, "loaded-from-disk");
+});
+
+test("#1911: installActivePointerWatch uses the Pinia store when $subscribe returns a stop handle", () => {
+  const store = piniaStore();
+  const observer = () => {};
+  const installed = installActivePointerWatch(observer, [store]);
+  assert.equal(installed.available, true);
+  assert.equal(typeof installed.stop, "function");
+  assert.equal(store.subscribers.length, 1);
+  installed.stop();
+  assert.equal(store.subscribers.length, 0);
+});
+
+test("#1911: installActivePointerWatch falls back to the workflow service when Pinia lookup misses", () => {
+  const service = piniaStore();
+  const observer = () => {};
+  const installed = installActivePointerWatch(observer, [null, service]);
+  assert.equal(installed.available, true, "the workflow service IS the Pinia store");
+  assert.equal(service.subscribers.length, 1);
+  installed.stop();
+});
+
+test("#1911: installActivePointerWatch is unavailable — not silently true — when no store exposes $subscribe", () => {
+  const installed = installActivePointerWatch(() => {}, [null, {}, { $subscribe: "nope" }]);
+  assert.equal(installed.available, false);
+  assert.equal(installed.stop, null);
+});
+
+test("#1911: $subscribe that does not return a stop handle does not count as installed", () => {
+  const installed = installActivePointerWatch(() => {}, [
+    { $subscribe: () => undefined },
+    { $subscribe: () => "not-a-function" },
+  ]);
+  assert.equal(installed.available, false);
+});
+
+test("#1911: a throwing $subscribe falls through to the next candidate", () => {
+  const service = piniaStore();
+  const installed = installActivePointerWatch(() => {}, [
+    {
+      $subscribe() {
+        throw new Error("pinia exploded");
+      },
+    },
+    service,
+  ]);
+  assert.equal(installed.available, true);
+  assert.equal(service.subscribers.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Wiring — deleting the call in workflow_open must fail these
+// ---------------------------------------------------------------------------
+
+test("#1911: workflow_open imports and calls the shipped capture-gate helper", () => {
+  assert.match(
+    SRC,
+    /import \{\s*decideLiveCanvasCapture,\s*installActivePointerWatch,\s*POINTER_WATCH_UNAVAILABLE_NOTICE,\s*\} from "\.\/lib\/live-canvas-capture-gate\.js"/,
+    "the shipped helper must be imported, not inlined",
+  );
+  assert.match(SRC, /installActivePointerWatch\(observeActivePointer/);
+  assert.match(SRC, /getPiniaStore\("workflow"\)/);
+  assert.match(
+    SRC,
+    /installActivePointerWatch\(observeActivePointer,\s*\[\s*getPiniaStore\("workflow"\),\s*s,\s*\]\)/,
+    "Pinia lookup first, then the workflow service object as the proven fallback",
+  );
+  assert.match(SRC, /decideLiveCanvasCapture\(\{/);
+  assert.match(SRC, /watchAvailable:\s*activePointerWatchAvailable/);
+  assert.match(SRC, /pointerMovedThisOpen/);
+});
+
+test("#1911: SOURCE flush is NOT gated on the Pinia watch — that is the #1215/#1295 invariant", () => {
+  const flushAt = SRC.indexOf("await flushSourceCanvasBeforeSwitch({");
+  const openAt = SRC.indexOf("await s.openWorkflow(target);");
+  assert.notEqual(flushAt, -1, "the source flush must exist");
+  assert.notEqual(openAt, -1);
+  assert.ok(flushAt < openAt, "the flush must run while SOURCE is still the active pointer");
+
+  const flushCall = SRC.slice(flushAt, SRC.indexOf("});", flushAt) + 3);
+  assert.match(flushCall, /source:\s*activeBefore/, "the flush target is the outgoing tab");
+  assert.doesNotMatch(
+    flushCall,
+    /activePointerWatchAvailable/,
+    "gating SOURCE flush on the watcher would reintroduce #1215",
+  );
+
+  const beforeFlush = SRC.slice(Math.max(0, flushAt - 500), flushAt);
+  assert.doesNotMatch(
+    beforeFlush,
+    /if\s*\(\s*activePointerWatchAvailable/,
+    "SOURCE flush must not sit behind a watch-available branch",
+  );
+});
+
+test("#1911: a missing watcher is named on the success reply, not swallowed", () => {
+  const keyAt = SRC.indexOf("pointer_watch_unavailable:");
+  assert.notEqual(keyAt, -1, "the caller must be told $subscribe could not be installed");
+  assert.match(SRC.slice(Math.max(0, keyAt - 250), keyAt), /\.\.\.\(pointerWatchUnavailable/);
+  assert.match(SRC, /POINTER_WATCH_UNAVAILABLE_NOTICE/);
+  assert.match(SRC, /if \(!activePointerWatchAvailable\) pointerWatchUnavailable = true/);
+});
+
+test("#1911: TARGET capture still requires the #1215 already-current / not-foreign proof", () => {
+  const gateAt = SRC.indexOf("const captureBinding = describeLiveCanvasBinding(target);");
+  assert.notEqual(gateAt, -1);
+  const captureAt = SRC.indexOf("await target.changeTracker?.checkState?.()", gateAt);
+  assert.notEqual(captureAt, -1);
+  const gate = SRC.slice(gateAt, captureAt);
+  assert.match(gate, /pointerMovedThisOpen = !sameWorkflowObject\(activeBefore, target\)/);
+  assert.match(gate, /!pointerMovedThisOpen/);
+  assert.match(gate, /captureBinding !== "foreign"/);
+  assert.match(gate, /decideLiveCanvasCapture/);
+  assert.doesNotMatch(
+    gate,
+    /if \(captureBinding !== "foreign"\)/,
+    '"not foreign" alone was the #1215 hole — the missing-watch path must not bring it back',
+  );
+});

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -11,6 +11,11 @@ import { settleOpenedWorkflowReadable } from "../../web/js/lib/settle-open-reada
 import { graphMutationReconnectGate } from "../../web/js/lib/reconnect-recovery.js";
 import { activeWorkflowPossiblyStale } from "../../web/js/lib/reconnect-staleness.js";
 import { classifyPinnedTarget } from "../../web/js/lib/workflow-chat-identity.js";
+import {
+  decideLiveCanvasCapture,
+  installActivePointerWatch,
+  POINTER_WATCH_UNAVAILABLE_NOTICE,
+} from "../../web/js/lib/live-canvas-capture-gate.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
@@ -100,7 +105,15 @@ function productionExecutor(methodName, environment) {
       `return { method: ${methodName}, guard: () => activeWorkflowReloadGuard(), ` +
       `proofs: () => ({ active: activeWorkflowResyncEpoch, post: postReconnectBindingProofEpoch }) };\n}`,
   );
-  const scope = new Proxy(environment, {
+  // Shipped #1911 helpers are the default so a production open eval drives the
+  // same gate the panel imports. A test may still override them.
+  const sandbox = {
+    decideLiveCanvasCapture,
+    installActivePointerWatch,
+    POINTER_WATCH_UNAVAILABLE_NOTICE,
+    ...environment,
+  };
+  const scope = new Proxy(sandbox, {
     has: () => true,
     get(target, key) {
       if (key === Symbol.unscopables) return undefined;
@@ -1120,4 +1133,103 @@ test("#887 workflow_open wires the settle probe before releasing its guards", ()
     /rebindFailed = new Error\([\s\S]*active canvas/,
     "an unstable result follows the fail-closed rebind path",
   );
+});
+
+test("#1911 production workflow_open without $subscribe captures already-current and discloses", async () => {
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  let captures = 0;
+  target.changeTracker = {
+    activeState: target.activeState,
+    checkState() {
+      captures += 1;
+    },
+  };
+  environment.activeWorkflowRef = () => target;
+  environment.app.extensionManager.workflow.openWorkflow = async () => {};
+  environment.describeLiveCanvasBinding = () => "bound";
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "no-subscribe-already-current" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(
+    captures,
+    1,
+    "already-current without a watcher still captures via the pre-watch proof — silent skip is the bug",
+  );
+  assert.equal(result.pointer_watch_unavailable, POINTER_WATCH_UNAVAILABLE_NOTICE);
+  assert.equal(panel.guard(), null);
+});
+
+test("#1911 production workflow_open without $subscribe skips switch capture, still flushes SOURCE, and discloses", async () => {
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  let captures = 0;
+  let flushed = 0;
+  target.changeTracker = {
+    activeState: target.activeState,
+    checkState() {
+      captures += 1;
+      throw new Error("switch capture without a watcher would be the #1215 poison");
+    },
+  };
+  environment.flushSourceCanvasBeforeSwitch = async () => {
+    flushed += 1;
+  };
+  environment.describeLiveCanvasBinding = () => "bound";
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "no-subscribe-switch" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(
+    flushed,
+    1,
+    "#1295 SOURCE flush must still run when the watcher cannot be installed",
+  );
+  assert.equal(
+    captures,
+    0,
+    "a tab switch without a pointer watch must not capture TARGET from SOURCE's canvas",
+  );
+  assert.equal(result.pointer_watch_unavailable, POINTER_WATCH_UNAVAILABLE_NOTICE);
+  assert.equal(panel.guard(), null);
+});
+
+test("#1911 production workflow_open uses the workflow service as $subscribe fallback", async () => {
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  const previous = { path: "workflows/previous.json" };
+  let active = previous;
+  let captures = 0;
+  const subscribers = [];
+  target.changeTracker = {
+    activeState: target.activeState,
+    checkState() {
+      captures += 1;
+    },
+  };
+  environment.activeWorkflowRef = () => active;
+  environment.describeLiveCanvasBinding = () => "bound";
+  environment.app.extensionManager.workflow.$subscribe = (subscriber) => {
+    subscribers.push(subscriber);
+    return () => {
+      const index = subscribers.indexOf(subscriber);
+      if (index >= 0) subscribers.splice(index, 1);
+    };
+  };
+  environment.app.extensionManager.workflow.openWorkflow = async () => {
+    active = target;
+  };
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "service-subscribe-fallback" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(
+    captures,
+    1,
+    "the workflow service $subscribe is a proven watch when Pinia lookup misses",
+  );
+  assert.equal(result.pointer_watch_unavailable, undefined);
+  assert.equal(subscribers.length, 0, "the fallback watch is cleaned up after the open");
+  assert.equal(panel.guard(), null);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -578,6 +578,11 @@ import {
   trackerCaptureSuppressed,
 } from "./lib/change-tracker-snapshot.js";
 import { flushSourceCanvasBeforeSwitch } from "./lib/flush-source-before-switch.js";
+import {
+  decideLiveCanvasCapture,
+  installActivePointerWatch,
+  POINTER_WATCH_UNAVAILABLE_NOTICE,
+} from "./lib/live-canvas-capture-gate.js";
 import { settleOpenedWorkflowTarget } from "./lib/settle-open-target.js";
 import { settleOwnedOpenedWorkflowActive } from "./lib/settle-open-active.js";
 import { settleOpenedWorkflowReadable } from "./lib/settle-open-readable.js";
@@ -21021,6 +21026,10 @@ const GRAPH_TOOL_EXECUTORS = {
     const activePointerHistory = [];
     let activePointerWatchStop = null;
     let activePointerWatchAvailable = false;
+    // #1911 — set the moment the watch cannot be installed, so a success reply
+    // cannot silently omit the missing-capability notice even if the later
+    // capture gate is skipped (loaded-from-disk, rebindFailed, …).
+    let pointerWatchUnavailable = false;
     const observeActivePointer = () => {
       let current;
       try {
@@ -21059,18 +21068,21 @@ const GRAPH_TOOL_EXECUTORS = {
       // The workflow service is a Pinia store, but it is also the strict
       // frontend-contract surface. Reach Pinia through the panel's supported
       // store lookup so `$subscribe` is not mistaken for a workflow-service
-      // member by the contract scanner.
-      const workflowPiniaStore = getPiniaStore("workflow");
-      if (typeof workflowPiniaStore?.$subscribe === "function") {
-        const stop = workflowPiniaStore.$subscribe(observeActivePointer, { detached: true, flush: "sync" });
-        if (typeof stop === "function") {
-          activePointerWatchStop = stop;
-          activePointerWatchAvailable = true;
-        }
+      // member by the contract scanner. If that lookup misses, the helper
+      // tries the service object itself (it IS the store) without the scanner
+      // seeing `s.$subscribe` (#1911).
+      const installed = installActivePointerWatch(observeActivePointer, [
+        getPiniaStore("workflow"),
+        s,
+      ]);
+      if (installed.available) {
+        activePointerWatchStop = installed.stop;
+        activePointerWatchAvailable = true;
       }
     } catch {
       // Older workflow stores may not expose a usable synchronous subscription.
     }
+    if (!activePointerWatchAvailable) pointerWatchUnavailable = true;
     // The outer try/finally below covers failed lookup, refresh, probe, handshake,
     // lock acquisition, and every later return. The watch must never outlive this open.
     let activePointerEpochAtOpen = null;
@@ -21642,28 +21654,42 @@ const GRAPH_TOOL_EXECUTORS = {
           } catch {
             activeIdentityAtCapture = false;
           }
-          const activePointerProof =
-            activePointerWatchAvailable &&
+          // Pointer-stability proof WITHOUT the watch-available conjunct. #1911:
+          // folding "no watcher" into this flag made a missing `$subscribe` look
+          // like "the watcher saw a move" and skipped capture with no other branch.
+          const pointerProof =
             activePointerOpenTransitionProven &&
             activePointerEpochAtOpen !== null &&
             activePointerEpoch === activePointerEpochAtOpen &&
             activeIdentityAtCapture;
           const captureSourceProof =
             captureBinding === "bound" || (captureBinding !== "foreign" && !pointerMovedThisOpen);
+          // #1575 — a state THIS command just read off disk is authoritative, and the
+          // canvas mounted behind it is whatever the closed tab left there. Serializing
+          // that over the fresh state is the #1215/#968 poisoning through a new entry
+          // point, and it can preserve nothing: nothing has run against a just-loaded
+          // tracker, so it holds no node-written values (#874) for the capture to save.
+          // A moved active pointer is the same uncertainty even when the stale root
+          // carries this target's UUID: that tag is not independent canvas proof. Use
+          // the target tracker's own state after a tab switch and fail closed on the
+          // unproven capture rather than turning the previous canvas into this tab's
+          // state (#1639).
+          //
+          // #1911 — `$subscribe` absence is not that unproven capture; it is no
+          // information. The helper either uses the pre-watch already-current proof
+          // or skips a switch capture and DISCLOSES. Silent skip is the remaining
+          // #1215 path (SOURCE widget values surviving onto TARGET).
+          const captureDecision = decideLiveCanvasCapture({
+            watchAvailable: activePointerWatchAvailable,
+            openLoaded: openSettled?.loaded === true,
+            captureSourceProof,
+            pointerProof,
+            pointerMovedThisOpen,
+          });
+          if (captureDecision.disclose) pointerWatchUnavailable = true;
           if (
-            // #1575 — a state THIS command just read off disk is authoritative, and the
-            // canvas mounted behind it is whatever the closed tab left there. Serializing
-            // that over the fresh state is the #1215/#968 poisoning through a new entry
-            // point, and it can preserve nothing: nothing has run against a just-loaded
-            // tracker, so it holds no node-written values (#874) for the capture to save.
-            // A moved active pointer is the same uncertainty even when the stale root
-            // carries this target's UUID: that tag is not independent canvas proof. Use
-            // the target tracker's own state after a tab switch and fail closed on the
-            // unproven capture rather than turning the previous canvas into this tab's
-            // state (#1639).
             openSettled?.loaded !== true &&
-            activePointerProof &&
-            captureSourceProof
+            captureDecision.capture
           ) {
             try {
               // AWAITED (codex). A frontend whose tracker captures asynchronously would
@@ -22818,6 +22844,13 @@ const GRAPH_TOOL_EXECUTORS = {
               "you need to a NEW path first: a plain save would write the canvas over the " +
               "workflow you asked for, because the active identity already names that one.",
           }
+        : {}),
+      // #1911 — missing `$subscribe` is a capability gap, not "the watcher saw a
+      // move". Name it on the success reply the same way unproven_source_state
+      // names an untagged switch: a silent skip is how SOURCE widget values
+      // survive onto TARGET (#1215).
+      ...(pointerWatchUnavailable
+        ? { pointer_watch_unavailable: POINTER_WATCH_UNAVAILABLE_NOTICE }
         : {}),
     };
     } finally {

--- a/web/js/lib/live-canvas-capture-gate.js
+++ b/web/js/lib/live-canvas-capture-gate.js
@@ -1,0 +1,123 @@
+/**
+ * #1911 — live-canvas capture must not skip silently when Pinia `$subscribe`
+ * cannot be installed.
+ *
+ * #1907 gated TARGET's `checkState()` on `activePointerWatchAvailable`, which
+ * is true only when `getPiniaStore("workflow")?.$subscribe` returns a stop
+ * handle. That flag collapsing "no watcher" and "watcher saw a move" into the
+ * same `false` skipped the capture with no other branch — on a switch, SOURCE
+ * widget values then survive onto TARGET (#1215 recurrence); on already-current,
+ * node-written canvas-only values are discarded (#874).
+ *
+ * Two answers, neither of which is silent skip:
+ *
+ *   1. Another proven watch. The workflow service object IS the Pinia store.
+ *      `getPiniaStore("workflow")` can miss (DOM lookup, store id) while `s`
+ *      is still in hand. Subscribe through this helper so the #268 contract
+ *      scanner never sees `s.$subscribe`.
+ *   2. If no watch can be installed: already-current uses the pre-#1907 proof
+ *      (not foreign, pointer did not move) and still captures; a tab switch
+ *      skips TARGET capture (fail closed for #1215/#1639) and DISCLOSES.
+ *
+ * SOURCE flush (`flushSourceCanvasBeforeSwitch`) is a different write, into
+ * SOURCE, before the pointer moves. This helper does not gate it.
+ */
+
+export const POINTER_WATCH_UNAVAILABLE_NOTICE =
+  "VERIFY THE GRAPH BEFORE EDITING. This frontend did not expose a usable " +
+  "Pinia $subscribe on the workflow store, so the panel could not watch the " +
+  "active-tab pointer during this open. Live-canvas capture of node-written " +
+  "values (#874) therefore used the pre-watch already-current proof, or was " +
+  "skipped on a tab switch so the previous canvas is not written into this " +
+  "tab (#1215/#1639/#1911). The SOURCE tab was still flushed before the " +
+  "switch (#1295). Read the graph (panel_graph_outline / panel_query_graph) " +
+  "and compare it against what you expect this workflow to contain. If it " +
+  "IS the wrong graph, panel_load_workflow with this workflow's path loads " +
+  "the saved copy from disk. That REPLACES the canvas.";
+
+/**
+ * Install a synchronous Pinia pointer watch on the first candidate store that
+ * exposes `$subscribe` and returns a stop handle.
+ *
+ * @param {() => void} observer
+ * @param {unknown[]} [stores]
+ * @returns {{ available: boolean, stop: (() => void) | null }}
+ */
+export function installActivePointerWatch(observer, stores = []) {
+  if (typeof observer !== "function") return { available: false, stop: null };
+  for (const store of stores) {
+    if (typeof store?.$subscribe !== "function") continue;
+    try {
+      const stop = store.$subscribe(observer, { detached: true, flush: "sync" });
+      if (typeof stop === "function") return { available: true, stop };
+    } catch {
+      // Try the next candidate; a throwing store is the same as a missing one.
+    }
+  }
+  return { available: false, stop: null };
+}
+
+/**
+ * Decide whether TARGET's live canvas may be captured after `openWorkflow`,
+ * and whether the missing-watch capability must be named on the reply.
+ *
+ * @param {{
+ *   watchAvailable?: boolean,
+ *   openLoaded?: boolean,
+ *   captureSourceProof?: boolean,
+ *   pointerProof?: boolean,
+ *   pointerMovedThisOpen?: boolean,
+ * }} [input]
+ * @returns {{
+ *   capture: boolean,
+ *   disclose: boolean,
+ *   reason: string,
+ *   notice?: string,
+ * }}
+ */
+export function decideLiveCanvasCapture({
+  watchAvailable = false,
+  openLoaded = false,
+  captureSourceProof = false,
+  pointerProof = false,
+  pointerMovedThisOpen = false,
+} = {}) {
+  const discloseMissingWatch = watchAvailable !== true;
+  const withNotice = (capture, reason) =>
+    discloseMissingWatch
+      ? {
+          capture,
+          disclose: true,
+          reason,
+          notice: POINTER_WATCH_UNAVAILABLE_NOTICE,
+        }
+      : { capture, disclose: false, reason };
+
+  // A state this command just read off disk holds no node-written values to
+  // save, and the canvas behind it is whatever the closed tab left there.
+  if (openLoaded === true) return withNotice(false, "loaded-from-disk");
+
+  if (watchAvailable === true) {
+    if (pointerProof === true && captureSourceProof === true) {
+      return { capture: true, disclose: false, reason: "pointer-proof" };
+    }
+    return {
+      capture: false,
+      disclose: false,
+      reason: pointerProof !== true ? "unproven-pointer" : "unproven-source",
+    };
+  }
+
+  // No watcher. "bound" on a switch is the #1639 hole (stale root UUID is not
+  // independent canvas proof), so the fallback is already-current only — the
+  // proof this path used before the watcher existed, minus the bound-after-move
+  // arm #1907 closed. A switch skips TARGET capture (do not poison) and names
+  // the missing capability instead of going quiet.
+  if (pointerMovedThisOpen === true) {
+    return withNotice(false, "watch-unavailable-switch");
+  }
+  if (captureSourceProof !== true) {
+    return withNotice(false, "watch-unavailable-unproven-source");
+  }
+  return withNotice(true, "watch-unavailable-already-current");
+}


### PR DESCRIPTION
Closes #1911.

## The silent skip

`workflow_open`'s TARGET live-canvas capture (`checkState`) was a required conjunct of `activePointerWatchAvailable`. That flag is true only when `getPiniaStore("workflow")?.$subscribe` returns a stop handle. **No watcher and a watcher that saw a move were the same `false`**, and the response to no-information was to skip capture with no other branch.

That is the remaining #1215 path: SOURCE widget values (`steps=28`, `dpmpp_2m`) survive onto a canvas whose disk state is `steps=24` / `dpmpp_2m_sde`, with no signal.

## What this does instead

A shipped helper, `decideLiveCanvasCapture` / `installActivePointerWatch`:

1. **Another proven watch.** The workflow service object IS the Pinia store. If `getPiniaStore("workflow")` misses, subscribe on `s` through the helper so the #268 contract scanner never sees `s.$subscribe`.
2. **Fail closed with a visible notice.** If neither store exposes `$subscribe`:
   - already-current still captures via the pre-#1907 proof (#874 node-written values)
   - a tab switch does **not** capture TARGET (do not write SOURCE's still-mounted canvas into TARGET — #1215/#1639)
   - the success reply carries `pointer_watch_unavailable`
3. **SOURCE flush stays ungated.** `flushSourceCanvasBeforeSwitch` still runs before `openWorkflow`. That is the #1295 inverse of #1215 and is pinned so it cannot be put behind the watch flag.

Silent skip is the one option that is gone.

## Evidence

Production `workflow_open` (eval of the shipped executor):

- `$subscribe` absent + already-current → captures and discloses
- `$subscribe` absent + switch → SOURCE flushed, TARGET not captured, discloses
- workflow-service `$subscribe` fallback still authorizes a proven-bound capture

Helper tests fail on `$subscribe` absent + silent skip; pass when the new path flushes or discloses. Existing #1639 pins (switch-away-and-back, bound-after-move) stay green.

**Suite:** 7115 tests, **7114 pass, 0 fail** (1 pre-existing todo).
