### PR TITLE
fix(1952): close resident panes and dismiss live cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - graph_unexpose_subgraph_input / _output re-point remaining host SubgraphNode links after a non-last boundary slot is removed, so later host wires stay valid at queue (#1969, artokun/comfyui-mcp#2437)
 - panel_connect to a raw rail id (`-20`/`-10`) refuses instead of silently auto-exposing a subgraph boundary slot (#1953)
+### Added
+- the Training / CivitAI side panel and live UI/media cards can now be closed/dismissed over the same bridge path the agent uses to open them, so a long session can shed resident renderer state (#1952, #1960)
 
 ## [0.15.119] - 2026-08-27
 

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -237,7 +237,7 @@ test("#2283: the command remains on the authenticated rid executor/reply path", 
   const source = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.match(source, /fetch_comfyui_read\(args = \{\}\)/);
   assert.match(source, /return fetchComfyUIReadForMcp\(args, \{ api \}\)/);
-  assert.match(source, /"ui_render", "ui_update", "fetch_image", "fetch_comfyui_read"/);
+  assert.match(source, /"ui_render", "ui_update", "ui_dismiss", "fetch_image", "fetch_comfyui_read"/);
   assert.match(source, /const isCommandFrame = msg && typeof msg\.rid === "string" && typeof msg\.cmd === "string"/);
   assert.match(source, /const executor = GRAPH_TOOL_EXECUTORS\[msg\.cmd\]/);
   assert.match(source, /reply = \{ rid: msg\.rid, ok: true, result: withViewingWitness\(result\) \}/);

--- a/browser_tests/unit/fetch-image.test.mjs
+++ b/browser_tests/unit/fetch-image.test.mjs
@@ -268,7 +268,7 @@ test("#2149: fetch_image is wired as a canvas-independent dispatcher command", (
   const source = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.match(source, /fetch_image\(args = \{\}\)/);
   assert.match(source, /return fetchImageForMcp\(args, \{ api \}\)/);
-  assert.match(source, /"ui_render", "ui_update", "fetch_image"/);
+  assert.match(source, /"ui_render", "ui_update", "ui_dismiss", "fetch_image"/);
   assert.equal(commandIsCanvasIndependent("fetch_image"), true);
   assert.equal(commandIsCanvasTargetless("fetch_image"), true);
 });

--- a/browser_tests/unit/resident-ui-close.test.mjs
+++ b/browser_tests/unit/resident-ui-close.test.mjs
@@ -1,0 +1,191 @@
+// #1952 / #1960 — agent path to shed resident renderer UI.
+//
+// The training wizard, CivitAI browser, live A2UI cards and painted media
+// cards could only ACCUMULATE. The user-facing ✕ already called handle.close()
+// / resolve(null); these tests drive the shipped functions the bridge now
+// uses so a long session can actually drop that state.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  closeSidePanelHandle,
+  dismissLiveA2uiCard,
+  dismissAllLiveA2uiCards,
+  unloadChatMediaCards,
+} from "../../web/js/lib/resident-ui-close.js";
+
+const panelSrc = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+const sideSrc = readFileSync(new URL("../../web/js/cmcp-sidepanel-ui.js", import.meta.url), "utf8");
+const trainSrc = readFileSync(new URL("../../web/js/cmcp-training-ui.js", import.meta.url), "utf8");
+const civitaiSrc = readFileSync(new URL("../../web/js/cmcp-civitai-ui.js", import.meta.url), "utf8");
+
+function fakeHandle({ tab = "training" } = {}) {
+  let open = true;
+  const teardowns = [];
+  return {
+    teardowns,
+    close() {
+      if (!open) return;
+      open = false;
+      for (const fn of teardowns) fn();
+    },
+    isOpen: () => open,
+    activeTab: () => tab,
+  };
+}
+
+// ── side panel ─────────────────────────────────────────────────────────────
+
+test("#1952 closeSidePanelHandle closes an open handle and reports the active tab", () => {
+  const h = fakeHandle({ tab: "training" });
+  let torn = 0;
+  h.teardowns.push(() => { torn += 1; });
+  const r = closeSidePanelHandle(h);
+  assert.deepEqual(r, { ok: true, closed: true, tab: "training" });
+  assert.equal(h.isOpen(), false);
+  assert.equal(torn, 1, "close must run the same teardown the user ✕ runs");
+});
+
+test("#1952 closeSidePanelHandle is idempotent — already-closed is success, not an error", () => {
+  const h = fakeHandle({ tab: "civitai" });
+  assert.equal(closeSidePanelHandle(h).closed, true);
+  assert.deepEqual(closeSidePanelHandle(h), { ok: true, closed: false, tab: null });
+  assert.deepEqual(closeSidePanelHandle(null), { ok: true, closed: false, tab: null });
+  assert.deepEqual(closeSidePanelHandle({}), { ok: true, closed: false, tab: null });
+});
+
+test("#1952 closing the civitai-active panel still sheds training content sitting in the same shell", () => {
+  // The unified shell keeps visited tabs in `contents` until close(). A close
+  // gated on the active tab would leave the TRAINING pane resident — the
+  // surface that was in the foreground at the #1960 kill.
+  const h = fakeHandle({ tab: "civitai" });
+  const shed = { training: false, civitai: false };
+  h.teardowns.push(() => { shed.training = true; shed.civitai = true; });
+  const r = closeSidePanelHandle(h);
+  assert.equal(r.tab, "civitai");
+  assert.equal(shed.training, true);
+  assert.equal(shed.civitai, true);
+});
+
+// ── A2UI cards ─────────────────────────────────────────────────────────────
+
+function fakeCard(id, { resolved = false } = {}) {
+  let isResolved = resolved;
+  const el = {
+    removed: false,
+    remove() { this.removed = true; },
+  };
+  const rec = { cardId: id, resolved, spec: { title: id } };
+  const handle = {
+    cardId: id,
+    el,
+    isResolved: () => isResolved,
+    resolve(choice) {
+      if (isResolved) return;
+      isResolved = true;
+      rec.choice = choice;
+    },
+  };
+  return { handle, rec, el };
+}
+
+test("#1952 dismissLiveA2uiCard resolves, drops the registry entry, and detaches the node", () => {
+  const live = new Map();
+  const a = fakeCard("a2ui-1");
+  live.set("a2ui-1", a);
+  const r = dismissLiveA2uiCard(live, "a2ui-1");
+  assert.equal(r.ok, true);
+  assert.equal(r.dismissed, true);
+  assert.equal(r.card_id, "a2ui-1");
+  assert.equal(a.handle.isResolved(), true);
+  assert.equal(a.rec.resolved, true);
+  assert.equal(a.rec.choice, null, "dismiss is resolve(null) — no agent message");
+  assert.equal(a.el.removed, true);
+  assert.equal(live.has("a2ui-1"), false);
+});
+
+test("#1952 dismissLiveA2uiCard throws the same no-live-card error ui_update uses", () => {
+  const live = new Map();
+  assert.throws(
+    () => dismissLiveA2uiCard(live, "gone"),
+    /no live card "gone" \(already resolved, dismissed, or from a previous view\)/,
+  );
+  assert.throws(
+    () => dismissLiveA2uiCard(live, ""),
+    /no live card/,
+  );
+});
+
+test("#1952 dismissAllLiveA2uiCards sheds every live card and does not throw on empty", () => {
+  const live = new Map();
+  const a = fakeCard("a");
+  const b = fakeCard("b");
+  live.set("a", a);
+  live.set("b", b);
+  const r = dismissAllLiveA2uiCards(live);
+  assert.equal(r.dismissed, 2);
+  assert.deepEqual(r.card_ids, ["a", "b"]);
+  assert.equal(live.size, 0);
+  assert.equal(a.el.removed && b.el.removed, true);
+  const empty = dismissAllLiveA2uiCards(new Map());
+  assert.deepEqual(empty, { ok: true, dismissed: 0, card_ids: [], recs: [] });
+});
+
+// ── media cards ────────────────────────────────────────────────────────────
+
+test("#1952 unloadChatMediaCards clears src, revokes blob URLs, and detaches the card", () => {
+  const revoked = [];
+  const img = {
+    tagName: "IMG",
+    src: "blob:http://127.0.0.1/media",
+    currentSrc: "blob:http://127.0.0.1/media",
+    removeAttribute(k) { if (k === "src") this.src = ""; },
+  };
+  const card = {
+    removed: false,
+    querySelectorAll(sel) { return sel.includes("img") ? [img] : []; },
+    remove() { this.removed = true; },
+  };
+  const log = { querySelectorAll(sel) { return sel === ".cmcp-imgcard" ? [card] : []; } };
+  const r = unloadChatMediaCards(log, { revokeObjectURL: (u) => revoked.push(u) });
+  assert.equal(r.unloaded, 1);
+  assert.deepEqual(revoked, ["blob:http://127.0.0.1/media"]);
+  assert.equal(img.src, "");
+  assert.equal(card.removed, true);
+});
+
+test("#1952 unloadChatMediaCards is a no-op on a missing log", () => {
+  assert.deepEqual(unloadChatMediaCards(null), { ok: true, unloaded: 0 });
+});
+
+// ── dispatcher wiring (the real bridge path, not a parallel copy) ──────────
+
+test("#1952 the panel imports and dispatches the shipped close/dismiss functions", () => {
+  assert.match(
+    panelSrc,
+    /import \{\s*closeSidePanelHandle,\s*dismissLiveA2uiCard,\s*dismissAllLiveA2uiCards,\s*unloadChatMediaCards,\s*\} from "\.\/lib\/resident-ui-close\.js"/,
+  );
+  assert.match(panelSrc, /msg\.cmd === "training_close"/);
+  assert.match(panelSrc, /msg\.cmd === "civitai_close"/);
+  assert.match(panelSrc, /msg\.cmd === "ui_dismiss"/);
+  assert.match(panelSrc, /if \(msg\.cmd === "training_close"\) return closeSidePanelHandle\(_sidePanelHandle\)/);
+  assert.match(panelSrc, /if \(msg\.cmd === "civitai_close"\) return closeSidePanelHandle\(_sidePanelHandle\)/);
+  assert.match(panelSrc, /onUiDismiss\(msg\) \{/);
+  assert.match(panelSrc, /dismissLiveA2uiCard\(liveA2uiCards, msg\.card_id/);
+  assert.match(panelSrc, /dismissAllLiveA2uiCards\(liveA2uiCards/);
+  assert.match(panelSrc, /unloadChatMediaCards\(log\)/);
+});
+
+test("#1952 close is on the training and civitai drive surfaces, and the shell facade does not gate it on the active tab", () => {
+  assert.match(trainSrc, /close: driveClose/);
+  assert.match(civitaiSrc, /close: driveClose/);
+  assert.match(sideSrc, /close: closeResident/);
+  assert.match(sideSrc, /const closeResident = \(\) => closeSidePanelHandle\(/);
+  // _driveOf throws "training wizard not open" when another tab is active.
+  // close must not go through it — training content stays resident until the
+  // shell tears down, which is the #1960 case (training open, then another tab).
+  const facadeClose = sideSrc.slice(sideSrc.indexOf("const closeResident"), sideSrc.indexOf("const civitai"));
+  assert.doesNotMatch(facadeClose, /_driveOf/);
+});

--- a/browser_tests/unit/training-tool-actions.test.mjs
+++ b/browser_tests/unit/training-tool-actions.test.mjs
@@ -370,3 +370,35 @@ test("every train_* call carries a non-empty action, and names only the three su
     assert.notEqual(c.args.action, "", "an empty action is not a dispatchable action");
   }
 });
+
+test("#1952 drive.close is the unused ✕ path, now agent-callable and idempotent", async (t) => {
+  const restore = installDom();
+  t.after(restore);
+  const { createTrainingContent } = await import("../../web/js/cmcp-training-ui.js");
+  let shellCloses = 0;
+  const modal = new El("div");
+  modal.querySelectorAll = () => [];
+  modal.querySelector = () => null;
+  const shell = {
+    modal,
+    close() {
+      shellCloses += 1;
+      view.teardown();
+    },
+    syncSearch() {},
+  };
+  const view = createTrainingContent(
+    { callTool: () => Promise.reject(new Error("unscripted")), api: null },
+    shell,
+    {},
+  );
+  const root = new El("div");
+  view.mount(root);
+  assert.equal(typeof view.drive.close, "function", "close must be on the agent-drive surface");
+  const first = view.drive.close();
+  assert.deepEqual(first, { ok: true, closed: true });
+  assert.equal(shellCloses, 1, "close must reach the shell that owns the overlay");
+  const second = view.drive.close();
+  assert.deepEqual(second, { ok: true, closed: false });
+  assert.equal(shellCloses, 1, "a second close must not re-enter the shell");
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -2327,6 +2327,13 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       highlighted: state.highlightOrder.slice(),
     };
   }
+  // The user-facing ✕ already called this (and teardown tears down the lightbox);
+  // exposing it on drive is the agent inverse of open_civitai (#1952). Idempotent.
+  function driveClose() {
+    if (!isOpen) return { ok: true, closed: false };
+    close();
+    return { ok: true, closed: true };
+  }
 
   // ── content provider (the shell owns the chrome; this owns the body) ──────
   let _started = false;
@@ -2367,6 +2374,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       switchTab: driveSwitchTab, search: driveSearch, getResults: driveGetResults,
       highlight: driveHighlight, clearHighlight: driveClearHighlight,
       openLightbox: driveOpenLightbox, getState: driveGetState,
+      close: driveClose,
     },
   };
 }

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -18,6 +18,7 @@
 // onActivate(), onDeactivate(), teardown(), escapeBlocked() }`.
 
 import { isImeComposing } from "./lib/ime.js";
+import { closeSidePanelHandle } from "./lib/resident-ui-close.js";
 import { createCivitaiContent } from "./cmcp-civitai-ui.js";
 import { createAppsContent } from "./cmcp-apps-ui.js";
 import { createTrainingContent } from "./cmcp-training-ui.js";
@@ -353,6 +354,15 @@ export function openSidePanel(ctx = {}, opts = {}) {
     }
     return c.drive[method](...args);
   }
+  // close() is the WHOLE panel, not the active tab: training/civitai content
+  // stays resident in `contents` until the shell tears down. Gating close on
+  // the active tab (via _driveOf) would leave the other surface's grids/polls
+  // in the renderer — the accumulation #1952/#1960 exist to shed.
+  const closeResident = () => closeSidePanelHandle({
+    close,
+    isOpen: () => isOpen,
+    activeTab: () => activeKey,
+  });
   const civitai = {
     getResults: (a) => _driveOf("civitai", "civitai browser not open", "getResults", [a]),
     highlight: (ids, o) => _driveOf("civitai", "civitai browser not open", "highlight", [ids, o]),
@@ -361,6 +371,7 @@ export function openSidePanel(ctx = {}, opts = {}) {
     search: (a) => _driveOf("civitai", "civitai browser not open", "search", [a]),
     openLightbox: (id, o) => _driveOf("civitai", "civitai browser not open", "openLightbox", [id, o]),
     getState: () => _driveOf("civitai", "civitai browser not open", "getState", []),
+    close: closeResident,
   };
   const training = {
     getState: () => _driveOf("training", "training wizard not open", "getState", []),
@@ -369,6 +380,7 @@ export function openSidePanel(ctx = {}, opts = {}) {
     setTarget: (t) => _driveOf("training", "training wizard not open", "setTarget", [t]),
     highlight: (r) => _driveOf("training", "training wizard not open", "highlight", [r]),
     clearHighlight: () => _driveOf("training", "training wizard not open", "clearHighlight", []),
+    close: closeResident,
   };
 
   return {

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -1777,6 +1777,13 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     for (const c of modal.querySelectorAll(".cmcp-agent-glow")) c.classList.remove("cmcp-agent-glow");
     return { ok: true };
   }
+  // The user-facing ✕ already called this; exposing it on drive is the agent
+  // inverse of open_training (#1952). Idempotent — already-closed is success.
+  function driveClose() {
+    if (closed) return { ok: true, closed: false };
+    close();
+    return { ok: true, closed: true };
+  }
 
   // ── content provider (the shell owns the chrome; this owns the body) ──────
   return {
@@ -1812,6 +1819,7 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     drive: {
       getState: driveGetState, setField: driveSetField, gotoStep: driveGotoStep,
       setTarget: driveSetTarget, highlight: driveHighlight, clearHighlight: driveClearHighlight,
+      close: driveClose,
     },
   };
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -320,6 +320,12 @@ import { recordSkillFromGraph, persistRecordedSkill } from "./lib/record-skill.j
 import { makeCommandBudget } from "./lib/command-budget.js";
 import { fetchImageForMcp } from "./lib/fetch-image.js";
 import { fetchComfyUIReadForMcp } from "./lib/fetch-comfyui-read.js";
+import {
+  closeSidePanelHandle,
+  dismissLiveA2uiCard,
+  dismissAllLiveA2uiCards,
+  unloadChatMediaCards,
+} from "./lib/resident-ui-close.js";
 // #1184 — the ORDER a backend switch commits in. A module because the defect is an
 // ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
 import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
@@ -26905,7 +26911,7 @@ function noteActiveWorkflowMove() {
   }
 }
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCommandReceived, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert, onHelloLanded }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCommandReceived, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onUiDismiss, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert, onHelloLanded }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -27757,7 +27763,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           } else if (
             msg.cmd === "civitai_results" || msg.cmd === "civitai_highlight" ||
             msg.cmd === "civitai_clear_highlight" || msg.cmd === "civitai_switch_tab" ||
-            msg.cmd === "civitai_search" || msg.cmd === "civitai_open_lightbox"
+            msg.cmd === "civitai_search" || msg.cmd === "civitai_open_lightbox" ||
+            msg.cmd === "civitai_close"
           ) {
             // Agent DRIVES the already-open CivitAI browser. onCivitaiCmd throws
             // an honest "civitai browser not open" when the modal isn't live, which
@@ -27767,7 +27774,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           } else if (
             msg.cmd === "open_training" || msg.cmd === "training_get_state" ||
             msg.cmd === "training_set_field" || msg.cmd === "training_goto_step" ||
-            msg.cmd === "training_set_target" || msg.cmd === "training_highlight"
+            msg.cmd === "training_set_target" || msg.cmd === "training_highlight" ||
+            msg.cmd === "training_close"
           ) {
             if (!onTrainingCmd) throw new Error("This panel build can't drive the training wizard.");
             result = await onTrainingCmd(msg);
@@ -27779,6 +27787,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           } else if (msg.cmd === "ui_update") {
             if (!onUiUpdate) throw new Error("This panel build can't render UI cards.");
             result = await onUiUpdate(msg);
+          } else if (msg.cmd === "ui_dismiss") {
+            if (!onUiDismiss) throw new Error("This panel build can't dismiss UI cards.");
+            result = await onUiDismiss(msg);
           } else {
             const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];
             if (!executor) throw new Error(`Unknown command "${msg.cmd}"`);
