### PR TITLE
fix(1925): dispatch promoted writes when the live root is verified-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_run no longer reports CompareFrames temp images as "no media": unrecognised `*images` outputs are counted and named, and none of them are attached (#1934)
 - panel_set_widget rebuilds generated custom-widget rows after a hidden backend write, so Deno Multi LoRA (and the same pattern) updates visible rows and height without leaving and re-entering (#1932)
 - panel_set_widget no longer reports success when a just-added primitive's frontend init later clears the value (#1922)
+- panel_set_widget dispatches a promoted-widget write when the live canvas is a verified-stable root, instead of refusing with "scope became unverifiable" (#1925, artokun/comfyui-mcp#2435)
 
 ## [0.15.118] - 2026-08-27
 

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -240,7 +240,7 @@ test("#2283: the command remains on the authenticated rid executor/reply path", 
   assert.match(source, /"ui_render", "ui_update", "fetch_image", "fetch_comfyui_read"/);
   assert.match(source, /const isCommandFrame = msg && typeof msg\.rid === "string" && typeof msg\.cmd === "string"/);
   assert.match(source, /const executor = GRAPH_TOOL_EXECUTORS\[msg\.cmd\]/);
-  assert.match(source, /reply = \{ rid: msg\.rid, ok: true, result \}/);
+  assert.match(source, /reply = \{ rid: msg\.rid, ok: true, result: withViewingWitness\(result\) \}/);
   assert.match(source, /deliverReply\(reply, msg\.cmd, superseded, inFlightMark\)/);
   assert.equal(commandIsCanvasIndependent("fetch_comfyui_read"), true);
   assert.equal(commandIsCanvasTargetless("fetch_comfyui_read"), true);

--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -233,8 +233,11 @@ test("#2314 detail rows explicitly classify ordinary and promoted nodes", () => 
   };
   graph._nodes.push(promoted);
   try {
-    const row = detailRows(query({ ids: [83], fields: "detail" }))[0];
+    const result = query({ ids: [83], fields: "detail" });
+    const row = detailRows(result)[0];
     assert.equal(row.is_subgraph, true);
+    assert.equal(result.nodes?.[0]?.is_subgraph, true, "#1925 pinpoint detail must publish a structured subgraph row");
+    assert.equal(result.nodes?.[0]?.id, 83);
   } finally {
     graph._nodes.pop();
   }

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -429,3 +429,186 @@ test("#2314 terminal endpoint is part of the shipped receiver fence", () => {
     /could not verify the terminal promotion endpoint/,
   );
 });
+
+function loadPromotedScopeHelper() {
+  const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
+  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production scope helper boundary not found");
+  return PANEL_SRC.slice(helperStart, helperEnd);
+}
+
+test("#1925 verified-stable root dispatches a promoted write on a subgraph instance", () => {
+  const childGraph = { name: "Video Generation" };
+  const wrapper = { id: 340, subgraph: childGraph, widgets: [], title: "LTX" };
+  const rootGraph = { _nodes: [wrapper], name: "root" };
+  const assertScope = new Function(
+    "describeActiveGraph",
+    "findSubgraphOwner",
+    `${loadPromotedScopeHelper()}; return assertExpectedPromotedScope;`,
+  )(
+    (graph) =>
+      graph === childGraph
+        ? {
+            scope: "subgraph",
+            owner_node_id: 340,
+            workflow_uuid: "workflow-a",
+            graph_identity: "graph:child",
+          }
+        : { scope: "root", workflow_uuid: "workflow-a", graph_identity: "graph:root" },
+    (_root, graph) => (graph === childGraph ? { id: 340, node: wrapper } : null),
+  );
+
+  const expected = {
+    scope: "subgraph",
+    owner_node_id: 340,
+    workflow_uuid: "workflow-a",
+    graph_identity: "graph:child",
+  };
+  assert.doesNotThrow(
+    () => assertScope({ graph: rootGraph, rootGraph }, expected),
+    "a verified-stable root must dispatch a promoted write aimed at a root-visible subgraph instance",
+  );
+});
+
+test("#1925 root expected_scope matches the live root graph identity", () => {
+  const wrapper = { id: 92, subgraph: { name: "klein" }, widgets: [] };
+  const rootGraph = { _nodes: [wrapper] };
+  const assertScope = new Function(
+    "describeActiveGraph",
+    "findSubgraphOwner",
+    `${loadPromotedScopeHelper()}; return assertExpectedPromotedScope;`,
+  )(
+    () => ({ scope: "root", workflow_uuid: "workflow-a", graph_identity: "graph:root" }),
+    () => null,
+  );
+  assert.doesNotThrow(() =>
+    assertScope({ graph: rootGraph, rootGraph }, {
+      scope: "root",
+      owner_node_id: 92,
+      workflow_uuid: "workflow-a",
+      graph_identity: "graph:root",
+    }),
+  );
+  assert.throws(
+    () =>
+      assertScope({ graph: rootGraph, rootGraph }, {
+        scope: "root",
+        owner_node_id: 92,
+        workflow_uuid: "workflow-a",
+        graph_identity: "graph:other-root",
+      }),
+    /expected root graph graph:other-root/,
+  );
+  assert.doesNotMatch(
+    (() => {
+      try {
+        assertScope({ graph: rootGraph, rootGraph }, {
+          scope: "root",
+          owner_node_id: 92,
+          workflow_uuid: "workflow-a",
+          graph_identity: "graph:other-root",
+        });
+        return "";
+      } catch (err) {
+        return String(err.message);
+      }
+    })(),
+    /unverifiable/,
+    "a mismatched but readable root must name the live identity, not 'unverifiable'",
+  );
+});
+
+test("#1925 a verified-stable root still refuses when the subgraph instance is gone", () => {
+  const rootGraph = { _nodes: [{ id: 1, type: "SaveVideo" }] };
+  const assertScope = new Function(
+    "describeActiveGraph",
+    "findSubgraphOwner",
+    `${loadPromotedScopeHelper()}; return assertExpectedPromotedScope;`,
+  )(
+    () => ({ scope: "root", workflow_uuid: "workflow-a", graph_identity: "graph:root" }),
+    () => null,
+  );
+  assert.throws(
+    () =>
+      assertScope({ graph: rootGraph, rootGraph }, {
+        scope: "subgraph",
+        owner_node_id: 340,
+        workflow_uuid: "workflow-a",
+        graph_identity: "graph:child",
+      }),
+    /expected subgraph instance owner 340/,
+  );
+});
+
+test("#1925 parent-rail check resolves the wrapper on the live root", () => {
+  const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
+  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  const promotionStart = PANEL_SRC.indexOf("function resolveSubgraphLink(");
+  const promotionEnd = PANEL_SRC.indexOf("\nfunction findPromotedHostInput", promotionStart);
+  const sourceForSubgraphInput = new Function(
+    `${PANEL_SRC.slice(promotionStart, promotionEnd)}; return sourceForSubgraphInput;`,
+  )();
+  const assertScope = new Function(
+    "describeActiveGraph",
+    "findSubgraphOwner",
+    "resolvePromotedInnerTarget",
+    "sourceForSubgraphInput",
+    `${PANEL_SRC.slice(helperStart, helperEnd)}; return assertExpectedPromotedScope;`,
+  );
+
+  const rail = { name: "value_5", value: true };
+  const innerWidget = { name: "value", value: true };
+  const innerInput = { name: "value", widget: { name: "value" } };
+  const inner = {
+    id: 12,
+    type: "PrimitiveBoolean",
+    inputs: [innerInput],
+    widgets: [innerWidget],
+  };
+  const childGraph = {
+    _nodes: [inner],
+    getNodeById: (id) => (String(id) === "12" ? inner : null),
+    getLink: (id) => (id === 1 ? { origin_id: 12, target_id: 12, target_slot: 0 } : null),
+  };
+  const hostInput = {
+    name: "value_5",
+    widget: rail,
+    _widget: rail,
+    widgetId: "root:340:value_5",
+    _subgraphSlot: { name: "value_5", linkIds: [1] },
+  };
+  const wrapper = { id: 340, widgets: [rail], inputs: [hostInput], subgraph: childGraph };
+  const rootGraph = { _nodes: [wrapper] };
+  const describeActiveGraph = () => ({
+    scope: "root",
+    workflow_uuid: "workflow-a",
+    graph_identity: "graph:root",
+  });
+  const fence = assertScope(
+    describeActiveGraph,
+    findSubgraphOwner,
+    resolvePromotedInnerTarget,
+    sourceForSubgraphInput,
+  );
+  const expected = {
+    scope: "subgraph",
+    owner_node_id: 340,
+    workflow_uuid: "workflow-a",
+    graph_identity: "graph:child",
+    promoted_widget: "value_5",
+    parent_rail: {
+      authoritative: true,
+      widget: "value_5",
+      widget_id: "root:340:value_5",
+    },
+  };
+  assert.doesNotThrow(
+    () => fence({ graph: rootGraph, rootGraph }, expected),
+    "the root-visible wrapper's promoted rail must be writable without entering",
+  );
+  hostInput.link = 99;
+  assert.throws(
+    () => fence({ graph: rootGraph, rootGraph }, expected),
+    /promoted parent rail changed or became unverifiable/,
+  );
+});

--- a/browser_tests/unit/graph-view-identity.test.mjs
+++ b/browser_tests/unit/graph-view-identity.test.mjs
@@ -74,3 +74,46 @@ test("production graph read callers publish the live viewing identity", () => {
   assert.ok(queryStart >= 0 && queryEnd > queryStart);
   assert.match(PANEL_SRC.slice(queryStart, queryEnd), /viewing: describeActiveGraph\(graph\)/);
 });
+
+test("#1925 production graph replies restock a parseable viewing witness", () => {
+  assert.match(PANEL_SRC, /function withViewingWitness\(/);
+  assert.match(PANEL_SRC, /result: withViewingWitness\(result\)/);
+  assert.match(PANEL_SRC, /viewing: liveParseableViewingWitness\(\) \?\? undefined/);
+});
+
+test("#1925 withViewingWitness keeps parseable viewing, replaces malformed, attaches missing", () => {
+  const start = PANEL_SRC.indexOf("function parseableViewingWitness");
+  const end = PANEL_SRC.indexOf("\nfunction canonicalExpectedPromotedOwner", start);
+  assert.ok(start >= 0 && end > start, "viewing-witness helpers not found");
+  const live = {
+    scope: "root",
+    workflow_uuid: "workflow-a",
+    graph_identity: "graph:root",
+  };
+  const withViewingWitness = new Function(
+    "getGraphCtx",
+    "describeActiveGraph",
+    `${PANEL_SRC.slice(start, end)}; return withViewingWitness;`,
+  )(
+    () => ({ graph: {} }),
+    () => live,
+  );
+
+  assert.deepEqual(withViewingWitness({ ok: true, viewing: live }), { ok: true, viewing: live });
+  assert.deepEqual(withViewingWitness({ applied: true }), { applied: true, viewing: live });
+  assert.deepEqual(
+    withViewingWitness({ viewing: null, applied: true }),
+    { applied: true, viewing: live },
+    "malformed viewing must be replaced, not recorded as unverifiable",
+  );
+  assert.equal(withViewingWitness("plain"), "plain");
+});
+
+test("#1925 pinpoint detail publishes a structured is_subgraph row", () => {
+  const queryStart = PANEL_SRC.indexOf("graph_query({");
+  const queryEnd = PANEL_SRC.indexOf("graph_find_nodes({", queryStart);
+  const query = PANEL_SRC.slice(queryStart, queryEnd);
+  assert.match(query, /pinpointNodes/);
+  assert.match(query, /is_subgraph: !!matched\[0\]\.subgraph/);
+  assert.match(query, /\.\.\.\(pinpointNodes \? \{ nodes: pinpointNodes \} : \{\}\)/);
+});

--- a/browser_tests/unit/reconnect-recovery.test.mjs
+++ b/browser_tests/unit/reconnect-recovery.test.mjs
@@ -531,7 +531,7 @@ test("#1529 wiring: the reply builder publishes `refusal` and leaves `error` alo
   // toasts among them — and the first occurrence is a workflow_new journal write,
   // not this. An anchor that matched the wrong one passed its assertions against
   // unrelated text, which is how a wiring test goes vacuous.
-  const start = SRC.indexOf("reply = { rid: msg.rid, ok: true, result };\n        } catch (err) {");
+  const start = SRC.indexOf("reply = { rid: msg.rid, ok: true, result: withViewingWitness(result) };\n        } catch (err) {");
   assert.notEqual(start, -1, "the acknowledged-error WIRE reply builder is still recognisable");
   const block = SRC.slice(start, start + 1800);
   assert.match(block, /reply = \{\n\s+rid: msg\.rid,\n\s+ok: false,/, "…and this is its failure branch");

--- a/browser_tests/unit/restart-confirmation-transport.test.mjs
+++ b/browser_tests/unit/restart-confirmation-transport.test.mjs
@@ -157,7 +157,7 @@ test("#1764 the real question painter settles the command before history persist
 test("#1764 production caller path keeps the original ask rid on the answer", () => {
   const bridge = namedFunctionSource(source, "createBridgeClient");
   assert.match(bridge, /result = await onAsk\(msg, thisSock\.__cmcpSocketId \?\? null\)/);
-  assert.match(bridge, /reply = \{ rid: msg\.rid, ok: true, result \}/);
+  assert.match(bridge, /reply = \{ rid: msg\.rid, ok: true, result: withViewingWitness\(result\) \}/);
   assert.match(bridge, /thisSock\["send"\]\(JSON\.stringify\(reply\)\)/);
   assert.match(bridge, /settleRid\(reply\)/);
 });

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -265,6 +265,19 @@ test("#296: resume rides the hello only when present", () => {
   assert.equal(buildHelloPayload({ tabId: "t", resume: "sess-1" }).resume, "sess-1");
 });
 
+test("#1925: hello carries a parseable current-view witness when the canvas is known", () => {
+  const viewing = {
+    scope: "root",
+    workflow_uuid: "e14c8786-dbbd-49ee-b19f-84c0032bb9bc",
+    graph_identity: "graph:f157b6b5-0ed3-4e58-a4b7-52619cb9150e",
+  };
+  const frame = buildHelloPayload({ tabId: "t", viewing });
+  assert.deepEqual(frame.viewing, viewing);
+  assert.equal("viewing" in buildHelloPayload({ tabId: "t" }), false);
+  assert.equal("viewing" in buildHelloPayload({ tabId: "t", viewing: { scope: "other" } }), false);
+  assert.equal("viewing" in buildHelloPayload({ tabId: "t", viewing: null }), false);
+});
+
 test("#570/#718: hello ALWAYS advertises both workflow-stamp fences so the orchestrator can safely allow graph edits", () => {
   // A current build fences at dispatch AND immediately before an async graph write.
   // Both flags must ride every hello (not gated behind optional fields), so the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10216,6 +10216,64 @@ function describeActiveGraph(graph) {
   return withLiveIdentity({ scope: "root" });
 }
 
+/** #1925 — a parseable current-view witness for the orchestrator's promoted-write
+ *  cache. Malformed `viewing` is recorded as known:false ("scope became
+ *  unverifiable"); omit rather than send that. A successful graph command that
+ *  never published `viewing` also left the cache cold after hello/reconnect. */
+function parseableViewingWitness(viewing) {
+  if (!viewing || typeof viewing !== "object" || Array.isArray(viewing)) return null;
+  if (viewing.scope !== "root" && viewing.scope !== "subgraph") return null;
+  const rawOwner = viewing.owner_node_id;
+  if (rawOwner !== undefined && rawOwner !== null) {
+    if (
+      (typeof rawOwner !== "number" || !Number.isSafeInteger(rawOwner)) &&
+      (typeof rawOwner !== "string" || rawOwner.length === 0)
+    ) {
+      return null;
+    }
+  }
+  const rawWorkflowUuid = viewing.workflow_uuid;
+  if (
+    rawWorkflowUuid !== undefined &&
+    (typeof rawWorkflowUuid !== "string" || rawWorkflowUuid.length === 0)
+  ) {
+    return null;
+  }
+  const rawGraphIdentity = viewing.graph_identity;
+  if (
+    rawGraphIdentity !== undefined &&
+    (typeof rawGraphIdentity !== "string" ||
+      rawGraphIdentity.length === 0 ||
+      rawGraphIdentity.length > 256)
+  ) {
+    return null;
+  }
+  return viewing;
+}
+
+function liveParseableViewingWitness() {
+  try {
+    return parseableViewingWitness(describeActiveGraph(getGraphCtx().graph));
+  } catch {
+    return null;
+  }
+}
+
+function withViewingWitness(result) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return result;
+  const existing = Object.prototype.hasOwnProperty.call(result, "viewing")
+    ? parseableViewingWitness(result.viewing)
+    : null;
+  if (existing) return result;
+  const live = liveParseableViewingWitness();
+  if (!live) {
+    if (!Object.prototype.hasOwnProperty.call(result, "viewing")) return result;
+    const { viewing: _dropped, ...rest } = result;
+    return rest;
+  }
+  return { ...result, viewing: live };
+}
+
 /** #2314 — validate the promoted receiver at the synchronous mutation boundary.
  * The MCP-side graph_query is only a classification read; navigation can replace
  * the viewed graph before the write resumes. The expected scope is therefore an
@@ -10228,14 +10286,27 @@ function canonicalExpectedPromotedOwner(value) {
   return Number.isSafeInteger(parsed) ? String(parsed) : null;
 }
 
+function findLiveSubgraphInstance(current, ownerId) {
+  if (!ownerId) return null;
+  const seen = new Set();
+  for (const graph of [current?.graph, current?.rootGraph]) {
+    if (!graph || seen.has(graph)) continue;
+    seen.add(graph);
+    for (const node of graph._nodes ?? []) {
+      if (canonicalExpectedPromotedOwner(node?.id) === ownerId && node?.subgraph) return node;
+    }
+  }
+  return null;
+}
+
 function assertExpectedPromotedScope(current, expectedScope, resolveTerminal) {
   if (expectedScope === undefined) return;
   if (!expectedScope || typeof expectedScope !== "object" || Array.isArray(expectedScope)) {
     throw new Error("graph_set_widget expected_scope must be a structured subgraph witness");
   }
   const expected = expectedScope;
-  if (expected.scope !== "subgraph") {
-    throw new Error("graph_set_widget expected_scope.scope must be \"subgraph\"");
+  if (expected.scope !== "subgraph" && expected.scope !== "root") {
+    throw new Error("graph_set_widget expected_scope.scope must be \"subgraph\" or \"root\"");
   }
   const expectedOwner = canonicalExpectedPromotedOwner(expected.owner_node_id);
   if (!expectedOwner) {
@@ -10256,20 +10327,49 @@ function assertExpectedPromotedScope(current, expectedScope, resolveTerminal) {
   }
 
   const liveViewing = describeActiveGraph(current.graph);
-  const liveOwner = findSubgraphOwner(current.rootGraph, current.graph);
-  const liveOwnerId = canonicalExpectedPromotedOwner(liveOwner?.id);
-  if (
+  const liveOwnerFromView = findSubgraphOwner(current.rootGraph, current.graph);
+  const liveOwnerIdFromView = canonicalExpectedPromotedOwner(liveOwnerFromView?.id);
+  const workflowMatches =
+    expected.workflow_uuid === undefined || liveViewing.workflow_uuid === expected.workflow_uuid;
+  const describeLiveOwner = () =>
+    liveOwnerIdFromView ??
+    (liveViewing.scope === "root" ? "root (no subgraph owner)" : "missing subgraph owner");
+  const describeLive = () =>
+    `${liveViewing.scope} owner ${describeLiveOwner()}` +
+    `${liveViewing.workflow_uuid ? ` in workflow ${liveViewing.workflow_uuid}` : ""}` +
+    `${liveViewing.graph_identity ? ` graph ${liveViewing.graph_identity}` : ""}`;
+
+  let liveOwner = liveOwnerFromView;
+  if (liveViewing.scope === "root" && workflowMatches) {
+    // #1925 — a promoted write addressed at a subgraph INSTANCE is issued from
+    // the verified-stable root (the wrapper is on the root canvas). The
+    // expected envelope still names that instance as owner; expected.graph_identity
+    // is the CHILD graph, so it must not be compared to the live ROOT identity.
+    const instance = findLiveSubgraphInstance(current, expectedOwner);
+    if (!instance) {
+      throw new Error(
+        `graph_set_widget promoted receiver changed before dispatch: expected subgraph instance owner ${expectedOwner}` +
+          `${expected.workflow_uuid ? ` in workflow ${expected.workflow_uuid}` : ""} on the live root, ` +
+          `found ${describeLive()}. Nothing was applied.`,
+      );
+    }
+    if (expected.scope === "root" && liveViewing.graph_identity !== expected.graph_identity) {
+      throw new Error(
+        `graph_set_widget promoted receiver changed before dispatch: expected root graph ${expected.graph_identity}, ` +
+          `found ${describeLive()}. Nothing was applied.`,
+      );
+    }
+    liveOwner = { id: instance.id, node: instance, title: instance.title };
+  } else if (
     liveViewing.scope !== "subgraph" ||
-    liveOwnerId !== expectedOwner ||
-    (expected.workflow_uuid !== undefined && liveViewing.workflow_uuid !== expected.workflow_uuid) ||
+    liveOwnerIdFromView !== expectedOwner ||
+    !workflowMatches ||
     liveViewing.graph_identity !== expected.graph_identity
   ) {
     throw new Error(
       `graph_set_widget promoted receiver changed before dispatch: expected subgraph owner ${expectedOwner}` +
         `${expected.workflow_uuid ? ` in workflow ${expected.workflow_uuid}` : ""}, ` +
-        `found ${liveViewing.scope} owner ${liveOwnerId ?? "unverifiable"}` +
-        `${liveViewing.workflow_uuid ? ` in workflow ${liveViewing.workflow_uuid}` : ""}. ` +
-      "Nothing was applied.",
+        `found ${describeLive()}. Nothing was applied.`,
     );
   }
 
@@ -10321,7 +10421,9 @@ function assertExpectedPromotedScope(current, expectedScope, resolveTerminal) {
       (expectedRail.widget_id !== undefined && liveWidgetId !== expectedRail.widget_id)
     ) {
       throw new Error(
-        "graph_set_widget promoted parent rail changed or became unverifiable before dispatch. Nothing was applied.",
+        ownerNode
+          ? "graph_set_widget promoted parent rail changed or became unverifiable before dispatch. Nothing was applied."
+          : "graph_set_widget promoted parent rail is missing: the subgraph instance owner is not on the live canvas. Nothing was applied.",
       );
     }
   }
@@ -14694,12 +14796,26 @@ const GRAPH_TOOL_EXECUTORS = {
       truncatedBy = "max_chars";
       text = assemble();
     }
+    // #1925 — a pinpoint detail read is the orchestrator's promoted-scope probe.
+    // That classifier prefers a structured `nodes` row with a boolean
+    // `is_subgraph`; `text` alone is a fallback. Publish the row beside the
+    // survey line so a verified-stable root subgraph instance is classifiable.
+    const pinpointNodes =
+      pinpoint && proj === "detail" && shown === 1 && matched[0]
+        ? [
+            {
+              ...capSummaryWidgets(summarizeNode(matched[0]), detailWidgetCap, maxChars),
+              is_subgraph: !!matched[0].subgraph,
+            },
+          ]
+        : null;
     return {
       ...meta, total, candidates: candidates.length, matched: matched.length, shown, truncated,
       // #809: expose the CAUSE structurally too, so a caller that reads fields rather
       // than prose still learns which lever applies.
       truncated_by: truncatedBy,
       text,
+      ...(pinpointNodes ? { nodes: pinpointNodes } : {}),
     };
   },
 
@@ -27919,7 +28035,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // until after the correlated reply is delivered (#581).
             changeTrackerToSnapshot = app.extensionManager?.workflow?.activeWorkflow?.changeTracker ?? null;
           }
-          reply = { rid: msg.rid, ok: true, result };
+          reply = { rid: msg.rid, ok: true, result: withViewingWitness(result) };
         } catch (err) {
           const reconnectRefusal = readReconnectRefusal(err);
           const workflowListReadiness = readWorkflowListReadinessRefusal(err);
@@ -28389,6 +28505,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // the orchestrator can resume an UNSAVED workflow's conversation without
             // cross-resuming a DIFFERENT same-title unsaved workflow.
             workflowUuid: (advertisedWorkflowUuid = workflowStableUuid()),
+            // #1925 — restock the promoted-scope cache that this hello is about to clear.
+            viewing: liveParseableViewingWitness() ?? undefined,
             // #508/#694 — NO lostReplies summaries here: the hello fires at
             // socket-open, BEFORE the models handshake stamps this socket's session
             // epoch, so any summary computed now is filtered with an unknown epoch

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -753,6 +753,7 @@ export function buildHelloPayload({
   resume,
   workflowUuid,
   lostReplies,
+  viewing,
 } = {}) {
   const frame = {
     type: "hello",
@@ -858,6 +859,17 @@ export function buildHelloPayload({
   // supported here for any caller whose timing is already post-handshake.
   if (Array.isArray(lostReplies) && lostReplies.length) {
     frame.lost_replies = lostReplies;
+  }
+  // #1925 — hello clears the orchestrator's promoted-scope cache. A parseable
+  // current-view witness on this frame is the only way a reconnect/tab-switch
+  // hello can restock that cache without waiting for a later graph read.
+  if (
+    viewing &&
+    typeof viewing === "object" &&
+    !Array.isArray(viewing) &&
+    (viewing.scope === "root" || viewing.scope === "subgraph")
+  ) {
+    frame.viewing = viewing;
   }
   return frame;
 }


### PR DESCRIPTION
## Summary

`panel_set_widget` refused promoted-widget writes on subgraph-instance nodes with:

> the receiving panel current-view scope became unverifiable. No graph_set_widget was dispatched

even when `panel_query_graph` showed a verified-stable **root** (`graph_identity` + `workflow_uuid`). Same byte-identical refusal as artokun/comfyui-mcp#2435 (FLUX.2 Klein, SAM3 after reconnect).

The panel-side predicate did not match observable reality:

- `assertExpectedPromotedScope` required live viewing to be `subgraph`, and reported the root owner as `"unverifiable"`.
- Hello/reconnect cleared the orchestrator's viewing cache, and graph command replies that never published a parseable `viewing` left it cold.
- Pinpoint `graph_query` detail hid `is_subgraph` in prose, so the orchestrator's promoted-scope probe could not classify a root-visible subgraph instance.

## Fix

- Dispatch a promoted write when the live canvas is a verified-stable root and the expected subgraph instance is on that root. Refusals now name the live identity (scope, owner, workflow, graph id) instead of `"unverifiable"`.
- Attach a parseable `viewing` witness to every successful graph command reply, and on hello, so reconnect/tab-switch does not leave the cache empty.
- Pinpoint detail publishes a structured `nodes[]` row with boolean `is_subgraph`.

## Tests

`node --test` on:

- `browser_tests/unit/graph-set-widget-target-fence.test.mjs` (#1925 root dispatch + parent rail)
- `browser_tests/unit/graph-view-identity.test.mjs` (viewing witness)
- `browser_tests/unit/session-rebind.test.mjs` (hello viewing)
- `browser_tests/unit/graph-query-detail-budget.test.mjs` (pinpoint `nodes`)

Log: `C:\Users\Artokun\AppData\Local\Temp\grok-goal-dba11719f7d4\implementer\tests-panel-1925.log`

Closes #1925
Related: artokun/comfyui-mcp#2435
