### PR TITLE
fix(1913): restart the ComfyUI bound to the live canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_restart_comfyui restarts the ComfyUI bound to the live canvas, not the orchestrator's boot target (#1913)
+
 ## [0.15.117] - 2026-08-27
 
 ### Fixed

--- a/browser_tests/unit/bound-restart-witness.test.mjs
+++ b/browser_tests/unit/bound-restart-witness.test.mjs
@@ -1,0 +1,192 @@
+/**
+ * #1913 — panel_restart_comfyui must restart the ComfyUI bound to the live
+ * canvas, not the orchestrator's boot target.
+ *
+ * THE REPORT. Panel bound to 127.0.0.1:8189, tool-server boot target
+ * 127.0.0.1:8188. Restart refused because the process at 8188 could not be
+ * identified as the canvas, leaving a newly installed custom node unloaded.
+ *
+ * THE REMAINING HALF. Naming the mismatch already ships. Routing through the
+ * bound origin is what was left: a live bridge/backend socket is a #871-grade
+ * witness that THIS instance, not a successor on the same port, will receive
+ * the Manager reboot.
+ *
+ * These drive the shipped helper. Restarting the boot target, or refusing the
+ * bound instance while the witness is live, fails them.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  decideBoundRestart,
+  normalizeBoundOrigin,
+  sameBoundOrigin,
+} from "../../web/js/lib/bound-restart-witness.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const BOUND = "http://127.0.0.1:8189";
+const BOOT = "http://127.0.0.1:8188";
+
+function rebootExecutorSource() {
+  const at = SRC.indexOf("  async comfy_reboot({ force } = {}) {");
+  assert.ok(at > 0, "comfy_reboot must exist");
+  return SRC.slice(at, SRC.indexOf("  async free_vram()", at));
+}
+
+test("#1913: trailing slash / path is not a different instance", () => {
+  assert.equal(normalizeBoundOrigin("http://127.0.0.1:8189/"), BOUND);
+  assert.equal(normalizeBoundOrigin("http://127.0.0.1:8189/comfy"), BOUND);
+  assert.equal(sameBoundOrigin("http://127.0.0.1:8189/", BOUND), true);
+});
+
+test("#1913: garbage is omitted, never guessed", () => {
+  for (const value of ["", "   ", null, undefined, 8189, "not-a-url", "ws://127.0.0.1:8189"]) {
+    assert.equal(normalizeBoundOrigin(value), "", String(value));
+  }
+});
+
+test("#1913: a live canvas bound to :8189 restarts :8189, not the :8188 boot target", () => {
+  const decision = decideBoundRestart({
+    boundOrigin: BOUND,
+    bootTarget: BOOT,
+    bridgeConnected: true,
+    witnessAlive: true,
+  });
+  assert.equal(decision.kind, "reboot_bound");
+  assert.equal(decision.target, BOUND);
+  assert.notEqual(decision.target, BOOT, "must not restart the boot target");
+  assert.match(decision.note, /8189/);
+  assert.match(decision.note, /8188/);
+});
+
+test("#1913: cannot-restart-bound fails — a live witness authorizes the bound instance even when it is not the boot target", () => {
+  // The remaining routing half. Refusing here is the filed bug: the canvas is
+  // identified, the connection is live, and the only thing "wrong" is that the
+  // orchestrator booted against a different port.
+  const decision = decideBoundRestart({
+    boundOrigin: BOUND,
+    bootTarget: BOOT,
+    bridgeConnected: true,
+    witnessAlive: false,
+  });
+  assert.equal(decision.kind, "reboot_bound", "a live bridge is enough witness");
+  assert.equal(decision.target, BOUND);
+});
+
+test("#1913: restarting the wrong instance fails — an explicit request for the boot target is refused", () => {
+  const decision = decideBoundRestart({
+    boundOrigin: BOUND,
+    bootTarget: BOOT,
+    requestedTarget: BOOT,
+    bridgeConnected: true,
+    witnessAlive: true,
+  });
+  assert.equal(decision.kind, "refuse_wrong_instance");
+  assert.equal(decision.target, null);
+  assert.match(decision.note, /DIFFERENT server/);
+  assert.match(decision.note, /8188/);
+  assert.match(decision.note, /8189/);
+});
+
+test("#1913: without a live witness, bound ≠ boot is not dispatched (successor risk)", () => {
+  const decision = decideBoundRestart({
+    boundOrigin: BOUND,
+    bootTarget: BOOT,
+    bridgeConnected: false,
+    witnessAlive: false,
+  });
+  assert.equal(decision.kind, "refuse_no_witness");
+  assert.equal(decision.target, null);
+  assert.match(decision.note, /successor/);
+});
+
+test("#1913: bound === boot with a live witness restarts that origin", () => {
+  const decision = decideBoundRestart({
+    boundOrigin: BOOT,
+    bootTarget: BOOT,
+    bridgeConnected: true,
+  });
+  assert.equal(decision.kind, "reboot_bound");
+  assert.equal(decision.target, BOOT);
+});
+
+test("#1913: an unidentified canvas with no witness is refused", () => {
+  const decision = decideBoundRestart({
+    boundOrigin: "",
+    bootTarget: BOOT,
+    bridgeConnected: false,
+    witnessAlive: false,
+  });
+  assert.equal(decision.kind, "refuse_unidentified");
+  assert.equal(decision.target, null);
+});
+
+test("#1913: a live command path with no readable origin still reboots (relative fetch hits the page host)", () => {
+  const decision = decideBoundRestart({
+    boundOrigin: "",
+    bootTarget: "",
+    bridgeConnected: true,
+  });
+  assert.equal(decision.kind, "reboot_bound");
+  assert.equal(decision.target, null);
+});
+
+test("#1913: localhost is not silently equated with 127.0.0.1", () => {
+  // Absence of proof is not proof of sameness — the orchestrator treats this
+  // the same way. A live witness still routes to the bound origin, not the boot.
+  const decision = decideBoundRestart({
+    boundOrigin: "http://127.0.0.1:8189",
+    bootTarget: "http://localhost:8189",
+    bridgeConnected: true,
+  });
+  assert.equal(decision.kind, "reboot_bound");
+  assert.equal(decision.target, "http://127.0.0.1:8189");
+});
+
+// ── production wiring ──────────────────────────────────────────────────────
+
+test("#1913: comfy_reboot consults the helper before any Manager POST", () => {
+  const reboot = rebootExecutorSource();
+  const helperAt = reboot.indexOf("decideBoundRestart(");
+  const fetchAt = reboot.indexOf("api.fetchApi(route, { method })");
+  assert.ok(helperAt > 0, "comfy_reboot must call decideBoundRestart");
+  assert.ok(fetchAt > helperAt, "the decision must precede the reboot POST");
+  assert.match(reboot, /kind !== ["']reboot_bound["']/);
+});
+
+test("#1913: the reboot POST is relative to the bound page, never the boot URL", () => {
+  const reboot = rebootExecutorSource();
+  assert.ok(reboot.includes("api.fetchApi(route, { method })"), "Manager reboot stays on the page origin");
+  assert.equal(reboot.includes("remoteUrlSetting()"), true, "boot/override is an input to the decision");
+  assert.doesNotMatch(reboot, /fetchApi\(\s*(bootTarget|remoteUrlSetting)/);
+});
+
+test("#1913: reboot replies name the bound canvas origin, not the hello override", () => {
+  // #851 taught the reply to name a host. Naming the hello override while the
+  // POST hits the page origin is a confident wrong answer — the reported 8189
+  // vs 8188 split. The bound origin is what actually goes down.
+  const fields = SRC.slice(
+    SRC.indexOf("function rebootTargetFields() {"),
+    SRC.indexOf("function rebootTargetFields() {") + 280,
+  );
+  assert.ok(fields.includes("rebootBoundOrigin()"), "target fields must read the bound origin");
+  assert.ok(!fields.includes("comfyuiUrlForAgent()"), "hello override must not label the reboot");
+
+  const label = SRC.slice(
+    SRC.indexOf("function rebootTargetLabel(prefix) {"),
+    SRC.indexOf("function rebootTargetFields() {"),
+  );
+  assert.ok(label.includes("rebootBoundOrigin()"), "prose must name the bound origin too");
+  assert.ok(!label.includes("comfyuiUrlForAgent()"));
+});
+
+test("#1913: the panel imports and calls the shipped helper", () => {
+  assert.match(SRC, /from "\.\/lib\/bound-restart-witness\.js"/);
+  assert.ok(SRC.includes("decideBoundRestart("));
+  assert.ok(SRC.includes("normalizeBoundOrigin("));
+});

--- a/browser_tests/unit/reboot-target-identity.test.mjs
+++ b/browser_tests/unit/reboot-target-identity.test.mjs
@@ -23,20 +23,21 @@ const reboot = (() => {
   return PANEL.slice(at, PANEL.indexOf("  async free_vram()", at));
 })();
 
-test("the target comes from the SAME value handed to the orchestrator in hello", () => {
-  // If this used its own notion of the ComfyUI URL, the identity a caller
-  // compares against its own target could drift from the one it was told to
-  // target — which is the entire failure being fixed.
+test("the target is the bound canvas origin — the host that actually goes down", () => {
+  // #851 named a host. #1913 says which host: the page origin, not the hello
+  // Remote-URL override. Naming the override while `api.fetchApi` hits the page
+  // is a confident wrong answer (panel 8189, boot/override 8188).
   const fn = PANEL.slice(
     PANEL.indexOf("function rebootTargetFields() {"),
     PANEL.indexOf("const GRAPH_TOOL_EXECUTORS = {"),
   );
   assert.ok(fn.length > 0, "the helper must precede the executors table");
-  assert.ok(fn.includes("comfyuiUrlForAgent()"), "it must reuse the hello identity");
+  assert.ok(fn.includes("rebootBoundOrigin()"), "it must name the bound canvas");
+  assert.ok(!fn.includes("comfyuiUrlForAgent()"), "hello override is not the reboot target");
 });
 
 test("an unknown target is OMITTED, never guessed", () => {
-  // `comfyuiUrlForAgent()` returns "" when it cannot read the location. Emitting
+  // `rebootBoundOrigin()` returns "" when it cannot read the location. Emitting
   // `target: ""` would be worse than saying nothing: a caller comparing hosts
   // would read it as a real, different one.
   const fn = PANEL.slice(
@@ -57,11 +58,12 @@ test("it is a plain function, not a method on the executors table", () => {
 
 // ── every branch, including the ones that failed ───────────────────────────
 
-test("all six reply branches name the target", () => {
+test("all seven reply branches name the target", () => {
   // The failures matter most: "which server refused?" is the whole question when
   // the panel and the headless tool disagree about what they are pointing at.
+  // #1913 adds the bound-identity refusal as a seventh named branch.
   const spread = (reboot.match(/\.\.\.rebootTargetFields\(\)/g) || []).length;
-  assert.equal(spread, 6, `expected 6 branches to carry the target, found ${spread}`);
+  assert.equal(spread, 7, `expected 7 branches to carry the target, found ${spread}`);
 });
 
 test("the successful reboot says which server is going down", () => {
@@ -153,7 +155,7 @@ test("the label appends nothing when the target is unknown", () => {
     PANEL.indexOf("function rebootTargetFields() {"),
   );
   assert.ok(fn.length > 0, "the label helper must exist");
-  assert.ok(fn.includes("comfyuiUrlForAgent()"), "it must reuse the hello identity too");
+  assert.ok(fn.includes("rebootBoundOrigin()"), "it must name the bound canvas too");
   assert.ok(fn.includes("target ? prefix"), "an unknown target must yield the bare prefix");
   assert.ok(fn.includes(": prefix;"), "…and nothing appended to it");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -583,6 +583,7 @@ import {
   installActivePointerWatch,
   POINTER_WATCH_UNAVAILABLE_NOTICE,
 } from "./lib/live-canvas-capture-gate.js";
+import { decideBoundRestart, normalizeBoundOrigin } from "./lib/bound-restart-witness.js";
 import { settleOpenedWorkflowTarget } from "./lib/settle-open-target.js";
 import { settleOwnedOpenedWorkflowActive } from "./lib/settle-open-active.js";
 import { settleOpenedWorkflowReadable } from "./lib/settle-open-readable.js";
@@ -13215,16 +13216,21 @@ let repaintHistoryList = null;
  * two were different.
  *
  * The panel is the one component that knows this for certain: it runs INSIDE the
- * ComfyUI it reboots. `comfyuiUrlForAgent()` is deliberately the SAME value handed to
- * the orchestrator in `hello`, so the identity a caller compares against its own
- * target cannot drift from the one it was told to target.
+ * ComfyUI it reboots. #1913: the host it names is the bound canvas origin (the
+ * page that is about to go down), NOT the hello / Remote-URL override — that
+ * override is what the orchestrator should *talk to*, and naming it on a reboot
+ * of a different origin is a confident wrong answer (panel 8189, boot 8188).
  *
  * A plain function, NOT a method on the executors table: dispatch invokes
  * `executor(msg)` with no receiver, so `this` is undefined in a module and a method
  * call here would throw instead of rebooting.
  */