@@ -28121,11 +28132,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // commands get the normal activity card.
         const SILENT_CMDS = new Set([
           "ask_user", "request_secret", "set_todo", "show_media", "open_civitai",
-          "ui_render", "ui_update", "fetch_image", "fetch_comfyui_read",
+          "ui_render", "ui_update", "ui_dismiss", "fetch_image", "fetch_comfyui_read",
           "civitai_results", "civitai_highlight", "civitai_clear_highlight",
           "civitai_switch_tab", "civitai_search", "civitai_open_lightbox",
+          "civitai_close",
           "open_training", "training_get_state", "training_set_field",
           "training_goto_step", "training_set_target", "training_highlight",
+          "training_close",
         ]);
         if (!SILENT_CMDS.has(msg.cmd)) {
           onCommand?.(msg.cmd, msg, reply);
@@ -38579,6 +38592,7 @@ function buildPanel() {
     // handle's civitai facade; throws an honest "civitai browser not open" error
     // (guard here, plus the facade re-checks the active tab).
     onCivitaiCmd(msg) {
+      if (msg.cmd === "civitai_close") return closeSidePanelHandle(_sidePanelHandle);
       const h = _sidePanelHandle;
       if (!h) throw new Error("civitai browser not open");
       switch (msg.cmd) {
@@ -38597,6 +38611,7 @@ function buildPanel() {
         openTraining({ dock: msg.dock !== false });
         return { ok: true };
       }
+      if (msg.cmd === "training_close") return closeSidePanelHandle(_sidePanelHandle);
       const h = _sidePanelHandle;
       if (!h) throw new Error("training wizard not open");
       switch (msg.cmd) {
@@ -38641,6 +38656,36 @@ function buildPanel() {
       persistThreads();
       setChatSurfaceForCards();
       return { ok: true };
+    },
+    // Inverse of ui_render / show_media: retire live cards so a long session can
+    // shed renderer state (#1952). A named card_id dismisses that A2UI card the
+    // same way the user ✕ does. Omitting it dismisses every live A2UI card and
+    // unloads painted media cards from the live log.
+    onUiDismiss(msg) {
+      const persistRec = (rec) => {
+        if (!rec) return;
+        try { historyStore.touchMessage(rec); persistThreads(); } catch { /* bookkeeping */ }
+      };
+      if (msg.card_id != null && String(msg.card_id).trim() !== "") {
+        const r = dismissLiveA2uiCard(liveA2uiCards, msg.card_id, { removeEl: true });
+        persistRec(r.rec);
+        setChatSurfaceForCards();
+        return { ok: true, dismissed: r.dismissed ? 1 : 0, card_ids: [r.card_id] };
+      }
+      const cards = dismissAllLiveA2uiCards(liveA2uiCards, { removeEl: true });
+      for (const rec of cards.recs) persistRec(rec);
+      if (_activeLightboxClose) {
+        try { _activeLightboxClose(); } catch { /* already gone */ }
+        _activeLightboxClose = null;
+      }
+      const media = unloadChatMediaCards(log);
+      setChatSurfaceForCards();
+      return {
+        ok: true,
+        dismissed: cards.dismissed,
+        card_ids: cards.card_ids,
+        media_unloaded: media.unloaded,
+      };
     },
     // Orchestrator pushed live download progress → render rows in the tray.
     onDownloads(list) {

--- a/web/js/lib/resident-ui-close.js
+++ b/web/js/lib/resident-ui-close.js
@@ -1,0 +1,105 @@
+// Lifecycle inverses for resident panel UI (#1952, #1960).
+//
+// Open-only surfaces (the unified Training/CivitAI side panel, live A2UI cards,
+// painted show_media cards) accumulate in the renderer with no agent path to
+// shed them. The user-facing ✕ already calls handle.close() / card resolve(null);
+// these functions ARE that same path, callable from the bridge.
+
+/**
+ * Close the unified side panel (Training / CivitAI / Apps / RunPod).
+ *
+ * Idempotent: a missing or already-closed handle is success with `closed:false`
+ * — shedding already-shed state is the goal, not an error. The user-facing ✕
+ * is the same `handle.close()`.
+ */
+export function closeSidePanelHandle(handle) {
+  if (!handle || typeof handle.close !== "function") {
+    return { ok: true, closed: false, tab: null };
+  }
+  const open = typeof handle.isOpen === "function" ? !!handle.isOpen() : true;
+  if (!open) return { ok: true, closed: false, tab: null };
+  const tab = typeof handle.activeTab === "function" ? handle.activeTab() ?? null : null;
+  handle.close();
+  return { ok: true, closed: true, tab };
+}
+
+const NO_LIVE_CARD = (id) =>
+  `no live card "${id}" (already resolved, dismissed, or from a previous view)`;
+
+/**
+ * Dismiss one live A2UI card the same way the user ✕ does: resolve(null)
+ * (inert, no agent message), drop it from the live registry, and detach the
+ * DOM node so the renderer can drop the card's pixels.
+ *
+ * Throws the same "no live card" error `ui_update` uses when the id is gone,
+ * so a stale id is a retryable tool error rather than a silent no-op.
+ */
+export function dismissLiveA2uiCard(liveMap, cardId, { removeEl = true } = {}) {
+  const id = cardId == null ? "" : String(cardId);
+  if (!id) throw new Error(NO_LIVE_CARD(cardId));
+  const entry = liveMap && typeof liveMap.get === "function" ? liveMap.get(id) : undefined;
+  if (!entry) throw new Error(NO_LIVE_CARD(id));
+  const handle = entry.handle;
+  if (!(handle && typeof handle.isResolved === "function" && handle.isResolved())) {
+    try { handle?.resolve?.(null); } catch { /* already resolved */ }
+  }
+  if (entry.rec) entry.rec.resolved = true;
+  if (typeof liveMap.delete === "function") liveMap.delete(id);
+  if (removeEl) {
+    try { handle?.el?.remove?.(); } catch { /* already gone */ }
+  }
+  return { ok: true, dismissed: true, card_id: id, rec: entry.rec };
+}
+
+/** Dismiss every live A2UI card. Never throws — an empty registry is success. */
+export function dismissAllLiveA2uiCards(liveMap, opts) {
+  const ids = liveMap && typeof liveMap.keys === "function" ? [...liveMap.keys()] : [];
+  const card_ids = [];
+  const recs = [];
+  for (const id of ids) {
+    const r = dismissLiveA2uiCard(liveMap, id, opts);
+    if (r.dismissed) card_ids.push(r.card_id);
+    if (r.rec) recs.push(r.rec);
+  }
+  return { ok: true, dismissed: card_ids.length, card_ids, recs };
+}
+
+/**
+ * Unload painted chat media so the renderer can drop decoded bitmaps.
+ *
+ * Clears img/video src (revoking blob: URLs) and detaches `.cmcp-imgcard`
+ * nodes. Does not rewrite history — a thread switch may replay persisted
+ * media. That is enough to shed the live session's decoder footprint.
+ */
+export function unloadChatMediaCards(logEl, { revokeObjectURL } = {}) {
+  if (!logEl || typeof logEl.querySelectorAll !== "function") {
+    return { ok: true, unloaded: 0 };
+  }
+  const revoke =
+    typeof revokeObjectURL === "function"
+      ? revokeObjectURL
+      : typeof URL !== "undefined" && typeof URL.revokeObjectURL === "function"
+        ? (u) => URL.revokeObjectURL(u)
+        : null;
+  const cards = [...logEl.querySelectorAll(".cmcp-imgcard")];
+  let unloaded = 0;
+  for (const card of cards) {
+    const media = typeof card.querySelectorAll === "function"
+      ? card.querySelectorAll("img, video, source")
+      : [];
+    for (const el of media) {
+      const src = el.currentSrc || el.src || "";
+      if (typeof src === "string" && src.startsWith("blob:") && revoke) {
+        try { revoke(src); } catch { /* already revoked */ }
+      }
+      try { el.removeAttribute?.("src"); } catch { /* ignore */ }
+      try { el.src = ""; } catch { /* ignore */ }
+      if (el.tagName === "VIDEO" && typeof el.load === "function") {
+        try { el.load(); } catch { /* ignore */ }
+      }
+    }
+    try { card.remove(); } catch { /* already gone */ }
+    unloaded += 1;
+  }
+  return { ok: true, unloaded };
+}


### PR DESCRIPTION
The renderer OOM in #1952 happened because agent-driven UI can only accumulate: `open_training` / `open_civitai` / `ui_render` / `show_media` have no inverse. #1960 places the kill while the Training pane was the active surface.

The user-facing X already called `handle.close()` (and card `resolve(null)`). This PR exposes that same path on the bridge:

- `training_close` / `civitai_close` close the unified side panel (Training content stays resident in the shell until the whole pane tears down, so close is not gated on the active tab)
- `ui_dismiss` with a `card_id` retires that live A2UI card the same way the user X does
- `ui_dismiss` without a `card_id` retires every live A2UI card and unloads painted media cards from the live log (clears src, revokes blob URLs, detaches the DOM)

No invented memory cap. Idempotent close of an already-closed pane is success.

Orchestrator follow-up: these are the same `cmd` names the panel already uses for `open_training` / `open_civitai` / `ui_render`. comfyui-mcp still needs to advertise the matching tools so the model can invoke them.

Closes #1952
Related: #1960