### PR TITLE
fix(1932): rebuild generated custom-widget rows after a hidden backend write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_set_widget refuses MiniMaxH3Director `timeline_data` and `builder_state` writes that leave the derived prompt stale (#1935)
 - SaveVideo keeps nested `format.codec` and drops the orphan top-level `codec`, so add and load stay queueable (#1931)
 - panel_run no longer reports CompareFrames temp images as "no media": unrecognised `*images` outputs are counted and named, and none of them are attached (#1934)
+- panel_set_widget rebuilds generated custom-widget rows after a hidden backend write, so Deno Multi LoRA (and the same pattern) updates visible rows and height without leaving and re-entering (#1932)
 
 ## [0.15.118] - 2026-08-27
 

--- a/browser_tests/unit/custom-generated-widgets-refresh.test.mjs
+++ b/browser_tests/unit/custom-generated-widgets-refresh.test.mjs
@@ -1,0 +1,391 @@
+/**
+ * Unit tests for #1932 — generated custom-widget refresh after a widget write —
+ * run with `node --test`.
+ *
+ * These drive runSetWidget(), the SAME async unit graph_set_widget delegates to,
+ * so the production path is exercised (not a parallel reimplementation).
+ *
+ * The fixtures reproduce Deno's Multi LoRA generated UI
+ * (`web/js/deno_multi_lora.js`) faithfully, because its exact split is the
+ * whole bug:
+ *
+ *     hideBackendWidgets(node);          // active_loras, lora_N, strengths, …
+ *     rebuildUi(node);                   // mint deno_multi_lora_row_1..N
+ *     function redraw(node) {            // in-node value tweak
+ *       node.setDirtyCanvas?.(true, true);
+ *     }
+ *
+ * `rebuildUi` is the only function that mints or drops rows, and it runs from
+ * setup/configure and from +Add/remove. `redraw()` never rebuilds. The panel
+ * write path updates the hidden backend widget and dirties the canvas, so
+ * `active_loras` 1→3 reported success while the visible rows/height stayed at
+ * 1 until the subgraph was left and re-entered.
+ *
+ * Invariants under test:
+ *   1. An `active_loras` write leaves generated rows matching the count, and
+ *      the result discloses the refresh (generated_widgets_refreshed + names).
+ *   2. Shrinking the count drops trailing generated rows and shrinks height.
+ *   3. A write to a hidden slot (`lora_2`) on a node whose generated list is
+ *      already behind also rebuilds, so the row that displays the value exists.
+ *   4. Keying is the PATTERN (hidden backend + serialize:false custom widgets),
+ *      never a node-type list — the LTX sibling with a different prefix refreshes
+ *      too, and a stock node is untouched.
+ *   5. The +Add generated control is never pressed (it would increment the count).
+ *   6. A rebuild that THROWS does not fail the verified write; the failure is
+ *      disclosed (generated_widgets_refresh_failed).
+ *   7. A rebuild that changes nothing is not claimed as a refresh.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import {
+  hasGeneratedCustomWidgetPattern,
+  refreshCustomGeneratedWidgetsAfterWrite,
+} from "../../web/js/lib/custom-generated-widgets-refresh.js";
+
+const REGISTRY = { DenoMultiLoraLoader: {}, DenoLTXMultiLoraLoader: {}, KSampler: {} };
+const FRESH = { DenoMultiLoraLoader: {}, DenoLTXMultiLoraLoader: {}, KSampler: {} };
+const freshOracle = { getFreshObjectInfo: async () => FRESH };
+const CANVAS = { isFakeCanvas: true };
+const NONE = "__none__";
+const LORA_OPTIONS = [NONE, "style.safetensors", "detail.safetensors"];
+
+class GeneratedRow {
+  constructor(index) {
+    this.name = `${this.constructor.prefix}row_${index}`;
+    this.type = "custom";
+    this.options = { serialize: false };
+    this.index = index;
+    this.value = "";
+  }
+}
+
+class DenoRow extends GeneratedRow {
+  static prefix = "deno_multi_lora_";
+}
+
+class LtxRow extends GeneratedRow {
+  static prefix = "deno_ltx_multi_lora_";
+}
+
+function hide(widget) {
+  widget.hidden = true;
+  widget.type = "converted-widget";
+  widget.computeSize = () => [0, -4];
+  return widget;
+}
+
+function generatedChrome(prefix) {
+  return [
+    { name: `${prefix}divider`, type: "custom", options: { serialize: false }, value: "" },
+    { name: `${prefix}header`, type: "custom", options: { serialize: false }, value: "" },
+  ];
+}
+
+function addButton(prefix, node) {
+  return {
+    name: `${prefix}add_button`,
+    type: "custom",
+    options: { serialize: false },
+    value: "",
+    presses: 0,
+    onMouseClick() {
+      this.presses += 1;
+      const count = node.widgets.find((w) => w.name === "active_loras");
+      if (count) count.value = Number(count.value) + 1;
+    },
+  };
+}
+
+/**
+ * A faithful stand-in for DenoMultiLoraLoader after setupNode/rebuildUi:
+ * hidden backend widgets, generated chrome + row_1..count + add_button,
+ * computeSize from the visible widget list, onConfigure rebuilding rows
+ * the way leaving and re-entering a subgraph does.
+ */
+function makeDenoNode({ count = 1, prefix = "deno_multi_lora_", Row = DenoRow, type = "DenoMultiLoraLoader" } = {}) {
+  const MAX = 8;
+  const node = {
+    id: 42,
+    type,
+    widgets: [],
+    size: [450, 90],
+    dirty: 0,
+    addCustomWidget(widget) {
+      this.widgets.push(widget);
+      return widget;
+    },
+    setDirtyCanvas() {
+      this.dirty += 1;
+    },
+    computeSize() {
+      const visible = this.widgets.filter((w) => !w.hidden && w.type !== "converted-widget");
+      return [450, 40 + visible.length * 24];
+    },
+  };
+
+  const backend = [];
+  backend.push(hide({ name: "active_loras", type: "number", value: count }));
+  for (let i = 1; i <= MAX; i++) {
+    backend.push(hide({ name: `enabled_${i}`, type: "toggle", value: true }));
+    backend.push(
+      hide({
+        name: `lora_${i}`,
+        type: "combo",
+        options: { values: LORA_OPTIONS.slice() },
+        value: NONE,
+      }),
+    );
+    backend.push(hide({ name: `model_strength_${i}`, type: "number", value: 1 }));
+    backend.push(hide({ name: `clip_strength_${i}`, type: "number", value: 1 }));
+  }
+  node.widgets.push(...backend);
+
+  const rebuildUi = () => {
+    const n = Number(node.widgets.find((w) => w.name === "active_loras")?.value) || 0;
+    const clamped = Math.max(0, Math.min(Math.round(n), MAX));
+    node.widgets = node.widgets.filter((w) => {
+      const name = String(w.name || "");
+      return !name.startsWith(prefix);
+    });
+    for (const chrome of generatedChrome(prefix)) node.addCustomWidget(chrome);
+    for (let i = 1; i <= clamped; i++) node.addCustomWidget(new Row(i));
+    node.addCustomWidget(addButton(prefix, node));
+    const computed = node.computeSize();
+    node.size = [Math.max(node.size[0], computed[0]), computed[1]];
+    node.setDirtyCanvas(true, true);
+  };
+
+  node.onConfigure = function () {
+    rebuildUi();
+  };
+  rebuildUi();
+  node.dirty = 0;
+  return node;
+}
+
+function generatedRowNames(node) {
+  return node.widgets
+    .filter((w) => typeof w.name === "string" && /row_\d+$/.test(w.name))
+    .map((w) => w.name);
+}
+
+test("#1932 repro: active_loras 1→3 rebuilds generated rows and discloses the new list", async () => {
+  const node = makeDenoNode({ count: 1 });
+  assert.deepEqual(generatedRowNames(node), ["deno_multi_lora_row_1"]);
+  const heightBefore = node.size[1];
+
+  const res = await runSetWidget(node, "active_loras", 3, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+
+  assert.equal(res.set.value, 3, "the write itself still reports the value that landed");
+  assert.equal(res.set.generated_widgets_refreshed, true);
+  assert.ok(res.set.generated_widgets.includes("deno_multi_lora_row_1"));
+  assert.ok(res.set.generated_widgets.includes("deno_multi_lora_row_2"));
+  assert.ok(res.set.generated_widgets.includes("deno_multi_lora_row_3"));
+  assert.deepEqual(generatedRowNames(node), [
+    "deno_multi_lora_row_1",
+    "deno_multi_lora_row_2",
+    "deno_multi_lora_row_3",
+  ]);
+  assert.ok(node.size[1] > heightBefore, "height grows with the minted rows");
+  const add = node.widgets.find((w) => w.name === "deno_multi_lora_add_button");
+  assert.equal(add.presses, 0, "the +Add control is never pressed");
+});
+
+test("#1932 shrinking the count drops trailing generated rows", async () => {
+  const node = makeDenoNode({ count: 4 });
+  const res = await runSetWidget(node, "active_loras", 2, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+
+  assert.equal(res.set.generated_widgets_refreshed, true);
+  assert.deepEqual(generatedRowNames(node), ["deno_multi_lora_row_1", "deno_multi_lora_row_2"]);
+  assert.equal(
+    node.widgets.some((w) => w.name === "deno_multi_lora_row_4"),
+    false,
+  );
+});
+
+test("#1932 WITHOUT the fix the generated rows stayed stale — dirty canvas is not a rebuild", () => {
+  const node = makeDenoNode({ count: 1 });
+  const countW = node.widgets.find((w) => w.name === "active_loras");
+  countW.value = 3;
+  node.setDirtyCanvas(true, true);
+  assert.deepEqual(
+    generatedRowNames(node),
+    ["deno_multi_lora_row_1"],
+    "redraw() dirties the canvas and does not mint rows",
+  );
+});
+
+test("#1932 a hidden lora_2 write rebuilds when the generated list is already behind", async () => {
+  const node = makeDenoNode({ count: 1 });
+  node.widgets.find((w) => w.name === "active_loras").value = 2;
+  assert.deepEqual(generatedRowNames(node), ["deno_multi_lora_row_1"], "rows have not caught up yet");
+
+  const res = await runSetWidget(node, "lora_2", "style.safetensors", {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+
+  assert.equal(res.set.value, "style.safetensors");
+  assert.equal(res.set.generated_widgets_refreshed, true);
+  assert.deepEqual(generatedRowNames(node), ["deno_multi_lora_row_1", "deno_multi_lora_row_2"]);
+});
+
+test("the LTX sibling with a different prefix still refreshes — keying is the pattern", async () => {
+  const node = makeDenoNode({
+    count: 1,
+    prefix: "deno_ltx_multi_lora_",
+    Row: LtxRow,
+    type: "DenoLTXMultiLoraLoader",
+  });
+  const res = await runSetWidget(node, "active_loras", 2, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.generated_widgets_refreshed, true);
+  assert.deepEqual(generatedRowNames(node), ["deno_ltx_multi_lora_row_1", "deno_ltx_multi_lora_row_2"]);
+});
+
+test("a stock node without the pattern is untouched and nothing is claimed", async () => {
+  const widget = { name: "steps", type: "number", value: 20 };
+  const node = { id: 3, type: "KSampler", widgets: [widget] };
+  const res = await runSetWidget(node, "steps", 30, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.value, 30);
+  assert.equal("generated_widgets_refreshed" in res.set, false);
+  assert.equal("generated_widgets" in res.set, false);
+  assert.equal("generated_widgets_refresh_failed" in res.set, false);
+});
+
+test("a rebuild that changes NOTHING is not reported as a refresh", async () => {
+  const node = makeDenoNode({ count: 2 });
+  const res = await runSetWidget(node, "active_loras", 2, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.value, 2);
+  assert.equal("generated_widgets_refreshed" in res.set, false, "nothing changed ⇒ nothing claimed");
+});
+
+test("a rebuild that THROWS does not fail the verified write; the failure is disclosed", async () => {
+  const node = makeDenoNode({ count: 1 });
+  node.onConfigure = () => {
+    throw new Error("pack code exploded");
+  };
+  const res = await runSetWidget(node, "active_loras", 3, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.value, 3, "the write is still reported as the verified success it is");
+  // Sync constructor-clone still mints rows after the throwing onConfigure, so the
+  // list may have moved — either way the throw is disclosed and the write is not
+  // rethrown.
+  assert.equal(typeof res.set.generated_widgets_refresh_failed, "string");
+  assert.match(res.set.generated_widgets_refresh_failed, /succeeded and was verified/);
+  assert.match(res.set.generated_widgets_refresh_failed, /pack code exploded/);
+  assert.equal("generated_widgets_refreshed" in res.set, false);
+});
+
+test("the refresh is bracketed by the command's undo-history hooks", async () => {
+  const node = makeDenoNode({ count: 1 });
+  let before = 0;
+  let after = 0;
+  const res = await runSetWidget(node, "active_loras", 3, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+    beforeChange: () => {
+      before += 1;
+    },
+    afterChange: () => {
+      after += 1;
+    },
+  });
+  assert.equal(res.set.generated_widgets_refreshed, true);
+  // One pair for the write itself, one pair for the generated-widget rebuild.
+  assert.equal(before, 2);
+  assert.equal(after, 2);
+});
+
+test("rows still mint when onConfigure is absent, from the existing row constructor", async () => {
+  const node = makeDenoNode({ count: 1 });
+  delete node.onConfigure;
+  const res = await runSetWidget(node, "active_loras", 3, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.generated_widgets_refreshed, true);
+  assert.deepEqual(generatedRowNames(node), [
+    "deno_multi_lora_row_1",
+    "deno_multi_lora_row_2",
+    "deno_multi_lora_row_3",
+  ]);
+});
+
+test("0→1 uses onConfigure when there is no row constructor to clone", async () => {
+  const node = makeDenoNode({ count: 0 });
+  assert.deepEqual(generatedRowNames(node), []);
+  const res = await runSetWidget(node, "active_loras", 1, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.generated_widgets_refreshed, true);
+  assert.deepEqual(generatedRowNames(node), ["deno_multi_lora_row_1"]);
+});
+
+// ── the lib's own contract, driven directly ──────────────────────────────────
+
+test("hasGeneratedCustomWidgetPattern requires hidden backend AND serialize:false custom widgets", () => {
+  assert.equal(hasGeneratedCustomWidgetPattern(makeDenoNode({ count: 1 })), true);
+  assert.equal(hasGeneratedCustomWidgetPattern({ widgets: [{ name: "steps", type: "number", value: 20 }] }), false);
+  assert.equal(
+    hasGeneratedCustomWidgetPattern({
+      widgets: [{ name: "active_loras", hidden: true, type: "converted-widget", value: 1 }],
+    }),
+    false,
+    "hidden backend alone is not the pattern",
+  );
+  assert.equal(
+    hasGeneratedCustomWidgetPattern({
+      widgets: [{ name: "row_1", type: "custom", options: { serialize: false } }],
+    }),
+    false,
+    "generated chrome alone is not the pattern",
+  );
+  assert.equal(hasGeneratedCustomWidgetPattern({}), false);
+  assert.equal(hasGeneratedCustomWidgetPattern(null), false);
+});
+
+test("refreshCustomGeneratedWidgetsAfterWrite returns null when there is no pattern, and never throws", () => {
+  assert.equal(refreshCustomGeneratedWidgetsAfterWrite({ id: 1 }), null);
+  assert.equal(refreshCustomGeneratedWidgetsAfterWrite(null), null);
+  const hostile = {};
+  Object.defineProperty(hostile, "widgets", {
+    get() {
+      throw new Error("nope");
+    },
+  });
+  const out = refreshCustomGeneratedWidgetsAfterWrite(hostile);
+  assert.ok(
+    out === null || typeof out.failed === "string",
+    "hostile reads degrade to a disclosure, never a throw",
+  );
+});

--- a/web/js/lib/custom-generated-widgets-refresh.js
+++ b/web/js/lib/custom-generated-widgets-refresh.js
@@ -1,0 +1,454 @@
+/**
+ * #1932 — after `panel_set_widget` writes a hidden backend widget, a node's
+ * generated custom-widget UI stayed STALE.
+ *
+ * ## The mechanism this works around, read from the pack
+ *
+ * Deno's Multi LoRA loaders (`DenoMultiLoraLoader`, `DenoLTXMultiLoraLoader`,
+ * `web/js/deno_multi_lora.js` / `deno_ltx_multi_lora.js`) keep the values the
+ * backend actually reads on HIDDEN widgets (`active_loras`, `lora_N`,
+ * strengths, …) and draw a generated row UI on top:
+ *
+ *     this.options = { serialize: false };
+ *     this.name = `${GENERATED_PREFIX}row_${index}`;   // type "custom"
+ *
+ * `rebuildUi()` is the only function that mints or drops those rows, and it
+ * runs from setup/configure and from the node's own +Add / remove handlers.
+ * `redraw()` — what an in-node value tweak calls — only `setDirtyCanvas()`s.
+ * It does not rebuild rows, and it does not recompute height.
+ *
+ * `panel_set_widget` writes the hidden backend widget (and dirties the canvas)
+ * the way an interactive edit of that widget would. There is no interactive
+ * edit of the hidden widget: the user clicks generated rows, which call
+ * `rebuildUi`. So a write to `active_loras` 1→3 (or to `lora_2` on a node
+ * whose generated list was already one row behind) reported success while
+ * the visible rows/height stayed at the previous count until the subgraph
+ * was left and re-entered — which is `onConfigure` → `setupNode` → `rebuildUi`.
+ *
+ * ## What this does
+ *
+ * After a write has succeeded and been verified, if the node the write landed
+ * on carries that pattern — hidden backend widgets PLUS generated
+ * non-serialized custom widgets — rebuild the generated rows to match the
+ * hidden `active_loras` count, recompute size, and dirty the canvas. The
+ * rebuild is the pack's own:
+ *
+ *   1. `onConfigure()` is the public re-entry the workaround already used
+ *      (Deno queues `setupNode` from it). Invoked when present.
+ *   2. Generated row widgets are then reconciled synchronously from an
+ *      existing row's constructor (`new RowCtor(index)`), because Deno's
+ *      `onConfigure` is a `queueMicrotask` and a caller that reads the node
+ *      in the same turn must see the new rows without waiting for paint.
+ *
+ * ## Why it is keyed this way
+ *
+ * NOT keyed on node.type: the two Deno loaders already share the pattern
+ * under different type names and generated-name prefixes, and a third pack
+ * that hides backend widgets behind serialize:false custom rows would
+ * silently keep the stale-UI behaviour. The key is the PATTERN itself.
+ *
+ * The +Add generated control is NEVER pressed. Auto-pressing it would
+ * increment `active_loras` (the #757 / pressable-widget.js lesson: a
+ * generic "this node has one button" rule mutates the graph on a typo).
+ * Rows are minted only to MATCH a count the write already stored.
+ *
+ * ## What it reports
+ *
+ *   - generated widget names or node size changed → `{ refreshed: true, widgets: [...] }`
+ *   - the rebuild threw → `{ failed: <sentence> }` (and `widgets` when the
+ *     list moved before the throw). Never thrown over a verified write.
+ *   - no such pattern, or the rebuild changed nothing → `null`.
+ *
+ * Never throws.
+ */
+
+const reflectApply = Reflect.apply;
+const MAX_SLOT_GUARD = 32;
+
+function coerceThrowMessage(err) {
+  try {
+    const msg = err?.message;
+    if (typeof msg === "string" && msg) return msg;
+    return String(err);
+  } catch {
+    return "the reason could not be rendered";
+  }
+}
+
+function widgetName(widget) {
+  try {
+    return typeof widget?.name === "string" ? widget.name : null;
+  } catch {
+    return null;
+  }
+}
+
+function isHiddenBackendWidget(widget) {
+  try {
+    if (!widget) return false;
+    if (widget.hidden === true) return true;
+    return widget.type === "converted-widget";
+  } catch {
+    return false;
+  }
+}
+
+function isGeneratedCustomWidget(widget) {
+  try {
+    if (!widget) return false;
+    if (isHiddenBackendWidget(widget)) return false;
+    const serialize = widget.options?.serialize;
+    return serialize === false;
+  } catch {
+    return false;
+  }
+}
+
+function readWidgets(node) {
+  try {
+    return Array.isArray(node?.widgets) ? node.widgets : null;
+  } catch {
+    return null;
+  }
+}
+
+function generatedNames(node) {
+  const widgets = readWidgets(node);
+  if (!widgets) return [];
+  const names = [];
+  for (const widget of widgets) {
+    if (!isGeneratedCustomWidget(widget)) continue;
+    names.push(widgetName(widget));
+  }
+  return names;
+}
+
+function sameNames(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function readSize(node) {
+  try {
+    const size = node?.size;
+    if (!Array.isArray(size) || size.length < 2) return [null, null];
+    return [size[0], size[1]];
+  } catch {
+    return [null, null];
+  }
+}
+
+function snapshot(node) {
+  const size = readSize(node);
+  return { names: generatedNames(node), size0: size[0], size1: size[1] };
+}
+
+function snapshotsEqual(a, b) {
+  return sameNames(a.names, b.names) && Object.is(a.size0, b.size0) && Object.is(a.size1, b.size1);
+}
+
+/**
+ * True when the node hides backend widgets AND draws generated custom widgets
+ * that do not serialize — the Deno Multi LoRA pattern. Never throws.
+ *
+ * @param {object} node
+ */
+export function hasGeneratedCustomWidgetPattern(node) {
+  try {
+    const widgets = readWidgets(node);
+    if (!widgets || !widgets.length) return false;
+    let hidden = false;
+    let generated = false;
+    for (const widget of widgets) {
+      if (!hidden && isHiddenBackendWidget(widget)) hidden = true;
+      if (!generated && isGeneratedCustomWidget(widget)) generated = true;
+      if (hidden && generated) return true;
+    }
+  } catch {
+    /* an unreadable node does not match */
+  }
+  return false;
+}
+
+function rowIndexOf(widget) {
+  try {
+    const name = widgetName(widget);
+    if (typeof name === "string") {
+      const match = /row_(\d+)$/.exec(name);
+      if (match) return Number(match[1]);
+    }
+    const index = widget?.index;
+    if (typeof index === "number" && Number.isFinite(index) && index >= 1) return index;
+  } catch {
+    /* not a row */
+  }
+  return null;
+}
+
+function hiddenCountWidget(widgets) {
+  for (const widget of widgets) {
+    try {
+      if (isHiddenBackendWidget(widget) && widgetName(widget) === "active_loras") return widget;
+    } catch {
+      /* skip */
+    }
+  }
+  return null;
+}
+
+function hiddenSlotCeiling(widgets) {
+  let max = 0;
+  for (const widget of widgets) {
+    try {
+      if (!isHiddenBackendWidget(widget)) continue;
+      const name = widgetName(widget);
+      if (!name) continue;
+      const match = /^(?:lora|enabled|model_strength|clip_strength|strength|video|audio|trigger|description)_(\d+)$/.exec(
+        name,
+      );
+      if (match) max = Math.max(max, Number(match[1]));
+    } catch {
+      /* skip */
+    }
+  }
+  return max;
+}
+
+function targetRowCount(node) {
+  const widgets = readWidgets(node);
+  if (!widgets) return null;
+  const countWidget = hiddenCountWidget(widgets);
+  if (!countWidget) return null;
+  let raw;
+  try {
+    raw = Number(countWidget.value);
+  } catch {
+    return null;
+  }
+  const n = Number.isFinite(raw) ? Math.round(raw) : 0;
+  const ceiling = hiddenSlotCeiling(widgets) || MAX_SLOT_GUARD;
+  return Math.max(0, Math.min(n, ceiling, MAX_SLOT_GUARD));
+}
+
+function removeStaleRowElement(widget) {
+  try {
+    const element = widget?.element;
+    if (!element) return;
+    if (element.parentNode && typeof element.parentNode.removeChild === "function") {
+      element.parentNode.removeChild(element);
+      return;
+    }
+    if (typeof element.remove === "function") element.remove();
+  } catch {
+    /* DOM teardown is best-effort */
+  }
+}
+
+function mintedRowLooksRight(row, index) {
+  try {
+    if (!row || typeof row !== "object") return false;
+    if (rowIndexOf(row) === index) return true;
+    const name = widgetName(row);
+    return typeof name === "string" && name.endsWith(`row_${index}`);
+  } catch {
+    return false;
+  }
+}
+
+function insertRow(node, row) {
+  const widgets = readWidgets(node);
+  if (!widgets) return false;
+  if (typeof node.addCustomWidget === "function") {
+    try {
+      reflectApply(node.addCustomWidget, node, [row]);
+    } catch {
+      /* fall through to splice onto whatever array we can still see */
+    }
+  }
+  const live = readWidgets(node);
+  if (!live) return false;
+  if (!live.includes(row)) live.push(row);
+  const at = live.indexOf(row);
+  const addIdx = live.findIndex((widget, i) => {
+    if (i === at) return false;
+    const name = widgetName(widget);
+    return typeof name === "string" && name.endsWith("add_button");
+  });
+  if (addIdx >= 0 && at >= 0 && at !== addIdx) {
+    live.splice(at, 1);
+    live.splice(at < addIdx ? addIdx - 1 : addIdx, 0, row);
+  }
+  return live.includes(row);
+}
+
+function dropRowsAbove(node, target) {
+  const widgets = readWidgets(node);
+  if (!widgets) return;
+  const kept = [];
+  for (const widget of widgets) {
+    const index = isGeneratedCustomWidget(widget) ? rowIndexOf(widget) : null;
+    if (index != null && index > target) {
+      removeStaleRowElement(widget);
+      continue;
+    }
+    kept.push(widget);
+  }
+  if (kept.length === widgets.length) return;
+  try {
+    node.widgets = kept;
+  } catch {
+    widgets.length = 0;
+    for (const widget of kept) widgets.push(widget);
+  }
+}
+
+function existingRows(node) {
+  const widgets = readWidgets(node);
+  const byIndex = new Map();
+  if (!widgets) return byIndex;
+  for (const widget of widgets) {
+    if (!isGeneratedCustomWidget(widget)) continue;
+    const index = rowIndexOf(widget);
+    if (index == null) continue;
+    if (!byIndex.has(index)) byIndex.set(index, widget);
+  }
+  return byIndex;
+}
+
+function rowConstructor(rows) {
+  for (const widget of rows.values()) {
+    try {
+      if (typeof widget?.constructor === "function") return widget.constructor;
+    } catch {
+      /* skip */
+    }
+  }
+  return null;
+}
+
+function reconcileGeneratedRows(node) {
+  const target = targetRowCount(node);
+  if (target == null) return;
+  dropRowsAbove(node, target);
+  if (target < 1) return;
+  const rows = existingRows(node);
+  const Ctor = rowConstructor(rows);
+  if (typeof Ctor !== "function") return;
+  for (let index = 1; index <= target; index++) {
+    if (rows.has(index)) continue;
+    let minted = null;
+    try {
+      minted = new Ctor(index);
+    } catch {
+      continue;
+    }
+    if (!mintedRowLooksRight(minted, index)) continue;
+    if (insertRow(node, minted)) rows.set(index, minted);
+  }
+}
+
+function recomputeSize(node) {
+  try {
+    const computed = typeof node.computeSize === "function" ? node.computeSize() : null;
+    if (!Array.isArray(computed) || computed.length < 2) return;
+    const next0 = computed[0];
+    const next1 = computed[1];
+    if (!Array.isArray(node.size)) {
+      node.size = [next0, next1];
+      return;
+    }
+    const cur0 = Number(node.size[0]);
+    node.size[0] = Number.isFinite(cur0) ? Math.max(cur0, Number(next0) || 0) : next0;
+    node.size[1] = next1;
+  } catch {
+    /* size is presentation; a throw must not fail a rebuild that already minted rows */
+  }
+}
+
+function dirtyCanvas(node, setDirty) {
+  try {
+    setDirty?.();
+  } catch {
+    /* a repaint hint is cosmetic */
+  }
+  try {
+    node.setDirtyCanvas?.(true, true);
+  } catch {
+    /* same */
+  }
+}
+
+/**
+ * Rebuild generated custom-widget rows after a successful write.
+ *
+ * Call ONLY from the synchronous write boundary of a write that has already
+ * succeeded and been verified — minting/dropping widgets is a graph mutation,
+ * so it must not sit across an await.
+ *
+ * @returns {null | { refreshed: true, widgets: (string|null)[] } | { failed: string, widgets?: (string|null)[] }}
+ */
+export function refreshCustomGeneratedWidgetsAfterWrite(node, { beforeChange, afterChange, setDirty } = {}) {
+  try {
+    if (!hasGeneratedCustomWidgetPattern(node)) return null;
+
+    const before = snapshot(node);
+    try {
+      beforeChange?.();
+    } catch {
+      /* history hook is best-effort */
+    }
+    let threw = null;
+    try {
+      // Pack-owned re-entry. Deno rebuilds generated rows from onConfigure →
+      // setupNode → rebuildUi (the same path leaving and re-entering a subgraph
+      // takes). Arguments are not supplied: this is a refresh of widgets already
+      // on the node, not a deserialize.
+      if (typeof node.onConfigure === "function") {
+        reflectApply(node.onConfigure, node, []);
+      }
+    } catch (err) {
+      threw = err;
+    }
+    try {
+      // Constructor-clone is independent of onConfigure: Deno queues setupNode
+      // on a microtask, and a throwing onConfigure must not skip the sync mint
+      // that makes the new rows visible in this turn.
+      reconcileGeneratedRows(node);
+      recomputeSize(node);
+    } catch (err) {
+      threw = threw ?? err;
+    } finally {
+      try {
+        afterChange?.();
+      } catch {
+        /* history hook is best-effort */
+      }
+    }
+
+    const after = snapshot(node);
+    const changed = !snapshotsEqual(before, after);
+    dirtyCanvas(node, setDirty);
+
+    if (threw) {
+      return {
+        failed:
+          `The write itself succeeded and was verified, but rebuilding the node's generated ` +
+          `custom widgets threw (${coerceThrowMessage(threw)}), so its visible rows may still ` +
+          `be stale${changed ? " — and may be PARTIALLY rebuilt, because the list changed before it threw" : ""}. ` +
+          `Read the node with panel_query_graph before relying on its widgets.`,
+        ...(changed ? { widgets: after.names } : {}),
+      };
+    }
+
+    if (!changed) return null;
+    return { refreshed: true, widgets: after.names };
+  } catch (err) {
+    return {
+      failed:
+        `The write itself succeeded and was verified, but refreshing the node's generated ` +
+        `custom widgets afterwards failed (${coerceThrowMessage(err)}), so they may still be ` +
+        `stale. Read the node with panel_query_graph before relying on its widgets.`,
+    };
+  }
+}

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -15,9 +15,11 @@
 //      on a genuinely-resolved direct node (never a placeholder).
 //   3. applyWidgetWrite with the resolved-target registry guard, which runs
 //      BEFORE value coercion and any mutation/callback.
-// Post-write, inside the same synchronous boundary (#1282): refresh the node's
-// dynamic input slots via its own "Update inputs"-style control when it exposes
-// one — disclosed on the success result, never thrown over a verified write.
+// Post-write, inside the same synchronous boundary (#1282, #1932): refresh the
+// node's dynamic input slots via its own "Update inputs"-style control when it
+// exposes one, and rebuild generated custom-widget rows that view hidden
+// backend widgets — disclosed on the success result, never thrown over a
+// verified write.
 
 import {
   applyWidgetWrite,
@@ -40,6 +42,7 @@ import { controlAfterGenerateWarning, controlEntryForWidget } from "./control-af
 import { isTypeScopedObjectInfo } from "./scoped-object-info.js";
 import { linkDrivenWidgets, drivenTag } from "./graph-read.js";
 import { refreshDynamicInputsAfterWrite } from "./dynamic-inputs-refresh.js";
+import { refreshCustomGeneratedWidgetsAfterWrite } from "./custom-generated-widgets-refresh.js";
 import { REFRESH_JOIN_ABANDONED } from "./refresh-coalesce.js";
 import {
   uploadInputConfig,
@@ -839,21 +842,48 @@ export async function runSetWidget(
       // never thrown over a verified write. The press runs inside its own
       // before/afterChange bracket so the slot changes join the command's undo
       // history.
-      const refresh = refreshDynamicInputsAfterWrite(resolvedTargetNode ?? node, {
+      const targetNode = resolvedTargetNode ?? node;
+      const refresh = refreshDynamicInputsAfterWrite(targetNode, {
         canvas,
         beforeChange,
         afterChange,
         setDirty,
       });
-      if (!refresh) return set;
-      if (refresh.failed) {
-        return {
-          ...set,
+      // #1932 — REBUILD GENERATED CUSTOM WIDGETS after the write. Deno Multi LoRA
+      // (and the LTX sibling) hide the backend widgets panel_set_widget writes and
+      // draw serialize:false custom rows on top. Their redraw() only dirties the
+      // canvas, so active_loras 1→3 reported success while the visible rows/height
+      // stayed at 1 until the subgraph was left and re-entered. Keyed on that
+      // pattern, not a node-type list — see lib/custom-generated-widgets-refresh.js.
+      // Same containment as the #1282 press: a rebuild failure is DISCLOSED on
+      // the success result, never thrown over a verified write.
+      const generated = refreshCustomGeneratedWidgetsAfterWrite(targetNode, {
+        canvas,
+        beforeChange,
+        afterChange,
+        setDirty,
+      });
+      let out = set;
+      if (refresh?.failed) {
+        out = {
+          ...out,
           dynamic_inputs_refresh_failed: refresh.failed,
           ...(refresh.inputs ? { dynamic_inputs: refresh.inputs } : {}),
         };
+      } else if (refresh?.refreshed) {
+        out = { ...out, dynamic_inputs_refreshed: true, dynamic_inputs: refresh.inputs };
       }
-      return { ...set, dynamic_inputs_refreshed: true, dynamic_inputs: refresh.inputs };
+      if (generated?.failed) {
+        return {
+          ...out,
+          generated_widgets_refresh_failed: generated.failed,
+          ...(generated.widgets ? { generated_widgets: generated.widgets } : {}),
+        };
+      }
+      if (generated?.refreshed) {
+        return { ...out, generated_widgets_refreshed: true, generated_widgets: generated.widgets };
+      }
+      return out;
     } catch (err) {
       // The write refused over a target this attempt had just created. Undo it in the same
       // synchronous stretch, so the graph the refusal is reported over is the graph the


### PR DESCRIPTION
Closes #1932.

## The stale generated UI

`panel_set_widget` can update hidden backend widgets on `DenoMultiLoraLoader` (`active_loras`, `lora_N`, slot strengths), but the node's generated frontend rows are not rebuilt.

Deno's `redraw()` only `setDirtyCanvas()`s. `rebuildUi()` — the only function that mints or drops rows, and recomputes height — runs from setup/configure and from +Add/remove. Graph inspection showed the new value; the visible rows/height stayed stale until leaving and re-entering the subgraph.

## What this does instead

A shipped helper, `refreshCustomGeneratedWidgetsAfterWrite`:

1. **Keyed on the pattern, not a type list.** Hidden backend widgets PLUS `options.serialize === false` custom widgets. The LTX sibling (`DenoLTXMultiLoraLoader`) refreshes too; a stock node is untouched.
2. **Pack-owned rebuild.** `onConfigure()` is the public re-entry the workaround already used (Deno queues `setupNode` → `rebuildUi` from it). Generated rows are then reconciled synchronously from an existing row constructor so a same-turn read sees them — Deno's `onConfigure` is a `queueMicrotask`.
3. **+Add is never pressed.** Auto-pressing it would increment `active_loras`. Rows are minted only to MATCH a count the write already stored.
4. **Effect-verified.** Changed generated names/size → `generated_widgets_refreshed`. A throwing rebuild is disclosed on the success result, never thrown over a verified write. Same containment as #1282.

`runSetWidget` calls it after the dynamic-input refresh, inside the same synchronous write boundary.

## Evidence

Production `runSetWidget` (eval of the shipped executor):

- `active_loras` 1→3 mints `row_2`/`row_3` and grows height
- shrinking drops trailing rows
- dirty canvas alone does not rebuild (the pack's `redraw()`)
- a behind-the-count `lora_2` write rebuilds so the displaying row exists
- LTX prefix still refreshes; KSampler is untouched
- +Add is never pressed

Helper tests fail on silent skip; pass when the new path rebuilds or discloses.

**Suite:** 7203 tests, **7202 pass, 0 fail** (1 pre-existing todo).
