### PR TITLE
fix(1934): count CompareFrames temp images instead of claiming none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_set_widget refuses MiniMaxH3Director `timeline_data` and `builder_state` writes that leave the derived prompt stale (#1935)
 - SaveVideo keeps nested `format.codec` and drops the orphan top-level `codec`, so add and load stay queueable (#1931)
+- panel_run no longer reports CompareFrames temp images as "no media": unrecognised `*images` outputs are counted and named, and none of them are attached (#1934)
 
 ## [0.15.118] - 2026-08-27
 

--- a/browser_tests/unit/inline-image-cache-bust.test.mjs
+++ b/browser_tests/unit/inline-image-cache-bust.test.mjs
@@ -28,6 +28,7 @@ import { readFileSync } from "node:fs";
 import { appendImageCacheBust } from "../../web/js/lib/storyboard-cache-identity.js";
 import { composeShowMediaReply } from "../../web/js/lib/media-preview.js";
 import { NO_PROMPT_KEY } from "../../web/js/lib/run-completion.js";
+import { collectNodeOutputMedia } from "../../web/js/lib/node-output-media.js";
 
 const panelSrc = readFileSync(
   new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
@@ -56,6 +57,7 @@ function productionOnExecuted() {
     "appendStoryboardCacheBust",
     "appendImageCacheBust",
     "NO_PROMPT_KEY",
+    "collectNodeOutputMedia",
     `return (${panelSrc.slice(start, end).trim()});`,
   )(
     (m) =>
@@ -72,6 +74,7 @@ function productionOnExecuted() {
     (url) => url,
     appendImageCacheBust,
     NO_PROMPT_KEY,
+    collectNodeOutputMedia,
   );
   return { onExecuted, painted, buffered };
 }

--- a/browser_tests/unit/run-completion-compareframes-temp.test.mjs
+++ b/browser_tests/unit/run-completion-compareframes-temp.test.mjs
@@ -1,0 +1,304 @@
+/**
+ * #1934 — CompareFrames temp images are not "no media", and they are not attached.
+ *
+ * THE REPORTED FAILURE. `panel_run({to_node_id:147})` finished successfully and
+ * the completion said "produced no image or video output." `get_history` for the
+ * same prompt showed node 147 had 384 `a_images` and 384 `b_images` temp PNGs.
+ * The extraction only read `images` / `gifs` / `videos`, so CompareFrames
+ * contributed nothing.
+ *
+ * THE HARMFUL FIX, as the owner named it: folding those bags into the completion
+ * frame. 768 temps would either blow the one-frame bound or be silently truncated
+ * to a handful that looks complete — a worse lie than "none".
+ *
+ * THE SHIPPED FIX is count-not-deliver. Unrecognised `*images` keys with ComfyUI
+ * `{filename, type, subfolder}` descriptors are counted and named; none of them
+ * ride the frame; a node with those keys is never reported as producing nothing.
+ *
+ * These tests drive the shipped functions (`collectNodeOutputMedia`,
+ * `parseHistoryEntry`, `composeRunCompletionFrame`, the tracker) so a revert of
+ * either property — "claim none" or "attach them all" — fails here.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  collectNodeOutputMedia,
+  formatWithheldMediaNote,
+} from "../../web/js/lib/node-output-media.js";
+import { parseHistoryEntry } from "../../web/js/lib/history-reconcile.js";
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+
+const A_COUNT = 384;
+const B_COUNT = 384;
+const TOTAL = A_COUNT + B_COUNT;
+
+function tempRef(filename) {
+  return { filename, subfolder: "", type: "temp" };
+}
+
+function bag(prefix, count) {
+  const out = [];
+  for (let i = 1; i <= count; i += 1) {
+    out.push(tempRef(`${prefix}_${String(i).padStart(5, "0")}.png`));
+  }
+  return out;
+}
+
+function compareFramesOutput(aCount = A_COUNT, bCount = B_COUNT) {
+  return {
+    a_images: bag("a", aCount),
+    b_images: bag("b", bCount),
+  };
+}
+
+function makeTracker() {
+  const flushes = [];
+  let clock = 1000;
+  const timers = new Set();
+  const tracker = createRunCompletionTracker({
+    onFlush: (payload) => flushes.push(payload),
+    now: () => clock,
+    setTimer: (fn, ms) => {
+      const t = { fn, at: clock + ms };
+      timers.add(t);
+      return t;
+    },
+    clearTimer: (t) => timers.delete(t),
+  });
+  return {
+    tracker,
+    flushes,
+    advance: (ms) => {
+      clock += ms;
+    },
+  };
+}
+
+const frameDeps = (sent) => ({
+  sendFrame: (f) => (sent.push(f), true),
+  coerceMessageText: (s) => String(s ?? ""),
+  formatDuration: (ms) => `${(ms / 1000).toFixed(1)}s`,
+  formatClock: () => "12:00:00",
+  agentReceivesImages: () => true,
+  warn: () => {},
+});
+
+// ---------------------------------------------------------------------------
+// 1. The collector — shipped function the live + history paths both call.
+// ---------------------------------------------------------------------------
+
+test("#1934 CompareFrames a_images/b_images are counted and not deliverable", () => {
+  const { deliverable, withheld } = collectNodeOutputMedia(compareFramesOutput());
+  assert.equal(deliverable.length, 0, "none of the 768 temps may ride the frame");
+  assert.equal(withheld.count, TOTAL);
+  assert.deepEqual(withheld.keys, ["a_images", "b_images"]);
+  assert.deepEqual(withheld.types, ["temp"]);
+});
+
+test("#1934 a standard images bag is still deliverable — attached count unchanged", () => {
+  const { deliverable, withheld } = collectNodeOutputMedia({
+    images: [{ filename: "final.png", type: "output", subfolder: "" }],
+  });
+  assert.equal(deliverable.length, 1);
+  assert.equal(deliverable[0].filename, "final.png");
+  assert.equal(withheld, null);
+});
+
+test("#1934 mixed SaveImage + CompareFrames attaches only the standard bag", () => {
+  const { deliverable, withheld } = collectNodeOutputMedia({
+    images: [{ filename: "final.png", type: "output", subfolder: "" }],
+    a_images: bag("a", A_COUNT),
+    b_images: bag("b", B_COUNT),
+  });
+  assert.equal(deliverable.length, 1, "the number attached does not change");
+  assert.equal(deliverable[0].filename, "final.png");
+  assert.equal(withheld.count, TOTAL);
+});
+
+test("#1934 an arbitrary array on a *images key is not mistaken for media", () => {
+  const { deliverable, withheld } = collectNodeOutputMedia({
+    foo_images: ["not", "media"],
+    notes_images: [{ text: "hello" }, { filename: "no-type.png" }],
+    text: ["a caption"],
+  });
+  assert.equal(deliverable.length, 0);
+  assert.equal(withheld, null);
+});
+
+test("#1934 gifs/videos standard keys stay deliverable, preview_gifs are withheld", () => {
+  const { deliverable, withheld } = collectNodeOutputMedia({
+    gifs: [{ filename: "clip.mp4", type: "output" }],
+    preview_gifs: [tempRef("preview.gif")],
+  });
+  assert.equal(deliverable.length, 1);
+  assert.equal(deliverable[0].filename, "clip.mp4");
+  assert.equal(withheld.count, 1);
+  assert.deepEqual(withheld.keys, ["preview_gifs"]);
+});
+
+// ---------------------------------------------------------------------------
+// 2. History parse — the /history recovery path uses the same split.
+// ---------------------------------------------------------------------------
+
+test("#1934 parseHistoryEntry does not copy CompareFrames temps into images", () => {
+  const parsed = parseHistoryEntry({
+    outputs: { 147: compareFramesOutput() },
+    status: { status_str: "success", completed: true },
+  });
+  assert.equal(parsed.images.length, 0, "attached count stays zero");
+  assert.equal(parsed.videos.length, 0);
+  assert.equal(parsed.withheld.count, TOTAL);
+  assert.deepEqual(parsed.withheld.keys, ["a_images", "b_images"]);
+});
+
+test("#1934 parseHistoryEntry still delivers a SaveImage images bag unchanged", () => {
+  const parsed = parseHistoryEntry({
+    outputs: { 9: { images: [{ filename: "final.png", type: "output" }] } },
+    status: { status_str: "success", completed: true },
+  });
+  assert.equal(parsed.images.length, 1);
+  assert.equal(parsed.withheld, null);
+});
+
+// ---------------------------------------------------------------------------
+// 3. The completion frame — never "produced no media", never attaches the dump.
+// ---------------------------------------------------------------------------
+
+test("#1934 withheld-only completion names the count and attaches none", async () => {
+  const sent = [];
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "prompt-cf",
+      images: [],
+      videos: [],
+      durationMs: 3000,
+      noMedia: true,
+      withheld: { count: TOTAL, keys: ["a_images", "b_images"], types: ["temp"] },
+    },
+    frameDeps(sent),
+  );
+
+  assert.ok(frame, "a frame is produced — silence is the original defect");
+  assert.equal(sent.length, 1);
+  assert.equal(frame.images.length, 0, "the number attached does not change");
+  assert.match(frame.note, /768 outputs/);
+  assert.match(frame.note, /`a_images` and `b_images`/);
+  assert.match(frame.note, /\(temp\)/);
+  assert.match(frame.note, /None were attached/);
+  assert.match(frame.note, /media budget/);
+  assert.match(frame.note, /get_history for prompt prompt-cf/);
+  assert.match(frame.note, /get_image/);
+  assert.match(frame.note, /This IS the completion you were told to wait for/i);
+  assert.doesNotMatch(
+    frame.note,
+    /produced no image or video output/,
+    "a node with unrecognised media keys is never reported as producing nothing",
+  );
+  assert.equal(frame.metadata[0].reason, "media_budget");
+  assert.equal(frame.metadata[0].count, TOTAL);
+});
+
+test("#1934 mixed stills + withheld keeps the still attached and names the rest", async () => {
+  const sent = [];
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "prompt-mixed",
+      images: [{ filename: "final.png", type: "output" }],
+      videos: [],
+      durationMs: 1200,
+      withheld: { count: TOTAL, keys: ["a_images", "b_images"], types: ["temp"] },
+    },
+    frameDeps(sent),
+  );
+
+  assert.equal(frame.images.length, 1, "the number attached does not change");
+  assert.equal(frame.images[0].filename, "final.png");
+  assert.match(frame.note, /768 outputs/);
+  assert.match(frame.note, /were not attached/);
+  assert.doesNotMatch(frame.note, /produced no image or video output/);
+});
+
+test("#1934 formatWithheldMediaNote is the wording the frame ships", () => {
+  const note = formatWithheldMediaNote({
+    withheld: { count: TOTAL, keys: ["a_images", "b_images"], types: ["temp"] },
+    promptId: "abc",
+    durationSuffix: " in 3.0s",
+  });
+  assert.match(note, /finished successfully in 3\.0s and produced 768 outputs/);
+  assert.match(note, /get_history for prompt abc/);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Tracker — live + reconcile, the shipped completion path.
+// ---------------------------------------------------------------------------
+
+test("#1934 live panel_run of CompareFrames flushes a count, not a dump", () => {
+  const h = makeTracker();
+  const P = "prompt-live-cf";
+  const { deliverable, withheld } = collectNodeOutputMedia(compareFramesOutput());
+
+  h.tracker.onQueued(P);
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, { images: deliverable, withheld });
+  h.advance(2500);
+  h.tracker.onExecutionSuccess(P);
+
+  assert.equal(h.flushes.length, 1);
+  assert.equal(h.flushes[0].images.length, 0, "attached count stays zero");
+  assert.equal(h.flushes[0].noMedia, true);
+  assert.equal(h.flushes[0].withheld.count, TOTAL);
+  assert.deepEqual(h.flushes[0].withheld.keys, ["a_images", "b_images"]);
+});
+
+test("#1934 /history reconcile of CompareFrames recovers the count, not the dump", async () => {
+  const h = makeTracker();
+  const P = "prompt-hist-cf";
+  h.tracker.onQueued(P);
+  await h.tracker.reconcile({
+    fetchHistory: async () => ({
+      status: { status_str: "success", completed: true },
+      outputs: { 147: compareFramesOutput() },
+    }),
+    fetchQueued: async () => false,
+  });
+
+  assert.equal(h.flushes.length, 1);
+  assert.equal(h.flushes[0].images.length, 0);
+  assert.equal(h.flushes[0].noMedia, true);
+  assert.equal(h.flushes[0].reconciled, true);
+  assert.equal(h.flushes[0].withheld.count, TOTAL);
+});
+
+test("#1934 live SaveImage + CompareFrames still attaches only the SaveImage", () => {
+  const h = makeTracker();
+  const P = "prompt-mixed-live";
+  const collected = collectNodeOutputMedia({
+    images: [{ filename: "final.png", type: "output", subfolder: "" }],
+    a_images: bag("a", A_COUNT),
+  });
+
+  h.tracker.onQueued(P);
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, { images: collected.deliverable, withheld: collected.withheld });
+  h.tracker.onExecutionSuccess(P);
+
+  assert.equal(h.flushes.length, 1);
+  assert.equal(h.flushes[0].images.length, 1);
+  assert.equal(h.flushes[0].images[0].filename, "final.png");
+  assert.notEqual(h.flushes[0].noMedia, true);
+  assert.equal(h.flushes[0].withheld.count, A_COUNT);
+});
+
+test("#1934 the live executed path in the panel uses collectNodeOutputMedia", () => {
+  const src = readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
+  assert.match(src, /collectNodeOutputMedia/, "the live harvest must call the shipped splitter");
+  assert.doesNotMatch(
+    src,
+    /\[\s*\.\.\.\(out\.images \|\| \[\]\),\s*\.\.\.\(out\.gifs \|\| \[\]\),\s*\.\.\.\(out\.videos \|\| \[\]\)\s*\]/,
+    "the three-literal-key harvest is what missed CompareFrames",
+  );
+});

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -22,6 +22,7 @@ import {
 import { createRunCompletionFlushHandler } from "../../web/js/lib/run-completion-delivery.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 import { runCompletionKeyMatchesContext } from "../../web/js/lib/run-completion-persistence.js";
+import { collectNodeOutputMedia } from "../../web/js/lib/node-output-media.js";
 
 /** Deterministic scheduler: timers are held until tick() fires the due ones. */
 function makeHarness({ debounceMs = 1500, maxRearms = 40 } = {}) {
@@ -600,6 +601,7 @@ test("#1805 production event wiring: a cached completion reaches the agent frame
     "appendStoryboardCacheBust",
     "appendImageCacheBust",
     "NO_PROMPT_KEY",
+    "collectNodeOutputMedia",
     `return (runCompletion) => [
       (${panelSrc.slice(onExecutedStart, onExecutedEnd).trim()}),
       (${panelSrc.slice(
@@ -623,7 +625,8 @@ test("#1805 production event wiring: a cached completion reaches the agent frame
     // by inline-image-cache-bust.test.mjs. Kept identity-ish so the image refs
     // buffered below stay comparable.
     (url) => url,
-  NO_PROMPT_KEY,
+    NO_PROMPT_KEY,
+    collectNodeOutputMedia,
   );
 
   const registrationStart = panelSrc.indexOf(

--- a/browser_tests/unit/video-poster.test.mjs
+++ b/browser_tests/unit/video-poster.test.mjs
@@ -21,6 +21,7 @@ import {
   createStoryboardIdentity,
 } from "../../web/js/lib/storyboard-cache-identity.js";
 import { NO_PROMPT_KEY } from "../../web/js/lib/run-completion.js";
+import { collectNodeOutputMedia } from "../../web/js/lib/node-output-media.js";
 
 const panelSrc = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
 const frameSrc = readFileSync(new URL("../../web/js/lib/run-completion-frame.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
@@ -145,6 +146,7 @@ test("#1718 production boundary: late poster results stay with their render atte
     "createStoryboardIdentity",
     "appendStoryboardCacheBust",
     "NO_PROMPT_KEY",
+    "collectNodeOutputMedia",
     `return (${panelSrc.slice(onExecutedStart, onExecutedEnd).trim()});`,
   )(
     (m) => `/view?filename=${m.filename}&type=${m.type || "output"}`,
@@ -159,6 +161,7 @@ test("#1718 production boundary: late poster results stay with their render atte
     createStoryboardIdentity,
     appendStoryboardCacheBust,
     NO_PROMPT_KEY,
+    collectNodeOutputMedia,
   );
 
   const painted = [];

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -800,6 +800,7 @@ import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-re
 import { createRunFetchInterceptor, dispatchScopedRun } from "./lib/run-scope-guard.js";
 import { prunedRetryNote } from "./lib/partial-run-prune.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
+import { collectNodeOutputMedia } from "./lib/node-output-media.js";
 import {
   normalizeModels,
   presentableModels,
@@ -40433,9 +40434,11 @@ function buildPanel() {
     const out = d.output || {};
     // ComfyUI groups a node's outputs by kind: `images`, plus `gifs`/`videos` for
     // VHS-style video nodes (e.g. LTX → VHS_VideoCombine). Render each by type so a
-    // video isn't shown as a broken <img>.
-    const media = [...(out.images || []), ...(out.gifs || []), ...(out.videos || [])];
-    if (!media.length) return;
+    // video isn't shown as a broken <img>. CompareFrames (and similar) write
+    // `a_images` / `b_images` instead — those are counted as withheld, never
+    // attached, so a 768-temp dump cannot flood the completion frame (#1934).
+    const { deliverable: media, withheld } = collectNodeOutputMedia(out);
+    if (!media.length && !withheld) return;
     const nodeId = d.node ?? d.display_node ?? null;
     // Viewable images (incl. animated gifs) go inline to the agent as-is. Video
     // refs are EXCLUDED here — the agent can't decode them — and instead get a
@@ -40508,8 +40511,8 @@ function buildPanel() {
     // deferred+grouped. Routing videos through the SAME lifecycle (rather than a
     // per-node timer) is what gives a video its real start→finish duration and
     // guarantees exactly one completion per prompt (#269/#468).
-    if (inlineImages.length || videos.length) {
-      runCompletion.onExecuted(d.prompt_id, { images: inlineImages, videos });
+    if (inlineImages.length || videos.length || withheld) {
+      runCompletion.onExecuted(d.prompt_id, { images: inlineImages, videos, withheld });
     }
     // #1286 — ComfyUI keys preview images by node id and will plant
     // $$canvas-image-preview on whatever node now holds that id (a freshly

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -1,3 +1,5 @@
+import { collectNodeOutputMedia, mergeWithheldMedia } from "./node-output-media.js";
+
 // Parse a ComfyUI `/history/<prompt_id>` entry into a terminal completion batch.
 //
 // The run-completion tracker keys delivery on live WS lifecycle events
@@ -15,8 +17,10 @@
 
 /**
  * @param {object|null} entry  The per-prompt value from `/history/<id>` — i.e.
- *   `historyResponse[promptId]`, shape `{ outputs:{[nodeId]:{images?,gifs?,videos?}},
- *   status:{status_str?, completed?} }`. Pass `null` when absent.
+ *   `historyResponse[promptId]`, shape `{ outputs:{[nodeId]:{images?,gifs?,videos?,…}},
+ *   status:{status_str?, completed?} }`. Pass `null` when absent. Extra keys
+ *   ending in images/gifs/videos (CompareFrames `a_images`/`b_images`) are
+ *   counted on `withheld` and never copied into `images`/`videos` (#1934).
  * @param {object}   [opts]
  * @param {(m:object)=>boolean} [opts.isVideo]  Classifies an output ref as video
  *   (else still image), matching the live path's classification.
@@ -24,6 +28,7 @@
  *   timestamp implausibly far in the future. Injectable for tests.
  * @returns {null | { terminal:boolean, status:("success"|"error"|"interrupted"|"unknown"),
  *   images:object[], videos:{m:object,nodeId:string}[],
+ *   withheld:({ count:number, keys:string[], types:string[] }|null),
  *   startedAt:(number|null), finishedAt:(number|null) }}
  *   `null` when there's no usable entry. `startedAt`/`finishedAt` are epoch ms
  *   recovered from the entry's own lifecycle messages, or null when this entry
@@ -58,16 +63,13 @@ export function parseHistoryEntry(entry, { isVideo, now = () => Date.now() } = {
 
   const images = [];
   const videos = [];
+  let withheld = null;
   const outputs = entry.outputs && typeof entry.outputs === "object" ? entry.outputs : {};
   for (const [nodeId, out] of Object.entries(outputs)) {
     if (!out || typeof out !== "object") continue;
-    const media = [
-      ...(Array.isArray(out.images) ? out.images : []),
-      ...(Array.isArray(out.gifs) ? out.gifs : []),
-      ...(Array.isArray(out.videos) ? out.videos : []),
-    ];
-    for (const m of media) {
-      if (!m || !m.filename) continue;
+    const collected = collectNodeOutputMedia(out);
+    withheld = mergeWithheldMedia(withheld, collected.withheld);
+    for (const m of collected.deliverable) {
       if (typeof isVideo === "function" && isVideo(m)) videos.push({ m, nodeId: String(nodeId) });
       else images.push(m);
     }
@@ -85,6 +87,7 @@ export function parseHistoryEntry(entry, { isVideo, now = () => Date.now() } = {
     status: isError ? "error" : isInterrupted ? "interrupted" : isSuccess ? "success" : "unknown",
     images,
     videos,
+    withheld,
     startedAt,
     finishedAt,
   };

--- a/web/js/lib/node-output-media.js
+++ b/web/js/lib/node-output-media.js
@@ -1,0 +1,149 @@
+/**
+ * #1934 — a node's ComfyUI outputs bag is not only `images` / `gifs` / `videos`.
+ *
+ * CompareFrames writes hundreds of temp PNGs under `a_images` / `b_images`. The
+ * completion path used to read three literal keys, find nothing, and tell the
+ * agent the run produced no media. Folding those bags into the completion frame
+ * is the other lie: the frame is one turn with a per-still budget, so 768 temps
+ * would either blow it or be truncated to a handful that looks complete.
+ *
+ * The honest split is deliverable vs withheld. Standard keys still attach.
+ * Other `*images` / `*gifs` / `*videos` bags whose entries look like ComfyUI
+ * media descriptors are counted and named, and none of them ride the frame.
+ */
+
+const STANDARD_MEDIA_KEYS = ["images", "gifs", "videos"];
+const STANDARD_MEDIA_KEY_SET = new Set(STANDARD_MEDIA_KEYS);
+const MEDIA_KEY_SUFFIX = /(?:images|gifs|videos)$/;
+
+/**
+ * A ComfyUI /view descriptor: `{ filename, type, subfolder }`.
+ *
+ * Required for WIDENED keys so an arbitrary array on a node's UI result cannot
+ * be mistaken for media. `subfolder` may be omitted (ComfyUI often drops the
+ * empty string); if present it must be a string.
+ */
+export function isMediaDescriptor(entry) {
+  if (entry == null || typeof entry !== "object" || Array.isArray(entry)) return false;
+  if (typeof entry.filename !== "string" || !entry.filename) return false;
+  if (typeof entry.type !== "string") return false;
+  if (entry.subfolder != null && typeof entry.subfolder !== "string") return false;
+  return true;
+}
+
+/**
+ * Split one node's `executed` / `/history` outputs bag.
+ *
+ * `deliverable` is the existing three-key harvest (filename present is enough,
+ * matching the live path). `withheld` is the count/keys/types of every other
+ * matching bag — never a copy of the refs, so a 768-image dump cannot leak
+ * onto the completion frame by accident.
+ *
+ * @param {object|null|undefined} out
+ * @returns {{ deliverable: object[], withheld: ({ count: number, keys: string[], types: string[] }|null) }}
+ */
+export function collectNodeOutputMedia(out) {
+  const deliverable = [];
+  if (out == null || typeof out !== "object" || Array.isArray(out)) {
+    return { deliverable, withheld: null };
+  }
+
+  for (const key of STANDARD_MEDIA_KEYS) {
+    const bag = out[key];
+    if (!Array.isArray(bag)) continue;
+    for (const m of bag) {
+      if (!m || !m.filename) continue;
+      deliverable.push(m);
+    }
+  }
+
+  const keys = [];
+  const types = [];
+  let count = 0;
+  for (const [key, bag] of Object.entries(out)) {
+    if (STANDARD_MEDIA_KEY_SET.has(key)) continue;
+    if (!Array.isArray(bag) || !MEDIA_KEY_SUFFIX.test(key)) continue;
+    let keyCount = 0;
+    for (const m of bag) {
+      if (!isMediaDescriptor(m)) continue;
+      keyCount += 1;
+      if (m.type && !types.includes(m.type)) types.push(m.type);
+    }
+    if (keyCount) {
+      keys.push(key);
+      count += keyCount;
+    }
+  }
+
+  return { deliverable, withheld: count ? { count, keys, types } : null };
+}
+
+/**
+ * Combine withheld summaries from several nodes of the same prompt.
+ *
+ * @param {({ count: number, keys: string[], types: string[] }|null|undefined)} a
+ * @param {({ count: number, keys: string[], types: string[] }|null|undefined)} b
+ */
+export function mergeWithheldMedia(a, b) {
+  const left = a?.count > 0 ? a : null;
+  const right = b?.count > 0 ? b : null;
+  if (!left) return right ? cloneWithheld(right) : null;
+  if (!right) return cloneWithheld(left);
+  const keys = [...left.keys];
+  for (const key of right.keys) if (!keys.includes(key)) keys.push(key);
+  const types = [...left.types];
+  for (const type of right.types) if (!types.includes(type)) types.push(type);
+  return { count: left.count + right.count, keys, types };
+}
+
+function cloneWithheld(summary) {
+  return { count: summary.count, keys: [...summary.keys], types: [...summary.types] };
+}
+
+function formatKeyList(keys) {
+  const quoted = keys.map((key) => `\`${key}\``);
+  if (!quoted.length) return "unrecognised media keys";
+  if (quoted.length === 1) return quoted[0];
+  if (quoted.length === 2) return `${quoted[0]} and ${quoted[1]}`;
+  return `${quoted.slice(0, -1).join(", ")}, and ${quoted[quoted.length - 1]}`;
+}
+
+/**
+ * Agent-facing note for withheld media. Count and name them; attach none.
+ *
+ * @param {object} opts
+ * @param {{ count: number, keys: string[], types: string[] }} opts.withheld
+ * @param {string|null} [opts.promptId]
+ * @param {string} [opts.durationSuffix]  e.g. ` in 3.0s` (leading space included)
+ * @param {boolean} [opts.attached]  true when standard stills/videos already ride the frame
+ */
+export function formatWithheldMediaNote({
+  withheld,
+  promptId = null,
+  durationSuffix = "",
+  attached = false,
+} = {}) {
+  const count = withheld?.count ?? 0;
+  const keys = Array.isArray(withheld?.keys) ? withheld.keys : [];
+  const types = Array.isArray(withheld?.types) ? withheld.types.filter(Boolean) : [];
+  const typeSuffix = types.length ? ` (${types.join(", ")})` : "";
+  const outputWord = count === 1 ? "output" : "outputs";
+  const promptClause =
+    promptId != null && String(promptId) !== ""
+      ? `get_history for prompt ${promptId}`
+      : "get_history";
+  if (attached) {
+    return (
+      `Also produced ${count} ${outputWord} across ${formatKeyList(keys)}${typeSuffix}. ` +
+      `Those were not attached — they exceed the completion frame's media budget. ` +
+      `Read them with ${promptClause}, or fetch individually with get_image.`
+    );
+  }
+  return (
+    `The run you queued finished successfully${durationSuffix} and produced ${count} ` +
+    `${outputWord} across ${formatKeyList(keys)}${typeSuffix}. None were attached — ` +
+    `this run exceeds the completion frame's media budget. Read them with ${promptClause}, ` +
+    `or fetch individually with get_image. This IS the completion you were told to wait ` +
+    `for — nothing further is coming, so do not keep waiting for media.`
+  );
+}

--- a/web/js/lib/run-completion-delivery.js
+++ b/web/js/lib/run-completion-delivery.js
@@ -54,6 +54,7 @@ export function createRunCompletionFlushHandler({
     looksCached,
     finishedAt,
     reconciled,
+    withheld,
   }) => {
     // #370/#1824: track whether the composed completion frame reached the
     // orchestrator. A route-scoped completion key means sendFrame returning true
@@ -90,6 +91,7 @@ export function createRunCompletionFlushHandler({
         looksCached,
         finishedAt,
         reconciled,
+        withheld,
       },
       {
         sendFrame: (frame) => {

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -25,6 +25,7 @@
 import { duplicateCompletionNote } from "./completion-dedupe.js";
 import { withTimeout } from "./bounded-step.js";
 import { completionCompositionDiagnostic } from "./completion-delivery-diagnostics.js";
+import { formatWithheldMediaNote } from "./node-output-media.js";
 import {
   appendImageCacheBust,
   appendStoryboardCacheBust,
@@ -51,7 +52,8 @@ export const STILLS_METADATA_TIMEOUT_MS = 1000;
  * batch was empty (no frame emitted).
  *
  * @param {{promptId:(string|null), images?:any[], videos?:any[], durationMs:(number|null),
- *   finishedAt?:(number|null), reconciled?:boolean}} payload
+ *   finishedAt?:(number|null), reconciled?:boolean,
+ *   withheld?:({ count:number, keys:string[], types:string[] }|null)}} payload
  *   `finishedAt` is epoch ms of the run's REAL finish; `reconciled` marks a
  *   completion recovered from /history rather than observed live (#1199).
  * @param {object} deps  Injected presentation helpers (see call site).
@@ -68,6 +70,7 @@ export async function composeRunCompletionFrame(
     looksCached = false,
     finishedAt: finishedAtMs = null,
     reconciled = false,
+    withheld = null,
   },
   deps,
 ) {
@@ -245,6 +248,22 @@ export async function composeRunCompletionFrame(
     if (note) noteSections.push(note);
   }
 
+  // #1934 — CompareFrames (and similar) produce media under unrecognised keys.
+  // Count and name them; do not attach. A withheld note is content, so it also
+  // keeps a no-images flush from falling through to "produced no media".
+  const withheldSummary = withheld?.count > 0 ? withheld : null;
+  const took = durationMs != null ? ` in ${formatDuration(durationMs)}` : "";
+  if (withheldSummary) {
+    noteSections.push(
+      formatWithheldMediaNote({
+        withheld: withheldSummary,
+        promptId,
+        durationSuffix: took,
+        attached: outImages.length > 0,
+      }),
+    );
+  }
+
   // #356 Bug 2 — a run that finished with no image and no video still has to be
   // REPORTED when the agent was told to wait for it. panel_run's reply says "you
   // will be notified automatically — do NOT poll — end your turn now and wait", so
@@ -258,7 +277,6 @@ export async function composeRunCompletionFrame(
   // relied on it.
   if (!outImages.length && noteSections.length <= leadingSectionCount) {
     if (!noMedia) return null;
-    const took = durationMs != null ? ` in ${formatDuration(durationMs)}` : "";
     const frame = {
       type: "agent_event",
       kind: "executed",
@@ -286,7 +304,16 @@ export async function composeRunCompletionFrame(
     kind: "executed",
     images: outImages,
     note: noteSections.join("\n\n"),
-    metadata,
+    metadata: withheldSummary && !outImages.length
+      ? [{
+          outputs: "withheld",
+          reason: "media_budget",
+          count: withheldSummary.count,
+          keys: withheldSummary.keys,
+          types: withheldSummary.types,
+          ...recoveryMetadata(),
+        }]
+      : metadata,
     completion_diagnostics: completionDiagnostics(),
     // Machine-readable attribution: which prompt this completion belongs to, so
     // a delayed prior-run flush can never be mistaken for the current run (#224).

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -47,6 +47,7 @@
 
 import { mediaSignature, createCompletionDeduper } from "./completion-dedupe.js";
 import { parseHistoryEntry } from "./history-reconcile.js";
+import { mergeWithheldMedia } from "./node-output-media.js";
 
 export const NO_PROMPT_KEY = "__no_prompt__";
 
@@ -758,6 +759,7 @@ export function createRunCompletionTracker({
       videos: buf.videos,
       durationMs,
       finishedAt: now(),
+      ...(buf.withheld ? { withheld: buf.withheld } : {}),
       // #986 — the agent is TOLD this output was already announced, never denied it.
       // Which of a replay or a fast re-render it is cannot be proven, so the panel
       // reports what it observed and lets the reader decide.
@@ -809,7 +811,7 @@ export function createRunCompletionTracker({
   function ensureBuffer(k) {
     let buf = buffers.get(k);
     if (!buf) {
-      buf = { images: [], videos: [], timer: null, rearms: 0 };
+      buf = { images: [], videos: [], withheld: null, timer: null, rearms: 0 };
       buffers.set(k, buf);
     }
     return buf;
@@ -1002,6 +1004,7 @@ export function createRunCompletionTracker({
         // Epoch ms of the REAL finish, or null when history records none (#1199).
         finishedAt: historyFinishedAt,
         reconciled: true,
+        ...(parsed.withheld ? { withheld: parsed.withheld } : {}),
         ...(mediaLessQueued ? { noMedia: true } : {}),
       });
     }
@@ -1142,10 +1145,11 @@ export function createRunCompletionTracker({
     /**
      * ComfyUI `executed` (per output node) — buffer this prompt's outputs.
      * @param {string|null} id
-     * @param {{images?: any[], videos?: any[]}} outputs
+     * @param {{images?: any[], videos?: any[], withheld?: { count:number, keys:string[], types:string[] }|null}} outputs
      */
-    onExecuted(id, { images = [], videos = [] } = {}) {
-      if (!images.length && !videos.length) return;
+    onExecuted(id, { images = [], videos = [], withheld = null } = {}) {
+      const extra = withheld?.count > 0 ? withheld : null;
+      if (!images.length && !videos.length && !extra) return;
       // Idempotency fence: if this prompt already reached TERMINAL (a /history
       // reconcile beat the live WS, which then replayed a late `executed`), do NOT
       // re-buffer it — otherwise the trailing execution_success would flush a
@@ -1164,7 +1168,11 @@ export function createRunCompletionTracker({
       const buf = ensureBuffer(k);
       if (images.length) buf.images.push(...images);
       if (videos.length) buf.videos.push(...videos);
-      arm(k);
+      if (extra) buf.withheld = mergeWithheldMedia(buf.withheld, extra);
+      // Withheld-only must not arm the orphan timer: flush() of an empty
+      // images/videos batch deletes the buffer and would drop the count
+      // before execution_success can report it.
+      if (images.length || videos.length) arm(k);
     },
 
     /** ComfyUI `execution_success` — the authoritative flush for THIS prompt. */
@@ -1197,8 +1205,12 @@ export function createRunCompletionTracker({
       // the duration start. A keyed panel_run remains pending until its receipt.
       // Snapshot this before flush(): flush() consumes the media buffers, so
       // checking hasBufferedMedia(k) afterwards would misclassify a media run
-      // as a late media-less success.
+      // as a late media-less success. Withheld CompareFrames bags live on the
+      // same buffer and must be read here too — flush() of an empty images/
+      // videos batch returns without emitting, which is what we want (attach
+      // none) but would otherwise drop the count (#1934).
       const hasMedia = hasBufferedMedia(k);
+      const withheld = buffers.get(k)?.withheld ?? null;
       const mediaLess = !hasMedia && panelQueued.has(k);
       const mediaLessStart = mediaLess ? starts.get(k) : null;
       flush(k);
@@ -1226,6 +1238,7 @@ export function createRunCompletionTracker({
           durationMs: mediaLessStart != null ? now() - mediaLessStart : null,
           finishedAt: now(),
           noMedia: true,
+          ...(withheld ? { withheld } : {}),
         });
         terminalNoMediaSuccess.delete(k);
       } else if (!hasMedia) {
@@ -1238,6 +1251,7 @@ export function createRunCompletionTracker({
           durationMs: starts.has(k) ? finishedAt - starts.get(k) : null,
           finishedAt,
           at: finishedAt,
+          ...(withheld ? { withheld } : {}),
         });
       }
       // Retire start for runs that buffered nothing (flush early-returns then).
@@ -1392,6 +1406,7 @@ export function createRunCompletionTracker({
           durationMs: lateSuccess.durationMs,
           finishedAt: lateSuccess.finishedAt,
           noMedia: true,
+          ...(lateSuccess.withheld ? { withheld: lateSuccess.withheld } : {}),
         });
       }
       return nextKey;


### PR DESCRIPTION
Closes #1934.

## The lie

`panel_run` finished a CompareFrames node successfully and the completion said `produced no image or video output`. `get_history` for the same prompt showed 384 `a_images` and 384 `b_images` temp PNGs.

The harvest only read three literal keys — `images` / `gifs` / `videos`. CompareFrames writes neither, so the completion truthfully reported what it found: nothing.

## Why including them is the other lie

Those 768 temps cannot ride the one-frame completion. The frame is hard-bounded (panel#1906 / storyboard budget). Folding the dump in would either blow the bound or be silently truncated to a handful that looks complete — worse than the current wording.

Owner analysis on the issue: count them, name where they are, deliver none.

## What this does

`collectNodeOutputMedia` splits one node's outputs bag:

- Standard `images` / `gifs` / `videos` stay deliverable. Attached count does not change.
- Other keys ending in `images` / `gifs` / `videos` whose entries look like ComfyUI `{filename, type, subfolder}` descriptors are **withheld**: counted and named, never copied onto the frame. An arbitrary array on a UI result cannot pass the shape check.

Live `onExecuted`, `parseHistoryEntry`, the tracker flush, and `composeRunCompletionFrame` all use that split. The agent is told there were 768 outputs across `a_images` and `b_images` (temp), none were attached because they exceed the budget, and `get_history` / `get_image` is how to read them.

A node with unrecognised media keys is never reported as producing nothing.

## Tests

`browser_tests/unit/run-completion-compareframes-temp.test.mjs` drives the shipped functions. Fail if CompareFrames temps are omitted as `no media`; fail if they are attached; pass on the count-not-deliver path.