### PR TITLE
fix(1956): correct four misleading agent-facing replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project are documented here. This project adheres to
 - panel_connect to a raw rail id (`-20`/`-10`) refuses instead of silently auto-exposing a subgraph boundary slot (#1953)
 ### Added
 - the Training / CivitAI side panel and live UI/media cards can now be closed/dismissed over the same bridge path the agent uses to open them, so a long session can shed resident renderer state (#1952, #1960)
+- panel_set_widget on an rgthree Fast Groups property (`matchTitle`/`matchColors`/`sort`/`toggleRestriction`) names `panel_set_property` instead of a pressable-widget dead end, and lists each available widget name once (#1956)
+- panel_add_node of a non-allowlisted frontend-only type (`Bookmark (rgthree)`) no longer claims the pack is missing; the allowlist is named (#1956)
+- panel_audit_prompt_director no longer emits HTTP 404 as a warning when the graph has zero director nodes (#1956)
+- panel_free_vram reports occupancy MB and which branch ran (`verified_system_stats` vs `bare_free_receipt`) instead of a bare `{freed:true}` receipt (#1956)
 
 ## [0.15.119] - 2026-08-27
 

--- a/browser_tests/unit/free-vram-occupancy.test.mjs
+++ b/browser_tests/unit/free-vram-occupancy.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * #1956 — panel_free_vram success must say which branch ran and include the
+ * occupancy numbers the shipped path actually has. `{freed:true}` alone is the
+ * misleading receipt.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  freeVramSuccessResult,
+  readVramOccupancy,
+  vramOccupancyFromStats,
+} from "../../web/js/lib/vram-occupancy.js";
+import { describeHttpFailure } from "../../web/js/lib/http-failure.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const MB = 1024 * 1024;
+const stats = (usedMb, totalMb = 16384) => ({
+  devices: [
+    {
+      name: "cuda:0 NVIDIA GeForce RTX 5080",
+      vram_total: totalMb * MB,
+      vram_free: (totalMb - usedMb) * MB,
+    },
+  ],
+});
+
+function jsonRes(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { get: () => "application/json" },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+const methodStart = panelSrc.indexOf("async free_vram()");
+assert.ok(methodStart > 0, "free_vram executor not found");
+const methodEnd = panelSrc.indexOf("\n  },", methodStart);
+const methodSrc = panelSrc.slice(methodStart, methodEnd + 4);
+
+function realFreeVram({ fetchApi, backendDown = false }) {
+  const factory = new Function(
+    "api",
+    "describeHttpFailure",
+    "comfyBackendIsDown",
+    "readVramOccupancy",
+    "freeVramSuccessResult",
+    `const executors = { ${methodSrc} };\nreturn executors.free_vram;`,
+  );
+  const api = { fetchApi };
+  return factory(api, describeHttpFailure, () => backendDown, readVramOccupancy, freeVramSuccessResult).call({});
+}
+
+test("#1956 occupancy parser reports used/free/total MB", () => {
+  const rows = vramOccupancyFromStats(stats(4096, 16384));
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].vram_used_mb, 4096);
+  assert.equal(rows[0].vram_free_mb, 12288);
+  assert.equal(rows[0].vram_total_mb, 16384);
+});
+
+test("#1956 verified before/after includes freed_mb and the branch name", () => {
+  const result = freeVramSuccessResult({
+    before: vramOccupancyFromStats(stats(8000)),
+    after: vramOccupancyFromStats(stats(1200)),
+  });
+  assert.equal(result.freed, true);
+  assert.equal(result.unload_models, true);
+  assert.equal(result.free_memory, true);
+  assert.equal(result.branch, "verified_system_stats");
+  assert.equal(result.occupancy.before_mb, 8000);
+  assert.equal(result.occupancy.after_mb, 1200);
+  assert.equal(result.occupancy.freed_mb, 6800);
+});
+
+test("#1956 missing occupancy is an honest bare /free receipt, still success", () => {
+  const result = freeVramSuccessResult({});
+  assert.equal(result.freed, true);
+  assert.equal(result.branch, "bare_free_receipt");
+  assert.equal(result.occupancy, undefined);
+  assert.match(result.note, /\/system_stats/);
+  assert.match(result.note, /no MB/);
+});
+
+test("#1956 readVramOccupancy swallows a miss rather than throwing", async () => {
+  assert.equal(await readVramOccupancy(null), null);
+  assert.equal(await readVramOccupancy(async () => jsonRes({}, 500)), null);
+  assert.equal(
+    await readVramOccupancy(async () => {
+      throw new Error("Failed to fetch");
+    }),
+    null,
+  );
+});
+
+test("#1956 shipped free_vram reports verified occupancy on a healthy /system_stats", async () => {
+  const calls = [];
+  const fetchApi = async (path, init) => {
+    calls.push({ path, method: init?.method });
+    if (path === "/system_stats") {
+      const used = calls.filter((c) => c.path === "/free").length ? 500 : 4000;
+      return jsonRes(stats(used));
+    }
+    if (path === "/free") return jsonRes({ success: true });
+    throw new Error(`unexpected ${path}`);
+  };
+  const result = await realFreeVram({ fetchApi });
+  assert.equal(result.freed, true);
+  assert.equal(result.branch, "verified_system_stats");
+  assert.equal(result.occupancy.before_mb, 4000);
+  assert.equal(result.occupancy.after_mb, 500);
+  assert.equal(result.occupancy.freed_mb, 3500);
+  assert.deepEqual(
+    calls.map((c) => c.path),
+    ["/system_stats", "/free", "/system_stats"],
+  );
+});
+
+test("#1956 shipped free_vram still succeeds when /system_stats is down — bare receipt", async () => {
+  const fetchApi = async (path) => {
+    if (path === "/system_stats") return jsonRes({}, 404);
+    if (path === "/free") return jsonRes({ success: true });
+    throw new Error(`unexpected ${path}`);
+  };
+  const result = await realFreeVram({ fetchApi });
+  assert.equal(result.freed, true);
+  assert.equal(result.branch, "bare_free_receipt");
+  assert.match(result.note, /bare|not re-read|no MB/i);
+});
+
+test("#1956 shipped free_vram still fails closed on a not-ok /free", async () => {
+  const fetchApi = async (path) => {
+    if (path === "/system_stats") return jsonRes(stats(1000));
+    if (path === "/free") return jsonRes({ error: "nope" }, 502);
+    throw new Error(`unexpected ${path}`);
+  };
+  await assert.rejects(() => realFreeVram({ fetchApi }), /free VRAM|502/);
+});
+
+test("#1956 WIRING: free_vram returns freeVramSuccessResult, not a bare {freed:true}", () => {
+  assert.match(methodSrc, /freeVramSuccessResult\(/);
+  assert.doesNotMatch(
+    methodSrc,
+    /return \{ freed: true, unload_models: true, free_memory: true \}/,
+  );
+});

--- a/browser_tests/unit/missing-widget-property.test.mjs
+++ b/browser_tests/unit/missing-widget-property.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * #1956 — panel_set_widget on an rgthree Fast Groups PROPERTY must name
+ * panel_set_property, not a pressable-widget dead end, and must not duplicate
+ * the available-widget name.
+ *
+ * The refusal itself is correct (matchTitle is not a widget). The defect was
+ * the guidance: "ask the user to click" + `RGTHREE_TOGGLE_AND_NAV` listed twice.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { applyWidgetWrite, WidgetWriteError } from "../../web/js/lib/widget-write.js";
+import { missingWidgetMessage, uniqueWidgetNames } from "../../web/js/lib/missing-widget.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WIDGET_WRITE = join(HERE, "../../web/js/lib/widget-write.js");
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+const HOOKS = {};
+const BYPASSER = "Fast Groups Bypasser (rgthree)";
+const MUTER = "Fast Groups Muter (rgthree)";
+
+function fastGroupsNode({ type = BYPASSER, extraWidgets = [] } = {}) {
+  return {
+    id: 12,
+    type,
+    properties: { matchTitle: "", matchColors: "", sort: "position", toggleRestriction: "default" },
+    widgets: [
+      { name: "RGTHREE_TOGGLE_AND_NAV", type: "custom", value: "", onMouseClick() {} },
+      { name: "RGTHREE_TOGGLE_AND_NAV", type: "custom", value: "", onMouseClick() {} },
+      ...extraWidgets,
+    ],
+  };
+}
+
+function assertPropertyRoute(err, widgetName) {
+  assert.ok(err instanceof WidgetWriteError);
+  assert.match(err.message, new RegExp(`has no widget "${widgetName}"`));
+  assert.match(err.message, /panel_set_property/);
+  assert.match(err.message, /PROPERTY/i);
+  assert.match(err.message, /matchTitle\/matchColors\/sort\/toggleRestriction/);
+  assert.doesNotMatch(err.message, /ask the user to click/i);
+  assert.doesNotMatch(err.message, /no tool to press a widget/i);
+  assert.doesNotMatch(err.message, /RGTHREE_TOGGLE_AND_NAV, RGTHREE_TOGGLE_AND_NAV/);
+  const available = err.message.match(/available: ([^)]*)/);
+  assert.ok(available, "must still list available widgets");
+  const names = available[1].split(", ").filter(Boolean);
+  assert.equal(names.filter((n) => n === "RGTHREE_TOGGLE_AND_NAV").length, 1);
+  return true;
+}
+
+test("#1956 uniqueWidgetNames lists a repeated Fast Groups row once", () => {
+  assert.deepEqual(uniqueWidgetNames(fastGroupsNode().widgets), ["RGTHREE_TOGGLE_AND_NAV"]);
+});
+
+test("#1956 set_widget on Fast Groups matchTitle points at panel_set_property", () => {
+  assert.throws(
+    () => applyWidgetWrite(fastGroupsNode(), "matchTitle", "Loaders", HOOKS),
+    (err) => assertPropertyRoute(err, "matchTitle"),
+  );
+});
+
+for (const name of ["matchColors", "sort", "toggleRestriction"]) {
+  test(`#1956 set_widget on Fast Groups ${name} points at panel_set_property`, () => {
+    assert.throws(
+      () => applyWidgetWrite(fastGroupsNode(), name, "x", HOOKS),
+      (err) => assertPropertyRoute(err, name),
+    );
+  });
+}
+
+test("#1956 Fast Groups Muter matchTitle is the same property route", () => {
+  assert.throws(
+    () => applyWidgetWrite(fastGroupsNode({ type: MUTER }), "matchTitle", "Loaders", HOOKS),
+    (err) => assertPropertyRoute(err, "matchTitle"),
+  );
+});
+
+test("#1956 Fast Groups known properties route even without a properties bag", () => {
+  const node = { id: 3, type: BYPASSER, widgets: [{ name: "RGTHREE_TOGGLE_AND_NAV", onMouseClick() {} }] };
+  const msg = missingWidgetMessage(node, "matchTitle");
+  assert.match(msg, /panel_set_property/);
+  assert.doesNotMatch(msg, /ask the user to click/i);
+});
+
+test("#1956 a genuine typo on Fast Groups still gets the pressable hint, not a property route", () => {
+  const msg = missingWidgetMessage(fastGroupsNode(), "matchTittle");
+  assert.doesNotMatch(msg, /panel_set_property/);
+  assert.match(msg, /cannot activate|no widget "matchTittle"/);
+});
+
+test("#1956 a property on an ordinary node still names panel_set_property", () => {
+  const node = {
+    id: 8,
+    type: "KSampler",
+    properties: { promptState: "" },
+    widgets: [{ name: "seed", type: "number", value: 1 }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "promptState", "x", HOOKS),
+    (err) => {
+      assert.match(err.message, /panel_set_property/);
+      assert.doesNotMatch(err.message, /ask the user to click/i);
+      return true;
+    },
+  );
+});
+
+test("#1956 a Power Lora Loader missing slot still gets the pressable hint", () => {
+  const node = {
+    id: 153,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "➕ Add Lora", type: "custom", value: "", onMouseClick() {} }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1", "x.safetensors", HOOKS),
+    (err) => {
+      assert.match(err.message, /no tool to press a widget/i);
+      assert.doesNotMatch(err.message, /panel_set_property/);
+      return true;
+    },
+  );
+});
+
+test("#1956 WIRING: both missing-widget refusals use missingWidgetMessage", () => {
+  const ww = readFileSync(WIDGET_WRITE, "utf8");
+  assert.match(ww, /import \{ missingWidgetMessage \} from "\.\/missing-widget\.js"/);
+  assert.match(ww, /missingWidgetMessage\(targetNode, widgetName\)/);
+
+  const panel = readFileSync(PANEL_JS, "utf8");
+  assert.match(panel, /import \{ missingWidgetMessage \} from "\.\/lib\/missing-widget\.js"/);
+  assert.match(panel, /missingWidgetMessage\(node, widget\)/);
+});

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -34,6 +34,7 @@ import {
   isSubgraphUuidType,
   subgraphTypeIsLoaded,
   subgraphUuidAddRefusal,
+  frontendOnlyNotAllowlistedRefusal,
 } from "../../web/js/lib/node-resolve.js";
 import { createObjectInfoHistory } from "../../web/js/lib/object-info-history.js";
 // The PRODUCTION graph_set_widget handler body — the executor and these tests
@@ -1479,6 +1480,69 @@ test("#1296 add_node: the reload diagnosis is scoped — provenance-bearing husk
       assert.doesNotMatch(err.message, /RELOAD the ComfyUI tab/);
       return true;
     },
+  );
+});
+
+// ---- #1956: a registered frontend-virtual type that is NOT on the addable
+//      allowlist (Bookmark (rgthree)) fails closed — correct — but must not
+//      claim the pack is missing. rgthree is installed; the type is absent
+//      from /object_info BY DESIGN. ------------------------------------------
+
+/** rgthree-style virtual class: base ctor throws on the default title. */
+class BookmarkRgthree {
+  constructor(title = "__NEED_CLASS_TITLE__") {
+    if (title === "__NEED_CLASS_TITLE__") throw new Error("needs overrides");
+    this.title = title;
+    this.isVirtualNode = true;
+  }
+}
+
+test('#1956 add_node: "Bookmark (rgthree)" is refused as frontend-only not-addable, not as a missing pack', async () => {
+  const fresh = objectInfo();
+  const reg = loadedRegistry();
+  reg["Bookmark (rgthree)"] = BookmarkRgthree;
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "Bookmark (rgthree)", ADD_OPTS(fresh)),
+    (err) => {
+      assert.match(err.message, /frontend-only type/);
+      assert.match(err.message, /deliberately not addable/);
+      assert.match(err.message, /Fast Groups Bypasser \(rgthree\)/);
+      assert.match(err.message, /Fast Groups Muter \(rgthree\)/);
+      assert.match(err.message, /Label \(rgthree\)/);
+      assert.match(err.message, /Reroute \(rgthree\)/);
+      assert.match(err.message, /Node Collector \(rgthree\)/);
+      assert.doesNotMatch(err.message, /Unknown node type/);
+      assert.doesNotMatch(err.message, /not installed, its pack was removed/);
+      assert.doesNotMatch(err.message, /failed to import/);
+      assert.doesNotMatch(err.message, /create_workflow \(action:"node_info"\)/);
+      return true;
+    },
+  );
+});
+
+test("#1956 add_node: the not-allowlisted refusal still fails closed — Bookmark is not added", async () => {
+  const msg = frontendOnlyNotAllowlistedRefusal("Bookmark (rgthree)");
+  assert.match(msg, /Cannot add "Bookmark \(rgthree\)"/);
+  assert.match(msg, /deliberately not addable/);
+  assert.doesNotMatch(msg, /Unknown node type|not installed|failed to import/);
+});
+
+test("#1956 add_node: a defless husk WITHOUT isVirtualNode keeps the generic unknown-type refusal", async () => {
+  // The #458 hole stays closed: a leftover class that does not prove virtual
+  // is not re-diagnosed as frontend-only.
+  const fresh = objectInfo();
+  const reg = loadedRegistry([], ["RemovedBackendNode"]);
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "RemovedBackendNode", ADD_OPTS(fresh)),
+    /Unknown node type "RemovedBackendNode"|backend does not provide/i,
+  );
+});
+
+test("#1956 add_node: allowlisted Fast Groups Bypasser stays addable", async () => {
+  const fresh = objectInfo();
+  const reg = loadedRegistry([], ["Fast Groups Bypasser (rgthree)"]);
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg, "Fast Groups Bypasser (rgthree)", ADD_OPTS(fresh)),
   );
 });
 

