### PR TITLE
fix(1922): retain the first widget write on a just-added primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 - SaveVideo keeps nested `format.codec` and drops the orphan top-level `codec`, so add and load stay queueable (#1931)
 - panel_run no longer reports CompareFrames temp images as "no media": unrecognised `*images` outputs are counted and named, and none of them are attached (#1934)
 - panel_set_widget rebuilds generated custom-widget rows after a hidden backend write, so Deno Multi LoRA (and the same pattern) updates visible rows and height without leaving and re-entering (#1932)
+- panel_set_widget no longer reports success when a just-added primitive's frontend init later clears the value (#1922)
 
 ## [0.15.118] - 2026-08-27
 

--- a/browser_tests/unit/primitive-widget-retain.test.mjs
+++ b/browser_tests/unit/primitive-widget-retain.test.mjs
@@ -1,0 +1,212 @@
+/**
+ * #1922 — `panel_set_widget` on a just-added PrimitiveStringMultiline can report
+ * success while a later frontend init (Vue mount / widget-value store) still
+ * replaces `value` with "". Repeating the identical write then sticks.
+ *
+ * These drive `runSetWidget()`, the SAME async unit `graph_set_widget` delegates
+ * to, so the production write path is exercised — not a parallel reimplementation.
+ *
+ * The unfixed race is: immediate verification sees the new string, the call
+ * returns ok, then a microtask+rAF initializer writes the empty default back.
+ * After that later init, the test requires either (a) the written value is still
+ * there or (b) the call threw. Success-then-empty is the lie this issue forbids.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { runSetWidget, awaitFrontendWidgetFlush } from "../../web/js/lib/set-widget.js";
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+const REGISTRY = { PrimitiveStringMultiline: {} };
+const FRESH = { PrimitiveStringMultiline: {} };
+const freshOracle = { getFreshObjectInfo: async () => FRESH };
+
+// The reporter's payload: a Windows glob written to a brand-new multiline primitive.
+const PATH = "X:\\root\\extra*\\**\\*";
+
+function makePrimitive(initial = "") {
+  let current = initial;
+  const widget = {
+    name: "value",
+    type: "customtext",
+    get value() {
+      return current;
+    },
+    set value(next) {
+      current = next;
+    },
+  };
+  const node = {
+    id: 12,
+    type: "PrimitiveStringMultiline",
+    widgets: [widget],
+  };
+  return { node, widget, read: () => current, write: (next) => { current = next; } };
+}
+
+async function drainFrontend() {
+  await new Promise((resolve) => queueMicrotask(resolve));
+  await new Promise((resolve) => queueMicrotask(resolve));
+  await new Promise((resolve) => queueMicrotask(resolve));
+}
+
+test("graph_set_widget still delegates the write to runSetWidget", () => {
+  const start = PANEL_SRC.indexOf("async graph_set_widget({");
+  const end = PANEL_SRC.indexOf("\n  // artokun/comfyui-mcp#938", start);
+  assert.ok(start >= 0, "graph_set_widget handler not found");
+  assert.ok(end > start, "graph_set_widget handler boundary not found");
+  const handler = PANEL_SRC.slice(start, end);
+  assert.ok(
+    handler.includes("await runSetWidget(node, widget, value, setWidgetOpts)"),
+    "the shipped handler must still await runSetWidget — a bypass would skip #1922's flush",
+  );
+});
+
+test("#1922: a later empty init cannot ride on a successful first write", async () => {
+  const { node, widget, read, write } = makePrimitive("");
+  let initRan = false;
+  const frontendInit = () => {
+    if (initRan) return;
+    initRan = true;
+    write("");
+  };
+
+  let thrown = null;
+  let res = null;
+  try {
+    res = await runSetWidget(node, "value", PATH, {
+      registry: REGISTRY,
+      ...freshOracle,
+      awaitFrontendWidgetFlush: async () => {
+        frontendInit();
+      },
+    });
+  } catch (err) {
+    thrown = err;
+  }
+  // The real frontend init is not owned by the write: if production returned
+  // before waiting, this is the overwrite the reporter then read.
+  frontendInit();
+  await drainFrontend();
+
+  if (thrown) {
+    assert.match(
+      String(thrown.message),
+      /did not retain|frontend widget store/i,
+      "a refusal must name the retention failure, not some unrelated gate",
+    );
+  } else {
+    assert.equal(res?.set?.value, PATH);
+    assert.equal(read(), PATH, "must not report success then lose the value to frontend init");
+    assert.equal(widget.value, PATH);
+  }
+});
+
+test("#1922: the first write is retained when init overwrites once then settles", async () => {
+  const { node, read, write } = makePrimitive("");
+  let initRan = false;
+  const res = await runSetWidget(node, "value", PATH, {
+    registry: REGISTRY,
+    ...freshOracle,
+    awaitFrontendWidgetFlush: async () => {
+      if (initRan) return;
+      initRan = true;
+      write("");
+    },
+  });
+  assert.equal(res.set.value, PATH);
+  assert.equal(read(), PATH);
+});
+
+test("#1922: a store that keeps reverting refuses instead of reporting success", async () => {
+  const { node, write, read } = makePrimitive("");
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "value", PATH, {
+        registry: REGISTRY,
+        ...freshOracle,
+        awaitFrontendWidgetFlush: async () => {
+          write("");
+        },
+      }),
+    (err) => {
+      assert.match(String(err.message), /did not retain|frontend widget store/i);
+      assert.equal(read(), "", "the lying success path is the one that returns ok while empty");
+      return true;
+    },
+  );
+});
+
+test("#1922: an ordinary write is unchanged when nothing overwrites after the flush", async () => {
+  const { node, read } = makePrimitive("old");
+  const res = await runSetWidget(node, "value", PATH, {
+    registry: REGISTRY,
+    ...freshOracle,
+  });
+  assert.equal(res.set.value, PATH);
+  assert.equal(res.set.previous, "old");
+  assert.equal(read(), PATH);
+});
+
+test("#1922: the default flush observes an rAF overwrite the immediate check would miss", async () => {
+  const previousRaf = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = (cb) => {
+    queueMicrotask(() => cb(0));
+    return 1;
+  };
+  try {
+    const primitive = makePrimitive("");
+    let armed = false;
+    Object.defineProperty(primitive.widget, "value", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return primitive.read();
+      },
+      set(next) {
+        primitive.write(next);
+        if (next === PATH && !armed) {
+          armed = true;
+          requestAnimationFrame(() => {
+            if (primitive.read() === PATH) primitive.write("");
+          });
+        }
+      },
+    });
+
+    const res = await runSetWidget(primitive.node, "value", PATH, {
+      registry: REGISTRY,
+      ...freshOracle,
+    });
+    await drainFrontend();
+    assert.equal(res.set.value, PATH);
+    assert.equal(primitive.read(), PATH, "default flush must see the rAF init overwrite");
+  } finally {
+    if (previousRaf === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = previousRaf;
+  }
+});
+
+test("#1922: awaitFrontendWidgetFlush waits for a queued animation frame", async () => {
+  const previousRaf = globalThis.requestAnimationFrame;
+  const calls = [];
+  globalThis.requestAnimationFrame = (cb) => {
+    calls.push(cb);
+    queueMicrotask(() => cb(0));
+    return calls.length;
+  };
+  try {
+    let sawFrame = false;
+    requestAnimationFrame(() => {
+      sawFrame = true;
+    });
+    await awaitFrontendWidgetFlush();
+    assert.equal(sawFrame, true, "the production flush must not resolve before rAF");
+    assert.ok(calls.length >= 1);
+  } finally {
+    if (previousRaf === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = previousRaf;
+  }
+});

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -20,6 +20,11 @@
 // exposes one, and rebuild generated custom-widget rows that view hidden
 // backend widgets — disclosed on the success result, never thrown over a
 // verified write.
+// After that stretch returns, #1922 waits for a frontend flush (microtask + rAF)
+// and re-reads the written widget: a just-added primitive can pass the immediate
+// check and then be cleared by Vue mount / widget-store init. The first write is
+// re-applied once after that overwrite; if it still does not hold, the call
+// refuses instead of reporting success.
 
 import {
   applyWidgetWrite,
@@ -95,6 +100,46 @@ function coerceAdvisoryMessage(err) {
  * call so the two can never disagree.
  */
 export const COMBO_REFRESH_NEVER_RAN = Symbol("combo-refresh-never-ran");
+
+/**
+ * #1922 — wait until a just-added node's frontend widget store has had a chance
+ * to initialize.
+ *
+ * Vue DOM widgets (PrimitiveStringMultiline `value` is one) capture their empty
+ * default at setup and write it back on mount, which lands on a microtask plus
+ * the next animation frame. The immediate post-write check in applyWidgetWrite
+ * therefore reports success, and a later init replaces the value with "".
+ *
+ * This is the smallest wait that observes that overwrite: one microtask, then
+ * one animation frame when the host has rAF, then another microtask so a mount
+ * that itself queues work is visible. No rAF in Node tests → two microtasks,
+ * so existing runSetWidget tests do not hang or grow a timer.
+ */
+export function awaitFrontendWidgetFlush() {
+  return new Promise((resolve) => {
+    queueMicrotask(() => {
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(() => queueMicrotask(resolve));
+      } else {
+        queueMicrotask(resolve);
+      }
+    });
+  });
+}
+
+function widgetValuesMatch(expected, actual) {
+  if (
+    (expected !== null && typeof expected === "object") ||
+    (actual !== null && typeof actual === "object")
+  ) {
+    try {
+      return JSON.stringify(expected) === JSON.stringify(actual);
+    } catch {
+      return false;
+    }
+  }
+  return Object.is(expected, actual);
+}
 
 /**
  * #1413/#1418 — the refusal for a stale-combo recovery that never revalidated the value.
@@ -284,6 +329,10 @@ export async function runSetWidget(
     // than done by the caller before this function, so the mutation lands at the write
     // boundary below where NO await follows it — see the note at `write`.
     prepareWriteTarget,
+    // #1922 — wait for the frontend widget store / Vue mount to finish before
+    // treating a verified write as retained. Production uses awaitFrontendWidgetFlush;
+    // unit tests inject a flush that reproduces the later empty overwrite.
+    awaitFrontendWidgetFlush: awaitFrontendWidgetFlushInjected,
   } = {},
 ) {
   // Never re-derived, and never cached: the oracle may not have run yet when this closure is
@@ -920,6 +969,56 @@ export async function runSetWidget(
     }
   };
 
+  const flushFrontendWidgets =
+    typeof awaitFrontendWidgetFlushInjected === "function"
+      ? awaitFrontendWidgetFlushInjected
+      : awaitFrontendWidgetFlush;
+
+  function readLiveWritten(set) {
+    const hosts = [node, resolvedTargetNode, authTarget].filter(Boolean);
+    const prefer = hosts.filter((host) => host.id === set?.node_id);
+    const rest = hosts.filter((host) => host.id !== set?.node_id);
+    for (const host of [...prefer, ...rest]) {
+      const live = host.widgets?.find((candidate) => candidate?.name === set?.widget);
+      if (live) return { found: true, value: live.value };
+    }
+    return { found: false, value: undefined };
+  }
+
+  function widgetStillHolds(set) {
+    const live = readLiveWritten(set);
+    return live.found && widgetValuesMatch(set?.value, live.value);
+  }
+
+  /**
+   * #1922 — applyWidgetWrite verifies synchronously. A just-added primitive's
+   * Vue/widget-store init can still replace the value on the next frame, so a
+   * success here would be a lie. Wait for that flush; if the value vanished,
+   * write once more (the init has now run, which is why the reporter's second
+   * call stuck); if it still does not hold, refuse.
+   */
+  async function retainVerifiedWrite(set, rewrite) {
+    await flushFrontendWidgets();
+    assertTargetStillCurrentNow();
+    if (widgetStillHolds(set)) return set;
+    const retried = rewrite();
+    await flushFrontendWidgets();
+    assertTargetStillCurrentNow();
+    if (widgetStillHolds(retried)) return retried;
+    const live = readLiveWritten(retried);
+    throw new WidgetWriteError(
+      `Widget "${retried?.widget}" on node ${retried?.node_id} (${node?.type}) did not retain the ` +
+        `requested value after the frontend widget store initialized: wrote ${JSON.stringify(retried?.value)} ` +
+        `but it became ${JSON.stringify(live.found ? live.value : undefined)}. ` +
+        `Nothing is being reported as success. Retry panel_set_widget now that the node is on the canvas.`,
+    );
+  }
+
+  async function succeedWrite(extra = {}, extraResult = {}) {
+    const set = await retainVerifiedWrite(write(extra), () => write(extra));
+    return withWarning({ set, ...extraResult });
+  }
+
   // #558: the value widget being written may be governed by a non-`fixed`
   // control_after_generate (seed randomize/increment/…), which SILENTLY overwrites
   // it after the next generation. Warn HONESTLY on success — the write "took", but it
@@ -1084,7 +1183,7 @@ export async function runSetWidget(
   };
 
   try {
-    return withWarning({ set: write() });
+    return await succeedWrite();
   } catch (err) {
     // Only a COMBO rejection is EVER retryable — every other WidgetWriteError
     // (numeric/boolean/promotion/composite/stuck-check) fails closed immediately.
@@ -1146,7 +1245,7 @@ export async function runSetWidget(
         );
       }
       try {
-        return withWarning({ set: write(), refreshed: true });
+        return await succeedWrite({}, { refreshed: true });
       } catch (retryErr) {
         if (!(retryErr instanceof WidgetWriteError)) throw retryErr;
         // A NON-combo failure on the retry is terminal — fail closed loudly.
@@ -1162,7 +1261,7 @@ export async function runSetWidget(
     // #387: server-confirmed upload asset (e.g. a subfolder-nested LoadImage image).
     if (await tryUploadAssetAccept()) {
       try {
-        return withWarning({ set: write(), refreshed: true, server_confirmed: true });
+        return await succeedWrite({}, { refreshed: true, server_confirmed: true });
       } catch (confErr) {
         if (confErr instanceof WidgetWriteError) {
           throw refusalFrame(confErr, " after confirming the uploaded asset exists on the server");
@@ -1208,11 +1307,13 @@ export async function runSetWidget(
         concreteWidgetName ?? writeTargetWidgetName ?? widgetName,
       )
     ) {
-      return withWarning({
-        set: write({ acceptEmptyComboOptions: true }),
-        ...(typeof refreshCombos === "function" ? { refreshed: true } : {}),
-        empty_option_list: true,
-      });
+      return await succeedWrite(
+        { acceptEmptyComboOptions: true },
+        {
+          ...(typeof refreshCombos === "function" ? { refreshed: true } : {}),
+          empty_option_list: true,
+        },
+      );
     }
 
     // #1126 UNREADABLE OPTION LIST — the sibling of the #507 branch above, and decided
@@ -1435,7 +1536,10 @@ export async function runSetWidget(
           // this call hoped for: an empty final read discloses `empty_option_list` (and carries
           // #507's rail label-adoption rule, correctly, because an empty list really does admit
           // any scalar), an unreadable one discloses `option_list_unreadable`.
-          set = write({ acceptUnreadableComboOptions: true, acceptEmptyComboOptions: true });
+          set = await retainVerifiedWrite(
+            write({ acceptUnreadableComboOptions: true, acceptEmptyComboOptions: true }),
+            () => write({ acceptUnreadableComboOptions: true, acceptEmptyComboOptions: true }),
+          );
         } catch (unreadableErr) {
           // A validation refusal from THIS attempt (a non-string value, a rail whose own
           // list is real and lacks the value) must arrive framed like every other refusal:


### PR DESCRIPTION
Closes #1922

## The lie

`panel_set_widget` immediately after `panel_add_node` of `PrimitiveStringMultiline` reported success, then a later frontend init (Vue mount / widget-value store) cleared `value` to empty. Repeating the identical write stuck. Immediate read-back in `applyWidgetWrite` is not enough: the overwrite happens on a microtask plus animation-frame boundary.

## What this does

After a verified write, `runSetWidget` waits for that flush and re-reads the widget.

- If init replaced the value, the write is applied **once more** (the reporter's second call is the observation that init has now run).
- If it still does not hold, the call **refuses** instead of returning success.
- An ordinary write with nothing to overwrite is unchanged.

The first write is retained when the store settles after one init; it never reports success-then-empty.

## Tests

`browser_tests/unit/primitive-widget-retain.test.mjs` drives shipped `runSetWidget` (the body `graph_set_widget` delegates to) with a later empty overwrite. Success-then-empty fails. `npm run test:unit`: 7196 pass, 1 todo.
