### PR TITLE
fix(1941): a root node is not a promoted container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget no longer refuses a root-level ordinary node as an unclassifiable promoted container: graph_get_subgraph throws the definitive "is not a subgraph" line, and pinpoint detail keeps a bounded `is_subgraph:false` row (#1941)
+
 ## [0.15.120] - 2026-08-27
 
 ### Fixed

--- a/browser_tests/unit/graph-get-subgraph-root-container.test.mjs
+++ b/browser_tests/unit/graph-get-subgraph-root-container.test.mjs
@@ -1,0 +1,166 @@
+/**
+ * artokun/comfyui-mcp-panel#1941 — a root-level ordinary node is not a promoted
+ * container. MCP's `preparePromotedWidgetWrite` calls graph_get_subgraph when
+ * the query probe is not a boolean `is_subgraph:false` at root. Anything other
+ * than the panel's own `Node <id> (<type>) is not a subgraph` line is treated
+ * as indeterminate and refused:
+ *
+ *   panel_set_widget refused the promoted "filename_prefix" write because
+ *   graph_get_subgraph could not determine whether the addressed node is a
+ *   promoted container. No graph_set_widget was dispatched.
+ *
+ * VHS_VideoCombine in the report is a plain root node. A truthy leftover
+ * `subgraph` that is not a live inner graph used to skip the throw, and a type
+ * with nested parentheses made the orchestrator miss the definitive form.
+ *
+ * Run with `node --test`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const PANEL_SRC = readFileSync(
+  new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+/** Copied from the orchestrator's `isDefinitiveNonPromotedSubgraphRead`. A
+ *  throw that does not match this is rewritten as the #1941 refusal. */
+const DEFINITIVE_NON_SUBGRAPH_RE =
+  /^Error:\s*Node\s+\S+(?:\s+\((?:(?:[^()]|\([^()]*\))*|[^)]*)\))?\s+is not a subgraph\b/i;
+
+function asOrchestratorError(err) {
+  return `Error: ${err instanceof Error ? err.message : String(err)}`;
+}
+
+function loadGetSubgraph() {
+  const start = PANEL_SRC.indexOf("graph_get_subgraph({ node_id }) {");
+  const end = PANEL_SRC.indexOf("async graph_add_node(", start);
+  assert.ok(start >= 0 && end > start, "graph_get_subgraph handler must remain extractable");
+  const method = PANEL_SRC.slice(start, end).replace(/,\s*$/, "");
+  return (node) =>
+    new Function(
+      "getGraphCtx",
+      "resolveNode",
+      "describeActiveGraph",
+      "subgraphValueProvenance",
+      "redactWidgetValue",
+      "graphViewIdentityFor",
+      "MAX_STATE_NODES",
+      "fixedCapNote",
+      "summarizeNode",
+      "promotedTerminalWitnesses",
+      `return ({${method}}).graph_get_subgraph;`,
+    )(
+      () => ({ graph: {} }),
+      () => node,
+      () => ({ scope: "root", graph_identity: "graph:root" }),
+      () => ({}),
+      () => ({}),
+      () => "graph:child",
+      50,
+      () => "truncation note",
+      (inner) => ({ id: inner.id, type: inner.type }),
+      () => [],
+    );
+}
+
+function assertDefinitiveNonContainer(node) {
+  const getSubgraph = loadGetSubgraph()(node);
+  let thrown;
+  try {
+    getSubgraph({ node_id: node.id });
+  } catch (err) {
+    thrown = err;
+  }
+  assert.ok(thrown, `expected a throw for node ${node.id}`);
+  assert.match(
+    asOrchestratorError(thrown),
+    DEFINITIVE_NON_SUBGRAPH_RE,
+    `ordinary node ${node.id} (${node.type}) must stay a parseable non-container, not an indeterminate probe`,
+  );
+}
+
+test("#1941 a root VHS_VideoCombine throws the definitive non-container line", () => {
+  const getSubgraph = loadGetSubgraph()({
+    id: 74,
+    type: "VHS_VideoCombine",
+    widgets: [{ name: "filename_prefix", value: "video/ComfyUI" }],
+  });
+  assert.throws(
+    () => getSubgraph({ node_id: 74 }),
+    (err) => {
+      assert.match(String(err.message), /Node 74 \(VHS_VideoCombine\) is not a subgraph/);
+      assert.match(asOrchestratorError(err), DEFINITIVE_NON_SUBGRAPH_RE);
+      return true;
+    },
+  );
+});
+
+test("#1941 a truthy leftover subgraph that is not a live inner graph is still not a container", () => {
+  // The unfixed predicate was `if (!sub)`. `{}` is truthy, so the handler
+  // returned a fake ownership envelope and MCP refused the write as
+  // indeterminate instead of dispatching graph_set_widget.
+  for (const leftover of [{}, { name: "not-a-graph" }, { nodes: "nope" }]) {
+    const getSubgraph = loadGetSubgraph()({
+      id: 74,
+      type: "VHS_VideoCombine",
+      subgraph: leftover,
+    });
+    assert.throws(
+      () => getSubgraph({ node_id: 74 }),
+      (err) => {
+        assert.match(asOrchestratorError(err), DEFINITIVE_NON_SUBGRAPH_RE);
+        return true;
+      },
+      `leftover subgraph ${JSON.stringify(leftover)} must not look like a container`,
+    );
+  }
+});
+
+test("#1941 nested parentheses in the node type still parse as definitive", () => {
+  const getSubgraph = loadGetSubgraph()({
+    id: 82,
+    type: "Foo (Bar (Baz))",
+  });
+  assert.throws(
+    () => getSubgraph({ node_id: 82 }),
+    (err) => {
+      assert.doesNotMatch(String(err.message), /\(.*\(.*\).*\)/);
+      assert.match(asOrchestratorError(err), DEFINITIVE_NON_SUBGRAPH_RE);
+      return true;
+    },
+  );
+});
+
+test("#1941 a parenthesised pack type stays parseable after flattening", () => {
+  assertDefinitiveNonContainer({ id: 43, type: "KSampler (Efficient)" });
+  assertDefinitiveNonContainer({ id: 82, type: "Power Lora Loader (rgthree)" });
+});
+
+test("#1941 a missing type still throws the canonical line", () => {
+  const getSubgraph = loadGetSubgraph()({ id: 9 });
+  assert.throws(
+    () => getSubgraph({ node_id: 9 }),
+    (err) => {
+      assert.equal(err.message, "Node 9 is not a subgraph");
+      assert.match(asOrchestratorError(err), DEFINITIVE_NON_SUBGRAPH_RE);
+      return true;
+    },
+  );
+});
+
+test("#1941 a live inner graph is still a container — the throw does not fire", () => {
+  const inner = { id: 12, type: "PrimitiveBoolean" };
+  const getSubgraph = loadGetSubgraph()({
+    id: 4,
+    type: "SubgraphNode",
+    title: "Video",
+    subgraph: { _nodes: [inner] },
+  });
+  const out = getSubgraph({ node_id: 4 });
+  assert.equal(out.subgraph_of.node_id, 4);
+  assert.equal(out.node_count, 1);
+  assert.equal(out.nodes[0].id, 12);
+  assert.deepEqual(out.promoted_terminals, []);
+});