--- a/browser_tests/unit/pressable-widget.test.mjs
+++ b/browser_tests/unit/pressable-widget.test.mjs
@@ -144,20 +144,18 @@ test("#757 several buttons read as plural, and all are named", () => {
   assert.equal(pressableWidgets(node).length, 2);
 });
 
-test("#757 WIRING: both missing-widget refusals carry the hint", () => {
-  // A pure helper nobody calls is not a fix. Two distinct refusal sites exist and
-  // the report's exact text came from the widget-write one.
+test("#757 WIRING: both missing-widget refusals still carry the hint (#1956 via missingWidgetMessage)", () => {
+  // The shipped refusals now go through missingWidgetMessage, which appends this
+  // hint unless the requested name is a node PROPERTY (#1956). A helper nobody
+  // calls is not a fix — pin the production import and the ordinary (non-property)
+  // path that still names the button.
+  const missing = readFileSync(join(HERE, "../../web/js/lib/missing-widget.js"), "utf8");
+  assert.match(missing, /import \{ pressableWidgetHint \} from "\.\/pressable-widget\.js"/);
+  assert.match(missing, /pressableWidgetHint\(node, widgetName\)/);
+
   const ww = readFileSync(WIDGET_WRITE, "utf8");
-  assert.match(ww, /import \{ pressableWidgetHint \} from "\.\/pressable-widget\.js"/);
-  assert.ok(
-    /has no widget "\$\{widgetName\}"[\s\S]{0,400}?pressableWidgetHint\(targetNode, widgetName\)/.test(ww),
-    "widget-write.js refusal must append the hint",
-  );
+  assert.match(ww, /missingWidgetMessage\(targetNode, widgetName\)/);
 
   const panel = readFileSync(PANEL_JS, "utf8");
-  assert.match(panel, /import \{ pressableWidgetHint \} from "\.\/lib\/pressable-widget\.js"/);
-  assert.ok(
-    /has no widget "\$\{widget\}"[\s\S]{0,400}?pressableWidgetHint\(node, widget\)/.test(panel),
-    "comfyui-mcp-panel.js refusal must append the hint",
-  );
+  assert.match(panel, /missingWidgetMessage\(node, widget\)/);
 });

--- a/browser_tests/unit/prompt-director-audit.test.mjs
+++ b/browser_tests/unit/prompt-director-audit.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * #1956 — panel_audit_prompt_director with zero director nodes is a correct
+ * empty result (count 0, changed:false). A 404 from /prompt_director/inspection
+ * is expected in that case and must not land as inspection_unavailable.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const methodMatch = panelSrc.match(/async graph_prompt_director_audit\(\) \{[\s\S]*?\n  \},/);
+assert.ok(methodMatch, "could not locate graph_prompt_director_audit in panel source");
+
+function realAudit({ nodes = [], fetchImpl }) {
+  const factory = new Function(
+    "getGraphCtx",
+    "fetch",
+    "describeActiveGraph",
+    `const executors = { ${methodMatch[0]} };\nreturn executors.graph_prompt_director_audit;`,
+  );
+  const fn = factory(
+    () => ({ graph: { _nodes: nodes } }),
+    fetchImpl,
+    () => ({ scope: "root" }),
+  );
+  return fn();
+}
+
+function http(status, body = { inspections: [] }) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+test("#1956 zero director nodes + HTTP 404 is not inspection_unavailable", async () => {
+  const result = await realAudit({
+    nodes: [{ id: 1, type: "KSampler", widgets: [] }],
+    fetchImpl: async () => http(404),
+  });
+  assert.equal(result.prompt_director_node_count, 0);
+  assert.equal(result.changed, false);
+  assert.ok(result.observations.some((o) => o.code === "prompt_director_not_present"));
+  assert.ok(
+    !result.observations.some((o) => o.code === "inspection_unavailable"),
+    `empty canvas must not warn about the expected 404: ${JSON.stringify(result.observations)}`,
+  );
+  assert.ok(
+    !result.observations.some((o) => /HTTP 404/.test(o.message ?? "")),
+    "must not mention HTTP 404 when node_count is 0",
+  );
+});
+
+test("#1956 zero director nodes + a thrown fetch is not inspection_unavailable", async () => {
+  const result = await realAudit({
+    nodes: [],
+    fetchImpl: async () => {
+      throw new Error("Failed to fetch");
+    },
+  });
+  assert.equal(result.prompt_director_node_count, 0);
+  assert.equal(result.changed, false);
+  assert.ok(!result.observations.some((o) => o.code === "inspection_unavailable"));
+});
+
+test("#1956 a live director node still surfaces a 404 as inspection_unavailable", async () => {
+  const result = await realAudit({
+    nodes: [{ id: 9, type: "PromptDirector", widgets: [], inputs: [], outputs: [], mode: 0 }],
+    fetchImpl: async () => http(404),
+  });
+  assert.equal(result.prompt_director_node_count, 1);
+  const warning = result.observations.find((o) => o.code === "inspection_unavailable");
+  assert.ok(warning, "a present director + 404 must still warn");
+  assert.match(warning.message, /HTTP 404/);
+});

--- a/browser_tests/unit/virtual-registry.test.mjs
+++ b/browser_tests/unit/virtual-registry.test.mjs
@@ -21,7 +21,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { collectFrontendVirtualTypes } from "../../web/js/lib/virtual-registry.js";
+import { collectFrontendVirtualTypes, isFrontendVirtualRegisteredType } from "../../web/js/lib/virtual-registry.js";
 import { commandIsCanvasIndependent } from "../../web/js/lib/workflow-chat-identity.js";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -82,6 +82,25 @@ class NeedsContextNode {
 test("#1400 a constructor-flagged class is reported virtual", () => {
   const registry = { GetNode: KjStyleBusNode, "Label (rgthree)": RgthreeStyleVirtualNode };
   assert.deepEqual(collectFrontendVirtualTypes(registry), ["GetNode", "Label (rgthree)"]);
+});
+
+test("#1956 isFrontendVirtualRegisteredType proves Bookmark (rgthree) and rejects a defless husk", () => {
+  class BookmarkRgthree {
+    constructor(title = "__NEED_CLASS_TITLE__") {
+      if (title === "__NEED_CLASS_TITLE__") throw new Error("needs overrides");
+      this.isVirtualNode = true;
+    }
+  }
+  function DeflessHusk() {}
+  const registry = {
+    "Bookmark (rgthree)": BookmarkRgthree,
+    RemovedBackendNode: DeflessHusk,
+    GetNode: KjStyleBusNode,
+  };
+  assert.equal(isFrontendVirtualRegisteredType(registry, "Bookmark (rgthree)"), true);
+  assert.equal(isFrontendVirtualRegisteredType(registry, "RemovedBackendNode"), false);
+  assert.equal(isFrontendVirtualRegisteredType(registry, "GetNode"), true);
+  assert.equal(isFrontendVirtualRegisteredType(registry, "NotRegistered"), false);
 });
 
 test("#1400 the probe passes a title — an rgthree-style sentinel-throwing ctor is covered", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -70,6 +70,8 @@ import {
   promotedInputAliases,
   resolvePromotedInnerTarget,
 } from "./lib/widget-write.js";
+import { missingWidgetMessage } from "./lib/missing-widget.js";
+import { freeVramSuccessResult, readVramOccupancy } from "./lib/vram-occupancy.js";
 import { describeVoiceError } from "./lib/voice-error.js";
 import { voiceRecognitionLang } from "./lib/voice-language.js";
 import { isEmbeddedDesktopShell, voiceInputSupport } from "./lib/voice-support.js";
@@ -106,7 +108,6 @@ import {
   PANEL_EXTENSION_NAME,
 } from "./lib/duplicate-panel-guard.js";
 import { tryRegisterWhenReady } from "./lib/resolve-comfy-app.js";
-import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
 import { sanitizeNodeAuxId, sanitizeNodesAuxId } from "./lib/aux-id-sanitize.js";
 import {
@@ -14865,9 +14866,14 @@ const GRAPH_TOOL_EXECUTORS = {
     try {
       const response = await fetch("/prompt_director/inspection");
       if (response.ok) runtimePayload = await response.json();
-      else addObservation("warning", "inspection_unavailable", `Prompt Director inspection returned HTTP ${response.status}.`);
+      else if (directorNodes.length) {
+        // #1956 — HTTP 404 is expected when the graph has zero director nodes.
+        addObservation("warning", "inspection_unavailable", `Prompt Director inspection returned HTTP ${response.status}.`);
+      }
     } catch (error) {
-      addObservation("warning", "inspection_unavailable", String(error?.message ?? error));
+      if (directorNodes.length) {
+        addObservation("warning", "inspection_unavailable", String(error?.message ?? error));
+      }
     }
     const runtimeByNode = new Map(
       (runtimePayload.inspections ?? []).map((item) => [String(item.node_id), item]),
@@ -25664,13 +25670,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const widgets = node.widgets ?? [];
     const w = widgets.find((x) => x && x.name === widget);
     if (!w) {
-      const names = widgets.map((x) => x?.name).filter(Boolean);
-      throw new Error(
-        `Node ${node.id} (${node.type}) has no widget "${widget}". Available: ${names.join(", ") || "(none)"}` +
-          // #757 — same disclosure as the widget-write path: a button the panel
-          // cannot press may be what creates the missing slot.
-          pressableWidgetHint(node, widget),
-      );
+      throw new Error(missingWidgetMessage(node, widget));
     }
     // The parent SubgraphNode instance(s) embedding this subgraph. For a nested
     // subgraph (root → node 142 → node 133), walk ALL graphs in the hierarchy
@@ -26501,6 +26501,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // Unload all resident models + free cached VRAM via ComfyUI's standard /free
     // endpoint (the same one the "Unload Models"/"Free memory" menu uses). Used to
     // unwedge a stuck/OOM ComfyUI when a cancel left memory pinned — no restart.
+    // Occupancy is best-effort: a /system_stats miss must not fail a /free that
+    // already landed (#1956).
+    const before = await readVramOccupancy((path, init) => api.fetchApi(path, init));
     const res = await api.fetchApi("/free", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -26537,7 +26540,8 @@ const GRAPH_TOOL_EXECUTORS = {
         }),
       );
     }
-    return { freed: true, unload_models: true, free_memory: true };
+    const after = await readVramOccupancy((path, init) => api.fetchApi(path, init));
+    return freeVramSuccessResult({ before, after });
   },
 };
 

--- a/web/js/lib/missing-widget.js
+++ b/web/js/lib/missing-widget.js
@@ -1,0 +1,104 @@
+/**
+ * #1956 — the missing-widget refusal must be a route, not a dead end.
+ *
+ * Two misdirections showed up on rgthree Fast Groups Bypasser:
+ *   1. `matchTitle` is a LiteGraph PROPERTY, not a widget. The refusal listed
+ *      duplicate toggle-row names and appended the #757 pressable-widget hint
+ *      ("ask the user to click"), which sent the agent to bother the user instead
+ *      of `panel_set_property`.
+ *   2. Fast Groups names every group-toggle row `RGTHREE_TOGGLE_AND_NAV`, so the
+ *      available-list repeated the same name.
+ *
+ * The refusal itself is unchanged (still fail-closed). This only names the
+ * documented property route when the requested name is a property, and lists
+ * each widget name once.
+ */
+import { pressableWidgetHint } from "./pressable-widget.js";
+
+const RGTHREE_FAST_GROUPS_TYPES = new Set([
+  "Fast Groups Bypasser (rgthree)",
+  "Fast Groups Muter (rgthree)",
+]);
+
+export const RGTHREE_FAST_GROUPS_PROPERTY_NAMES = [
+  "matchTitle",
+  "matchColors",
+  "sort",
+  "toggleRestriction",
+];
+
+const FAST_GROUPS_PROPERTY_SET = new Set(RGTHREE_FAST_GROUPS_PROPERTY_NAMES);
+
+function nodeType(node) {
+  try {
+    const t = node?.type ?? node?.comfyClass;
+    return typeof t === "string" ? t : "";
+  } catch {
+    return "";
+  }
+}
+
+/** True when `name` is a property on this node, not a widget. */
+export function isNodePropertyName(node, name) {
+  if (typeof name !== "string" || !name) return false;
+  if (RGTHREE_FAST_GROUPS_TYPES.has(nodeType(node)) && FAST_GROUPS_PROPERTY_SET.has(name)) {
+    return true;
+  }
+  let props;
+  try {
+    props = node?.properties;
+  } catch {
+    return false;
+  }
+  if (!props || typeof props !== "object" || Array.isArray(props)) return false;
+  try {
+    return Object.prototype.hasOwnProperty.call(props, name);
+  } catch {
+    return false;
+  }
+}
+
+/** Widget names in draw order, each name once. */
+export function uniqueWidgetNames(widgets) {
+  const seen = new Set();
+  const names = [];
+  for (const w of Array.isArray(widgets) ? widgets : []) {
+    let n;
+    try {
+      n = w?.name;
+    } catch {
+      continue;
+    }
+    if (typeof n !== "string" || !n || seen.has(n)) continue;
+    seen.add(n);
+    names.push(n);
+  }
+  return names;
+}
+
+function propertyRouteHint(node, widgetName) {
+  const fastGroups = FAST_GROUPS_PROPERTY_SET.has(widgetName) || RGTHREE_FAST_GROUPS_TYPES.has(nodeType(node));
+  const known = RGTHREE_FAST_GROUPS_PROPERTY_NAMES.join("/");
+  return (
+    ` "${widgetName}" is a node PROPERTY, not a widget — set it with panel_set_property` +
+    ` (name: "${widgetName}"), not panel_set_widget.` +
+    (fastGroups
+      ? ` On rgthree Fast Groups Bypasser/Muter, ${known} are properties.`
+      : "")
+  );
+}
+
+/**
+ * The missing-widget refusal text. Fail-closed: the caller still throws.
+ *
+ * @param {object} node
+ * @param {string} widgetName
+ */
+export function missingWidgetMessage(node, widgetName) {
+  const names = uniqueWidgetNames(node?.widgets);
+  const available = names.join(", ") || "none";
+  const head =
+    `Node ${node?.id} (${node?.type}) has no widget "${widgetName}" (available: ${available}).`;
+  if (isNodePropertyName(node, widgetName)) return head + propertyRouteHint(node, widgetName);
+  return head + pressableWidgetHint(node, widgetName);
+}

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -29,6 +29,7 @@ export const COMFY_CORE_SENTINEL_TYPES = [
 ];
 
 import { importFailureNote, relevantPackImportFailures } from "./pack-import-failures.js";
+import { isFrontendVirtualRegisteredType } from "./virtual-registry.js";
 
 /** True when `type` is registered in the live LiteGraph registry object
  *  (LG.registered_node_types). */
@@ -181,6 +182,25 @@ export const FRONTEND_ONLY_NODE_TYPES = new Set([
   "SetNode",
   "GetNode",
 ]);
+
+/**
+ * #1956 — refusal for a registered frontend-virtual type that is deliberately
+ * outside FRONTEND_ONLY_NODE_TYPES. Fail-closed (not addable); do not claim the
+ * pack is missing. The rgthree names are derived from the allowlist so this
+ * cannot drift from FRONTEND_ONLY_NODE_TYPES.
+ */
+export function frontendOnlyNotAllowlistedRefusal(class_type) {
+  const allowlisted = [...FRONTEND_ONLY_NODE_TYPES]
+    .filter((t) => t.endsWith("(rgthree)"))
+    .sort();
+  return (
+    `Cannot add "${class_type}": it is a frontend-only type — the ComfyUI backend never ` +
+    `provides it, so its absence from /object_info is expected (not a missing, removed, or ` +
+    `failed-to-import pack) — but it is deliberately not addable. The panel's frontend-only ` +
+    `allowlist covers ${allowlisted.join(", ")}. Refusing to add rather than mint a node ` +
+    `the panel cannot drive.`
+  );
+}
 
 /**
  * True for a genuinely FRONTEND-ONLY / native node type — one that is registered in
@@ -728,6 +748,19 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
             `it is not installed (or its frontend JS failed to load). Refusing to add rather than ` +
             `let LiteGraph mint an unresolved placeholder node (#458).`,
         );
+      }
+      // #1956 — a type the live registry PROVES frontend-virtual (isVirtualNode on a
+      // probe instance) that is NOT on FRONTEND_ONLY_NODE_TYPES. The refusal is
+      // correct — the allowlist is the only addable frontend-only set — but the
+      // generic "Unknown node type / not installed / pack removed" below sends the
+      // agent to reinstall a healthy pack. Bookmark (rgthree) is the reported case:
+      // rgthree is installed, the type is absent from /object_info BY DESIGN.
+      if (
+        verdict === "never-seen" &&
+        isFrontendVirtualRegisteredType(readRegistry(), class_type) &&
+        !FRONTEND_ONLY_NODE_TYPES.has(class_type)
+      ) {
+        throw new Error(frontendOnlyNotAllowlistedRefusal(class_type));
       }
       // #1523 — a subgraph UUID is never in /object_info (registerSubgraphNodeDef
       // synthesizes the class locally from the workflow's definitions). Treating

--- a/web/js/lib/virtual-registry.js
+++ b/web/js/lib/virtual-registry.js
@@ -53,6 +53,44 @@
 import { hasBackendProvenance } from "./node-resolve.js";
 
 /**
+ * True when THIS registered class proves frontend-virtual: no backend provenance,
+ * and a discarded probe instance carries `isVirtualNode === true`. Fail-closed
+ * on anything unreadable — a throwing ctor, a provenance marker, a loose flag.
+ *
+ * The title argument is the TYPE, not the display title: rgthree's base
+ * constructor throws on its unset "__NEED_CLASS_TITLE__" default, so a
+ * no-arg probe would refuse every rgthree class for a cosmetic reason.
+ */
+export function isFrontendVirtualRegisteredType(registry, type) {
+  if (!registry || typeof registry !== "object" || typeof type !== "string" || !type) return false;
+  let ctor;
+  try {
+    ctor = registry[type];
+  } catch {
+    return false;
+  }
+  if (typeof ctor !== "function") return false;
+  let backend = true;
+  try {
+    backend = hasBackendProvenance(ctor);
+  } catch {
+    return false;
+  }
+  if (backend) return false;
+  let probe;
+  try {
+    probe = new ctor(type);
+  } catch {
+    return false;
+  }
+  try {
+    return !!probe && probe.isVirtualNode === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * The registered node types this page PROVES frontend-virtual, sorted.
  *
  * `registry` is LiteGraph.registered_node_types (type name → node class).
@@ -70,39 +108,7 @@ export function collectFrontendVirtualTypes(registry) {
     return [];
   }
   for (const type of names) {
-    let ctor;
-    try {
-      ctor = registry[type];
-    } catch {
-      continue; // a throwing getter exempts nothing
-    }
-    if (typeof ctor !== "function") continue;
-    // The server's own classes are never probed: a backend-derived (or stale
-    // backend husk) class is /object_info's question, not this registry's.
-    let backend = true;
-    try {
-      backend = hasBackendProvenance(ctor);
-    } catch {
-      continue; // a verdict we cannot read is not "frontend-only"
-    }
-    if (backend) continue;
-    let probe;
-    try {
-      // The title argument is the TYPE, not the display title: rgthree's base
-      // constructor throws on its unset "__NEED_CLASS_TITLE__" default, so a
-      // no-arg probe would refuse every rgthree class for a cosmetic reason.
-      // The probe is discarded; its title is never shown anywhere.
-      probe = new ctor(type);
-    } catch {
-      continue; // a class that cannot be bare-constructed proves nothing
-    }
-    let virtual = false;
-    try {
-      virtual = !!probe && probe.isVirtualNode === true;
-    } catch {
-      virtual = false;
-    }
-    if (virtual) out.add(type);
+    if (isFrontendVirtualRegisteredType(registry, type)) out.add(type);
   }
   return [...out].sort();
 }

--- a/web/js/lib/vram-occupancy.js
+++ b/web/js/lib/vram-occupancy.js
@@ -1,0 +1,113 @@
+/**
+ * #1956 — panel_free_vram success used to return `{freed:true, unload_models, free_memory}`
+ * with no MB, no before/after, and no indication whether occupancy was re-read.
+ *
+ * Two honest branches, both still success after POST /free 2xx:
+ *   - `verified_system_stats` — /system_stats answered, so the numbers we actually have
+ *   - `bare_free_receipt` — /free accepted, occupancy was not re-read
+ *
+ * Occupancy reads never decide the command: a /system_stats miss degrades to the
+ * bare receipt instead of failing a free that already landed.
+ */
+
+const BYTES_PER_MB = 1024 * 1024;
+
+function roundMb(n) {
+  return Math.round(Number(n) / BYTES_PER_MB);
+}
+
+/**
+ * Device occupancy rows from a ComfyUI `/system_stats` payload.
+ * Unreadable devices are skipped; an unreadable payload is `[]`.
+ */
+export function vramOccupancyFromStats(stats) {
+  const devices = Array.isArray(stats?.devices) ? stats.devices : [];
+  const out = [];
+  for (const d of devices) {
+    let total;
+    let free;
+    try {
+      total = Number(d?.vram_total);
+      free = Number(d?.vram_free);
+    } catch {
+      continue;
+    }
+    if (!Number.isFinite(total) || !Number.isFinite(free)) continue;
+    let name = "";
+    try {
+      name = typeof d?.name === "string" ? d.name : "";
+    } catch {
+      name = "";
+    }
+    out.push({
+      name,
+      vram_total_mb: roundMb(total),
+      vram_free_mb: roundMb(free),
+      vram_used_mb: roundMb(total - free),
+    });
+  }
+  return out;
+}
+
+function usedMb(rows) {
+  return rows.reduce((sum, d) => sum + d.vram_used_mb, 0);
+}
+
+/**
+ * Best-effort occupancy. Returns `null` rather than throwing — a miss must not
+ * fail a /free that already succeeded.
+ */
+export async function readVramOccupancy(fetchApi) {
+  try {
+    if (typeof fetchApi !== "function") return null;
+    const res = await fetchApi("/system_stats", { cache: "no-store" });
+    if (!res || !res.ok) return null;
+    const stats = await res.json();
+    const rows = vramOccupancyFromStats(stats);
+    return rows.length ? rows : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Success payload after POST /free 2xx. Always `{freed:true, unload_models, free_memory}`;
+ * occupancy and `branch` are whatever this call actually measured.
+ */
+export function freeVramSuccessResult({ before = null, after = null } = {}) {
+  const base = { freed: true, unload_models: true, free_memory: true };
+  const beforeOcc = Array.isArray(before) && before.length ? before : null;
+  const afterOcc = Array.isArray(after) && after.length ? after : null;
+  if (beforeOcc && afterOcc) {
+    const beforeMb = usedMb(beforeOcc);
+    const afterMb = usedMb(afterOcc);
+    return {
+      ...base,
+      branch: "verified_system_stats",
+      occupancy: {
+        before_mb: beforeMb,
+        after_mb: afterMb,
+        freed_mb: beforeMb - afterMb,
+        devices_before: beforeOcc,
+        devices_after: afterOcc,
+      },
+    };
+  }
+  if (afterOcc) {
+    return {
+      ...base,
+      branch: "verified_system_stats",
+      occupancy: {
+        after_mb: usedMb(afterOcc),
+        devices_after: afterOcc,
+      },
+    };
+  }
+  return {
+    ...base,
+    branch: "bare_free_receipt",
+    note:
+      "POST /free accepted this request (unload_models and free_memory). Occupancy was not " +
+      "re-read from /system_stats, so no MB before/after is available.",
+  };
+}

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,5 +1,5 @@
 import { fireNodeWidgetChanged } from "./node-widget-changed.js";
-import { pressableWidgetHint } from "./pressable-widget.js";
+import { missingWidgetMessage } from "./missing-widget.js";
 import { explainNumericNormalization, normalizationNote } from "./widget-normalization.js";
 import { isNonSerializingValueSource } from "./virtual-source-promotion.js";
 import {
@@ -1735,14 +1735,11 @@ export function resolveWidgetWrite(
     }
   }
   if (!widget) {
-    const names = (targetNode.widgets ?? []).map((cand) => cand?.name).join(", ");
-    throw new WidgetWriteError(
-      `Node ${targetNode.id} (${targetNode.type}) has no widget "${widgetName}" (available: ${names || "none"}).` +
-        // #757 — the available list may already contain the answer without saying
-        // so: a button that CREATES the missing slot. Empty for a node with no
-        // pressable widget, which is the ordinary typo case.
-        pressableWidgetHint(targetNode, widgetName),
-    );
+    // #757 — pressable-widget hint for a button that CREATES the missing slot.
+    // #1956 — if the name is a node PROPERTY (rgthree Fast Groups matchTitle/…),
+    // point at panel_set_property instead of a click dead-end, and list each
+    // available widget name once (Fast Groups repeats RGTHREE_TOGGLE_AND_NAV).
+    throw new WidgetWriteError(missingWidgetMessage(targetNode, widgetName));
   }
 
   // Gate on the RESOLVED target BEFORE coercion (#458). coerceWidgetValue reads —


### PR DESCRIPTION
Closes #1956.

## Four correct outcomes, four misleading texts

QA on 0.15.114: each path already failed closed or succeeded. The agent was sent the wrong way.

1. **`panel_set_widget` on rgthree Fast Groups `matchTitle`** refused (not a widget) but listed `RGTHREE_TOGGLE_AND_NAV` twice and said "ask the user to click". It never named `panel_set_property`. An agent following that bothers the user.

2. **`panel_add_node` of `Bookmark (rgthree)`** failed closed (not allowlisted) but claimed "Unknown node type / backend does not provide it / pack removed". rgthree is installed; the type is absent from `/object_info` by design. The suggested `node_info` check returns empty and reinforces the wrong install.

3. **`panel_audit_prompt_director` with zero director nodes** answered count 0, "No Prompt Director nodes are present", `changed:false` — and also `inspection_unavailable` HTTP 404. When `node_count` is 0 the 404 is expected.

4. **`panel_free_vram`** returned `{freed:true, unload_models, free_memory}` with no MB, no before/after, no branch. The description promises occupancy reporting.

Outcomes are unchanged.

## What the shipped text says now

- Missing-widget refusal: unique available names. If the requested name is a node property (`matchTitle`/`matchColors`/`sort`/`toggleRestriction` on Fast Groups, or any own property), point at `panel_set_property`. Otherwise keep the #757 pressable hint.
- Non-allowlisted frontend-virtual add: "frontend-only, deliberately not addable"; allowlist names derived from `FRONTEND_ONLY_NODE_TYPES` (Fast Groups Bypasser/Muter, Label, Reroute, Node Collector, …). A defless husk without `isVirtualNode` still gets the generic unknown-type refusal (#458).
- Prompt Director inspection 404/throw is recorded only when director nodes are present.
- `free_vram` best-effort `/system_stats` before and after `/free`. Success still `{freed:true}`; branch is `verified_system_stats` (with MB) or `bare_free_receipt`. A stats miss cannot fail a landed `/free`.

## Tests

Fail on the old misleading strings; pass on the corrected shipped messages. Drive production helpers and extracted executors.

**Suite:** 7273 tests, **7272 pass, 0 fail** (1 pre-existing todo).
