### PR TITLE
fix(1943): defer host-mutating update UI on remote clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- remote, tunnelled, and mobile clients never see the in-app update prompt or one-click install+restart; those stay deferred until the next local host session (#1943, #1944)
+
 ## [0.15.121] - 2026-08-27
 
 ### Fixed

--- a/browser_tests/unit/update-notify.test.mjs
+++ b/browser_tests/unit/update-notify.test.mjs
@@ -16,6 +16,7 @@ import {
   PANEL_REGISTRY_URL,
   UPDATE_NOTICE_DISMISS_KEY,
   classifyClientContext,
+  decideUpdateNoticeAffordance,
   dismissToken,
   fetchPublishedPanelVersions,
   isDismissed,
@@ -25,6 +26,7 @@ import {
   parseRegistryNode,
   parseRegistryVersions,
   pickInstallableLatest,
+  readBrowserClientContext,
   resolveUpdateState,
   shouldOfferHostMutation,
   shouldSurfaceUpdateNotice,
@@ -45,14 +47,43 @@ const rel = (version, status = "NodeVersionStatusActive", changelog = "") => ({
 });
 
 // ---------------------------------------------------------------------------
-// Client context
+// Client context — #1943 / #1944
 // ---------------------------------------------------------------------------
 
+const DESKTOP_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0";
+const IPHONE_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605";
+const ANDROID_UA = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile";
+const IPAD_UA = "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605";
+
+const LOCAL_HOSTS = ["localhost", "127.0.0.1", "127.0.0.2", "[::1]", "::1", "LOCALHOST", "panel.localhost"];
+
+const REMOTE_CLIENTS = [
+  { hostname: "192.168.1.10", userAgent: DESKTOP_UA, why: "LAN" },
+  { hostname: "10.0.0.5", userAgent: DESKTOP_UA, why: "LAN" },
+  { hostname: "172.16.0.2", userAgent: DESKTOP_UA, why: "LAN" },
+  { hostname: "comfy.local", userAgent: DESKTOP_UA, why: "mdns" },
+  { hostname: "gpu-box", userAgent: DESKTOP_UA, why: "hostname" },
+  { hostname: "", userAgent: DESKTOP_UA, why: "empty-origin" },
+  { hostname: "abc.trycloudflare.com", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "x.ngrok-free.app", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "x.ngrok.io", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "x.ngrok.app", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "foo.loca.lt", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "foo.localtunnel.me", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "host.tailscale.net", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "box.ts.net", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "access.cloudflareaccess.com", userAgent: DESKTOP_UA, why: "tunnel" },
+  { hostname: "127.0.0.1", userAgent: IPHONE_UA, why: "mobile-on-loopback" },
+  { hostname: "localhost", userAgent: ANDROID_UA, why: "mobile-on-loopback" },
+  { hostname: "localhost", userAgent: IPAD_UA, why: "mobile-on-loopback" },
+  { hostname: "abc.trycloudflare.com", userAgent: IPHONE_UA, why: "mobile-over-tunnel" },
+];
+
 test("#1943 loopback desktop is the local host client", () => {
-  for (const hostname of ["localhost", "127.0.0.1", "[::1]", "::1", "LOCALHOST"]) {
+  for (const hostname of LOCAL_HOSTS) {
     assert.equal(isLoopbackHostname(hostname), true, hostname);
     assert.equal(
-      classifyClientContext({ hostname, userAgent: "Mozilla/5.0 Chrome/120" }),
+      classifyClientContext({ hostname, userAgent: DESKTOP_UA }),
       "local",
       hostname,
     );
@@ -62,7 +93,7 @@ test("#1943 loopback desktop is the local host client", () => {
 test("#1943 a LAN, hostname, or empty origin is remote", () => {
   for (const hostname of ["192.168.1.10", "10.0.0.5", "172.16.0.2", "comfy.local", "gpu-box", ""]) {
     assert.equal(
-      classifyClientContext({ hostname, userAgent: "Mozilla/5.0 Chrome/120" }),
+      classifyClientContext({ hostname, userAgent: DESKTOP_UA }),
       "remote",
       hostname,
     );
@@ -75,13 +106,16 @@ test("#1943/#1944 a tunnel hostname is remote even on a desktop UA", () => {
     "abc.trycloudflare.com",
     "x.ngrok-free.app",
     "x.ngrok.io",
+    "x.ngrok.app",
     "foo.loca.lt",
+    "foo.localtunnel.me",
     "host.tailscale.net",
     "box.ts.net",
+    "access.cloudflareaccess.com",
   ]) {
     assert.equal(isTunnelHostname(hostname), true, hostname);
     assert.equal(
-      classifyClientContext({ hostname, userAgent: "Mozilla/5.0 Chrome/120" }),
+      classifyClientContext({ hostname, userAgent: DESKTOP_UA }),
       "remote",
       hostname,
     );
@@ -89,25 +123,117 @@ test("#1943/#1944 a tunnel hostname is remote even on a desktop UA", () => {
 });
 
 test("#1944 a mobile UA is remote even on loopback", () => {
-  assert.equal(isMobileUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)"), true);
-  assert.equal(isMobileUserAgent("Mozilla/5.0 (Linux; Android 14)"), true);
+  assert.equal(isMobileUserAgent(IPHONE_UA), true);
+  assert.equal(isMobileUserAgent(ANDROID_UA), true);
+  assert.equal(isMobileUserAgent(IPAD_UA), true);
   assert.equal(
-    classifyClientContext({
-      hostname: "127.0.0.1",
-      userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0) AppleWebKit/605",
-    }),
+    classifyClientContext({ hostname: "127.0.0.1", userAgent: IPHONE_UA }),
     "remote",
     "a phone pointed at loopback is still not the host session",
   );
 });
 
-test("#1944 remote never surfaces the notice and never offers install+restart", () => {
+test("#1944 surfacing is the same gate as offering — no inform-without-button", () => {
   assert.equal(shouldSurfaceUpdateNotice("remote"), false);
   assert.equal(shouldOfferHostMutation("remote"), false);
   assert.equal(shouldSurfaceUpdateNotice("local"), true);
   assert.equal(shouldOfferHostMutation("local"), true);
-  // No degrade path: informing without the button is the half-measure #1944 rejects.
   assert.equal(shouldSurfaceUpdateNotice("remote"), shouldOfferHostMutation("remote"));
+  assert.equal(shouldSurfaceUpdateNotice("local"), shouldOfferHostMutation("local"));
+});
+
+test("#1943/#1944 remote/tunnelled/mobile never get the update prompt or install+restart", () => {
+  for (const client of REMOTE_CLIENTS) {
+    for (const kind of ["update", "restart", "none"]) {
+      const d = decideUpdateNoticeAffordance({ ...client, kind });
+      assert.equal(d.clientContext, "remote", `${client.why} ${client.hostname}`);
+      assert.equal(d.surfaceNotice, false, `${client.why} ${kind} notice`);
+      assert.equal(d.offerInstall, false, `${client.why} ${kind} install`);
+      assert.equal(d.offerRestart, false, `${client.why} ${kind} restart`);
+    }
+  }
+});
+
+test("#1943/#1944 local host clients still get the notice and the host action", () => {
+  for (const hostname of LOCAL_HOSTS) {
+    const update = decideUpdateNoticeAffordance({
+      hostname,
+      userAgent: DESKTOP_UA,
+      kind: "update",
+    });
+    assert.equal(update.clientContext, "local", hostname);
+    assert.equal(update.surfaceNotice, true, `${hostname} update notice`);
+    assert.equal(update.offerInstall, true, `${hostname} update install`);
+    assert.equal(update.offerRestart, true, `${hostname} update restart`);
+
+    const restart = decideUpdateNoticeAffordance({
+      hostname,
+      userAgent: DESKTOP_UA,
+      kind: "restart",
+    });
+    assert.equal(restart.surfaceNotice, true, `${hostname} restart notice`);
+    assert.equal(restart.offerInstall, false, `${hostname} restart is not an install`);
+    assert.equal(restart.offerRestart, true, `${hostname} restart action`);
+
+    const none = decideUpdateNoticeAffordance({
+      hostname,
+      userAgent: DESKTOP_UA,
+      kind: "none",
+    });
+    assert.equal(none.surfaceNotice, false);
+    assert.equal(none.offerInstall, false);
+    assert.equal(none.offerRestart, false);
+  }
+});
+
+test("#1944 decideUpdateNoticeAffordance never surfaces without a host action", () => {
+  const kinds = ["update", "restart", "none", "", undefined];
+  const clients = [
+    ...LOCAL_HOSTS.map((hostname) => ({ hostname, userAgent: DESKTOP_UA })),
+    ...REMOTE_CLIENTS,
+    {},
+  ];
+  for (const client of clients) {
+    for (const kind of kinds) {
+      const d = decideUpdateNoticeAffordance({ ...client, kind });
+      if (d.surfaceNotice) {
+        assert.equal(
+          d.offerInstall || d.offerRestart,
+          true,
+          "notice without install/restart is the #1944 half-measure",
+        );
+      }
+      if (!d.offerInstall && !d.offerRestart) {
+        assert.equal(d.surfaceNotice, false);
+      }
+    }
+  }
+});
+
+test("#1943 readBrowserClientContext fails closed without location/navigator", () => {
+  assert.equal(readBrowserClientContext({}), "remote");
+  assert.equal(readBrowserClientContext(), "remote");
+  assert.equal(
+    readBrowserClientContext({
+      location: { hostname: "127.0.0.1" },
+      navigator: { userAgent: DESKTOP_UA },
+    }),
+    "local",
+  );
+  assert.equal(
+    readBrowserClientContext({
+      location: { hostname: "abc.trycloudflare.com" },
+      navigator: { userAgent: DESKTOP_UA },
+    }),
+    "remote",
+  );
+  assert.equal(
+    readBrowserClientContext({
+      location: { hostname: "127.0.0.1" },
+      navigator: { userAgent: IPHONE_UA },
+    }),
+    "remote",
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -285,7 +411,8 @@ test("#1942 the panel imports the notify helpers and gates on client context", (
     /from "\.\/lib\/update-notify\.js"/,
     "the panel must import the shipped helpers, not a local copy",
   );
-  assert.match(PANEL_SRC, /classifyClientContext\(/);
+  assert.match(PANEL_SRC, /readBrowserClientContext\(/);
+  assert.match(PANEL_SRC, /decideUpdateNoticeAffordance\(/);
   assert.match(PANEL_SRC, /shouldSurfaceUpdateNotice\(/);
   assert.match(PANEL_SRC, /shouldOfferHostMutation\(/);
   assert.match(PANEL_SRC, /resolveUpdateState\(/);
@@ -299,13 +426,24 @@ test("#1944 a remote client returns before the notice is painted", () => {
   const surface = body.indexOf("shouldSurfaceUpdateNotice(");
   const earlyReturn = body.indexOf("return;", surface);
   const paint = body.indexOf("dataset.testid = \"panel-update-available\"");
+  const install = body.indexOf("dataset.testid = \"panel-update-install\"");
   assert.ok(surface !== -1 && earlyReturn !== -1, "the surface gate must be able to return");
   assert.ok(paint > earlyReturn, "the notice is painted only after the remote client has been filtered out");
+  assert.ok(install > paint, "the install+restart button is part of the notice, not a separate path");
+  assert.doesNotMatch(
+    body.slice(paint, install),
+    /shouldOfferHostMutation\(/,
+    "no inner offer-gate after paint — that is the inform-without-button half-measure",
+  );
   assert.doesNotMatch(
     body,
     /Install it from the panel on the host machine/,
     "no degrade-to-info copy — that is the #1944 half-measure",
   );
+  assert.match(body, /decideUpdateNoticeAffordance\(/);
+  const decide = body.indexOf("decideUpdateNoticeAffordance(");
+  const decideReturn = body.indexOf("if (!affordance.surfaceNotice)", decide);
+  assert.ok(decideReturn !== -1 && decideReturn < paint, "kind=none / remote is filtered before paint");
 });
 
 test("#1942 the local action is graph_update_node then comfy_reboot, not a new installer", () => {
@@ -315,10 +453,15 @@ test("#1942 the local action is graph_update_node then comfy_reboot, not a new i
   assert.match(body, /GRAPH_TOOL_EXECUTORS\.graph_update_node/);
   assert.match(body, /GRAPH_TOOL_EXECUTORS\.comfy_reboot/);
   assert.match(body, /comfyui-agent-panel/);
+  assert.match(body, /readBrowserClientContext\(/);
   assert.match(body, /shouldOfferHostMutation\(/);
+  const classify = body.indexOf("readBrowserClientContext(");
+  const gate = body.indexOf("shouldOfferHostMutation(");
   const update = body.indexOf("graph_update_node");
   const reboot = body.indexOf("comfy_reboot");
-  assert.ok(update !== -1 && reboot > update, "install is queued before the restart");
+  assert.ok(classify !== -1 && gate > classify, "click re-classifies this tab before mutating");
+  assert.ok(update !== -1 && update > gate, "the host mutation sits behind the live gate");
+  assert.ok(reboot > update, "install is queued before the restart");
 });
 
 test("#1942 the notice is scheduled on mount the way what's-new is, and is not awaited", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -233,10 +233,11 @@ import { describeOpenActiveBinding } from "./lib/open-active-binding.js";
 import { compareVersions, releasesSince, summarizeReleases, updateAnnouncement } from "./lib/changelog-delta.js";
 import {
   UPDATE_NOTICE_DISMISS_KEY,
-  classifyClientContext,
+  decideUpdateNoticeAffordance,
   dismissToken,
   fetchPublishedPanelVersions,
   isDismissed,
+  readBrowserClientContext,
   resolveUpdateState,
   shouldOfferHostMutation,
   shouldSurfaceUpdateNotice,
@@ -37073,10 +37074,14 @@ function buildPanel() {
    * #1942 — one-click install+restart, only on a local host client (#1943).
    *
    * Reuses the existing Manager update + reboot executors rather than a new
-   * installer. A remote/mobile caller is a no-op even if a button somehow
-   * existed — the notice itself is not painted there (#1944).
+   * installer. Re-classifies from this tab's location/UA at click time so a
+   * captured "local" from notify cannot authorize a remote caller. Fail closed.
    */
-  async function applyPanelUpdate({ kind, clientContext, button } = {}) {
+  async function applyPanelUpdate({ kind, button } = {}) {
+    const clientContext = readBrowserClientContext({
+      location: typeof location !== "undefined" ? location : undefined,
+      navigator: typeof navigator !== "undefined" ? navigator : undefined,
+    });
     if (!shouldOfferHostMutation(clientContext)) return;
     const installLabel = tr("panel.install_and_restart", "Install and restart");
     const restartLabel = tr("panel.restart_comfyui", "Restart ComfyUI");
@@ -37142,15 +37147,18 @@ function buildPanel() {
    * host session what it fixes and offer install+restart.
    *
    * #1944 — remote/tunnelled/mobile clients return before anything is painted.
-   * The check itself still runs so a later local session has fresh evidence.
+   * No badge, no banner, no "install it on the host" copy. The Registry probe
+   * is skipped here too: its result is not persisted, so running it would not
+   * inform the next local session.
    */
   async function notifyAvailablePanelUpdate({ force = false } = {}) {
     try {
-      const clientContext = classifyClientContext({
-        hostname: typeof location !== "undefined" ? location.hostname : "",
-        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "",
-      });
-      if (!shouldSurfaceUpdateNotice(clientContext)) return;
+      const hostname = typeof location !== "undefined" ? location.hostname : "";
+      const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
+      if (!shouldSurfaceUpdateNotice(readBrowserClientContext({
+        location: typeof location !== "undefined" ? location : undefined,
+        navigator: typeof navigator !== "undefined" ? navigator : undefined,
+      }))) return;
 
       const probeInstalled = (async () => {
         if (typeof api?.fetchApi !== "function") return "";
@@ -37172,7 +37180,12 @@ function buildPanel() {
         installed,
         latest,
       });
-      if (state.kind === "none") {
+      const affordance = decideUpdateNoticeAffordance({
+        hostname,
+        userAgent,
+        kind: state.kind,
+      });
+      if (!affordance.surfaceNotice) {
         updateBadge.hidden = true;
         return;
       }
@@ -37240,20 +37253,18 @@ function buildPanel() {
       }
       const actionsRow = document.createElement("div");
       actionsRow.className = "cmcp-update-actions";
-      if (shouldOfferHostMutation(clientContext)) {
-        const go = document.createElement("button");
-        go.type = "button";
-        go.className = "cmcp-update-btn";
-        go.dataset.testid = "panel-update-install";
-        go.textContent =
-          state.kind === "update"
-            ? tr("panel.install_and_restart", "Install and restart")
-            : tr("panel.restart_comfyui", "Restart ComfyUI");
-        go.addEventListener("click", () => {
-          void applyPanelUpdate({ kind: state.kind, clientContext, button: go });
-        });
-        actionsRow.appendChild(go);
-      }
+      // Always the host action when we surface. No inform-without-button path (#1944).
+      const go = document.createElement("button");
+      go.type = "button";
+      go.className = "cmcp-update-btn";
+      go.dataset.testid = "panel-update-install";
+      go.textContent = affordance.offerInstall
+        ? tr("panel.install_and_restart", "Install and restart")
+        : tr("panel.restart_comfyui", "Restart ComfyUI");
+      go.addEventListener("click", () => {
+        void applyPanelUpdate({ kind: state.kind, button: go });
+      });
+      actionsRow.appendChild(go);
       const dismiss = document.createElement("button");
       dismiss.type = "button";
       dismiss.className = "cmcp-update-dismiss";

--- a/web/js/lib/update-notify.js
+++ b/web/js/lib/update-notify.js
@@ -5,8 +5,8 @@
  * #1943/#1944 — host-mutating affordances are gated on client context. A remote,
  * tunnelled, or mobile client never sees the notice at all: telling someone about
  * an action they cannot take, while they are away from the machine, manufactures
- * the motivation to work around the missing button. The check may still run;
- * only the *surfacing* is deferred until the next loopback desktop session.
+ * the motivation to work around the missing button. Only the *surfacing* is
+ * deferred until the next loopback desktop session.
  *
  * Pure / dependency-injected (no DOM, no ComfyUI globals) so the verdict is
  * unit-testable without a browser.
@@ -27,8 +27,6 @@ export const UPDATE_NOTICE_DISMISS_KEY = "comfyui-mcp.panel.updateNoticeDismisse
 /** Registry statuses a user can actually install through Manager. */
 export const INSTALLABLE_VERSION_STATUS = "NodeVersionStatusActive";
 
-const LOOPBACK_HOST = /^(localhost|127\.0\.0\.1|\[::1\]|::1)$/i;
-
 /** Hostnames that are a tunnel in front of the ComfyUI origin, not the host. */
 const TUNNEL_HOST =
   /(?:^|\.)(trycloudflare\.com|cloudflareaccess\.com|ngrok(?:-free)?\.(?:app|io|dev)|loca\.lt|localtunnel\.me|tailscale\.net|ts\.net|github\.dev|gitpod\.io)$/i;
@@ -46,7 +44,11 @@ function normVersion(v) {
 
 export function isLoopbackHostname(hostname) {
   if (typeof hostname !== "string") return false;
-  return LOOPBACK_HOST.test(hostname.trim());
+  const host = hostname.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (!host) return false;
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1") return true;
+  return /^127(?:\.\d{1,3}){3}$/.test(host);
 }
 
 export function isTunnelHostname(hostname) {
@@ -74,17 +76,58 @@ export function classifyClientContext({ hostname, userAgent } = {}) {
   return "remote";
 }
 
-/** #1944 — surface the notice only on a local host client. */
-export function shouldSurfaceUpdateNotice(clientContext) {
+/**
+ * #1943 — install / restart is a host mutation. Fail closed on anything that
+ * is not a loopback desktop session.
+ */
+export function shouldOfferHostMutation(clientContext) {
   return clientContext === "local";
 }
 
 /**
- * #1943 — install / restart is a host mutation. Same gate as surfacing for
- * this feature: there is no "inform but hide the button" path (#1944).
+ * #1944 — surfacing IS offering. A remote user is not told an update exists
+ * unless they can act on it from this tab.
  */
-export function shouldOfferHostMutation(clientContext) {
-  return clientContext === "local";
+export function shouldSurfaceUpdateNotice(clientContext) {
+  return shouldOfferHostMutation(clientContext);
+}
+
+/**
+ * Classify this tab from the browser globals the panel actually has.
+ * Missing location / navigator is remote: fail closed.
+ */
+export function readBrowserClientContext({ location, navigator } = {}) {
+  const hostname = typeof location?.hostname === "string" ? location.hostname : "";
+  const userAgent = typeof navigator?.userAgent === "string" ? navigator.userAgent : "";
+  return classifyClientContext({ hostname, userAgent });
+}
+
+/**
+ * The whole update-notify UX for this tab, as one verdict.
+ *
+ * Remote / tunnel / mobile: notice, install, and restart are all false — the
+ * #1944 correction. A local host session still gets the #1942 prompt:
+ * update → notice + install + restart; restart-only → notice + restart.
+ * There is no `{ surfaceNotice: true, offerInstall: false, offerRestart: false }`
+ * row; that is the "inform but hide the button" half-measure.
+ */
+export function decideUpdateNoticeAffordance({ hostname, userAgent, kind } = {}) {
+  const clientContext = classifyClientContext({ hostname, userAgent });
+  const hostOk = shouldOfferHostMutation(clientContext);
+  if (!hostOk || (kind !== "update" && kind !== "restart")) {
+    return {
+      clientContext,
+      surfaceNotice: false,
+      offerInstall: false,
+      offerRestart: false,
+    };
+  }
+  return {
+    clientContext,
+    surfaceNotice: true,
+    offerInstall: kind === "update",
+    offerRestart: true,
+  };
 }
 
 export function isInstallableStatus(status) {


### PR DESCRIPTION
Closes #1943.
Closes #1944.

## The correction

#1942 shipped in-app update notify + one-click install+restart. It already classified local vs remote, but the paint path still allowed the #1943 half-measure: show the notice, then maybe hide the button.

#1944 (Sean's correction): **defer the notification entirely** on a remote / tunnelled / mobile client. No badge, no banner, no "install it from the panel on the host machine." Telling someone about an action they cannot take, while they are away from the machine, is the motivation to work around the missing button.

Local loopback desktop sessions keep the #1942 prompt unchanged.

## What landed

- `decideUpdateNoticeAffordance` is the single verdict tests drive. Remote/tunnel/mobile → notice, install, and restart are all false. Local + update → all three true. There is no inform-without-button row.
- `notifyAvailablePanelUpdate` returns before paint when that verdict says not to surface. The install+restart button is part of the notice, not a nested offer-gate after it.
- `applyPanelUpdate` re-classifies from this tab's `location` / `userAgent` at click time and fail-closes. A captured "local" from notify cannot authorize a remote caller.

## Tests

`browser_tests/unit/update-notify.test.mjs` drives the shipped helpers:

- fail if a remote, tunnelled, or mobile client still gets the update prompt or install+restart
- pass when those are deferred entirely and local/host clients still get them
- pin that surfacing a notice without a host action is the #1944 half-measure

**Suite:** `npm run test:unit` → 7334 tests, **7333 pass, 0 fail** (1 pre-existing todo). Log: `tests-panel-1943.log`.

Do not merge from this PR — parent merges after the swarm.