--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -218,6 +218,36 @@ test("#2436 shipped graph_query keeps is_subgraph on an oversized-node stub", ()
   }
 });
 
+test("#1941 pinpoint structured nodes row stays bounded on a wide root node", () => {
+  // The orchestrator's ordinary-root fast path reads `result.nodes[0]`, not the
+  // survey text. That structured row used to be the uncapped summary, so a
+  // VHS_VideoCombine-shaped node could time out the probe and fall through to
+  // an indeterminate graph_get_subgraph refusal.
+  const wide = {
+    id: 74,
+    type: "VHS_VideoCombine",
+    title: "VHS_VideoCombine",
+    widgets: [{ name: "filename_prefix", value: "video/ComfyUI" }],
+    inputs: Array.from({ length: 4000 }, (_, i) => ({ name: `in${i}`, type: "INT" })),
+    outputs: [],
+  };
+  graph._nodes.push(wide);
+  try {
+    const result = query({ ids: [74], fields: "detail", max_chars: 300 });
+    const row = result.nodes?.[0];
+    assert.ok(row, "pinpoint detail must publish a structured nodes row");
+    assert.equal(row.id, 74);
+    assert.equal(typeof row.is_subgraph, "boolean");
+    assert.equal(row.is_subgraph, false);
+    assert.ok(
+      JSON.stringify(row).length <= 300,
+      `structured row must respect max_chars; got ${JSON.stringify(row).length}`,
+    );
+  } finally {
+    graph._nodes.pop();
+  }
+});
+
 test("#2314 detail rows explicitly classify ordinary and promoted nodes", () => {
   const ordinary = detailRows(query({ ids: [78], fields: "detail" }))[0];
   assert.equal(ordinary.is_subgraph, false);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14813,15 +14813,34 @@ const GRAPH_TOOL_EXECUTORS = {
     // That classifier prefers a structured `nodes` row with a boolean
     // `is_subgraph`; `text` alone is a fallback. Publish the row beside the
     // survey line so a verified-stable root subgraph instance is classifiable.
-    const pinpointNodes =
-      pinpoint && proj === "detail" && shown === 1 && matched[0]
-        ? [
-            {
-              ...capSummaryWidgets(summarizeNode(matched[0]), detailWidgetCap, maxChars),
-              is_subgraph: !!matched[0].subgraph,
-            },
-          ]
-        : null;
+    // #1941 — fit the structured row the same way as the survey line. An
+    // uncapped VHS/high-fan-in summary used to dwarf `max_chars` while the
+    // text stub stayed bounded; a timed-out/truncated probe then fell through
+    // to graph_get_subgraph and refused a root node as an unclassifiable
+    // promoted container.
+    const pinpointNodes = (() => {
+      if (!(pinpoint && proj === "detail" && shown === 1 && matched[0])) return null;
+      const summary = {
+        ...capSummaryWidgets(summarizeNode(matched[0]), detailWidgetCap, maxChars),
+        is_subgraph: !!matched[0].subgraph,
+      };
+      const fitted = fitDetailLine(
+        JSON.stringify(summary),
+        { id: summary.id, type: summary.type, title: summary.title, is_subgraph: summary.is_subgraph },
+        maxChars,
+      );
+      try {
+        return [JSON.parse(fitted)];
+      } catch {
+        return [
+          {
+            id: summary.id,
+            type: summary.type,
+            is_subgraph: !!matched[0].subgraph,
+          },
+        ];
+      }
+    })();
     return {
       ...meta, total, candidates: candidates.length, matched: matched.length, shown, truncated,
       // #809: expose the CAUSE structurally too, so a caller that reads fields rather
@@ -15229,7 +15248,23 @@ const GRAPH_TOOL_EXECUTORS = {
     const { graph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
     const sub = node.subgraph;
-    if (!sub) throw new Error(`Node ${node.id} (${node.type}) is not a subgraph`);
+    // #1941 — MCP's promoted-write probe treats anything other than this exact
+    // "is not a subgraph" line as indeterminate and refuses the write. A root
+    // node is not a promoted container: only a live inner graph (nodes list or
+    // getNodeById) is one. A truthy leftover `subgraph` used to skip the throw
+    // and look like an unclassifiable container. Nested parentheses in `type`
+    // also made the orchestrator miss its own definitive form, so flatten them.
+    const isContainer =
+      !!sub &&
+      typeof sub === "object" &&
+      (Array.isArray(sub._nodes) || Array.isArray(sub.nodes) || typeof sub.getNodeById === "function");
+    if (!isContainer) {
+      const rawType = typeof node.type === "string" ? node.type : "";
+      const type = rawType.replace(/[()]/g, " ").replace(/\s+/g, " ").trim();
+      throw new Error(
+        type ? `Node ${node.id} (${type}) is not a subgraph` : `Node ${node.id} is not a subgraph`,
+      );
+    }
     const inner = [...(sub._nodes ?? sub.nodes ?? [])];
     const promotedTerminals = promotedTerminalWitnesses(node);
     // #1729 — provenance is a second structured-read path: its raw instance_widgets


### PR DESCRIPTION
Closes #1941.

## Root cause

`panel_set_widget` probes `graph_get_subgraph` when it cannot prove the addressed node is an ordinary root node. The only reply MCP treats as "not a promoted container" is:

```
Error: Node <id> (<type>) is not a subgraph
```

Anything else is rewritten as:

> panel_set_widget refused the promoted "filename_prefix" write because graph_get_subgraph could not determine whether the addressed node is a promoted container. No graph_set_widget was dispatched.

Two panel-side gaps produced that on a root-level `VHS_VideoCombine`:

1. **The container predicate was `if (!sub)`.** A truthy leftover `subgraph` that is not a live inner graph (`{}`, `{name: "not-a-graph"}`) skipped the throw and looked like an unclassifiable container.
2. **Nested parentheses in `node.type`** (`Foo (Bar (Baz))`, and pack types like `KSampler (Efficient)`) made the orchestrator regex miss its own definitive form.
3. **Pinpoint `graph_query` published an unbounded structured `nodes` row.** The ordinary-root fast path reads `result.nodes[0]`, not the survey text. A wide node could time out that probe and fall through to (1).

#1954's fresh-subgraph "scope unverifiable" path is left alone.

## Fix

- `graph_get_subgraph` throws the definitive line unless the node has a live inner graph (`_nodes` / `nodes` / `getNodeById`). Parentheses in the type are flattened so the classifier always matches.
- Pinpoint detail fits the structured `nodes` row through `fitDetailLine`, so a wide root node stays a bounded `is_subgraph: false` witness.

## Tests

- `browser_tests/unit/graph-get-subgraph-root-container.test.mjs` drives the shipped handler: VHS_VideoCombine, leftover subgraph objects, nested-paren types, missing type, and a real inner graph.
- `browser_tests/unit/graph-query-detail-budget.test.mjs` pins the bounded pinpoint `nodes` row on a 4000-input VHS-shaped node.

**Suite:** `npm run test:unit` → 7253 tests, **7252 pass, 0 fail** (1 pre-existing todo). Log: `tests-panel-1941.log`.

Do not merge from this PR — parent merges after the swarm.
