### PR TITLE
fix(1914): refuse workflow_open after an unsettled reconnect handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_restart_comfyui restarts the ComfyUI bound to the live canvas, not the orchestrator's boot target (#1913)
+- panel_open_workflow no longer times out undetermined after a restart: an unsettled reconnect is a retryable refusal (`applied: false`) instead of a delivered command with no receipt (#1914)
 
 ## [0.15.117] - 2026-08-27
 

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -41,6 +41,8 @@ import { confirmCanvasNavigation } from "../../web/js/lib/canvas-navigation.js";
 import {
   watchPostReconnectSettle,
   waitForReconnectHandshakeBeforeOpen,
+  workflowOpenReadinessRefusalError,
+  readWorkflowOpenReadinessRefusal,
   graphMutationReconnectGate,
 } from "../../web/js/lib/reconnect-recovery.js";
 import {
@@ -96,11 +98,13 @@ test("panel ↔ media-preview.js / run-completion-frame.js ↔ bounded-step.js e
   assert.equal(typeof withTimeout, "function");
 });
 
-test("panel ↔ node-def-refresh.js / canvas-navigation.js / reconnect-recovery.js edges link (#635/#619/#663/#646/#1641)", () => {
+test("panel ↔ node-def-refresh.js / canvas-navigation.js / reconnect-recovery.js edges link (#635/#619/#663/#646/#1641/#1914)", () => {
   assert.equal(typeof describeNodeDefRefresh, "function");
   assert.equal(typeof confirmCanvasNavigation, "function");
   assert.equal(typeof watchPostReconnectSettle, "function");
   assert.equal(typeof waitForReconnectHandshakeBeforeOpen, "function");
+  assert.equal(typeof workflowOpenReadinessRefusalError, "function");
+  assert.equal(typeof readWorkflowOpenReadinessRefusal, "function");
   assert.equal(typeof graphMutationReconnectGate, "function");
 });
 

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -8,7 +8,11 @@ import {
   settleOwnedOpenedWorkflowActive,
 } from "../../web/js/lib/settle-open-active.js";
 import { settleOpenedWorkflowReadable } from "../../web/js/lib/settle-open-readable.js";
-import { graphMutationReconnectGate } from "../../web/js/lib/reconnect-recovery.js";
+import {
+  graphMutationReconnectGate,
+  workflowOpenReadinessRefusalError,
+  readWorkflowOpenReadinessRefusal,
+} from "../../web/js/lib/reconnect-recovery.js";
 import { activeWorkflowPossiblyStale } from "../../web/js/lib/reconnect-staleness.js";
 import { classifyPinnedTarget } from "../../web/js/lib/workflow-chat-identity.js";
 import {
@@ -111,6 +115,8 @@ function productionExecutor(methodName, environment) {
     decideLiveCanvasCapture,
     installActivePointerWatch,
     POINTER_WATCH_UNAVAILABLE_NOTICE,
+    workflowOpenReadinessRefusalError,
+    readWorkflowOpenReadinessRefusal,
     ...environment,
   };
   const scope = new Proxy(sandbox, {

--- a/browser_tests/unit/open-workflow-after-restart.test.mjs
+++ b/browser_tests/unit/open-workflow-after-restart.test.mjs
@@ -35,7 +35,10 @@ import { fileURLToPath } from "node:url";
 import {
   OPEN_RECONNECT_HANDSHAKE_STEPS_MS,
   waitForReconnectHandshakeBeforeOpen,
+  workflowOpenReadinessRefusalError,
+  readWorkflowOpenReadinessRefusal,
 } from "../../web/js/lib/reconnect-recovery.js";
+import { installActivePointerWatch } from "../../web/js/lib/live-canvas-capture-gate.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
@@ -236,5 +239,241 @@ test("#1641 wiring: the panel imports the shipped helper, not a local copy", () 
   assert.match(
     SRC,
     /import \{[\s\S]*?waitForReconnectHandshakeBeforeOpen,[\s\S]*?\} from "\.\/lib\/reconnect-recovery\.js"/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #1914 — a handshake miss must refuse, not proceed into a delivered hang.
+// ---------------------------------------------------------------------------
+
+test("#1914 minted open-readiness refusal is applied:false and unforgeable", () => {
+  const err = workflowOpenReadinessRefusalError("the restored canvas binding is not yet proven");
+  const refusal = readWorkflowOpenReadinessRefusal(err);
+  assert.deepEqual(refusal, {
+    code: "reconnect-not-ready",
+    ready: false,
+    applied: false,
+    stage: "pre-open",
+    retryable: true,
+  });
+  assert.match(err.message, /did not start because the restored canvas binding is not yet proven/);
+  assert.match(err.message, /canvas is unchanged/);
+  assert.equal(
+    readWorkflowOpenReadinessRefusal(new Error(err.message)),
+    null,
+    "a lookalike sentence is not a minted refusal",
+  );
+  assert.equal(readWorkflowOpenReadinessRefusal({ message: err.message }), null);
+});
+
+test("#1914 wiring: handshake timeout throws the shipped open-readiness refusal", () => {
+  assert.match(
+    OPEN_BODY,
+    /const readiness = await waitForReconnectHandshakeBeforeOpen\(\{/,
+    "workflow_open must observe the wait's ready/timeout verdict",
+  );
+  assert.match(
+    OPEN_BODY,
+    /if \(readiness === "timeout"\)[\s\S]*?throw failOpen\(workflowOpenReadinessRefusalError\(/,
+    "a timeout must be a journaled retryable refusal, not freeze/load",
+  );
+  const waitAt = OPEN_BODY.indexOf("const readiness = await waitForReconnectHandshakeBeforeOpen({");
+  const refuseAt = OPEN_BODY.indexOf("throw failOpen(workflowOpenReadinessRefusalError(");
+  const freezeAt = OPEN_BODY.indexOf("acquireCanvasInteractionLock(canvasView)");
+  const openAt = OPEN_BODY.indexOf("await s.openWorkflow(target);");
+  assert.ok(waitAt < refuseAt, "the verdict is checked before any mutator step");
+  assert.ok(refuseAt < freezeAt, "do not freeze a canvas the reconnect has not settled");
+  assert.ok(refuseAt < openAt, "do not switch tabs after a handshake miss");
+});
+
+test("#1914 wiring: the refusal is separate structured pre-open evidence", () => {
+  assert.match(SRC, /readWorkflowOpenReadinessRefusal\(err\)/);
+  assert.match(
+    SRC,
+    /\.\.\.\(workflowOpenReadiness \? \{ workflow_open_readiness: workflowOpenReadiness \} : \{\}\)/,
+    "the bridge must publish the open-readiness refusal without treating it as a graph refusal",
+  );
+  assert.match(
+    SRC,
+    /import \{[\s\S]*?workflowOpenReadinessRefusalError,[\s\S]*?readWorkflowOpenReadinessRefusal,[\s\S]*?\} from "\.\/lib\/reconnect-recovery\.js"/,
+  );
+});
+
+function balancedFrom(src, marker, openAt = null) {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `missing marker: ${marker}`);
+  const open = openAt ?? src.indexOf("{", start + marker.length);
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === "/" && src[i + 1] === "/") {
+      i = src.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "*") {
+      i = src.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < src.length; i += 1) {
+        if (src[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (src[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated block: ${marker}`);
+}
+
+const RELOAD_GUARD_SOURCE = SRC.match(
+  /let workflowReloadGuard = null;[\s\S]*?function activeWorkflowReloadGuard\(\) \{[\s\S]*?\n\}/,
+);
+assert.ok(RELOAD_GUARD_SOURCE, "could not locate the production reload guard block");
+const PINIA_STORE_HELPER_SOURCE = balancedFrom(SRC, "function getPiniaStore(id)");
+
+function productionOpen(environment) {
+  const signature = "async workflow_open({";
+  const sigStart = SRC.indexOf(signature);
+  assert.notEqual(sigStart, -1, "workflow_open not found");
+  const bodyBrace = SRC.indexOf(") {", sigStart) + 1;
+  const methodSource = balancedFrom(SRC, signature, bodyBrace).replace(
+    /^async workflow_open\(/,
+    "async function workflow_open(",
+  );
+  const factory = new Function(
+    "sandbox",
+    `with (sandbox) {\n${RELOAD_GUARD_SOURCE[0]}\n${PINIA_STORE_HELPER_SOURCE}\n${methodSource}\n` +
+      `return workflow_open;\n}`,
+  );
+  const sandbox = {
+    installActivePointerWatch,
+    workflowOpenReadinessRefusalError,
+    readWorkflowOpenReadinessRefusal,
+    ...environment,
+  };
+  const scope = new Proxy(sandbox, {
+    has: () => true,
+    get(target, key) {
+      if (key === Symbol.unscopables) return undefined;
+      return Object.prototype.hasOwnProperty.call(target, key) ? target[key] : globalThis[key];
+    },
+  });
+  return factory(scope);
+}
+
+function deliveredOpenHangEnvironment({ handshake }) {
+  const target = {
+    path: "workflows/LTX-2.5_Director_CHUNKS_MODULAR_DEBUG.json",
+    filename: "LTX-2.5_Director_CHUNKS_MODULAR_DEBUG.json",
+    isModified: false,
+    changeTracker: { activeState: { nodes: [], links: [] } },
+  };
+  const receipts = [];
+  let opened = 0;
+  let frozen = 0;
+  const hang = () => new Promise(() => {});
+  const app = {
+    extensionManager: {
+      workflow: {
+        openWorkflows: [target],
+        workflows: [],
+        getWorkflowByPath: () => target,
+        openWorkflow: async () => {
+          opened += 1;
+          return hang();
+        },
+      },
+    },
+  };
+  return {
+    target,
+    receipts,
+    counters: () => ({ opened, frozen }),
+    environment: {
+      backendReconnectEpoch: 4,
+      app,
+      activeWorkflowRef: () => target,
+      sameWorkflowObject: (a, b) => a === b,
+      workflowTabId: (workflow) => `wf:${workflow.path}`,
+      workflowRecordMatchesSelector: () => true,
+      waitForReconnectHandshakeBeforeOpen: async () => handshake,
+      workflowOpenReadinessRefusalError,
+      comfyBackendIsDown: () => false,
+      postReconnectBindingSettleWindow: () => true,
+      nodeDefRefreshInFlight: null,
+      noteOpenAttempt: (entry) => {
+        receipts.push(entry);
+        return { seq: receipts.length, ...entry };
+      },
+      coerceMessageText: (value) => String(value ?? ""),
+      acquireCanvasInteractionLock: () => {
+        frozen += 1;
+        return "lock-token";
+      },
+      flushSourceCanvasBeforeSwitch: hang,
+      installActivePointerWatch,
+    },
+  };
+}
+
+test(
+  "#1914 production workflow_open refuses a handshake miss instead of hanging after delivery",
+  { timeout: 1500 },
+  async () => {
+    const { target, receipts, counters, environment } = deliveredOpenHangEnvironment({
+      handshake: "timeout",
+    });
+    const workflow_open = productionOpen(environment);
+    let err;
+    try {
+      await Promise.race([
+        workflow_open({ path: target.path, rid: "rid-1914-timeout" }),
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error("timeout-after-delivered-open")), 1000);
+        }),
+      ]);
+    } catch (caught) {
+      err = caught;
+    }
+    assert.ok(err, "an unsettled reconnect must not report a successful open");
+    assert.notEqual(
+      err.message,
+      "timeout-after-delivered-open",
+      "the shipped open must reply before the orchestrator's 15s delivery timeout",
+    );
+    assert.notEqual(err.message, "proceeded past handshake into freeze");
+    const refusal = readWorkflowOpenReadinessRefusal(err);
+    assert.equal(refusal?.code, "reconnect-not-ready");
+    assert.equal(refusal?.applied, false, "nothing was frozen, switched, or loaded");
+    assert.equal(refusal?.retryable, true);
+    assert.equal(refusal?.stage, "pre-open");
+    assert.equal(counters().opened, 0, "openWorkflow must not run after a handshake miss");
+    assert.equal(counters().frozen, 0, "the canvas lock must not be taken after a handshake miss");
+    assert.ok(receipts.length >= 1, "failOpen journals a rid-correlated negative receipt");
+    assert.ok(receipts.every((entry) => entry.applied === false));
+    assert.equal(receipts[0].rid, "rid-1914-timeout");
+    assert.equal(receipts[0].cmd, "workflow_open");
+  },
+);
+
+test("#1914 production workflow_open still proceeds once the handshake is ready", async () => {
+  const { target, environment } = deliveredOpenHangEnvironment({ handshake: "ready" });
+  environment.acquireCanvasInteractionLock = () => {
+    throw new Error("proceeded past handshake into freeze");
+  };
+  const workflow_open = productionOpen(environment);
+  await assert.rejects(
+    () => workflow_open({ path: target.path, rid: "rid-1914-ready" }),
+    /proceeded past handshake into freeze/,
+    "a ready handshake must not be turned into a false refusal",
   );
 });

--- a/browser_tests/unit/reload-blocked.test.mjs
+++ b/browser_tests/unit/reload-blocked.test.mjs
@@ -194,6 +194,7 @@ function buildCommandReplyClient(onReload) {
       abandonedInteractiveError: () => "abandoned",
       readReconnectRefusal: () => null,
       readWorkflowListReadinessRefusal: () => null,
+      readWorkflowOpenReadinessRefusal: () => null,
       readRouteRegistrationReadinessRefusal: () => null,
       markOpenReceiptReplySent: noop,
       openReceipts: [],

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -350,6 +350,8 @@ import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import {
   watchPostReconnectSettle,
   waitForReconnectHandshakeBeforeOpen,
+  workflowOpenReadinessRefusalError,
+  readWorkflowOpenReadinessRefusal,
   graphMutationReconnectGate,
   reconnectRefusalError,
   readReconnectRefusal,
@@ -21237,10 +21239,17 @@ const GRAPH_TOOL_EXECUTORS = {
     // no fence — so the orchestrator answers "FENCE: NOT cleared (active identity
     // UNCONFIRMED after reconnect handshake)". A retry a moment later succeeds
     // without changing the workflow. Wait here, BEFORE the freeze and the load,
-    // so the first open is the one that succeeds. If the handshake never lands
-    // the open still proceeds: it is the #646 recovery for a restore that never
-    // settles. Bounded (~2.9s); a healthy already-settled tab returns immediately.
-    await waitForReconnectHandshakeBeforeOpen({
+    // so the first open is the one that succeeds. Bounded (~2.9s); a healthy
+    // already-settled tab returns immediately.
+    //
+    // #1914 — if that bounded wait still times out, REFUSE. Proceeding is the
+    // timeout-after-delivered-open: the command was already handed to the tab,
+    // freeze/load never replies, and the orchestrator reports undetermined with
+    // no rid-correlated receipt. `applied: false` is true because this throw is
+    // still before freeze/load. After the settle window closes, `needsWait` is
+    // false, the waiter returns "ready", and the open proceeds as the #646
+    // recovery for a restore that never settles.
+    const readiness = await waitForReconnectHandshakeBeforeOpen({
       needsWait: () =>
         comfyBackendIsDown() ||
         postReconnectBindingSettleWindow() ||
@@ -21258,6 +21267,14 @@ const GRAPH_TOOL_EXECUTORS = {
         return true;
       },
     });
+    if (readiness === "timeout") {
+      const reason = comfyBackendIsDown()
+        ? "the backend socket is still reconnecting"
+        : nodeDefRefreshInFlight != null
+          ? "the post-reconnect node-definition refresh is still running"
+          : "the restored canvas binding is not yet proven";
+      throw failOpen(workflowOpenReadinessRefusalError(reason));
+    }
     } catch (err) {
       // The reload guard below owns the normal-operation cleanup. Before it is
       // acquired, however, lookup/probe/handshake failures still have to retire
@@ -27874,6 +27891,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         } catch (err) {
           const reconnectRefusal = readReconnectRefusal(err);
           const workflowListReadiness = readWorkflowListReadinessRefusal(err);
+          const workflowOpenReadiness = readWorkflowOpenReadinessRefusal(err);
           const routeRegistrationReadiness = readRouteRegistrationReadinessRefusal(err);
           reply = {
             rid: msg.rid,
@@ -27899,6 +27917,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // cannot confuse a workflow-list readiness miss with a graph
             // command blocked by a different fence.
             ...(workflowListReadiness ? { workflow_list_readiness: workflowListReadiness } : {}),
+            // #1914 — mutator, but still pre-open: freeze/load have not run.
+            // Keep it out of the graph-mutation `refusal` field so a caller
+            // cannot treat an unsettled open as a gated graph write.
+            ...(workflowOpenReadiness ? { workflow_open_readiness: workflowOpenReadiness } : {}),
             // #1787 — this is a read-only, pre-refresh refusal. The route handoff
             // did not settle, so no node definitions were fetched or registered.
             ...(routeRegistrationReadiness

--- a/web/js/lib/reconnect-recovery.js
+++ b/web/js/lib/reconnect-recovery.js
@@ -106,10 +106,18 @@ export async function watchPostReconnectSettle({
  * `FENCE: NOT cleared (active identity UNCONFIRMED after reconnect handshake)`.
  * A retry a moment later succeeds without changing the workflow.
  *
- * This wait is NOT a binding proof and does not repaint. If the handshake never
- * lands, the open proceeds: it is the documented recovery for a restore that
- * never settles (#646). The wait only buys a settled canvas for the common
- * case so the first open is the one that succeeds.
+ * This wait is NOT a binding proof and does not repaint. It only buys a
+ * settled canvas for the common case so the first open is the one that
+ * succeeds. Callers decide what a `"timeout"` means:
+ *
+ *   - `workflow_list` refuses (#1785): a read must not publish a pre-reconnect
+ *     active pointer as targeting success.
+ *   - `workflow_open` refuses (#1914): proceeding into freeze/load after a
+ *     miss is the timeout-after-delivered-open — the command was already
+ *     handed to the tab, no receipt is written, and the orchestrator reports
+ *     undetermined. After the settle window closes, `needsWait` is false, this
+ *     waiter returns `"ready"`, and the open proceeds as the #646 recovery
+ *     for a restore that never settles.
  *
  * Cadence matches the orchestrator's post-open handshake ([400, 900, 1600] ms)
  * so a caller that already waited there is not waiting a second, longer budget
@@ -157,6 +165,52 @@ export async function waitForReconnectHandshakeBeforeOpen({
     if (ready() || !pending()) return "ready";
   }
   return ready() ? "ready" : "timeout";
+}
+
+/**
+ * #1914 — typed readiness refusal for `workflow_open` after a reconnect
+ * handshake miss.
+ *
+ * Distinct from `workflow_list`'s pre-probe refusal (#1785): this is a mutator,
+ * but it has not yet frozen, switched, or loaded anything, so `applied: false`
+ * is a claim this throw is entitled to make. That is the load-bearing part —
+ * it converts "command was already delivered; outcome undetermined" into
+ * "nothing happened, retry".
+ *
+ * Authority lives in a WeakSet of the Error objects this function minted, the
+ * same unforgeable shape as the graph-mutation gate. A property on the Error
+ * would be inherited and settable; membership here is not.
+ */
+const OPEN_READINESS_REFUSALS = new WeakSet();
+
+export function workflowOpenReadinessRefusalError(reason) {
+  const detail =
+    typeof reason === "string" && reason.trim()
+      ? reason.trim()
+      : "the reconnect handshake is still settling";
+  const error = new Error(
+    "workflow_open did not start because " +
+      detail +
+      " within the bounded readiness window. Nothing was opened, reloaded, or rebound — " +
+      "the canvas is unchanged — so this is safe to retry in a moment.",
+  );
+  OPEN_READINESS_REFUSALS.add(error);
+  return error;
+}
+
+/**
+ * @returns {{code: "reconnect-not-ready", ready: false, applied: false,
+ *   stage: "pre-open", retryable: true}|null}
+ */
+export function readWorkflowOpenReadinessRefusal(error) {
+  if (!error || typeof error !== "object" || !OPEN_READINESS_REFUSALS.has(error)) return null;
+  return {
+    code: "reconnect-not-ready",
+    ready: false,
+    applied: false,
+    stage: "pre-open",
+    retryable: true,
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #1914.

## The timeout after delivery

After `node_pack` restarts ComfyUI, `panel_open_workflow` for an already-open tab can be **delivered** into the post-restart window and then never reply. The orchestrator waits 15s and reports undetermined: the command was handed to the tab, but no request-id-correlated receipt arrived.

`awaitReachable()` only proves the tab re-registered. That happens before the backend socket, the node-def refresh kicked on `reconnected`, and the restored canvas binding have finished one handshake. `#1641` already waits that handshake (~2.9s). On a miss it still proceeded into freeze/load — and a load that never replies is exactly this report.

## What this does instead

Same shape as `#1785` (`workflow_list`), for a mutator that has not yet mutated:

1. Wait the shipped handshake (`waitForReconnectHandshakeBeforeOpen`).
2. If it still times out, refuse with a minted pre-open readiness error:
   `{ code: "reconnect-not-ready", ready: false, applied: false, stage: "pre-open", retryable: true }`
3. `applied: false` is load-bearing: freeze/load have not run, so retry is safe. `failOpen` journals the rid-correlated negative.
4. After the settle window closes, `needsWait` is false, the waiter returns `"ready"`, and the open still proceeds as the `#646` recovery for a restore that never settles.

The `#1785` service stays scoped to `workflow_list`. This publishes `workflow_open_readiness` so a caller cannot treat an unsettled open as a gated graph write.

## Evidence

Production `workflow_open` (eval of the shipped executor):

- handshake `"timeout"` + hanging freeze/load → refuses in milliseconds, `applied: false`, `openWorkflow` never runs
- same hanging path with the timeout check disabled → `timeout-after-delivered-open` (test fails)
- handshake `"ready"` still proceeds into freeze (not a false refusal)

Helper tests pin `applied: false` and reject lookalike forgeries. Wiring scans fail if the timeout check is deleted or moved past freeze/load.

**Suite:** 7176 tests, **7175 pass, 0 fail** (1 pre-existing todo).
