### PR TITLE
fix(1969): reindex remaining host links after unexpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- graph_unexpose_subgraph_input / _output re-point remaining host SubgraphNode links after a non-last boundary slot is removed, so later host wires stay valid at queue (#1969, artokun/comfyui-mcp#2437)
+
 ## [0.15.119] - 2026-08-27
 
 ### Fixed

--- a/browser_tests/unit/rail-slot.test.mjs
+++ b/browser_tests/unit/rail-slot.test.mjs
@@ -17,7 +17,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { findExistingRailSlot, railSlotIndex, resolveRailSlotForRemoval } from "../../web/js/lib/rail-slot.js";
+import { findExistingRailSlot, railSlotIndex, resolveRailSlotForRemoval, reindexHostRailLinks } from "../../web/js/lib/rail-slot.js";
 
 /** A rail with twelve slots, none of them named with digits — the reported shape. */
 const RAIL = Array.from({ length: 12 }, (_, i) => ({ name: `in_${i}`, type: "STRING", slot: i }));
@@ -110,7 +110,7 @@ test("#1114 WIRING: the panel uses the shared lookup and keeps no copy", () => {
   );
   assert.match(
     panel,
-    /import \{ findExistingRailSlot, resolveRailSlotForRemoval, countHostRailLinks \} from "\.\/lib\/rail-slot\.js";/,
+    /import \{ findExistingRailSlot, resolveRailSlotForRemoval, countHostRailLinks, reindexHostRailLinks \} from "\.\/lib\/rail-slot\.js";/,
     "the panel imports the shared lookups",
   );
   assert.doesNotMatch(
@@ -128,12 +128,19 @@ test("#1114 WIRING: the panel uses the shared lookup and keeps no copy", () => {
     /function countHostRailLinks\s*\(/,
     "and keeps no local copy of the host-wire counter either",
   );
+  assert.doesNotMatch(
+    panel,
+    /function reindexHostRailLinks\s*\(/,
+    "and keeps no local copy of the host-link reindexer either",
+  );
   // Both rail branches must go through it: outputs (to_input) and inputs (from_output).
   const uses = panel.match(/findExistingRailSlot\(graph\.(inputs|outputs),/g) ?? [];
   assert.equal(uses.length, 2, "both rail branches resolve through it");
   // And both unexpose executors resolve through the removal resolver.
   const removals = panel.match(/resolveRailSlotForRemoval\(subgraph\.(inputs|outputs),/g) ?? [];
   assert.equal(removals.length, 2, "both unexpose executors resolve through it");
+  const reindexes = panel.match(/reindexHostRailLinks\(rootGraph, subgraph, "(input|output)", slotIndex\)/g) ?? [];
+  assert.equal(reindexes.length, 2, "both unexpose executors reindex remaining host links");
 });
 
 test("#1294 removal resolves a slot by name or index, like a connect", () => {
@@ -207,4 +214,55 @@ test("#1114 a digit-named slot AT its own index is not ambiguous", () => {
 test("#1114 a digit name with NO matching index still resolves by name", () => {
   const named = [{ name: "a", slot: 0 }, { name: "7", slot: 1 }];
   assert.equal(findExistingRailSlot(named, "7")?.slot, 1); // index 7 does not exist
+});
+
+test("#1969 reindexHostRailLinks writes the live index onto object-form and array-form links", () => {
+  const objectLink = { id: 1, origin_id: 2, origin_slot: 0, target_id: 7, target_slot: 2 };
+  const arrayLink = [2, 3, 0, 7, 3, "IMAGE"];
+  const subgraph = {};
+  const host = {
+    id: 7,
+    subgraph,
+    inputs: [{ name: "keep", link: 1 }, { name: "shifted", link: 2 }],
+  };
+  const root = { _nodes: [host], links: { 1: objectLink, 2: arrayLink } };
+  host.graph = root;
+  reindexHostRailLinks(root, subgraph, "input", 1);
+  assert.equal(objectLink.target_slot, 2, "slots before the removed index are left alone");
+  assert.equal(arrayLink[4], 1);
+
+  const objectAgain = { id: 1, origin_id: 2, origin_slot: 0, target_id: 7, target_slot: 2 };
+  const arrayAgain = [2, 3, 0, 7, 3, "IMAGE"];
+  host.inputs = [
+    { name: "shifted-object", link: 1 },
+    { name: "shifted-array", link: 2 },
+  ];
+  root.links = { 1: objectAgain, 2: arrayAgain };
+  reindexHostRailLinks(root, subgraph, "input", 0);
+  assert.equal(objectAgain.target_slot, 0);
+  assert.equal(arrayAgain[4], 1);
+});
+
+test("#1969 reindexHostRailLinks walks nested hosts and skips foreign links", () => {
+  const subgraph = {};
+  const nestedLink = { id: 4, origin_id: 1, origin_slot: 0, target_id: 15, target_slot: 2 };
+  const foreign = { id: 5, origin_id: 1, origin_slot: 0, target_id: 99, target_slot: 2 };
+  const nestedHost = {
+    id: 15,
+    subgraph,
+    inputs: [{ name: "a", link: null }, { name: "b", link: 4 }],
+  };
+  const parentSub = { _nodes: [nestedHost], links: { 4: nestedLink } };
+  nestedHost.graph = parentSub;
+  const decoy = {
+    id: 8,
+    subgraph,
+    inputs: [{ name: "a", link: null }, { name: "b", link: 5 }],
+    graph: { links: { 5: foreign } },
+  };
+  const root = { _nodes: [{ subgraph: parentSub }, decoy] };
+  decoy.graph.links = { 5: foreign };
+  reindexHostRailLinks(root, subgraph, "input", 1);
+  assert.equal(nestedLink.target_slot, 1);
+  assert.equal(foreign.target_slot, 2, "a link that does not target this host is left alone");
 });

--- a/browser_tests/unit/unexpose-boundary-slot.test.mjs
+++ b/browser_tests/unit/unexpose-boundary-slot.test.mjs
@@ -16,13 +16,16 @@
  *    decides, and the throw is disclosed as a warning;
  *  - the wires that crossed the boundary are counted BEFORE the removal and
  *    reported, never silently dropped.
+ *  - #1969: remaining host SubgraphNode links after a non-last splice must be
+ *    re-pointed at the live index; a positional `inputs[i].link` check cannot
+ *    see the stale target_slot / origin_slot graphToPrompt uses.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { resolveRailSlotForRemoval, countHostRailLinks } from "../../web/js/lib/rail-slot.js";
+import { resolveRailSlotForRemoval, countHostRailLinks, reindexHostRailLinks } from "../../web/js/lib/rail-slot.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -40,15 +43,16 @@ function sliceMethod(signature) {
 const unexposeOutSrc = sliceMethod("  graph_unexpose_subgraph_output({ name }) {");
 const unexposeInSrc = sliceMethod("  graph_unexpose_subgraph_input({ name }) {");
 
-function buildExecutors(graph, rootGraph, canvas = {}) {
+function buildExecutors(graph, rootGraph, canvas = {}, src = { out: unexposeOutSrc, inn: unexposeInSrc }) {
   const factory = new Function(
     "getGraphCtx",
     "resolveRailSlotForRemoval",
     "countHostRailLinks",
+    "reindexHostRailLinks",
     "findSubgraphHostNode",
     `const GRAPH_TOOL_EXECUTORS = {
-${unexposeOutSrc}
-${unexposeInSrc}
+${src.out}
+${src.inn}
 };
 return GRAPH_TOOL_EXECUTORS;`,
   );
@@ -56,8 +60,98 @@ return GRAPH_TOOL_EXECUTORS;`,
     () => ({ graph, canvas, rootGraph }),
     resolveRailSlotForRemoval,
     countHostRailLinks,
+    reindexHostRailLinks,
     () => null, // findSubgraphHostNode — no promoted views to refresh in a double
   );
+}
+
+/** The #1969 reporter shape: STRING `text` at index 3, remaining IMAGE host links
+ *  later on the rail. `removeInput` splices the rail AND the host slots in lockstep
+ *  (frontend) but does NOT rewrite remaining link.target_slot — that is the bug. */
+function mkShiftedInputGraph() {
+  const names = ["unet_name", "clip_name", "vae_name", "text", "image", "image_1", "noise_seed"];
+  const hostCalls = { disconnectInput: 0, connect: 0 };
+  const subgraph = {
+    inputs: names.map((name) => ({
+      name,
+      type: name.startsWith("image") ? "IMAGE" : name === "text" ? "STRING" : "COMBO",
+      linkIds: name === "text" ? [7] : [],
+    })),
+    outputs: [],
+    outputNode: { id: -20 },
+    inputNode: { id: -10 },
+    setDirtyCanvas() {},
+  };
+  const imageLink = { id: 10, origin_id: 1, origin_slot: 0, target_id: 92, target_slot: 4, type: "IMAGE" };
+  const image1Link = { id: 11, origin_id: 2, origin_slot: 0, target_id: 92, target_slot: 5, type: "IMAGE" };
+  const vaeLink = { id: 9, origin_id: 3, origin_slot: 0, target_id: 92, target_slot: 2, type: "COMBO" };
+  const links = { 9: vaeLink, 10: imageLink, 11: image1Link };
+  const host = {
+    id: 92,
+    subgraph,
+    inputs: names.map((name) => ({
+      name,
+      link: name === "image" ? 10 : name === "image_1" ? 11 : name === "vae_name" ? 9 : null,
+    })),
+    outputs: [],
+    disconnectInput() { hostCalls.disconnectInput++; },
+    connect() { hostCalls.connect++; },
+  };
+  const rootGraph = {
+    _nodes: [host],
+    links,
+    getLink: (id) => links[id] ?? null,
+  };
+  host.graph = rootGraph;
+  subgraph.removeInput = (slot) => {
+    const i = subgraph.inputs.indexOf(slot);
+    if (i < 0) return;
+    subgraph.inputs.splice(i, 1);
+    host.inputs.splice(i, 1);
+  };
+  subgraph.removeOutput = () => {};
+  return { subgraph, host, rootGraph, imageLink, image1Link, vaeLink, hostCalls };
+}
+
+function mkShiftedOutputGraph() {
+  const names = ["latent", "images", "mask"];
+  const hostCalls = { disconnectOutput: 0, connect: 0 };
+  const subgraph = {
+    outputs: names.map((name) => ({ name, type: name === "latent" ? "LATENT" : "IMAGE", linkIds: [] })),
+    inputs: [],
+    outputNode: { id: -20 },
+    inputNode: { id: -10 },
+    setDirtyCanvas() {},
+  };
+  const imagesLink = { id: 20, origin_id: 5, origin_slot: 1, target_id: 8, target_slot: 0, type: "IMAGE" };
+  const maskLink = { id: 21, origin_id: 5, origin_slot: 2, target_id: 9, target_slot: 0, type: "MASK" };
+  const links = { 20: imagesLink, 21: maskLink };
+  const host = {
+    id: 5,
+    subgraph,
+    inputs: [],
+    outputs: [
+      { name: "latent", links: [] },
+      { name: "images", links: [20] },
+      { name: "mask", links: [21] },
+    ],
+    disconnectOutput() { hostCalls.disconnectOutput++; },
+    connect() { hostCalls.connect++; },
+  };
+  const rootGraph = {
+    _nodes: [host],
+    links,
+    getLink: (id) => links[id] ?? null,
+  };
+  host.graph = rootGraph;
+  subgraph.removeOutput = (slot) => {
+    const i = subgraph.outputs.indexOf(slot);
+    if (i < 0) return;
+    subgraph.outputs.splice(i, 1);
+    host.outputs.splice(i, 1);
+  };
+  subgraph.removeInput = () => {};
+  return { subgraph, host, rootGraph, imagesLink, maskLink, hostCalls };
 }
 
 /**
@@ -178,4 +272,61 @@ test("#1294 the ROOT graph is refused — unexpose runs INSIDE a subgraph", () =
     () => buildExecutors(subgraph, subgraph).graph_unexpose_subgraph_output({ name: "images" }),
     /must be run INSIDE a subgraph/,
   );
+});
+
+test("#1969 unexpose INPUT of a non-last slot reindexes remaining host links", () => {
+  const { subgraph, host, rootGraph, imageLink, image1Link, vaeLink, hostCalls } = mkShiftedInputGraph();
+  const res = buildExecutors(subgraph, rootGraph).graph_unexpose_subgraph_input({ name: "text" });
+  assert.equal(res.removed.slot, 3);
+  assert.equal(host.inputs.map((s) => s.name).join(","), "unet_name,clip_name,vae_name,image,image_1,noise_seed");
+  // The live backlink still names the same wires — that is what query/outline see.
+  assert.equal(host.inputs[3].link, 10);
+  assert.equal(host.inputs[4].link, 11);
+  // Serialization reads target_slot. After removing index 3, image must be 3 and
+  // image_1 must be 4 — leaving 4 and 5 is the queue-time miss.
+  assert.equal(imageLink.target_slot, 3);
+  assert.equal(image1Link.target_slot, 4);
+  assert.equal(vaeLink.target_slot, 2, "slots before the removal must not be rewritten");
+  assert.equal(hostCalls.disconnectInput, 0, "reindex must not disconnect (#668)");
+  assert.equal(hostCalls.connect, 0, "reindex must not reconnect");
+});
+
+test("#1969 unexpose OUTPUT of a non-last slot reindexes remaining host links", () => {
+  const { subgraph, host, rootGraph, imagesLink, maskLink, hostCalls } = mkShiftedOutputGraph();
+  buildExecutors(subgraph, rootGraph).graph_unexpose_subgraph_output({ name: "latent" });
+  assert.equal(host.outputs.map((s) => s.name).join(","), "images,mask");
+  assert.equal(imagesLink.origin_slot, 0);
+  assert.equal(maskLink.origin_slot, 1);
+  assert.equal(hostCalls.disconnectOutput, 0);
+  assert.equal(hostCalls.connect, 0);
+});
+
+test("#1969 stripping the reindex call leaves remaining host links at the old index", () => {
+  const strip = (src) => src.replace(/\s*reindexHostRailLinks\([^;]+;/g, "");
+  const { subgraph, rootGraph, imageLink, image1Link } = mkShiftedInputGraph();
+  const res = buildExecutors(subgraph, rootGraph, {}, { out: strip(unexposeOutSrc), inn: strip(unexposeInSrc) })
+    .graph_unexpose_subgraph_input({ name: "text" });
+  assert.equal(res.removed.name, "text");
+  assert.equal(imageLink.target_slot, 4, "without reindex, image still points at the pre-splice index");
+  assert.equal(image1Link.target_slot, 5, "without reindex, image_1 still points at the pre-splice index");
+});
+
+test("#1969 a last-slot unexpose does not rewrite earlier host links", () => {
+  const { subgraph, host, rootGraph, imageLink, image1Link, vaeLink } = mkShiftedInputGraph();
+  buildExecutors(subgraph, rootGraph).graph_unexpose_subgraph_input({ name: "noise_seed" });
+  assert.equal(host.inputs.at(-1).name, "image_1");
+  assert.equal(imageLink.target_slot, 4);
+  assert.equal(image1Link.target_slot, 5);
+  assert.equal(vaeLink.target_slot, 2);
+});
+
+test("#1969 a canceled removal does not reindex remaining host links", () => {
+  const { subgraph, rootGraph, imageLink, image1Link } = mkShiftedInputGraph();
+  subgraph.removeInput = () => {};
+  assert.throws(
+    () => buildExecutors(subgraph, rootGraph).graph_unexpose_subgraph_input({ name: "text" }),
+    /still on the rail after removeInput returned/,
+  );
+  assert.equal(imageLink.target_slot, 4);
+  assert.equal(image1Link.target_slot, 5);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -452,7 +452,7 @@ import {
 } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
-import { findExistingRailSlot, resolveRailSlotForRemoval, countHostRailLinks } from "./lib/rail-slot.js";
+import { findExistingRailSlot, resolveRailSlotForRemoval, countHostRailLinks, reindexHostRailLinks } from "./lib/rail-slot.js";
 import { VENDORED_VOCABULARY_HASH } from "./lib/vocabulary-hash.js";
 import { managerFetchFailureMessage } from "./lib/manager-fetch-failure.js";
 import { withoutFrontendVirtualTypes } from "./lib/frontend-virtual-nodes.js";
@@ -23652,6 +23652,12 @@ const GRAPH_TOOL_EXECUTORS = {
       // slot may be gone anyway. The live rail below is the only reading.
       removeErr = err;
     } finally {
+      // #1969 — remaining host links keep the OLD origin_slot after a non-last
+      // splice. Re-point them inside the same change group; do not disconnect
+      // (#668 cascade). A canceled remove leaves the slot on the rail and skips.
+      if (!(subgraph.outputs ?? []).includes(slot)) {
+        reindexHostRailLinks(rootGraph, subgraph, "output", slotIndex);
+      }
       subgraph.afterChange?.();
     }
     // OBSERVED, not "the call returned": LGraph.removeOutput dispatches a
@@ -23707,6 +23713,11 @@ const GRAPH_TOOL_EXECUTORS = {
     } catch (err) {
       removeErr = err;
     } finally {
+      // #1969 — same host-link shift as the output twin: remaining later
+      // target_slot values stay at the pre-splice index unless we re-point.
+      if (!(subgraph.inputs ?? []).includes(slot)) {
+        reindexHostRailLinks(rootGraph, subgraph, "input", slotIndex);
+      }
       subgraph.afterChange?.();
     }
     // See the output twin: a cancelable "removing-input" event means a clean

--- a/web/js/lib/rail-slot.js
+++ b/web/js/lib/rail-slot.js
@@ -145,3 +145,105 @@ export function countHostRailLinks(rootGraph, subgraph, side, slotIndex) {
   }
   return count;
 }
+
+/**
+ * #1969 — after subgraph.removeInput/removeOutput splices a non-last rail slot,
+ * host SubgraphNode slots shift in lockstep but remaining parent-graph links
+ * keep the OLD origin_slot/target_slot. Readers (query/outline) look at
+ * `node.inputs[i].link` and still see a wire; graphToPrompt uses the link
+ * record's slot index and reports `Required input is missing`.
+ *
+ * Sync survivors to the live positional index. Do NOT disconnect/reconnect:
+ * #668 saw a SubgraphNode disconnect cascade delete unrelated nodes. Idempotent
+ * if the frontend already reindexed. Never throws — the unexpose has landed.
+ */
+export function reindexHostRailLinks(rootGraph, subgraph, side, removedIndex) {
+  if (!rootGraph || !subgraph || (side !== "input" && side !== "output")) return;
+  if (!Number.isInteger(removedIndex) || removedIndex < 0) return;
+  try {
+    const stack = [{ graph: rootGraph, nodes: rootGraph._nodes ?? [] }];
+    while (stack.length) {
+      const frame = stack.pop();
+      const graph = frame?.graph;
+      for (const node of frame?.nodes ?? []) {
+        if (!node) continue;
+        if (node.subgraph === subgraph) {
+          if (side === "input") reindexHostInputLinks(node, graph, removedIndex);
+          else reindexHostOutputLinks(node, graph, removedIndex);
+        }
+        if (node.subgraph?._nodes?.length) {
+          stack.push({ graph: node.subgraph, nodes: node.subgraph._nodes });
+        }
+      }
+    }
+  } catch {
+    /* a landed unexpose must not become a throw because a host walk failed */
+  }
+}
+
+function readHostGraphLink(node, graph, linkId) {
+  if (linkId == null) return null;
+  const stores = [node?.graph, graph];
+  for (const g of stores) {
+    if (!g) continue;
+    try {
+      if (typeof g.getLink === "function") {
+        const stored = g.getLink(linkId);
+        if (stored != null) return stored;
+      }
+      const links = g.links;
+      if (!links) continue;
+      const stored = typeof links.get === "function" ? links.get(linkId) : links[linkId];
+      if (stored != null) return stored;
+    } catch {
+      /* try the next store */
+    }
+  }
+  return null;
+}
+
+function linkEndpointId(link, role) {
+  if (link == null) return null;
+  if (Array.isArray(link)) return role === "origin" ? link[1] : link[3];
+  return role === "origin" ? (link.origin_id ?? link.originId) : (link.target_id ?? link.targetId);
+}
+
+function setLinkSlotIndex(link, role, index) {
+  const prop = role === "origin" ? "origin_slot" : "target_slot";
+  const arrIdx = role === "origin" ? 2 : 4;
+  if (Array.isArray(link)) {
+    if (link.length > arrIdx) link[arrIdx] = index;
+    if (Object.prototype.hasOwnProperty.call(link, prop)) link[prop] = index;
+    return;
+  }
+  if (link && typeof link === "object") link[prop] = index;
+}
+
+function reindexHostInputLinks(node, graph, removedIndex) {
+  const inputs = node?.inputs;
+  if (!Array.isArray(inputs)) return;
+  for (let i = removedIndex; i < inputs.length; i++) {
+    const linkId = inputs[i]?.link;
+    if (linkId == null) continue;
+    const link = readHostGraphLink(node, graph, linkId);
+    if (!link) continue;
+    const targetId = linkEndpointId(link, "target");
+    if (targetId == null || String(targetId) !== String(node.id)) continue;
+    setLinkSlotIndex(link, "target", i);
+  }
+}
+
+function reindexHostOutputLinks(node, graph, removedIndex) {
+  const outputs = node?.outputs;
+  if (!Array.isArray(outputs)) return;
+  for (let i = removedIndex; i < outputs.length; i++) {
+    for (const linkId of outputs[i]?.links ?? []) {
+      if (linkId == null) continue;
+      const link = readHostGraphLink(node, graph, linkId);
+      if (!link) continue;
+      const originId = linkEndpointId(link, "origin");
+      if (originId == null || String(originId) !== String(node.id)) continue;
+      setLinkSlotIndex(link, "origin", i);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`graph_unexpose_subgraph_input` / `_output` splice a non-last boundary slot without re-pointing remaining host SubgraphNode links. After removing STRING `text` at index 3, later IMAGE host links still look connected in `panel_query_graph` / `panel_graph_outline` (they read `node.inputs[i].link`) and fail at queue:

```
ImageScaleToTotalPixels (node 92:110): Required input is missing (image)
```

Disconnect + reconnect those remaining host links **by name** repairs it. A positional post-check cannot see the bug: after `removeInput`, index N still holds *a* link.

MCP remaining piece (disclosure + reconnect-by-name repair in the unexpose reply) already shipped in artokun/comfyui-mcp#2456; it does **not** reindex.

## Fix

After a landed `removeInput` / `removeOutput`, reindex remaining host links so each survivor's `target_slot` / `origin_slot` matches the live positional array. The patch is in-place on the link records, inside the same `beforeChange`/`afterChange` group.

Do **not** disconnect/reconnect — #668 saw a SubgraphNode disconnect cascade delete unrelated nodes.

## Tests

Drive the shipped unexpose executors extracted from `web/js/comfyui-mcp-panel.js`:

- remaining host input/output links after a non-last unexpose point at the new index
- stripping the `reindexHostRailLinks` call from the shipped body leaves the old index (the queue-time miss)
- last-slot unexpose and canceled removal do not rewrite other host links
- reindex does not call `disconnectInput` / `connect`

`npm run test:unit`: 7253 tests, 7252 pass / 0 fail / 1 todo

Log: `C:\Users\Artokun\AppData\Local\Temp\grok-goal-dba11719f7d4\implementer\tests-panel-1969.log`

Closes #1969
Related: artokun/comfyui-mcp#2437