### PR TITLE
fix(1953): refuse panel_connect to a raw rail id instead of auto-exposing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - graph_unexpose_subgraph_input / _output re-point remaining host SubgraphNode links after a non-last boundary slot is removed, so later host wires stay valid at queue (#1969, artokun/comfyui-mcp#2437)
+- panel_connect to a raw rail id (`-20`/`-10`) refuses instead of silently auto-exposing a subgraph boundary slot (#1953)
 
 ## [0.15.119] - 2026-08-27
 

--- a/browser_tests/unit/connect-raw-rail-refuse.test.mjs
+++ b/browser_tests/unit/connect-raw-rail-refuse.test.mjs
@@ -1,0 +1,426 @@
+/**
+ * #1953 — `panel_connect` to a raw rail id silently auto-exposed.
+ *
+ * Documented contract (panel_expose_subgraph_output):
+ *   "do NOT panel_connect to a guessed rail node id"
+ * Documented contract (panel_unexpose_subgraph_output):
+ *   a rail_node_id "is forwarded to the panel, which REFUSES it"
+ *
+ * The refusal did not exist. Inside a subgraph the reported call
+ *
+ *     panel_connect { from_node_id: 2, from_output: "LATENT", to_node_id: -20 }
+ *
+ * SUCCEEDED with `{ exposed: { name: "LATENT", … } }` and minted a new
+ * boundary slot — a shape panel_connect's own description never mentions.
+ * A typo'd to_node_id that happened to hit a rail mutated the subgraph's
+ * public interface with no error.
+ *
+ * These tests run the REAL shipped `graph_connect`, extracted from
+ * web/js/comfyui-mcp-panel.js, with a STUB expose that records the call and
+ * returns `{ exposed }` — so leftover auto-expose is a SUCCESS the assertions
+ * fail on, not a TypeError `assert.throws` would swallow. Connecting to an
+ * EXISTING named rail slot is still a connect (not this bug).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  isLinkPersisted,
+  removePhantomLink,
+  isWidgetBackedInput,
+  inputLinkIds,
+  railSlotLinkIds,
+  linkIdExclusionSet,
+  findLandedInboundLink,
+  findLandedRailLink,
+  isRailLinkPersisted,
+  landedAfterThrowWarning,
+  verifyConnect,
+  snapshotInputSlotLinks,
+  connectCollateralBullets,
+  connectCollateralWarning,
+} from "../../web/js/lib/connect-verify.js";
+import { snapshotGraphState } from "../../web/js/lib/disconnect-verify.js";
+import { findExistingRailSlot, refuseConnectToRawRail } from "../../web/js/lib/rail-slot.js";
+import {
+  captureNodeTitles,
+  describeTitleRewrites,
+  titleRewriteWarning,
+} from "../../web/js/lib/node-title-rewrite.js";
+import {
+  captureSlotNames,
+  describeSlotRewrites,
+  slotRewriteWarning,
+} from "../../web/js/lib/slot-rename-disclosure.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+function sliceMethod(signature) {
+  const lines = panelSrc.split("\n");
+  const start = lines.findIndex((l) => l === signature);
+  assert.ok(start >= 0, `could not locate "${signature}" in the panel source`);
+  const end = lines.findIndex((l, i) => i > start && l === "  },");
+  assert.ok(end > start, `could not locate the end of "${signature}"`);
+  return lines.slice(start, end + 1).join("\n");
+}
+
+const connectSrc = sliceMethod(
+  "  graph_connect({ from_node_id, from_output, to_node_id, to_input, auto_match }) {",
+);
+
+function resolveNode(graph, id) {
+  const n = graph.getNodeById(id);
+  if (!n) throw new Error(`No node with id ${id}`);
+  return n;
+}
+
+function resolveSlot(slots, ref, kind) {
+  const list = slots ?? [];
+  if (typeof ref === "number") {
+    if (ref < 0 || ref >= list.length) throw new Error(`no ${kind} slot ${ref}`);
+    return ref;
+  }
+  const i = list.findIndex((s) => s?.name === ref);
+  if (i === -1) throw new Error(`no ${kind} named ${ref}`);
+  return i;
+}
+
+function resolveRail(graph, ref) {
+  const inNode = graph?.inputNode ?? null;
+  const outNode = graph?.outputNode ?? null;
+  if (typeof ref === "string") {
+    const key = ref.trim().toLowerCase();
+    if (key === "input" || key === "input_rail" || key === "inputs" || key === "in") {
+      return inNode ? { rail: "input", node: inNode } : null;
+    }
+    if (key === "output" || key === "output_rail" || key === "outputs" || key === "out") {
+      return outNode ? { rail: "output", node: outNode } : null;
+    }
+  }
+  const num = Number(ref);
+  if (Number.isFinite(num)) {
+    if (inNode && (Number(inNode.id) === num || num === -10)) return { rail: "input", node: inNode };
+    if (outNode && (Number(outNode.id) === num || num === -20)) return { rail: "output", node: outNode };
+  }
+  return null;
+}
+
+const railIntent = (ref) => {
+  const r = resolveRail({ inputNode: { id: -10 }, outputNode: { id: -20 } }, ref);
+  return r?.rail ?? null;
+};
+const isEmptyRailSlotRef = (ref) =>
+  ref == null || ref === "" || (typeof ref === "string" && ["new", "empty", "+"].includes(ref.trim().toLowerCase()));
+const slotDiagnostic = () => "slot diagnostic";
+const loopbackRefusalReason = () => "loopback";
+const findSubgraphHostNode = () => null;
+const uniqueSubgraphOutputName = (_g, base) => base;
+const uniqueSubgraphInputName = (_g, base) => base;
+
+function autoMatchSlots(origin, target, from_output, to_input) {
+  return {
+    outIdx: resolveSlot(origin.outputs, from_output ?? 0, "output"),
+    inIdx: resolveSlot(target.inputs, to_input ?? 0, "input"),
+    autoMatched: [],
+  };
+}
+
+function mkLinkStore() {
+  const isIndex = (prop) => typeof prop === "string" && /^(?:0|[1-9]\d*)$/.test(prop);
+  const map = new Map();
+  const proxy = new Proxy(map, {
+    get(target, prop) {
+      if (isIndex(prop)) return target.get(Number(prop));
+      const v = Reflect.get(target, prop, target);
+      return typeof v === "function" ? v.bind(target) : v;
+    },
+    has: (target, prop) => (isIndex(prop) ? target.has(Number(prop)) : Reflect.has(target, prop)),
+    deleteProperty: (target, prop) =>
+      isIndex(prop) ? target.delete(Number(prop)) : Reflect.deleteProperty(target, prop),
+    ownKeys: (target) => [...target.keys()].map(String),
+    getOwnPropertyDescriptor(target, prop) {
+      if (isIndex(prop) && target.has(Number(prop))) {
+        return { value: target.get(Number(prop)), enumerable: true, configurable: true, writable: true };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  });
+  return { map, proxy };
+}
+
+function mkRailOutput(graph, name, type) {
+  const slot = { name, type, linkIds: [] };
+  slot.connect = (outputSlot, node) => {
+    const outIdx = node.outputs.indexOf(outputSlot);
+    const id = ++graph.lastLinkId;
+    const link = { id, origin_id: node.id, origin_slot: outIdx, target_id: -20, target_slot: 0 };
+    graph._links.set(id, link);
+    slot.linkIds[0] = id;
+    (outputSlot.links ??= []).push(id);
+    return link;
+  };
+  return slot;
+}
+
+function mkRailInput(graph, name, type) {
+  const slot = { name, type, linkIds: [] };
+  slot.connect = (inputSlot, node) => {
+    const inIdx = node.inputs.indexOf(inputSlot);
+    const id = ++graph.lastLinkId;
+    const link = { id, origin_id: -10, origin_slot: 0, target_id: node.id, target_slot: inIdx };
+    graph._links.set(id, link);
+    slot.linkIds.push(id);
+    inputSlot.link = id;
+    return link;
+  };
+  return slot;
+}
+
+function mkGraph() {
+  const store = mkLinkStore();
+  const graph = {
+    lastLinkId: 0,
+    _links: store.map,
+    links: store.proxy,
+    nodes: [],
+    outputs: [],
+    inputs: [],
+    outputNode: { id: -20 },
+    inputNode: { id: -10 },
+    getNodeById: (id) => graph.nodes.find((n) => String(n.id) === String(id)) ?? null,
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+    addOutput(name, type) {
+      const slot = mkRailOutput(graph, name, type);
+      graph.outputs.push(slot);
+      return slot;
+    },
+    addInput(name, type) {
+      const slot = mkRailInput(graph, name, type);
+      graph.inputs.push(slot);
+      return slot;
+    },
+    getLink: (id) => store.map.get(id) ?? null,
+  };
+  return graph;
+}
+
+function mkNode(graph, id, inputs, outputs) {
+  const node = { id, inputs, outputs, graph };
+  graph.nodes.push(node);
+  return node;
+}
+
+/**
+ * Build shipped `graph_connect` with stub expose twins that RECORD a call and
+ * return `{ exposed }` — leftover auto-expose is then a success, not a throw.
+ */
+function buildConnect(graph, exposeCalls) {
+  const deps = {
+    getGraphCtx: () => ({ graph, canvas: {}, app: {}, rootGraph: graph, LG: {} }),
+    resolveNode,
+    resolveSlot,
+    resolveRail,
+    railIntent,
+    isEmptyRailSlotRef,
+    findExistingRailSlot,
+    refuseConnectToRawRail,
+    findSubgraphHostNode,
+    autoMatchSlots,
+    slotDiagnostic,
+    loopbackRefusalReason,
+    uniqueSubgraphOutputName,
+    uniqueSubgraphInputName,
+    isLinkPersisted,
+    removePhantomLink,
+    isWidgetBackedInput,
+    inputLinkIds,
+    railSlotLinkIds,
+    linkIdExclusionSet,
+    findLandedInboundLink,
+    findLandedRailLink,
+    isRailLinkPersisted,
+    landedAfterThrowWarning,
+    snapshotGraphState,
+    snapshotInputSlotLinks,
+    verifyConnect,
+    connectCollateralBullets,
+    connectCollateralWarning,
+    captureNodeTitles,
+    describeTitleRewrites,
+    titleRewriteWarning,
+    captureSlotNames,
+    describeSlotRewrites,
+    slotRewriteWarning,
+    exposeCalls,
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const GRAPH_TOOL_EXECUTORS = {
+${connectSrc}
+  graph_expose_subgraph_output(args) {
+    exposeCalls.push({ side: "output", args });
+    return {
+      exposed: {
+        name: args.name || "LATENT",
+        type: "LATENT",
+        slot: 0,
+        on_host_subgraph_node: true,
+        from: { node_id: String(args.from_node_id), output: args.from_output },
+      },
+    };
+  },
+  graph_expose_subgraph_input(args) {
+    exposeCalls.push({ side: "input", args });
+    return {
+      exposed: {
+        name: args.name || "model",
+        type: "MODEL",
+        slot: 0,
+        on_host_subgraph_node: true,
+        to: { node_id: String(args.to_node_id), input: args.to_input },
+      },
+    };
+  },
+};
+return GRAPH_TOOL_EXECUTORS.graph_connect;`,
+  );
+  return factory(...names.map((n) => deps[n]));
+}
+
+function documentedOutputRefusal(err) {
+  assert.match(err.message, /do NOT panel_connect to a guessed rail node id/);
+  assert.match(err.message, /panel_connect REFUSES it/);
+  assert.match(err.message, /panel_expose_subgraph_output/);
+  assert.match(err.message, /rail_node_id/);
+  assert.match(err.message, /Nothing was exposed/);
+  assert.doesNotMatch(err.message, /graph_expose_subgraph_output/);
+  return true;
+}
+
+function documentedInputRefusal(err) {
+  assert.match(err.message, /do NOT panel_connect to a guessed rail node id/);
+  assert.match(err.message, /panel_connect REFUSES it/);
+  assert.match(err.message, /panel_expose_subgraph_input/);
+  assert.match(err.message, /Nothing was exposed/);
+  assert.doesNotMatch(err.message, /graph_expose_subgraph_input/);
+  return true;
+}
+
+test("#1953 WIRING: graph_connect no longer falls through to graph_expose_subgraph_*", () => {
+  assert.doesNotMatch(
+    connectSrc,
+    /graph_expose_subgraph_output/,
+    "output-rail auto-expose must be gone from graph_connect",
+  );
+  assert.doesNotMatch(
+    connectSrc,
+    /graph_expose_subgraph_input/,
+    "input-rail auto-expose must be gone from graph_connect",
+  );
+  assert.match(connectSrc, /refuseConnectToRawRail\(to_node_id, "output"\)/);
+  assert.match(connectSrc, /refuseConnectToRawRail\(from_node_id, "input"\)/);
+});
+
+test("#1953 the reported call (to_node_id: -20, no to_input) REFUSES and exposes NOTHING", () => {
+  const graph = mkGraph();
+  mkNode(graph, 2, [], [{ name: "LATENT", type: "LATENT", links: [] }]);
+  const exposeCalls = [];
+  const graph_connect = buildConnect(graph, exposeCalls);
+
+  assert.throws(
+    () => graph_connect({ from_node_id: 2, from_output: "LATENT", to_node_id: -20 }),
+    documentedOutputRefusal,
+  );
+  assert.equal(exposeCalls.length, 0, "auto-expose must not run");
+  assert.equal(graph.outputs.length, 0, "the boundary rail must be untouched");
+  assert.equal(graph._links.size, 0);
+});
+
+test("#1953 string '-20' (MCP coercion) is refused the same way", () => {
+  const graph = mkGraph();
+  mkNode(graph, 2, [], [{ name: "LATENT", type: "LATENT", links: [] }]);
+  const exposeCalls = [];
+  const graph_connect = buildConnect(graph, exposeCalls);
+
+  assert.throws(
+    () => graph_connect({ from_node_id: 2, from_output: "LATENT", to_node_id: "-20" }),
+    documentedOutputRefusal,
+  );
+  assert.equal(exposeCalls.length, 0);
+  assert.equal(graph.outputs.length, 0);
+});
+
+test("#1953 a missing to_input name still refuses — it must not mint that slot", () => {
+  const graph = mkGraph();
+  mkNode(graph, 2, [], [{ name: "LATENT", type: "LATENT", links: [] }]);
+  const exposeCalls = [];
+  const graph_connect = buildConnect(graph, exposeCalls);
+
+  assert.throws(
+    () => graph_connect({ from_node_id: 2, from_output: "LATENT", to_node_id: -20, to_input: "LATENT" }),
+    documentedOutputRefusal,
+  );
+  assert.equal(exposeCalls.length, 0);
+  assert.equal(graph.outputs.length, 0);
+});
+
+test("#1953 connect FROM -10 without a matching input-rail slot REFUSES", () => {
+  const graph = mkGraph();
+  mkNode(graph, 2, [{ name: "model", type: "MODEL", link: null }], []);
+  const exposeCalls = [];
+  const graph_connect = buildConnect(graph, exposeCalls);
+
+  assert.throws(
+    () => graph_connect({ from_node_id: -10, from_output: "model", to_node_id: 2, to_input: "model" }),
+    documentedInputRefusal,
+  );
+  assert.equal(exposeCalls.length, 0);
+  assert.equal(graph.inputs.length, 0);
+});
+
+test("#1953 connecting to an EXISTING named output-rail slot still wires (not an expose)", () => {
+  const graph = mkGraph();
+  mkNode(graph, 2, [], [{ name: "LATENT", type: "LATENT", links: [] }]);
+  const rail = mkRailOutput(graph, "LATENT", "LATENT");
+  graph.outputs.push(rail);
+  const exposeCalls = [];
+  const graph_connect = buildConnect(graph, exposeCalls);
+
+  const res = graph_connect({
+    from_node_id: 2,
+    from_output: "LATENT",
+    to_node_id: -20,
+    to_input: "LATENT",
+  });
+  assert.equal(res.connected.to.subgraph_output, "LATENT");
+  assert.equal(res.exposed, undefined, "must not return the auto-expose shape");
+  assert.equal(exposeCalls.length, 0);
+  assert.equal(graph.outputs.length, 1);
+  assert.equal(rail.linkIds.length, 1);
+});
+
+test("#1953 connecting FROM an EXISTING named input-rail slot still wires", () => {
+  const graph = mkGraph();
+  mkNode(graph, 2, [{ name: "model", type: "MODEL", link: null }], []);
+  const rail = mkRailInput(graph, "model", "MODEL");
+  graph.inputs.push(rail);
+  const exposeCalls = [];
+  const graph_connect = buildConnect(graph, exposeCalls);
+
+  const res = graph_connect({
+    from_node_id: -10,
+    from_output: "model",
+    to_node_id: 2,
+    to_input: "model",
+  });
+  assert.equal(res.connected.from.subgraph_input, "model");
+  assert.equal(res.exposed, undefined);
+  assert.equal(exposeCalls.length, 0);
+  assert.equal(graph.inputs.length, 1);
+});

--- a/browser_tests/unit/connect-slot-rename.test.mjs
+++ b/browser_tests/unit/connect-slot-rename.test.mjs
@@ -58,7 +58,7 @@ import {
   connectCollateralWarning,
 } from "../../web/js/lib/connect-verify.js";
 import { snapshotGraphState } from "../../web/js/lib/disconnect-verify.js";
-import { findExistingRailSlot } from "../../web/js/lib/rail-slot.js";
+import { findExistingRailSlot, refuseConnectToRawRail } from "../../web/js/lib/rail-slot.js";
 import {
   captureNodeTitles,
   describeTitleRewrites,
@@ -142,6 +142,7 @@ function buildConnect(graph, overrides = {}) {
     railIntent,
     isEmptyRailSlotRef,
     findExistingRailSlot,
+    refuseConnectToRawRail,
     findSubgraphHostNode,
     autoMatchSlots,
     slotDiagnostic,

--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -60,7 +60,7 @@ import {
   describeSlotRewrites,
   slotRewriteWarning,
 } from "../../web/js/lib/slot-rename-disclosure.js";
-import { findExistingRailSlot } from "../../web/js/lib/rail-slot.js";
+import { findExistingRailSlot, refuseConnectToRawRail } from "../../web/js/lib/rail-slot.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -138,6 +138,7 @@ function buildExecutors(graph, canvas = {}) {
     "railIntent",
     "isEmptyRailSlotRef",
     "findExistingRailSlot",
+    "refuseConnectToRawRail",
     "findSubgraphHostNode",
     "autoMatchSlots",
     "slotDiagnostic",
@@ -180,6 +181,7 @@ return GRAPH_TOOL_EXECUTORS;`,
     railIntent,
     isEmptyRailSlotRef,
     findExistingRailSlot,
+    refuseConnectToRawRail,
     findSubgraphHostNode,
     autoMatchSlots,
     slotDiagnostic,

--- a/browser_tests/unit/connect-title-rewrite.test.mjs
+++ b/browser_tests/unit/connect-title-rewrite.test.mjs
@@ -48,7 +48,7 @@ import {
   connectCollateralWarning,
 } from "../../web/js/lib/connect-verify.js";
 import { snapshotGraphState } from "../../web/js/lib/disconnect-verify.js";
-import { findExistingRailSlot } from "../../web/js/lib/rail-slot.js";
+import { findExistingRailSlot, refuseConnectToRawRail } from "../../web/js/lib/rail-slot.js";
 import {
   captureNodeTitles,
   describeTitleRewrites,
@@ -158,6 +158,7 @@ function buildConnect(graph, titleDeps = {}) {
     railIntent,
     isEmptyRailSlotRef,
     findExistingRailSlot,
+    refuseConnectToRawRail,
     findSubgraphHostNode,
     autoMatchSlots,
     slotDiagnostic,

--- a/browser_tests/unit/rail-slot.test.mjs
+++ b/browser_tests/unit/rail-slot.test.mjs
@@ -17,7 +17,13 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { findExistingRailSlot, railSlotIndex, resolveRailSlotForRemoval, reindexHostRailLinks } from "../../web/js/lib/rail-slot.js";
+import {
+  findExistingRailSlot,
+  railSlotIndex,
+  refuseConnectToRawRail,
+  resolveRailSlotForRemoval,
+  reindexHostRailLinks,
+} from "../../web/js/lib/rail-slot.js";
 
 /** A rail with twelve slots, none of them named with digits — the reported shape. */
 const RAIL = Array.from({ length: 12 }, (_, i) => ({ name: `in_${i}`, type: "STRING", slot: i }));
@@ -110,7 +116,7 @@ test("#1114 WIRING: the panel uses the shared lookup and keeps no copy", () => {
   );
   assert.match(
     panel,
-    /import \{ findExistingRailSlot, resolveRailSlotForRemoval, countHostRailLinks, reindexHostRailLinks \} from "\.\/lib\/rail-slot\.js";/,
+    /import \{\s*findExistingRailSlot,\s*resolveRailSlotForRemoval,\s*countHostRailLinks,\s*reindexHostRailLinks,\s*refuseConnectToRawRail,\s*\} from "\.\/lib\/rail-slot\.js";/,
     "the panel imports the shared lookups",
   );
   assert.doesNotMatch(
@@ -133,6 +139,11 @@ test("#1114 WIRING: the panel uses the shared lookup and keeps no copy", () => {
     /function reindexHostRailLinks\s*\(/,
     "and keeps no local copy of the host-link reindexer either",
   );
+  assert.doesNotMatch(
+    panel,
+    /function refuseConnectToRawRail\s*\(/,
+    "and keeps no local copy of the raw-rail connect refusal either",
+  );
   // Both rail branches must go through it: outputs (to_input) and inputs (from_output).
   const uses = panel.match(/findExistingRailSlot\(graph\.(inputs|outputs),/g) ?? [];
   assert.equal(uses.length, 2, "both rail branches resolve through it");
@@ -141,6 +152,36 @@ test("#1114 WIRING: the panel uses the shared lookup and keeps no copy", () => {
   assert.equal(removals.length, 2, "both unexpose executors resolve through it");
   const reindexes = panel.match(/reindexHostRailLinks\(rootGraph, subgraph, "(input|output)", slotIndex\)/g) ?? [];
   assert.equal(reindexes.length, 2, "both unexpose executors reindex remaining host links");
+  // Both connect-to-rail auto-expose fallthroughs refuse through the shared helper.
+  const refusals = panel.match(/refuseConnectToRawRail\((?:to_node_id|from_node_id),/g) ?? [];
+  assert.equal(refusals.length, 2, "both raw-rail connect fallthroughs refuse through it");
+});
+
+test("#1953 a raw output rail id uses the documented connect refusal wording", () => {
+  assert.throws(
+    () => refuseConnectToRawRail(-20, "output"),
+    (err) => {
+      assert.match(err.message, /do NOT panel_connect to a guessed rail node id/);
+      assert.match(err.message, /panel_connect REFUSES it/);
+      assert.match(err.message, /panel_expose_subgraph_output/);
+      assert.match(err.message, /rail_node_id/);
+      assert.match(err.message, /Nothing was exposed/);
+      assert.doesNotMatch(err.message, /graph_expose_subgraph_output/);
+      return true;
+    },
+  );
+});
+
+test("#1953 a raw input rail id names panel_expose_subgraph_input, not the output twin", () => {
+  assert.throws(
+    () => refuseConnectToRawRail(-10, "input"),
+    (err) => {
+      assert.match(err.message, /do NOT panel_connect to a guessed rail node id/);
+      assert.match(err.message, /panel_expose_subgraph_input/);
+      assert.doesNotMatch(err.message, /panel_expose_subgraph_output/);
+      return true;
+    },
+  );
 });
 
 test("#1294 removal resolves a slot by name or index, like a connect", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -452,7 +452,13 @@ import {
 } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
-import { findExistingRailSlot, resolveRailSlotForRemoval, countHostRailLinks, reindexHostRailLinks } from "./lib/rail-slot.js";
+import {
+  findExistingRailSlot,
+  resolveRailSlotForRemoval,
+  countHostRailLinks,
+  reindexHostRailLinks,
+  refuseConnectToRawRail,
+} from "./lib/rail-slot.js";
 import { VENDORED_VOCABULARY_HASH } from "./lib/vocabulary-hash.js";
 import { managerFetchFailureMessage } from "./lib/manager-fetch-failure.js";
 import { withoutFrontendVirtualTypes } from "./lib/frontend-virtual-nodes.js";
@@ -16430,163 +16436,156 @@ const GRAPH_TOOL_EXECUTORS = {
     const { graph } = getGraphCtx();
 
     // Rail tolerance: when an endpoint is a subgraph boundary rail (by real id
-    // -10/-20 or alias "input"/"output"/..), route to the boundary I/O logic
-    // instead of throwing "No node with id". Normal node-to-node connect below
-    // is unchanged.
+    // -10/-20 or alias "input"/"output"/..), route to the EXISTING-slot I/O
+    // logic instead of throwing "No node with id". A raw rail id with no
+    // matching slot REFUSES rather than auto-exposing (#1953) — that is
+    // panel_expose_subgraph_output / panel_expose_subgraph_input. Normal
+    // node-to-node connect below is unchanged.
     const fromRail = resolveRail(graph, from_node_id);
     const toRail = resolveRail(graph, to_node_id);
 
     if (toRail?.rail === "output") {
-      // internal node OUTPUT -> subgraph OUTPUT rail.
-      const node = resolveNode(graph, from_node_id);
-      const outIdx = resolveSlot(node.outputs, from_output ?? 0, "output");
-      const outputSlot = node.outputs[outIdx];
+      // internal node OUTPUT -> existing subgraph OUTPUT rail slot.
       const existing = isEmptyRailSlotRef(to_input)
         ? null
         : findExistingRailSlot(graph.outputs, to_input);
-      if (existing && typeof existing.connect === "function") {
-        // #1272 — the rail slot's own link ids BEFORE the mutation, so a wire that
-        // pre-dated this call can never be credited to it on the throw path below.
-        const railLinkIdsBefore = linkIdExclusionSet(railSlotLinkIds(existing));
-        graph.beforeChange?.();
-        let link;
-        let railConnectErr = null;
-        try {
-          link = existing["connect"](outputSlot, node);
-        } catch (err) {
-          // #1272 — SubgraphOutput.connect writes subgraph._links, the rail slot's
-          // linkIds and the node output's links, and only THEN calls
-          // node.onConnectionsChange. So a throw carries no information about
-          // whether the wire exists. This is the issue's SECOND repro
-          // (to_node_id: -20): it threw, and panel_graph_outline then showed the
-          // link. Decide on the observed post-state instead of on the exception.
-          railConnectErr = err;
-        } finally {
-          graph.afterChange?.();
-        }
-        graph.setDirtyCanvas?.(true, true);
-        // #397 adopted at THIS call site — it had only ever been applied to the
-        // node-to-node branch, so this branch reported success on LiteGraph's
-        // truthy return alone. Ask the live graph on BOTH paths: with the link
-        // connect() returned when there is one, by scanning the rail slot for a
-        // NEW link when it threw instead.
-        const railLanded = railConnectErr
-          ? findLandedRailLink(graph, existing, node, outIdx, "output", railLinkIdsBefore)
-          : isRailLinkPersisted(graph, existing, node, outIdx, "output", link)
-            ? { linkId: String(link.id) }
-            : null;
-        if (!railLanded) {
-          if (railConnectErr) {
-            throw new Error(
-              `panel_connect from node ${node.id} output "${outputSlot?.name ?? outIdx}" to subgraph ` +
-                `output "${existing.name}" threw and NOTHING landed (#1272): ` +
-                `${railConnectErr?.message ?? railConnectErr}. Observed post-state of the live graph: ` +
-                `this call left no new link from that output on the rail slot. Re-read with ` +
-                `panel_graph_outline ` +
-                `before retrying.`,
-            );
-          }
-          if (!link) {
-            throw new Error(
-              `connect refused — node ${node.id} output "${outputSlot?.name ?? outIdx}" ` +
-                `(${outputSlot?.type}) is not compatible with subgraph output "${existing.name}" (${existing.type})`,
-            );
-          }
+      if (!(existing && typeof existing.connect === "function")) {
+        refuseConnectToRawRail(to_node_id, "output");
+      }
+      const node = resolveNode(graph, from_node_id);
+      const outIdx = resolveSlot(node.outputs, from_output ?? 0, "output");
+      const outputSlot = node.outputs[outIdx];
+      // #1272 — the rail slot's own link ids BEFORE the mutation, so a wire that
+      // pre-dated this call can never be credited to it on the throw path below.
+      const railLinkIdsBefore = linkIdExclusionSet(railSlotLinkIds(existing));
+      graph.beforeChange?.();
+      let link;
+      let railConnectErr = null;
+      try {
+        link = existing["connect"](outputSlot, node);
+      } catch (err) {
+        // #1272 — SubgraphOutput.connect writes subgraph._links, the rail slot's
+        // linkIds and the node output's links, and only THEN calls
+        // node.onConnectionsChange. So a throw carries no information about
+        // whether the wire exists. This is the issue's SECOND repro
+        // (to_node_id: -20): it threw, and panel_graph_outline then showed the
+        // link. Decide on the observed post-state instead of on the exception.
+        railConnectErr = err;
+      } finally {
+        graph.afterChange?.();
+      }
+      graph.setDirtyCanvas?.(true, true);
+      // #397 adopted at THIS call site — it had only ever been applied to the
+      // node-to-node branch, so this branch reported success on LiteGraph's
+      // truthy return alone. Ask the live graph on BOTH paths: with the link
+      // connect() returned when there is one, by scanning the rail slot for a
+      // NEW link when it threw instead.
+      const railLanded = railConnectErr
+        ? findLandedRailLink(graph, existing, node, outIdx, "output", railLinkIdsBefore)
+        : isRailLinkPersisted(graph, existing, node, outIdx, "output", link)
+          ? { linkId: String(link.id) }
+          : null;
+      if (!railLanded) {
+        if (railConnectErr) {
           throw new Error(
-            `panel_connect reported no persisted link: node ${node.id} output ` +
-              `"${outputSlot?.name ?? outIdx}" (${outputSlot?.type}) → subgraph output ` +
-              `"${existing.name}" (${existing.type}). LiteGraph accepted the connection but the rail ` +
-              `slot does not carry it, so refusing to report a false success (#397).`,
+            `panel_connect from node ${node.id} output "${outputSlot?.name ?? outIdx}" to subgraph ` +
+              `output "${existing.name}" threw and NOTHING landed (#1272): ` +
+              `${railConnectErr?.message ?? railConnectErr}. Observed post-state of the live graph: ` +
+              `this call left no new link from that output on the rail slot. Re-read with ` +
+              `panel_graph_outline ` +
+              `before retrying.`,
           );
         }
-        findSubgraphHostNode(graph)?.invalidatePromotedViews?.();
-        return {
-          connected: {
-            from: { node_id: node.id, output: outputSlot?.name ?? outIdx },
-            to: { subgraph_output: existing.name },
-          },
-          ...(railConnectErr ? { warning: landedAfterThrowWarning(railConnectErr) } : {}),
-        };
+        if (!link) {
+          throw new Error(
+            `connect refused — node ${node.id} output "${outputSlot?.name ?? outIdx}" ` +
+              `(${outputSlot?.type}) is not compatible with subgraph output "${existing.name}" (${existing.type})`,
+          );
+        }
+        throw new Error(
+          `panel_connect reported no persisted link: node ${node.id} output ` +
+            `"${outputSlot?.name ?? outIdx}" (${outputSlot?.type}) → subgraph output ` +
+            `"${existing.name}" (${existing.type}). LiteGraph accepted the connection but the rail ` +
+            `slot does not carry it, so refusing to report a false success (#397).`,
+        );
       }
-      return GRAPH_TOOL_EXECUTORS.graph_expose_subgraph_output({
-        from_node_id,
-        from_output,
-        name: typeof to_input === "string" && !isEmptyRailSlotRef(to_input) ? to_input : undefined,
-      });
+      findSubgraphHostNode(graph)?.invalidatePromotedViews?.();
+      return {
+        connected: {
+          from: { node_id: node.id, output: outputSlot?.name ?? outIdx },
+          to: { subgraph_output: existing.name },
+        },
+        ...(railConnectErr ? { warning: landedAfterThrowWarning(railConnectErr) } : {}),
+      };
     }
 
     if (fromRail?.rail === "input") {
-      // subgraph INPUT rail -> internal node INPUT.
-      const node = resolveNode(graph, to_node_id);
-      const inIdx = resolveSlot(node.inputs, to_input ?? 0, "input");
-      const inputSlot = node.inputs[inIdx];
+      // subgraph INPUT rail slot -> internal node INPUT.
       const existing = isEmptyRailSlotRef(from_output)
         ? null
         : findExistingRailSlot(graph.inputs, from_output);
-      if (existing && typeof existing.connect === "function") {
-        // #1272 — see the OUTPUT rail branch above: pre-existing rail links are
-        // excluded so the throw path cannot credit this call with someone else's wire.
-        const railLinkIdsBefore = linkIdExclusionSet(railSlotLinkIds(existing));
-        graph.beforeChange?.();
-        let link;
-        let railConnectErr = null;
-        try {
-          link = existing["connect"](inputSlot, node);
-        } catch (err) {
-          // #1272 — SubgraphInput.connect has the same ordering as its output
-          // twin: the link is written to subgraph._links / linkIds / slot.link
-          // before node.onConnectionsChange runs, so a throw does not mean the
-          // wire is absent.
-          railConnectErr = err;
-        } finally {
-          graph.afterChange?.();
-        }
-        graph.setDirtyCanvas?.(true, true);
-        // #397 adopted at THIS call site too (see the output rail above).
-        const railLanded = railConnectErr
-          ? findLandedRailLink(graph, existing, node, inIdx, "input", railLinkIdsBefore)
-          : isRailLinkPersisted(graph, existing, node, inIdx, "input", link)
-            ? { linkId: String(link.id) }
-            : null;
-        if (!railLanded) {
-          if (railConnectErr) {
-            throw new Error(
-              `panel_connect from subgraph input "${existing.name}" to node ${node.id} input ` +
-                `"${inputSlot?.name ?? inIdx}" threw and NOTHING landed (#1272): ` +
-                `${railConnectErr?.message ?? railConnectErr}. Observed post-state of the live graph: ` +
-                `this call left no new link to that input on the rail slot. Re-read with ` +
-                `panel_graph_outline ` +
-                `before retrying.`,
-            );
-          }
-          if (!link) {
-            throw new Error(
-              `connect refused — subgraph input "${existing.name}" (${existing.type}) is not ` +
-                `compatible with node ${node.id} input "${inputSlot?.name ?? inIdx}" (${inputSlot?.type})`,
-            );
-          }
+      if (!(existing && typeof existing.connect === "function")) {
+        refuseConnectToRawRail(from_node_id, "input");
+      }
+      const node = resolveNode(graph, to_node_id);
+      const inIdx = resolveSlot(node.inputs, to_input ?? 0, "input");
+      const inputSlot = node.inputs[inIdx];
+      // #1272 — see the OUTPUT rail branch above: pre-existing rail links are
+      // excluded so the throw path cannot credit this call with someone else's wire.
+      const railLinkIdsBefore = linkIdExclusionSet(railSlotLinkIds(existing));
+      graph.beforeChange?.();
+      let link;
+      let railConnectErr = null;
+      try {
+        link = existing["connect"](inputSlot, node);
+      } catch (err) {
+        // #1272 — SubgraphInput.connect has the same ordering as its output
+        // twin: the link is written to subgraph._links / linkIds / slot.link
+        // before node.onConnectionsChange runs, so a throw does not mean the
+        // wire is absent.
+        railConnectErr = err;
+      } finally {
+        graph.afterChange?.();
+      }
+      graph.setDirtyCanvas?.(true, true);
+      // #397 adopted at THIS call site too (see the output rail above).
+      const railLanded = railConnectErr
+        ? findLandedRailLink(graph, existing, node, inIdx, "input", railLinkIdsBefore)
+        : isRailLinkPersisted(graph, existing, node, inIdx, "input", link)
+          ? { linkId: String(link.id) }
+          : null;
+      if (!railLanded) {
+        if (railConnectErr) {
           throw new Error(
-            `panel_connect reported no persisted link: subgraph input "${existing.name}" ` +
-              `(${existing.type}) → node ${node.id} input "${inputSlot?.name ?? inIdx}" ` +
-              `(${inputSlot?.type}). LiteGraph accepted the connection but the rail slot does not ` +
-              `carry it, so refusing to report a false success (#397).`,
+            `panel_connect from subgraph input "${existing.name}" to node ${node.id} input ` +
+              `"${inputSlot?.name ?? inIdx}" threw and NOTHING landed (#1272): ` +
+              `${railConnectErr?.message ?? railConnectErr}. Observed post-state of the live graph: ` +
+              `this call left no new link to that input on the rail slot. Re-read with ` +
+              `panel_graph_outline ` +
+              `before retrying.`,
           );
         }
-        findSubgraphHostNode(graph)?.invalidatePromotedViews?.();
-        return {
-          connected: {
-            from: { subgraph_input: existing.name },
-            to: { node_id: node.id, input: inputSlot?.name ?? inIdx },
-          },
-          ...(railConnectErr ? { warning: landedAfterThrowWarning(railConnectErr) } : {}),
-        };
+        if (!link) {
+          throw new Error(
+            `connect refused — subgraph input "${existing.name}" (${existing.type}) is not ` +
+              `compatible with node ${node.id} input "${inputSlot?.name ?? inIdx}" (${inputSlot?.type})`,
+          );
+        }
+        throw new Error(
+          `panel_connect reported no persisted link: subgraph input "${existing.name}" ` +
+            `(${existing.type}) → node ${node.id} input "${inputSlot?.name ?? inIdx}" ` +
+            `(${inputSlot?.type}). LiteGraph accepted the connection but the rail slot does not ` +
+            `carry it, so refusing to report a false success (#397).`,
+        );
       }
-      return GRAPH_TOOL_EXECUTORS.graph_expose_subgraph_input({
-        to_node_id,
-        to_input,
-        name:
-          typeof from_output === "string" && !isEmptyRailSlotRef(from_output) ? from_output : undefined,
-      });
+      findSubgraphHostNode(graph)?.invalidatePromotedViews?.();
+      return {
+        connected: {
+          from: { subgraph_input: existing.name },
+          to: { node_id: node.id, input: inputSlot?.name ?? inIdx },
+        },
+        ...(railConnectErr ? { warning: landedAfterThrowWarning(railConnectErr) } : {}),
+      };
     }
 
     if (fromRail?.rail === "output") {

--- a/web/js/lib/rail-slot.js
+++ b/web/js/lib/rail-slot.js
@@ -127,6 +127,39 @@ export function resolveRailSlotForRemoval(slots, ref, side) {
  * the reply can say what was dropped; the same subgraph can be instanced by
  * several host nodes (and nested), so the walk collects ALL of them.
  */
+/**
+ * #1953 — panel_connect to a raw rail id used to silently AUTO-EXPOSE.
+ *
+ * `panel_connect({ from_node_id: 2, from_output: "LATENT", to_node_id: -20 })`
+ * inside a subgraph returned `{ exposed: { name: "LATENT", … } }` and minted a
+ * new boundary slot. panel_expose_subgraph_output documents "do NOT
+ * panel_connect to a guessed rail node id"; panel_unexpose_subgraph_output
+ * documents that a rail_node_id "is forwarded to the panel, which REFUSES it".
+ * The refusal did not exist — a typo'd to_node_id that happened to hit a rail
+ * mutated the subgraph's public interface with no error.
+ *
+ * Connecting to an EXISTING named rail slot is still a connect (the slot is
+ * already on the boundary). This refusal is only the fallthrough that used to
+ * call graph_expose_subgraph_* — the caller must use the expose tool instead.
+ *
+ * Throws rather than returning a message: a fallthrough that "handles" the
+ * Error object would re-introduce the silent mutate.
+ *
+ * @param {number|string} ref  the to_node_id / from_node_id that resolved as a rail
+ * @param {"input"|"output"} side
+ * @returns {never}
+ */
+export function refuseConnectToRawRail(ref, side) {
+  const tool =
+    side === "input" ? "panel_expose_subgraph_input" : "panel_expose_subgraph_output";
+  const what = side === "input" ? "input" : "output";
+  throw new Error(
+    `Id ${ref} is a rail_node_id — the synthetic id of the WHOLE ${side} RAIL, not of a ` +
+      `slot on it. panel_connect REFUSES it: do NOT panel_connect to a guessed rail node id. ` +
+      `Use ${tool} with the interior node + the ${what} you want exposed. Nothing was exposed.`,
+  );
+}
+
 export function countHostRailLinks(rootGraph, subgraph, side, slotIndex) {
   if (!rootGraph || !subgraph) return 0;
   let count = 0;


### PR DESCRIPTION
Closes #1953.

## Root cause

Inside a subgraph, `panel_connect { from_node_id: 2, from_output: "LATENT", to_node_id: -20 }` hit `graph_connect`'s output-rail branch, found no matching slot, and **fell through to `graph_expose_subgraph_output`**. The reply was `{ exposed: { name: "LATENT", … } }` — a shape `panel_connect` never documents — and a new boundary slot appeared on the host subgraph node.

`panel_expose_subgraph_output` already says "do NOT panel_connect to a guessed rail node id". `panel_unexpose_subgraph_output` already says a rail_node_id "is forwarded to the panel, which REFUSES it". The connect-path refusal did not exist, so a typo'd `to_node_id` that happened to hit `-20` mutated the subgraph's public interface with no error.

## Fix

- Shared helper `refuseConnectToRawRail` in `web/js/lib/rail-slot.js` throws the documented wording (`do NOT panel_connect to a guessed rail node id`, `panel_connect REFUSES it`, names `panel_expose_subgraph_output` / `_input`, `Nothing was exposed`).
- `graph_connect` uses it on both rail fallthroughs (output `to_node_id` / input `from_node_id`) instead of calling `graph_expose_subgraph_*`.
- Connecting to an **existing named rail slot** (`to_node_id: -20`, `to_input: "LATENT"` when that slot is already on the rail) is unchanged.

## Tests

`browser_tests/unit/connect-raw-rail-refuse.test.mjs` drives the shipped `graph_connect` with a stub expose that would return `{ exposed }` if auto-expose still ran — so leftover auto-expose is a success the assertions fail on, not a TypeError `assert.throws` would swallow.

- reported call (`to_node_id: -20`, no `to_input`) refuses, exposes nothing
- string `"-20"` (MCP coercion) same
- missing `to_input` name does not mint that slot
- `from_node_id: -10` without a matching input-rail slot refuses
- existing named rail slots still wire (`connected`, not `exposed`)
- wiring: `graph_connect` no longer contains `graph_expose_subgraph_*`

**Suite:** `npm run test:unit` → 7255 tests, **7254 pass, 0 fail** (1 pre-existing todo). Log: `tests-panel-1953.log`.

Do not merge from this PR — parent merges after the swarm.