+function rebootBoundOrigin() {
+  return normalizeBoundOrigin(pageComfyOrigin());
+}
+
 /**
- * The same identity, for prose (#851).
+ * The same identity, for prose (#851 / #1913).
  *
  * `target` is for a caller comparing hosts; these strings are what a HUMAN reads,
  * and "could not reach any reboot endpoint" that cannot say WHICH server it failed
@@ -13232,12 +13238,12 @@ let repaintHistoryList = null;
  * unknown, rather than naming a blank one.
  */
 function rebootTargetLabel(prefix) {
-  const target = comfyuiUrlForAgent();
+  const target = rebootBoundOrigin();
   return target ? prefix + " on " + target : prefix;
 }
 
 function rebootTargetFields() {
-  const target = comfyuiUrlForAgent();
+  const target = rebootBoundOrigin();
   return target ? { target } : {};
 }
 
@@ -26181,6 +26187,24 @@ const GRAPH_TOOL_EXECUTORS = {
   async comfy_reboot({ force } = {}) {
     // Restart the ComfyUI server (to load newly installed nodes). ComfyUI and the
     // orchestrator go down briefly; the panel auto-reconnects + resumes after.
+    // #1913 — route through the origin bound to THIS canvas. A live bridge
+    // (this command arrived on it) or an open backend socket is the instance
+    // witness; without one, bound ≠ boot is not dispatched. The POST below
+    // stays relative to the page host, never the boot URL.
+    const boundDecision = decideBoundRestart({
+      boundOrigin: rebootBoundOrigin(),
+      bootTarget: remoteUrlSetting(),
+      bridgeConnected: true,
+      witnessAlive: comfyBackendSocketReadyState() === 1,
+    });
+    if (boundDecision.kind !== "reboot_bound") {
+      return {
+        rebooting: false,
+        refused: true,
+        ...rebootTargetFields(),
+        error: boundDecision.note,
+      };
+    }
     // GUARD: a reboot ABORTS any in-progress/queued generation. Don't silently kill
     // a render the user is waiting on — check the queue first and refuse (with a
     // clear message the agent relays) unless force:true.

--- a/web/js/lib/bound-restart-witness.js
+++ b/web/js/lib/bound-restart-witness.js
@@ -1,0 +1,135 @@
+/**
+ * #1913 — which ComfyUI `panel_restart_comfyui` may restart.
+ *
+ * The panel can be bound to a live canvas at :8189 while the orchestrator's
+ * boot target is :8188. Manager reboot is identity-free in *mechanism* (POST
+ * to a base, that server stops itself) and emphatically not in *safety*: a
+ * URL is not an instance. Rebooting the boot target would take down a server
+ * this tab has not been working on; refusing because the two differ would
+ * leave the bound instance unrestartable (newly installed nodes stay unloaded).
+ *
+ * The panel case has something the headless case does not: a live connection
+ * to the very server in question (the bridge the command arrived on, and/or
+ * the ComfyUI backend socket this page is holding). That connection is a
+ * #871-grade witness — a successor at the same URL cannot inherit it. If it
+ * is still open at dispatch, Manager reboot of the bound origin hits THIS
+ * instance.
+ *
+ * A closed connection is inconclusive, not proof of replacement (tunnels
+ * hiccup; our own reboot closes it by design). Without a live witness we do
+ * not dispatch: the reboot may reach a successor, not the instance we just
+ * assessed.
+ */
+
+/**
+ * Scheme+host+port, or "" when the value is not a usable http(s) origin.
+ * Trailing slashes and paths are dropped — a reboot target is a host, not a
+ * mount. Empty / non-string / unparseable is omitted, never guessed.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeBoundOrigin(value) {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+    if (!url.host) return "";
+    return url.origin;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * @param {unknown} a
+ * @param {unknown} b
+ * @returns {boolean}
+ */
+export function sameBoundOrigin(a, b) {
+  const left = normalizeBoundOrigin(a);
+  const right = normalizeBoundOrigin(b);
+  if (!left || !right) return false;
+  return left === right;
+}
+
+/**
+ * @param {{
+ *   boundOrigin?: unknown,
+ *   bootTarget?: unknown,
+ *   requestedTarget?: unknown,
+ *   bridgeConnected?: boolean,
+ *   witnessAlive?: boolean,
+ * }} [input]
+ * @returns {{
+ *   kind: "reboot_bound" | "refuse_wrong_instance" | "refuse_no_witness" | "refuse_unidentified",
+ *   target: string | null,
+ *   note: string,
+ * }}
+ */
+export function decideBoundRestart({
+  boundOrigin,
+  bootTarget = "",
+  requestedTarget = "",
+  bridgeConnected = false,
+  witnessAlive = false,
+} = {}) {
+  const bound = normalizeBoundOrigin(boundOrigin);
+  const boot = normalizeBoundOrigin(bootTarget);
+  const requested = normalizeBoundOrigin(requestedTarget);
+  const liveWitness = bridgeConnected === true || witnessAlive === true;
+
+  // An explicit request to restart a host that is not the live canvas is the
+  // wrong-instance hazard: it may find nothing, or it may SUCCEED and take
+  // down a ComfyUI this tab has not been working on.
+  if (requested && bound && !sameBoundOrigin(requested, bound)) {
+    return {
+      kind: "refuse_wrong_instance",
+      target: null,
+      note:
+        `Refusing to restart ${requested}: the live canvas is bound to ${bound}, ` +
+        "a DIFFERENT server. Restarting the requested target would take down a " +
+        "ComfyUI you have not been working on.",
+    };
+  }
+
+  // Bound ≠ boot is the reported case. The live connection is what makes
+  // routing to the bound origin tractable: without it we cannot prove the
+  // thing that reboots is the instance we just assessed.
+  if (bound && boot && !sameBoundOrigin(bound, boot)) {
+    if (!liveWitness) {
+      return {
+        kind: "refuse_no_witness",
+        target: null,
+        note:
+          `Refusing to restart: the live canvas is bound to ${bound} while the ` +
+          `boot target is ${boot}, and no live connection witnesses that ${bound} ` +
+          "is still this instance. A URL is not an instance — a successor on that " +
+          "port would receive the reboot.",
+      };
+    }
+    return {
+      kind: "reboot_bound",
+      target: bound,
+      note:
+        `Restarting the ComfyUI bound to the live canvas (${bound}), not the ` +
+        `boot target (${boot}).`,
+    };
+  }
+
+  if (!bound && !liveWitness) {
+    return {
+      kind: "refuse_unidentified",
+      target: null,
+      note: "Refusing to restart: the ComfyUI bound to the live canvas could not be identified.",
+    };
+  }
+
+  return {
+    kind: "reboot_bound",
+    target: bound || null,
+    note: bound ? `Restarting the ComfyUI bound to the live canvas (${bound}).` : "",
+  };
+}


### PR DESCRIPTION
Closes #1913.

## The remaining routing half

The panel can be bound to ComfyUI at `:8189` while the orchestrator booted against `:8188`. Naming that mismatch already shipped. What did not: **restart the bound instance**.

A URL is not an instance. Manager reboot is identity-free in mechanism (POST, that server stops itself) and not in safety — a successor on the same port would receive it. The panel case has a live connection to the very server in question (the bridge this command arrived on, and/or the ComfyUI backend socket this page holds). That is a #871-grade witness: a successor cannot inherit it.

## What this does

Shipped helper `decideBoundRestart`:

1. **Reboot the bound origin.** Live witness + canvas at `:8189` restarts `:8189`, not boot `:8188`.
2. **Refuse the wrong instance.** An explicit request for a host that is not the live canvas is not dispatched.
3. **Refuse without a witness** when bound ≠ boot — the reboot may reach a successor.
4. **Name the bound canvas on the reply.** `target` is `pageComfyOrigin()`, not the hello Remote-URL override. The Manager POST stays relative to the page host.

## Evidence

`browser_tests/unit/bound-restart-witness.test.mjs` drives the helper. Fail on restarting `:8188` while bound to `:8189`, or on refusing the bound instance while the witness is live. Pass on the routing.

**Suite:** 7185 tests, **7184 pass, 0 fail** (1 pre-existing todo).
