### PR TITLE
fix(1931): keep SaveVideo nested format.codec, drop orphan codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_set_widget refuses MiniMaxH3Director `timeline_data` and `builder_state` writes that leave the derived prompt stale (#1935)
+- SaveVideo keeps nested `format.codec` and drops the orphan top-level `codec`, so add and load stay queueable (#1931)
 
 ## [0.15.118] - 2026-08-27
 

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -82,49 +82,84 @@ import {
 // `image` combo; the registry this page loaded still holds the OLD shape.
 // ---------------------------------------------------------------------------
 
+const DYNAMIC_COMBO_V3 = "COMFY_DYNAMICCOMBO_V3";
+
+function saveVideoCodecSpec() {
+  return [
+    DYNAMIC_COMBO_V3,
+    {
+      options: [
+        { key: "auto", inputs: {} },
+        {
+          key: "h264",
+          inputs: {
+            required: {
+              encoding: [
+                DYNAMIC_COMBO_V3,
+                {
+                  options: [
+                    { key: "auto", inputs: {} },
+                    { key: "re-encode", inputs: { required: { crf: ["FLOAT", { default: 23 }] } } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ];
+}
+
+/** #2254 schema: ordinary `format` plus required DynamicCombo `codec`. */
+function legacySaveVideoDef() {
+  return {
+    name: "SaveVideo",
+    input: {
+      required: {
+        video: ["VIDEO"],
+        filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+        format: [["auto", "mp4"], { default: "auto" }],
+        codec: saveVideoCodecSpec(),
+      },
+    },
+    output: ["VIDEO"],
+  };
+}
+
+/** Current ComfyUI SaveVideo: `format` is the required DynamicCombo; `codec` is nested. */
+function nestedSaveVideoDef() {
+  return {
+    name: "SaveVideo",
+    input: {
+      required: {
+        video: ["VIDEO"],
+        filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+        format: [
+          DYNAMIC_COMBO_V3,
+          {
+            options: [
+              { key: "auto", inputs: { required: { codec: saveVideoCodecSpec() } } },
+              { key: "mp4", inputs: { required: { codec: saveVideoCodecSpec() } } },
+            ],
+          },
+        ],
+      },
+      optional: { codec: saveVideoCodecSpec() },
+    },
+    output: ["VIDEO"],
+  };
+}
+
 /** The live backend /object_info. A fresh object each call, exactly like a fetch. */
-function backendObjectInfo() {
+function backendObjectInfo({ nestedFormat = false } = {}) {
   return {
     LoadImage: {
       name: "LoadImage",
       input: { required: { image: [["a.png", "b.png"], {}] } },
       output: ["IMAGE", "MASK"],
     },
-    SaveVideo: {
-      name: "SaveVideo",
-      input: {
-        required: {
-          video: ["VIDEO"],
-          filename_prefix: ["STRING", { default: "video/ComfyUI" }],
-          format: [["auto", "mp4"], { default: "auto" }],
-          codec: [
-            "COMFY_DYNAMICCOMBO_V3",
-            {
-              options: [
-                { key: "auto", inputs: {} },
-                {
-                  key: "h264",
-                  inputs: {
-                    required: {
-                      encoding: [
-                        "COMFY_DYNAMICCOMBO_V3",
-                        {
-                          options: [
-                            { key: "auto", inputs: {} },
-                            { key: "re-encode", inputs: { required: { crf: ["FLOAT", { default: 23 }] } } },
-                          ],
-                        },
-                      ],
-                    },
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      },
-      output: ["VIDEO"],
-    },
+    SaveVideo: nestedFormat ? nestedSaveVideoDef() : legacySaveVideoDef(),
   };
 }
 
@@ -137,7 +172,7 @@ function staleLoadImageNodeData() {
   };
 }
 
-function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
+function makeComfy({ stale = true, dynamicSetterThrows = false, nestedFormat = false } = {}) {
   const widgetValueStore = new Map();
   const storeEvents = [];
   function widgetStoreKey(nodeId, widget) {
@@ -157,8 +192,39 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
   }
 
   let throwNextNativeSetter = dynamicSetterThrows;
-  function installNativeDynamicCombo(node, widget) {
+  function installNativeDynamicCombo(node, widget, spec) {
     let value = widget.value;
+    function rebuild() {
+      for (let index = node.widgets.length - 1; index >= 0; index--) {
+        const candidate = node.widgets[index];
+        if (candidate !== widget && candidate.name.startsWith(`${widget.name}.`)) {
+          candidate.onRemove?.();
+          deleteWidget(candidate.widgetId);
+          node.widgets.splice(index, 1);
+        }
+      }
+      for (let index = node.inputs.length - 1; index >= 0; index--) {
+        if (node.inputs[index].name.startsWith(`${widget.name}.`)) node.inputs.splice(index, 1);
+      }
+      const option = spec?.[1]?.options?.find((entry) => entry.key === value) ?? spec?.[1]?.options?.[0];
+      const required = option?.inputs?.required ?? {};
+      for (const [childName, childSpec] of Object.entries(required)) {
+        const childWidgetName = `${widget.name}.${childName}`;
+        const child = node.addWidget(
+          "combo",
+          childWidgetName,
+          Array.isArray(childSpec) && childSpec[0] === DYNAMIC_COMBO_V3
+            ? childSpec[1]?.options?.[0]?.key ?? "auto"
+            : childSpec?.[1]?.default ?? "auto",
+          null,
+          {},
+        );
+        if (Array.isArray(childSpec) && childSpec[0] === DYNAMIC_COMBO_V3) {
+          installNativeDynamicCombo(node, child, childSpec);
+        }
+        node.inputs.push({ name: childWidgetName, type: DYNAMIC_COMBO_V3, link: null });
+      }
+    }
     Object.defineProperty(widget, "value", {
       configurable: true,
       get() {
@@ -169,21 +235,11 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
         if (state) state.value = next;
         value = next;
         node.dynamicRebuilds.push(widget.name);
-        if (throwNextNativeSetter && node.graph && widget.name === "codec") {
+        if (throwNextNativeSetter && node.graph && (widget.name === "codec" || widget.name === "format")) {
           throwNextNativeSetter = false;
           throw new Error("native codec rebuild failed");
         }
-        for (let index = node.widgets.length - 1; index >= 0; index--) {
-          const candidate = node.widgets[index];
-          if (candidate !== widget && candidate.name.startsWith(`${widget.name}.`)) {
-            candidate.onRemove?.();
-            deleteWidget(candidate.widgetId);
-            node.widgets.splice(index, 1);
-          }
-        }
-        for (let index = node.inputs.length - 1; index >= 0; index--) {
-          if (node.inputs[index].name.startsWith(`${widget.name}.`)) node.inputs.splice(index, 1);
-        }
+        rebuild();
       },
     });
     widget.value = value;
@@ -205,7 +261,7 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
         null,
         {},
       );
-      installNativeDynamicCombo(node, widget);
+      installNativeDynamicCombo(node, widget, spec);
       return { widget };
     },
   };
@@ -249,6 +305,7 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
             registerWidget(widget, nodeId);
           };
           node.widgets.push(widget);
+          if (node.graph && node.id != null) widget.setNodeId(node.id);
           return widget;
         },
       };
@@ -259,11 +316,17 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
         else node.inputs.push({ name, type: declared });
       }
       if (type === "SaveVideo") {
-        // Current SaveVideo has ordinary `format` plus DynamicCombo `codec`. This is
-        // the stale row left by the old dynamic-format construction, before the node
-        // is registered and its current codec store exists.
-        node.addWidget("combo", "format.codec", "auto", null, {});
-        node.inputs.push({ name: "format.codec", type: "COMFY_DYNAMICCOMBO_V3", link: null });
+        if (nestedFormat) {
+          // Hidden/optional top-level `codec` — the #1931 orphan next to `format.codec`.
+          widgets.COMFY_DYNAMICCOMBO_V3(node, "codec", saveVideoCodecSpec());
+          node.inputs.push({ name: "codec", type: DYNAMIC_COMBO_V3, link: null });
+        } else {
+          // #2254: ordinary `format` plus DynamicCombo `codec`. This is the stale row
+          // left by the old dynamic-format construction, before the node is registered
+          // and its current codec store exists.
+          node.addWidget("combo", "format.codec", "auto", null, {});
+          node.inputs.push({ name: "format.codec", type: DYNAMIC_COMBO_V3, link: null });
+        }
       }
       return node;
     },
@@ -285,8 +348,8 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
   // makes this a DRIFT case rather than a freshly-installed-class case. Whether
   // the entry is the stale page-load one or already current is the scenario knob.
   void app.registerNodesFromDefs({
-    LoadImage: stale ? staleLoadImageNodeData() : backendObjectInfo().LoadImage,
-    SaveVideo: backendObjectInfo().SaveVideo,
+    LoadImage: stale ? staleLoadImageNodeData() : backendObjectInfo({ nestedFormat }).LoadImage,
+    SaveVideo: backendObjectInfo({ nestedFormat }).SaveVideo,
   });
 
   const graph = {
@@ -311,6 +374,31 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
   app.graphToPrompt = async () => {
     const node = graph._nodes.find((candidate) => candidate.type === "SaveVideo");
     if (!node) return { output: {} };
+    if (nestedFormat) {
+      if (
+        node.widgets.some((widget) => widget.name === "codec") ||
+        node.inputs.some((input) => input.name === "codec")
+      ) {
+        throw new Error("Dynamic widget doesn't exist on node");
+      }
+      const nested = node.widgets.find((widget) => widget.name === "format.codec");
+      if (!nested || !widgetValueStore.has(nested.widgetId)) {
+        throw new Error("format.codec widget store state is missing");
+      }
+      return {
+        output: {
+          [node.id]: {
+            class_type: "SaveVideo",
+            inputs: {
+              video: ["source", 0],
+              filename_prefix: node.widgets.find((widget) => widget.name === "filename_prefix")?.value,
+              format: node.widgets.find((widget) => widget.name === "format")?.value,
+              codec: nested.value,
+            },
+          },
+        },
+      };
+    }
     if (node.widgets.some((widget) => widget.name === "format.codec")) {
       throw new Error("Dynamic widget doesn't exist on node");
     }
@@ -333,7 +421,7 @@ function makeComfy({ stale = true, dynamicSetterThrows = false } = {}) {
     };
   };
 
-  return { app, LG, graph, registry, widgetValueStore, storeEvents };
+  return { app, LG, graph, registry, widgetValueStore, storeEvents, nestedFormat };
 }
 
 /** Build the SHIPPED graph_add_node with its collaborators injected. */
@@ -342,14 +430,15 @@ function realGraphAddNode(comfy, overrides = {}) {
   const context = { app, LG, graph, rootGraph: graph, workflow: { uuid: "wf" } };
   const refreshCalls = [];
 
+  const objectInfo = () => backendObjectInfo({ nestedFormat: comfy.nestedFormat === true });
   const api = {
     async getNodeDefs() {
-      return backendObjectInfo();
+      return objectInfo();
     },
     // ComfyUI's per-class route, faithful to its real shape: absence is `{}` with HTTP 200.
     async fetchApi(route) {
       const cls = decodeURIComponent(String(route).replace("/object_info/", ""));
-      const all = backendObjectInfo();
+      const all = objectInfo();
       const body = Object.prototype.hasOwnProperty.call(all, cls) ? { [cls]: all[cls] } : {};
       return { status: 200, json: async () => body };
     },
@@ -369,7 +458,7 @@ function realGraphAddNode(comfy, overrides = {}) {
     // Tests that need it to fail or to lie pass their own through overrides.
     refreshComfyNodeDefs: async (defs, opts) => {
       refreshCalls.push({ defs, opts });
-      await app.registerNodesFromDefs(defs ?? backendObjectInfo());
+      await app.registerNodesFromDefs(defs ?? objectInfo());
       return { refreshed: true };
     },
     summarizeNode: (node) => ({
@@ -619,4 +708,38 @@ test("#2254: a native dynamic setter throw refuses the add and leaves a retryabl
     true,
     "rollback cleanup deletes the original stale store key too",
   );
+});
+
+test("#1931: adding SaveVideo drops the orphan codec and keeps nested format.codec", async () => {
+  const comfy = makeComfy({ stale: false, nestedFormat: true });
+  const { graph_add_node } = realGraphAddNode(comfy);
+
+  const res = await graph_add_node({ class_type: "SaveVideo" });
+  const node = comfy.graph._nodes[0];
+
+  assert.equal(res.added.type, "SaveVideo");
+  assert.deepEqual(
+    node.widgets.map((widget) => widget.name).filter((name) => !name.includes("__cmcp_")),
+    ["filename_prefix", "format", "format.codec"],
+    "only the nested child exists after add",
+  );
+  assert.equal(node.inputs.some((input) => input.name === "codec"), false);
+  assert.equal(node.inputs.some((input) => input.name === "format.codec"), true);
+  assert.equal(
+    [...comfy.widgetValueStore.keys()].some((key) => /:(codec)$/.test(key)),
+    false,
+    "the orphan codec store entry is gone",
+  );
+  const prompt = await comfy.app.graphToPrompt();
+  assert.equal(prompt.output[node.id].inputs.format, "auto");
+  assert.equal(prompt.output[node.id].inputs.codec, "auto");
+});
+
+test("#1931: a duplicate format.codec AND codec set is not queueable before reconcile", async () => {
+  const comfy = makeComfy({ stale: false, nestedFormat: true });
+  const node = comfy.LG.createNode("SaveVideo");
+  comfy.graph.add(node);
+  assert.ok(node.widgets.some((widget) => widget.name === "format.codec"));
+  assert.ok(node.widgets.some((widget) => widget.name === "codec"));
+  await assert.rejects(comfy.app.graphToPrompt(), /Dynamic widget doesn't exist on node/);
 });

--- a/browser_tests/unit/dynamic-widget-reconcile.test.mjs
+++ b/browser_tests/unit/dynamic-widget-reconcile.test.mjs
@@ -1,0 +1,383 @@
+// #1931 — SaveVideo's `codec` exists only as a child of a chosen `format` option.
+// The panel was materialising both `format.codec` (correct) and a bare orphan
+// `codec`. graphToPrompt then threw "Dynamic widget doesn't exist on node".
+//
+// add_node and load-of-saved-workflow share reconcileFreshDynamicWidgets /
+// reconcileGraphDynamicWidgets. These tests fail on the duplicate/orphan set
+// and pass on the shipped nested set.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  reconcileFreshDynamicWidgets,
+  reconcileGraphDynamicWidgets,
+} from "../../web/js/lib/dynamic-widget-reconcile.js";
+
+const DYNAMIC = "COMFY_DYNAMICCOMBO_V3";
+
+function codecSpec(optionalHidden = false) {
+  const spec = [
+    DYNAMIC,
+    {
+      options: [
+        { key: "auto", inputs: {} },
+        {
+          key: "h264",
+          inputs: {
+            required: {
+              encoding: [
+                DYNAMIC,
+                {
+                  options: [
+                    { key: "auto", inputs: {} },
+                    { key: "re-encode", inputs: { required: { crf: ["FLOAT", { default: 23 }] } } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+      ...(optionalHidden ? { hidden: true } : {}),
+    },
+  ];
+  return spec;
+}
+
+/** Current ComfyUI SaveVideo: `format` is the required DynamicCombo; `codec` is nested. */
+function nestedFormatDef({ hiddenCodec = true } = {}) {
+  const def = {
+    name: "SaveVideo",
+    input: {
+      required: {
+        video: ["VIDEO"],
+        filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+        format: [
+          DYNAMIC,
+          {
+            options: [
+              { key: "auto", inputs: { required: { codec: codecSpec() } } },
+              { key: "mp4", inputs: { required: { codec: codecSpec() } } },
+            ],
+          },
+        ],
+      },
+    },
+  };
+  if (hiddenCodec) {
+    def.input.optional = { codec: codecSpec(true) };
+  }
+  return def;
+}
+
+/** #2254 schema: ordinary `format` plus required DynamicCombo `codec`. */
+function legacyCodecDef() {
+  return {
+    name: "SaveVideo",
+    input: {
+      required: {
+        video: ["VIDEO"],
+        filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+        format: [["auto", "mp4"], { default: "auto" }],
+        codec: codecSpec(),
+      },
+    },
+  };
+}
+
+function widgetStoreKey(nodeId, widget) {
+  return `${nodeId}:${widget.name}`;
+}
+
+function makeNode({ def, extraWidgets = [], extraInputs = [], throwOn } = {}) {
+  const store = new Map();
+  const storeEvents = [];
+  const node = {
+    id: 15,
+    type: "SaveVideo",
+    constructor: { nodeData: def },
+    widgets: [],
+    inputs: [],
+    dynamicRebuilds: [],
+    graph: true,
+  };
+
+  function deleteWidget(widgetId) {
+    if (!widgetId) return false;
+    const deleted = store.delete(widgetId);
+    if (deleted) storeEvents.push({ type: "delete", widgetId });
+    return deleted;
+  }
+
+  function registerWidget(widget, nodeId) {
+    const widgetId = widgetStoreKey(nodeId, widget);
+    store.set(widgetId, { value: widget.value });
+    storeEvents.push({ type: "register", widgetId });
+    return widgetId;
+  }
+
+  function installNativeDynamicCombo(widget, spec) {
+    let value = widget.value;
+    function rebuild() {
+      for (let index = node.widgets.length - 1; index >= 0; index--) {
+        const candidate = node.widgets[index];
+        if (candidate !== widget && typeof candidate.name === "string" && candidate.name.startsWith(`${widget.name}.`)) {
+          candidate.onRemove?.();
+          deleteWidget(candidate.widgetId);
+          node.widgets.splice(index, 1);
+        }
+      }
+      for (let index = node.inputs.length - 1; index >= 0; index--) {
+        if (node.inputs[index].name.startsWith(`${widget.name}.`)) node.inputs.splice(index, 1);
+      }
+      const option =
+        spec?.[1]?.options?.find((entry) => entry.key === value) ?? spec?.[1]?.options?.[0];
+      const required = option?.inputs?.required ?? {};
+      for (const [childName, childSpec] of Object.entries(required)) {
+        const childWidgetName = `${widget.name}.${childName}`;
+        const child = node.addWidget(
+          "combo",
+          childWidgetName,
+          Array.isArray(childSpec) && childSpec[0] === DYNAMIC
+            ? childSpec[1]?.options?.[0]?.key ?? "auto"
+            : childSpec?.[1]?.default ?? "auto",
+          null,
+          {},
+        );
+        if (Array.isArray(childSpec) && childSpec[0] === DYNAMIC) {
+          installNativeDynamicCombo(child, childSpec);
+        }
+        node.inputs.push({ name: childWidgetName, type: DYNAMIC, link: null });
+      }
+    }
+    Object.defineProperty(widget, "value", {
+      configurable: true,
+      get() {
+        return store.get(widget.widgetId)?.value ?? value;
+      },
+      set(next) {
+        const state = store.get(widget.widgetId);
+        if (state) state.value = next;
+        value = next;
+        node.dynamicRebuilds.push(widget.name);
+        if (throwOn && widget.name === throwOn) {
+          throwOn = null;
+          throw new Error("native rebuild failed");
+        }
+        rebuild();
+      },
+    });
+    widget.value = value;
+  }
+
+  node.addWidget = function addWidget(kind, name, value, callback, options) {
+    let boundNodeId = node.id;
+    const widget = {
+      type: kind,
+      name,
+      value,
+      callback,
+      options: options ?? {},
+      onRemove() {},
+    };
+    Object.defineProperty(widget, "widgetId", {
+      configurable: true,
+      get() {
+        return boundNodeId == null ? null : widgetStoreKey(boundNodeId, widget);
+      },
+    });
+    widget.setNodeId = (nodeId) => {
+      boundNodeId = nodeId;
+      registerWidget(widget, nodeId);
+    };
+    node.widgets.push(widget);
+    registerWidget(widget, node.id);
+    return widget;
+  };
+
+  for (const [name, spec] of Object.entries(def.input?.required ?? {})) {
+    const declared = Array.isArray(spec) ? spec[0] : null;
+    if (declared === DYNAMIC) {
+      const widget = node.addWidget("combo", name, spec[1]?.options?.[0]?.key ?? "auto", null, {});
+      installNativeDynamicCombo(widget, spec);
+      node.inputs.push({ name, type: DYNAMIC, link: null });
+    } else if (Array.isArray(declared)) {
+      node.addWidget("combo", name, declared[0], null, { values: declared });
+    } else if (declared === "STRING") {
+      node.addWidget("text", name, spec[1]?.default ?? "", null, {});
+    } else {
+      node.inputs.push({ name, type: declared, link: null });
+    }
+  }
+  for (const extra of extraWidgets) {
+    const widget = node.addWidget("combo", extra.name, extra.value ?? "auto", null, {});
+    if (extra.dynamic) installNativeDynamicCombo(widget, extra.spec ?? codecSpec());
+    node.inputs.push({ name: extra.name, type: DYNAMIC, link: extra.link ?? null });
+  }
+  for (const extra of extraInputs) node.inputs.push(extra);
+
+  function graphToPrompt() {
+    if (node.widgets.some((widget) => widget.name === "codec") || node.inputs.some((input) => input.name === "codec")) {
+      throw new Error("Dynamic widget doesn't exist on node");
+    }
+    const format = node.widgets.find((widget) => widget.name === "format");
+    const nested = node.widgets.find((widget) => widget.name === "format.codec");
+    if (!format || !nested) throw new Error("nested format.codec is missing");
+    return {
+      output: {
+        [node.id]: {
+          class_type: "SaveVideo",
+          inputs: { format: format.value, codec: nested.value },
+        },
+      },
+    };
+  }
+
+  return { node, store, storeEvents, graphToPrompt };
+}
+
+test("#1931: the duplicate set (format.codec AND codec) is not queueable", () => {
+  const { graphToPrompt } = makeNode({
+    def: nestedFormatDef(),
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  assert.throws(graphToPrompt, /Dynamic widget doesn't exist on node/);
+});
+
+test("#1931: reconcile drops the orphan codec and keeps nested format.codec", () => {
+  const def = nestedFormatDef();
+  const { node, store, graphToPrompt } = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+
+  assert.ok(node.widgets.some((widget) => widget.name === "format.codec"));
+  assert.ok(node.widgets.some((widget) => widget.name === "codec"));
+
+  const result = reconcileFreshDynamicWidgets(node, def);
+  assert.equal(result.failures.length, 0, result.failures.map((f) => `${f.name}:${f.phase}`).join(", "));
+  assert.ok(result.relocated.includes("codec"), "the bare codec is relocated into format's group");
+  assert.deepEqual(
+    node.widgets.map((widget) => widget.name).filter((name) => !name.includes("__cmcp_")),
+    ["filename_prefix", "format", "format.codec"],
+  );
+  assert.equal(node.inputs.some((input) => input.name === "codec"), false);
+  assert.equal(node.inputs.some((input) => input.name === "format.codec"), true);
+  assert.equal([...store.keys()].some((key) => key.endsWith(":codec")), false);
+
+  const prompt = graphToPrompt();
+  assert.equal(prompt.output[15].inputs.format, "auto");
+  assert.equal(prompt.output[15].inputs.codec, "auto");
+});
+
+test("#1931: the shipped nested set is left alone and stays queueable", () => {
+  const def = nestedFormatDef({ hiddenCodec: false });
+  const { node, graphToPrompt } = makeNode({ def });
+
+  assert.deepEqual(
+    node.widgets.map((widget) => widget.name),
+    ["filename_prefix", "format", "format.codec"],
+  );
+  const result = reconcileFreshDynamicWidgets(node, def);
+  assert.equal(result.failures.length, 0);
+  assert.deepEqual(result.relocated, []);
+  assert.deepEqual(
+    node.widgets.map((widget) => widget.name),
+    ["filename_prefix", "format", "format.codec"],
+  );
+  const prompt = graphToPrompt();
+  assert.equal(prompt.output[15].inputs.codec, "auto");
+});
+
+test("#1931: orphan codec descendants (codec.encoding) are removed with the orphan root", () => {
+  const def = nestedFormatDef();
+  const { node } = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true, value: "h264" }],
+  });
+  // The hidden codec DynamicCombo builds codec.encoding for h264.
+  assert.ok(node.widgets.some((widget) => widget.name === "codec"));
+  assert.ok(node.widgets.some((widget) => widget.name === "codec.encoding"));
+
+  const result = reconcileFreshDynamicWidgets(node, def);
+  assert.equal(result.failures.length, 0);
+  const names = node.widgets.map((widget) => widget.name).filter((name) => !name.includes("__cmcp_"));
+  assert.equal(names.includes("codec"), false);
+  assert.equal(names.includes("codec.encoding"), false);
+  assert.equal(names.includes("format.codec"), true);
+});
+
+test("#1931: a loaded graph is cleaned by the shared materialiser", () => {
+  const def = nestedFormatDef();
+  const { node, graphToPrompt } = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  const graph = { _nodes: [node] };
+  assert.throws(graphToPrompt, /Dynamic widget doesn't exist on node/);
+
+  const results = reconcileGraphDynamicWidgets(graph);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].failures.length, 0);
+  assert.deepEqual(
+    node.widgets.map((widget) => widget.name).filter((name) => !name.includes("__cmcp_")),
+    ["filename_prefix", "format", "format.codec"],
+  );
+  assert.doesNotThrow(graphToPrompt);
+});
+
+test("#1931: nested subgraphs are walked on load", () => {
+  const def = nestedFormatDef();
+  const inner = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  inner.node.id = 7;
+  const host = {
+    id: 1,
+    type: "Subgraph",
+    constructor: { nodeData: { input: { required: {} } } },
+    widgets: [],
+    subgraph: { _nodes: [inner.node] },
+  };
+  const results = reconcileGraphDynamicWidgets({ _nodes: [host] });
+  assert.ok(results.length >= 1);
+  assert.equal(
+    inner.node.widgets.some((widget) => widget.name === "codec"),
+    false,
+    "the inner SaveVideo orphan is cleaned",
+  );
+  assert.equal(inner.node.widgets.some((widget) => widget.name === "format.codec"), true);
+});
+
+test("#1931: a saved nested codec value survives orphan cleanup", () => {
+  const def = nestedFormatDef();
+  const { node } = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  const nested = node.widgets.find((widget) => widget.name === "format.codec");
+  nested.value = "h264";
+  assert.equal(nested.value, "h264");
+
+  reconcileFreshDynamicWidgets(node, def);
+  const after = node.widgets.find((widget) => widget.name === "format.codec");
+  assert.ok(after);
+  assert.equal(after.value, "h264");
+  assert.equal(node.widgets.some((widget) => widget.name === "codec"), false);
+});
+
+test("#2254: stale format.codec is still removed when codec is the required root", () => {
+  const def = legacyCodecDef();
+  const { node } = makeNode({
+    def,
+    extraWidgets: [{ name: "format.codec", dynamic: true }],
+  });
+  // format is an ordinary combo here; format.codec is leftover from the old construction.
+  const result = reconcileFreshDynamicWidgets(node, def);
+  assert.equal(result.failures.length, 0);
+  assert.ok(result.relocated.includes("format.codec"));
+  assert.equal(node.widgets.some((widget) => widget.name === "format.codec"), false);
+  assert.equal(node.widgets.some((widget) => widget.name === "codec"), true);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -386,7 +386,7 @@ import {
   releaseReconnectScopePin,
 } from "./lib/reconnect-scope-fence.js";
 import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "./lib/set-widget.js";
-import { reconcileFreshDynamicWidgets } from "./lib/dynamic-widget-reconcile.js";
+import { reconcileFreshDynamicWidgets, reconcileGraphDynamicWidgets } from "./lib/dynamic-widget-reconcile.js";
 import {
   createDeferredWidgetEditQueue,
   deferredWidgetQueueCounts,
@@ -4192,6 +4192,22 @@ function installCreateBoundaryFork(appRef) {
         // Never let disclosure bookkeeping break a graph load either.
       }
       const result = orig(graphData, clean, restoreView, workflow, options);
+      // #1931 — SaveVideo (and any other nested DynamicCombo) can land from a saved
+      // workflow already carrying a bare orphan next to the real dotted child
+      // (`codec` AND `format.codec`). add_node and load share the same materialiser;
+      // run it after the graph is live. `typeof` keeps extracted-fork tests, which
+      // do not bind this helper, from throwing on an unresolved identifier.
+      const reconcileLoaded = () => {
+        try {
+          if (typeof reconcileGraphDynamicWidgets === "function") {
+            reconcileGraphDynamicWidgets(appRef?.graph);
+          }
+        } catch {
+          // Post-load dynamic-widget cleanup must never break a graph load.
+        }
+      };
+      if (result && typeof result.then === "function") result.then(reconcileLoaded, () => {});
+      else reconcileLoaded();
       if (ownerlessStampUuid) {
         // #349 r3/r6 P0 — a creation-minted tag must NEVER float ownerless when
         // its receiving tab can be PROVEN — but registration must never guess.
@@ -15691,9 +15707,10 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.add(node);
       // COMFY_DYNAMICCOMBO_V3 first runs its value setter while LG.createNode is still
       // detached from a graph. Replay it after registration so the widget-value store and
-      // dynamic rows match the fresh node. A schema-verified stale path such as
-      // `format.codec` is routed through the current `codec` root so the frontend's own
-      // widget/store cleanup removes it.
+      // dynamic rows match the fresh node. Nested children stay on their dotted path
+      // (`format.codec`); a bare name that duplicates one (`codec`) and a schema-verified
+      // stale dotted residue are routed through the current dynamic root so the frontend's
+      // own widget/store cleanup removes them.
       const dynamicReconciliation = reconcileFreshDynamicWidgets(node, currentDef);
       if (dynamicReconciliation.failures.length) {
         const storeCleanup = dynamicReconciliation.cleanupStore?.() ?? { cleaned: true };
@@ -16064,6 +16081,11 @@ const GRAPH_TOOL_EXECUTORS = {
         // canvas too, and must be as undoable as any other graph edit this turn.
         captureGraphSnapshot(null, "before loading an API-format workflow");
         await app.loadApiJson(apiClone, "graph_load.json");
+        try {
+          reconcileGraphDynamicWidgets(app?.graph);
+        } catch {
+          // Post-load dynamic-widget cleanup must never break a graph load.
+        }
         if (typeof markWorkflowGraphProvenanceUnknown === "function") {
           markWorkflowGraphProvenanceUnknown(apiTargetWorkflow);
         }
@@ -16226,6 +16248,13 @@ const GRAPH_TOOL_EXECUTORS = {
       throw new Error(
         "graph_load target workflow changed while restore retry was settling; the retry was skipped",
       );
+    }
+    // #1931 — a saved SaveVideo can restore both `format.codec` and a bare `codec`.
+    // Run after the configure retry so a late-built widget set is cleaned too.
+    try {
+      reconcileGraphDynamicWidgets(app?.graph);
+    } catch {
+      // Post-load dynamic-widget cleanup must never break a graph load.
     }
     // #874 remaining load path — SubgraphNode.configure seeds host rails from
     // INNER definition widgets, so a saved subgraph host lands at defaults

--- a/web/js/lib/dynamic-widget-reconcile.js
+++ b/web/js/lib/dynamic-widget-reconcile.js
@@ -25,15 +25,54 @@ function storeCleanupAlias(dynamicRoot, widgetId, index) {
   };
 }
 
+function isDynamicComboSpec(spec) {
+  return Array.isArray(spec) && spec[0] === DYNAMIC_COMBO_V3;
+}
+
+function walkDynamicComboChildren(spec, visit) {
+  if (!isDynamicComboSpec(spec)) return;
+  const options = spec[1]?.options;
+  if (!Array.isArray(options)) return;
+  for (const option of options) {
+    const inputs = option?.inputs;
+    if (!inputs || typeof inputs !== "object") continue;
+    for (const group of ["required", "optional"]) {
+      const groupInputs = inputs[group];
+      if (!groupInputs || typeof groupInputs !== "object") continue;
+      for (const [childName, childSpec] of Object.entries(groupInputs)) {
+        if (typeof childName !== "string" || !childName) continue;
+        visit(childName, childSpec);
+        walkDynamicComboChildren(childSpec, visit);
+      }
+    }
+  }
+}
+
+function nestedChildNamesByRoot(required) {
+  const byRoot = new Map();
+  for (const [name, spec] of Object.entries(required)) {
+    if (!isDynamicComboSpec(spec)) continue;
+    const children = new Set();
+    walkDynamicComboChildren(spec, (childName) => children.add(childName));
+    if (children.size) byRoot.set(name, children);
+  }
+  return byRoot;
+}
+
+function isInternalRelocationName(name) {
+  return typeof name === "string" && name.includes("__cmcp_");
+}
+
 function staleDynamicGroup(name, required, dynamicNames) {
-  if (typeof name !== "string") return null;
+  if (typeof name !== "string" || isInternalRelocationName(name)) return null;
   const parts = name.split(".");
   if (parts.length < 2) return null;
 
   // This is the one schema migration that needs cleanup here: an ordinary current
   // input can retain a dotted child whose path contains a CURRENT dynamic root (the
-  // SaveVideo `format.codec` residue). The current definition proves both sides of
-  // that decision. Do not infer a root from an arbitrary dotted accessor parent.
+  // SaveVideo `format.codec` residue when `codec` itself is the required DynamicCombo).
+  // The current definition proves both sides of that decision. Do not infer a root
+  // from an arbitrary dotted accessor parent.
   const parent = parts[0];
   if (!Object.prototype.hasOwnProperty.call(required, parent) || dynamicNames.has(parent)) {
     return null;
@@ -42,15 +81,80 @@ function staleDynamicGroup(name, required, dynamicNames) {
   return dynamicPart ?? null;
 }
 
+function orphanParentRoot(name, nestedByRoot, widgets) {
+  if (typeof name !== "string" || isInternalRelocationName(name)) return null;
+  const matches = [];
+  for (const [root, children] of nestedByRoot) {
+    if (name === root || name.startsWith(`${root}.`)) continue;
+    const first = name.split(".")[0];
+    if (children.has(first)) matches.push(root);
+  }
+  if (!matches.length) return null;
+  if (matches.length === 1) return matches[0];
+  const first = name.split(".")[0];
+  const withDotted = matches.find((root) =>
+    widgets.some((widget) => widget?.name === `${root}.${first}`),
+  );
+  return withDotted ?? matches[0];
+}
+
+function isNestedChildName(name, nestedByRoot) {
+  if (typeof name !== "string") return false;
+  for (const children of nestedByRoot.values()) {
+    if (children.has(name)) return true;
+  }
+  return false;
+}
+
+function capturePrefixedValues(node, rootName) {
+  const values = new Map();
+  for (const widget of node.widgets ?? []) {
+    const name = widget?.name;
+    if (typeof name !== "string" || isInternalRelocationName(name)) continue;
+    if (!name.startsWith(`${rootName}.`)) continue;
+    values.set(name, widget.value);
+  }
+  return values;
+}
+
+function restorePrefixedValues(node, values) {
+  if (!values.size) return;
+  const byName = new Map(
+    (node.widgets ?? [])
+      .filter((widget) => typeof widget?.name === "string")
+      .map((widget) => [widget.name, widget]),
+  );
+  const names = [...values.keys()].sort((a, b) => a.split(".").length - b.split(".").length);
+  for (const name of names) {
+    const widget = byName.get(name);
+    if (!widget) continue;
+    const next = values.get(name);
+    if (widget.value === next) continue;
+    try {
+      widget.value = next;
+    } catch {
+      // A restore that the native setter rejects is not a reason to fail the reconcile;
+      // the rebuilt child already has the definition's default.
+    }
+  }
+}
+
 /**
  * Re-run the native value setter for dynamic-combo roots on a newly-created node.
  *
  * COMFY_DYNAMICCOMBO_V3 installs its rebuild logic as an own `value` setter. The
  * constructor runs that setter before `graph.add`, when the widget-value store has no
  * node identity yet. Replaying the same value after registration makes the node's
- * dynamic rows and store state agree. A schema-verified legacy dotted path (for
- * example `format.codec`) is temporarily placed in the current dynamic root's group
- * so the native setter removes it through the frontend's normal widget/store cleanup.
+ * dynamic rows and store state agree.
+ *
+ * Two schema-verified leftovers are routed through a current dynamic root so the
+ * native setter removes them:
+ *   - a dotted child of an ordinary current input (`format.codec` when `codec` is
+ *     the required DynamicCombo — #2254)
+ *   - a bare name that also exists as a nested child of a required DynamicCombo
+ *     (`codec` next to `format.codec` when `format` is the required DynamicCombo —
+ *     #1931). SaveVideo declares `codec` only under a chosen `format` option; a
+ *     top-level `codec` widget is an orphan the queue-time serializer trips on.
  *
  * @param {object} node
  * @param {object} currentDef
@@ -69,11 +173,12 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
 
   const dynamicNames = new Set(
     Object.entries(required)
-      .filter(([, spec]) => Array.isArray(spec) && spec[0] === DYNAMIC_COMBO_V3)
+      .filter(([, spec]) => isDynamicComboSpec(spec))
       .map(([name]) => name),
   );
   if (!dynamicNames.size) return empty;
 
+  const nestedByRoot = nestedChildNamesByRoot(required);
   const byName = new Map(
     widgets
       .filter((widget) => typeof widget?.name === "string")
@@ -82,16 +187,12 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
   const roots = new Set();
   const relocated = [];
   const failures = [];
+  const relocatedWidgets = new Set();
 
-  // A current dynamic root is the only accessor we are authorized to replay. Before
-  // doing so, move a schema-verified legacy child into that root's native group. This
-  // lets the native setter call its own onRemove/widget-store deletion logic; simply
-  // filtering node.widgets would leave a stale store entry behind.
   let relocationIndex = 0;
   const relocationByName = new Map();
-  for (const widget of widgets) {
-    const dynamicRoot = staleDynamicGroup(widget?.name, required, dynamicNames);
-    if (!dynamicRoot) continue;
+
+  const relocateInto = (widget, dynamicRoot) => {
     const oldName = widget.name;
     const oldWidgetId = readWidgetId(widget);
     let replacement = relocationByName.get(oldName);
@@ -101,11 +202,12 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
     }
     try {
       widget.name = replacement;
+      relocatedWidgets.add(widget);
       // Current LiteGraph widgets derive widgetId from name. graph.add() already
-      // registered the old `format.codec` key, so renaming alone leaves that key
-      // behind and the native setter would delete only the newly-derived key.
-      // Re-register the renamed widget, then give native cleanup an alias carrying
-      // the original key so both registrations are deleted by deleteWidget().
+      // registered the old key, so renaming alone leaves that key behind and the
+      // native setter would delete only the newly-derived key. Re-register the
+      // renamed widget, then give native cleanup an alias carrying the original
+      // key so both registrations are deleted by deleteWidget().
       if (oldWidgetId) {
         node.widgets.push(storeCleanupAlias(dynamicRoot, oldWidgetId, relocationIndex++));
       }
@@ -116,6 +218,22 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
     } catch (error) {
       failures.push({ name: oldName, phase: "relocate", error });
     }
+  };
+
+  // A current dynamic root is the only accessor we are authorized to replay. Before
+  // doing so, move a schema-verified leftover into that root's native group. This
+  // lets the native setter call its own onRemove/widget-store deletion logic; simply
+  // filtering node.widgets would leave a stale store entry behind.
+  for (const widget of widgets) {
+    const dynamicRoot = staleDynamicGroup(widget?.name, required, dynamicNames);
+    if (!dynamicRoot) continue;
+    relocateInto(widget, dynamicRoot);
+  }
+  for (const widget of widgets) {
+    if (relocatedWidgets.has(widget)) continue;
+    const dynamicRoot = orphanParentRoot(widget?.name, nestedByRoot, node.widgets ?? widgets);
+    if (!dynamicRoot) continue;
+    relocateInto(widget, dynamicRoot);
   }
   if (Array.isArray(node.inputs)) {
     for (const input of node.inputs) {
@@ -125,10 +243,15 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
   }
 
   // Current dynamic declarations must be replayed even when they have no stale rows.
+  // A required name that is only a nested child of another required DynamicCombo is
+  // the orphan we just relocated, not a missing root.
   for (const name of dynamicNames) {
     const widget = byName.get(name);
-    if (!widget) {
-      failures.push({ name, phase: "missing-root", error: new Error("dynamic widget root is missing") });
+    if (!widget || relocatedWidgets.has(widget) || widget.name !== name) {
+      if (isNestedChildName(name, nestedByRoot)) continue;
+      if (!widget) {
+        failures.push({ name, phase: "missing-root", error: new Error("dynamic widget root is missing") });
+      }
       continue;
     }
     if (!hasValueSetter(widget)) {
@@ -143,10 +266,12 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
     if (!roots.has(widget) || !node.widgets.includes(widget) || !hasValueSetter(widget)) {
       continue;
     }
+    const preserved = capturePrefixedValues(node, widget.name);
     try {
       const value = widget.value;
       widget.value = value;
       replayed.push(widget.name);
+      restorePrefixedValues(node, preserved);
     } catch (error) {
       failures.push({ name: widget.name, phase: "setter", error });
     }
@@ -183,4 +308,37 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
   };
 
   return { replayed, relocated, failures, cleanupStore };
+}
+
+/**
+ * Apply {@link reconcileFreshDynamicWidgets} to every node on a loaded graph.
+ *
+ * add_node and load share this materialiser: SaveVideo's nested `format.codec`
+ * must exist and a bare orphan `codec` must not, whether the node was just
+ * created or restored from a saved workflow.
+ *
+ * Failures are recorded per node and never thrown — a load of a 30-node graph
+ * must not abort because one SaveVideo leftover could not be cleaned.
+ *
+ * @param {object} graph
+ * @returns {Array<object>}
+ */
+export function reconcileGraphDynamicWidgets(graph) {
+  const nodes = Array.isArray(graph?._nodes) ? graph._nodes : [];
+  const results = [];
+  for (const node of nodes) {
+    try {
+      const def = node?.constructor?.nodeData;
+      if (def) results.push(reconcileFreshDynamicWidgets(node, def));
+      if (node?.subgraph) results.push(...reconcileGraphDynamicWidgets(node.subgraph));
+    } catch (error) {
+      results.push({
+        replayed: [],
+        relocated: [],
+        failures: [{ name: String(node?.type ?? node?.id ?? "node"), phase: "graph", error }],
+        cleanupStore: () => ({ cleaned: false, error }),
+      });
+    }
+  }
+  return results;
 }


### PR DESCRIPTION
## Summary

`panel_add_node("SaveVideo")` and load-of-saved-workflow were materialising both nested `format.codec` (the real DynamicCombo child) and a bare orphan `codec`. `panel_run` then failed pre-queue with `Dynamic widget doesn't exist on node`.

SaveVideo's current schema declares `codec` only as a child of a chosen `format` option. The shared materialiser now keeps the dotted child and routes the orphan through the parent DynamicCombo so native widget/store cleanup removes it. `#2254`'s inverse case (stale `format.codec` when `codec` is the required root) is unchanged.

## Test plan

- [x] `node --test browser_tests/unit/dynamic-widget-reconcile.test.mjs` — duplicate/orphan fails queue; shipped nested set stays queueable; load-graph walk; nested subgraph; saved nested value preserved; `#2254` still drops stale `format.codec`
- [x] `node --test browser_tests/unit/add-node-schema-auto-refresh.test.mjs` — add_node of current SaveVideo ships `filename_prefix, format, format.codec` only
- [x] Related: graph-to-prompt-failure, graph-binding (loadGraphData fork), changelog-integrity, add-node-command-budget

Closes #1931