### PR TITLE
fix(1964): read the live CivitAI lightbox on the shipped results path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - remote, tunnelled, and mobile clients never see the in-app update prompt or one-click install+restart; those stay deferred until the next local host session (#1943, #1944)
+### Added
+- panel_civitai_results reports the live CivitAI lightbox (open model, version ladder + selection, files, creator note, download target) so "Ask agent to download" is no longer a request about a screen the agent cannot see (#1964)
 
 ## [0.15.121] - 2026-08-27
 

--- a/browser_tests/unit/civitai-lightbox-read.test.mjs
+++ b/browser_tests/unit/civitai-lightbox-read.test.mjs
@@ -269,8 +269,8 @@ test("WIRING: Ask agent to download carries the current lightbox (items 1–4)",
 });
 
 test("WIRING: the shipped cmd is civitai_results, not a new tool name", async () => {
-  // Vocabulary is vendored; a new panel_civitai_lightbox would not exist on the
-  // orchestrator. The read has to ride the already-shipped results path.
+  // Vocabulary is vendored; a new lightbox-named panel tool would not exist on
+  // the orchestrator. The read has to ride the already-shipped results path.
   const panel = await readFile(PANEL, "utf8");
   const start = panel.indexOf("onCivitaiCmd(msg) {");
   assert.ok(start >= 0, "onCivitaiCmd handler must exist");

--- a/browser_tests/unit/civitai-lightbox-read.test.mjs
+++ b/browser_tests/unit/civitai-lightbox-read.test.mjs
@@ -1,0 +1,284 @@
+// #1964 — Lightbox read contract for the CivitAI pane.
+//
+// "Ask agent to download" already routes user intent to an agent that cannot
+// see the view it comes from. These tests fail if the shipped read
+// (`panel_civitai_results` / `civitai_results`) still omits the live lightbox,
+// and they fail if someone "fixes" that by re-fetching the public CivitAI API
+// instead of copying the pane's already-open view (#1962: RED is not on the API).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  serializeCivitaiLightbox,
+  htmlToPlain,
+  civitaiDownloadSubfolder,
+  CIVITAI_NOTE_CAP,
+} from "../../web/js/lib/civitai-lightbox-read.js";
+
+const LIB = new URL("../../web/js/lib/civitai-lightbox-read.js", import.meta.url);
+const UI = new URL("../../web/js/cmcp-civitai-ui.js", import.meta.url);
+const PANEL = new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url);
+const SHELL = new URL("../../web/js/cmcp-sidepanel-ui.js", import.meta.url);
+
+const int8 = {
+  id: 401, name: "V4.0 INT8 CONVROT", baseModel: "Flux.1 D",
+  fileName: "krea-v4-int8.safetensors",
+  descriptionHtml: "<p>download link is already in my discord</p>",
+  trainedWords: ["krea"],
+  availability: "Public",
+  earlyAccessEndsAt: null,
+  earlyAccessConfig: null,
+  files: [{
+    id: 11, name: "krea-v4-int8.safetensors", sizeKB: 6500, type: "Model",
+    format: "SafeTensor", primary: true,
+    pickleScanResult: "Success", virusScanResult: "Success",
+    hashes: { SHA256: "aa", AutoV2: "bb" },
+  }],
+  examples: [
+    { id: 91, type: "image", author: "sean", reactions: 3, thumbnailUrl: "/t/91", fullUrl: "/f/91" },
+    { id: 92, type: "image", author: "sean", reactions: 0, gated: true, thumbnailUrl: "/t/92", fullUrl: "/f/92" },
+  ],
+};
+const bf16 = {
+  id: 402, name: "V7.0 BF16", baseModel: "Flux.1 D",
+  fileName: "krea-v7-bf16.safetensors",
+  descriptionHtml: null,
+  trainedWords: [],
+  availability: "EarlyAccess",
+  earlyAccessEndsAt: "2026-09-01T00:00:00.000Z",
+  earlyAccessConfig: { timeframe: 14, chargeForDownload: true, downloadPrice: 2500 },
+  files: [{
+    id: 12, name: "krea-v7-bf16.safetensors", sizeKB: 24.48 * 1024, type: "Model",
+    format: "SafeTensor", primary: true,
+    pickleScanResult: "Success", virusScanResult: "Success",
+    hashes: { SHA256: "cc" },
+  }],
+  examples: [],
+};
+const fp8 = {
+  id: 403, name: "v5.0 Converted FP8", baseModel: "Flux.1 D",
+  fileName: "krea-v5-fp8.safetensors",
+  trainedWords: [],
+  files: [{
+    id: 13, name: "krea-v5-fp8.safetensors", sizeKB: 12000, type: "Model",
+    format: "SafeTensor", primary: true,
+  }],
+  examples: [],
+};
+
+const detail = {
+  id: 2731187,
+  name: "Moody Krea 2 Mix (uncensored)",
+  type: "Checkpoint",
+  creator: "cutie",
+  descriptionHtml: "<p>model-level note</p>",
+  versions: [bf16, int8, fp8],
+};
+
+function modelView(version = int8) {
+  return { open: true, kind: "model", loading: false, detail, version };
+}
+
+test("closed lightbox is an honest close, not a missing field", () => {
+  assert.deepEqual(serializeCivitaiLightbox(null), { open: false });
+  assert.deepEqual(serializeCivitaiLightbox({}), { open: false });
+  assert.deepEqual(serializeCivitaiLightbox({ open: false }), { open: false });
+});
+
+test("model lightbox returns the FULL version ladder with the ACTIVE selection", () => {
+  // Field-tested: the grid only named the 24.48 GB BF16 "best match", so the
+  // agent warned it would not fit a 16 GB card while INT8/FP8 sat one pill away.
+  const out = serializeCivitaiLightbox(modelView(int8));
+  assert.equal(out.open, true);
+  assert.equal(out.kind, "model");
+  assert.equal(out.loading, false);
+  assert.equal(out.id, 2731187);
+  assert.equal(out.title, "Moody Krea 2 Mix (uncensored)");
+  assert.equal(out.creator, "cutie");
+  assert.equal(out.versions.length, 3);
+  assert.deepEqual(out.versions.map((v) => v.name), [
+    "V7.0 BF16", "V4.0 INT8 CONVROT", "v5.0 Converted FP8",
+  ]);
+  const selected = out.versions.filter((v) => v.selected);
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].name, "V4.0 INT8 CONVROT");
+  assert.equal(out.selectedVersion.id, 401);
+  assert.equal(out.selectedVersion.name, "V4.0 INT8 CONVROT");
+});
+
+test("selected version carries file name, size, format, verification, Early Access", () => {
+  const int8Out = serializeCivitaiLightbox(modelView(int8)).selectedVersion;
+  assert.equal(int8Out.fileName, "krea-v4-int8.safetensors");
+  assert.equal(int8Out.files[0].name, "krea-v4-int8.safetensors");
+  assert.equal(int8Out.files[0].sizeKB, 6500);
+  assert.equal(int8Out.files[0].format, "SafeTensor");
+  assert.equal(int8Out.files[0].pickleScanResult, "Success");
+  assert.equal(int8Out.files[0].virusScanResult, "Success");
+  assert.deepEqual(int8Out.files[0].hashes, { SHA256: "aa", AutoV2: "bb" });
+  assert.equal(int8Out.earlyAccess.availability, "Public");
+
+  const ea = serializeCivitaiLightbox(modelView(bf16)).selectedVersion.earlyAccess;
+  assert.equal(ea.availability, "EarlyAccess");
+  assert.equal(ea.endsAt, "2026-09-01T00:00:00.000Z");
+  assert.equal(ea.chargeForDownload, true);
+  assert.equal(ea.downloadPrice, 2500);
+});
+
+test("creator note is the lightbox description text, not HTML", () => {
+  const out = serializeCivitaiLightbox(modelView(int8));
+  assert.equal(out.creatorNote, "download link is already in my discord");
+  assert.equal(htmlToPlain("<p>download link is already in my discord</p>"),
+    "download link is already in my discord");
+});
+
+test("a version without its own note falls back to the model description", () => {
+  const out = serializeCivitaiLightbox(modelView(fp8));
+  assert.equal(out.creatorNote, "model-level note");
+});
+
+test("downloadTarget is the CURRENT pill, not the grid's first-version file", () => {
+  const out = serializeCivitaiLightbox(modelView(int8));
+  assert.deepEqual(out.downloadTarget, {
+    model_id: 2731187,
+    model_version_id: 401,
+    versionName: "V4.0 INT8 CONVROT",
+    type: "Checkpoint",
+    subfolder: "checkpoints",
+    fileName: "krea-v4-int8.safetensors",
+  });
+  assert.equal(civitaiDownloadSubfolder("LORA"), "loras");
+  assert.notEqual(out.downloadTarget.model_version_id, bf16.id,
+    "must not silently report the BF16 'best match' the grid showed");
+});
+
+test("examples honor the gated contract (flag, keep URLs, never bytes)", () => {
+  const out = serializeCivitaiLightbox(modelView(int8));
+  assert.equal(out.examples.length, 2);
+  assert.equal(out.examples[0].gated, false);
+  assert.deepEqual(out.examples[0].urls, ["/t/91", "/f/91"]);
+  assert.equal(out.examples[1].gated, true);
+  for (const ex of out.examples) {
+    for (const u of ex.urls) assert.equal(typeof u, "string");
+  }
+});
+
+test("Ask-agent payload drops examples (items 1–4 only) and still names the pill", () => {
+  const out = serializeCivitaiLightbox(modelView(int8), { forDownload: true });
+  assert.deepEqual(out.examples, []);
+  assert.equal(out.title, "Moody Krea 2 Mix (uncensored)");
+  assert.equal(out.selectedVersion.name, "V4.0 INT8 CONVROT");
+  assert.equal(out.creatorNote, "download link is already in my discord");
+  assert.equal(out.downloadTarget.model_version_id, 401);
+  assert.equal(out.versions.length, 3);
+});
+
+test("a still-loading model lightbox is open, not closed", () => {
+  const out = serializeCivitaiLightbox({
+    open: true, kind: "model", loading: true,
+    id: 2731187, title: "Moody Krea 2 Mix (uncensored)", creator: "cutie",
+  });
+  assert.equal(out.open, true);
+  assert.equal(out.loading, true);
+  assert.equal(out.id, 2731187);
+  assert.equal(out.title, "Moody Krea 2 Mix (uncensored)");
+  assert.equal(out.selectedVersion, null);
+  assert.equal(out.downloadTarget, null);
+});
+
+test("media lightbox reports the open item and the gating flag", () => {
+  const out = serializeCivitaiLightbox({
+    open: true, kind: "media",
+    item: {
+      id: 77, type: "image", author: "alice", reactions: 4,
+      thumbnailUrl: "/t/77", fullUrl: "/f/77",
+    },
+    index: 2, total: 10, done: false,
+  });
+  assert.equal(out.open, true);
+  assert.equal(out.kind, "media");
+  assert.equal(out.id, 77);
+  assert.equal(out.creator, "alice");
+  assert.equal(out.index, 2);
+  assert.equal(out.total, 10);
+  assert.equal(out.more, true);
+  assert.equal(out.item.gated, false);
+});
+
+test("a long creator note is capped so the receipt stays bounded", () => {
+  const long = `<p>${"x".repeat(CIVITAI_NOTE_CAP + 80)}</p>`;
+  const out = serializeCivitaiLightbox({
+    open: true, kind: "model", loading: false,
+    detail: { ...detail, versions: [{ ...int8, descriptionHtml: long }], descriptionHtml: null },
+    version: { ...int8, descriptionHtml: long },
+  });
+  assert.equal(out.creatorNote.length, CIVITAI_NOTE_CAP + 1);
+  assert.ok(out.creatorNote.endsWith("…"));
+});
+
+test("the serializer is pure: no fetch, no CivitAI host, no image bytes", async () => {
+  const src = await readFile(LIB, "utf8");
+  assert.equal(/fetch\s*\(/.test(src), false, "a fetch here would be the #1962 public-API workaround");
+  assert.equal(/civitai\.com/.test(src), false, "must not name the public API host");
+  assert.equal(/fetchModelDetail/.test(src), false);
+  assert.equal(/_get\s*\(/.test(src), false);
+  assert.equal(/arrayBuffer|blob\b|uint8array/i.test(src), false);
+});
+
+test("WIRING: panel_civitai_results actually returns the live lightbox", async () => {
+  const src = await readFile(UI, "utf8");
+  assert.match(src, /import \{ serializeCivitaiLightbox \} from "\.\/lib\/civitai-lightbox-read\.js";/,
+    "the pane-path serializer must be imported");
+
+  const ret = src.slice(src.indexOf("async function driveGetResults"));
+  const body = ret.slice(0, ret.indexOf("async function driveHighlight"));
+  assert.ok(body.includes("lightbox: serializeCivitaiLightbox(_readLightbox())"),
+    "driveGetResults must copy the LIVE reader — without this the agent still cannot see the lightbox");
+  assert.equal(body.includes("fetchModelDetail"), false,
+    "the shipped read must not re-fetch model detail");
+  assert.equal(/civitai\.com/.test(body), false,
+    "the shipped read must not hit the public CivitAI API");
+});
+
+test("WIRING: the live reader is the open lightbox, not a stale close", async () => {
+  const src = await readFile(UI, "utf8");
+  assert.ok(src.includes("function setLightboxReader("),
+    "openModelDetail / openViewer must install a live reader");
+  assert.ok(src.includes("kind: \"model\""),
+    "the model-detail surface (Ask agent to download) must be readable");
+  assert.ok(src.includes("kind: \"media\""),
+    "the media lightbox must be readable too");
+  // Version pills mutate `version`; the reader must close over that binding
+  // so a later civitai_results sees the pill the user clicked, not versions[0].
+  const openModel = src.slice(src.indexOf("async function openModelDetail"));
+  const body = openModel.slice(0, src.indexOf("async function pickModel") - src.indexOf("async function openModelDetail"));
+  assert.ok(body.includes("setLightboxReader("), "openModelDetail must install the reader");
+  assert.ok(body.includes("return { open: true, kind: \"model\", loading: false, detail, version }"),
+    "the reader must close over the SELECTED version binding");
+});
+
+test("WIRING: Ask agent to download carries the current lightbox (items 1–4)", async () => {
+  const src = await readFile(UI, "utf8");
+  const pick = src.slice(src.indexOf("async function pickModel"));
+  const body = pick.slice(0, src.indexOf("// ── filters") - src.indexOf("async function pickModel"));
+  assert.ok(body.includes("serializeCivitaiLightbox("),
+    "the click must attach the live view, not just model_id + version id");
+  assert.ok(body.includes("forDownload: true"),
+    "the click payload is items 1–4 (identity, versions, files, note), not the examples grid");
+  assert.ok(body.includes("Live CivitAI lightbox (what I'm looking at)"),
+    "the agent-side event must name the view so it cannot be mistaken for a search result");
+});
+
+test("WIRING: the shipped cmd is civitai_results, not a new tool name", async () => {
+  // Vocabulary is vendored; a new panel_civitai_lightbox would not exist on the
+  // orchestrator. The read has to ride the already-shipped results path.
+  const panel = await readFile(PANEL, "utf8");
+  const start = panel.indexOf("onCivitaiCmd(msg) {");
+  assert.ok(start >= 0, "onCivitaiCmd handler must exist");
+  const body = panel.slice(start, panel.indexOf("onTrainingCmd(msg) {", start));
+  assert.ok(body.includes('case "civitai_results": return h.civitai.getResults'),
+    "civitai_results is the shipped read");
+  assert.equal(body.includes("fetchModelDetail"), false);
+  const shell = await readFile(SHELL, "utf8");
+  assert.ok(shell.includes('getResults: (a) => _driveOf("civitai"'),
+    "the side-panel facade must still route getResults at the live pane");
+});

--- a/browser_tests/unit/civitai-workflow.test.mjs
+++ b/browser_tests/unit/civitai-workflow.test.mjs
@@ -160,7 +160,37 @@ test("_versionFromJson carries the files list (id/name/size/type/format)", () =>
   const v = client._versionFromJson({
     id: 9, files: [{ id: 5, name: "wf.zip", sizeKB: 4.9, type: "Archive", metadata: { format: "Other" } }],
   }, [1]);
-  assert.deepEqual(v.files, [{ id: 5, name: "wf.zip", sizeKB: 4.9, type: "Archive", format: "Other" }]);
+  assert.deepEqual(v.files, [{
+    id: 5, name: "wf.zip", sizeKB: 4.9, type: "Archive", format: "Other",
+    primary: false, pickleScanResult: null, virusScanResult: null, hashes: null,
+  }]);
+});
+
+test("#1964: _versionFromJson keeps Early Access + file verification from the pane fetch", () => {
+  // The lightbox read serializes these off the already-fetched version object.
+  // Dropping them here would force a public-API re-fetch, which cannot see RED.
+  const client = new CivitaiClient({ apiURL: (p) => p });
+  const v = client._versionFromJson({
+    id: 11, name: "V4.0 INT8 CONVROT",
+    availability: "EarlyAccess",
+    earlyAccessEndsAt: "2026-09-01T00:00:00.000Z",
+    earlyAccessConfig: { timeframe: 7, chargeForDownload: true, downloadPrice: 500, extra: "drop-me" },
+    files: [{
+      id: 7, name: "model.safetensors", sizeKB: 4200, type: "Model",
+      primary: true, pickleScanResult: "Success", virusScanResult: "Success",
+      hashes: { SHA256: "abc", AutoV2: "def" },
+      metadata: { format: "SafeTensor" },
+    }],
+  }, [1]);
+  assert.equal(v.availability, "EarlyAccess");
+  assert.equal(v.earlyAccessEndsAt, "2026-09-01T00:00:00.000Z");
+  assert.deepEqual(v.earlyAccessConfig, {
+    timeframe: 7, chargeForDownload: true, downloadPrice: 500,
+  });
+  assert.equal(v.files[0].primary, true);
+  assert.equal(v.files[0].pickleScanResult, "Success");
+  assert.equal(v.files[0].virusScanResult, "Success");
+  assert.deepEqual(v.files[0].hashes, { SHA256: "abc", AutoV2: "def" });
 });
 
 // ── zip reader ──────────────────────────────────────────────────────────────

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -16,6 +16,7 @@ import {
   filtersDirty, bitmask, parseCreatorQuery, levelLabel,
 } from "./cmcp-civitai.js";
 import { summarizeSearchFilters } from "./lib/civitai-search-echo.js";
+import { serializeCivitaiLightbox } from "./lib/civitai-lightbox-read.js";
 import {
   awaitReloadWithin,
   classifyHighlightOutcome,
@@ -392,6 +393,19 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   let isOpen = true;
   let _oauthPollIv = null;         // sign-in completion poll (accountFlow)
   let _activeLightboxClose = null; // openViewer's teardown (owns its own doc keydown listener)
+  // Live lightbox snapshot for panel_civitai_results (#1964). A function so
+  // version-pill clicks / media paging are visible without a second write —
+  // the reader closes over the same `let version` / `let idx` the UI mutates.
+  // Epoch so a later open's close cannot blank a newer lightbox.
+  let _lightboxEpoch = 0;
+  let _readLightbox = () => ({ open: false });
+  function setLightboxReader(fn) {
+    const epoch = ++_lightboxEpoch;
+    _readLightbox = typeof fn === "function" ? fn : () => ({ open: false });
+    return () => {
+      if (_lightboxEpoch === epoch) _readLightbox = () => ({ open: false });
+    };
+  }
   let searchTimer = null;
   const close = () => { try { shell.close(); } catch { /* already gone */ } };
   function teardown() {
@@ -406,6 +420,8 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     // it down through this one path (codex finding).
     if (_activeLightboxClose) { try { _activeLightboxClose(); } catch { /* already gone */ } _activeLightboxClose = null; }
     try { closeSubModals(); } catch { /* already gone */ }
+    _lightboxEpoch++;
+    _readLightbox = () => ({ open: false });
   }
 
   // The search box is the shell's single input (aliased `search`). The debounce +
@@ -932,10 +948,19 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       const b = el("button", "cmcp-cv-iconbtn"); b.innerHTML = `<i class="pi ${icon}"></i>`;
       if (title) b.title = title; b.addEventListener("click", fn); return b;
     };
+    const releaseLightbox = setLightboxReader(() => {
+      const it = state.items[idx];
+      if (!it) return { open: true, kind: "media", loading: true, id: null, item: null };
+      return {
+        open: true, kind: "media", item: it,
+        index: idx, total: state.items.length, done: !!state.done,
+      };
+    });
     const closeLb = () => {
       lb.remove();
       document.removeEventListener("keydown", onKey, true);
       if (_activeLightboxClose === closeLb) _activeLightboxClose = null;
+      releaseLightbox();
     };
     // Track the live lightbox so the modal's unified close() can dismiss it (and
     // remove its listener) on a programmatic reopen (codex finding).
@@ -1405,9 +1430,19 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
 
   // ── model detail ─────────────────────────────────────────────────────
   async function openModelDetail(m) {
-    const sheet = openSubModal(m.name);
-    sheet.body.appendChild(el("div", "cmcp-cv-loading", tr("civitai_ui.loading", "Loading…")));
     let detail;
+    let version;
+    const releaseLightbox = setLightboxReader(() => {
+      if (!detail) {
+        return {
+          open: true, kind: "model", loading: true,
+          id: m.id, title: m.name || null, creator: m.creator || null, type: m.type || null,
+        };
+      }
+      return { open: true, kind: "model", loading: false, detail, version };
+    });
+    const sheet = openSubModal(m.name, releaseLightbox);
+    sheet.body.appendChild(el("div", "cmcp-cv-loading", tr("civitai_ui.loading", "Loading…")));
     try { detail = await client.fetchModelDetail(m.id, { levels: state.filters.browsingLevels }); }
     catch (e) {
       sheet.body.innerHTML = "";
@@ -1415,7 +1450,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       return;
     }
     sheet.body.innerHTML = "";
-    let version = detail.versions[0];
+    version = detail.versions[0];
 
     const versionRow = el("div", "cmcp-cv-frow");
     const renderBody = () => {
@@ -1549,10 +1584,15 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     } else {
       // The request itself stays English — see buildCaption: it is a prompt for the
       // agent, carrying wire ids and the API's own `detail.type` ("Checkpoint"/"LORA").
+      const live = serializeCivitaiLightbox(
+        { open: true, kind: "model", loading: false, detail, version },
+        { forDownload: true },
+      );
       ctx.sendUserMessage(
         `Please download the CivitAI ${detail.type} "${detail.name}"` +
         (version.name ? ` (version "${version.name}")` : "") +
-        ` — model_id ${detail.id}, version ${version.id} — into ${subfolder}, then we'll use it.`);
+        ` — model_id ${detail.id}, version ${version.id} — into ${subfolder}, then we'll use it.` +
+        `\n\nLive CivitAI lightbox (what I'm looking at):\n${JSON.stringify(live)}`);
       ctx.bringChatForward();
       toast(tr("civitai_ui.asked_the_agent_to_download_it", "Asked the agent to download it."));
     }
@@ -2212,6 +2252,9 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     const ser = serializeCivitaiResults(source, { model, limit, loading: state.loading });
     return {
       ...ser, // { items, total, loading }
+      // Live lightbox — what the user is looking at, copied from pane state.
+      // Not a CivitAI re-fetch (#1962): RED content only exists on this surface.
+      lightbox: serializeCivitaiLightbox(_readLightbox()),
       count: ser.items.length,
       done: !!state.done,
       renderRev: state.renderRev,

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -869,17 +869,33 @@ export class CivitaiClient {
     const examples = (v.images || [])
       .filter((img) => (((img.nsfwLevel || 1) & mask) !== 0))
       .map((img) => this._fromRest({ ...img, url: img.url }));
+    const cfg = v.earlyAccessConfig && typeof v.earlyAccessConfig === "object"
+      ? v.earlyAccessConfig : null;
     return {
       id: v.id, name: v.name || null, baseModel: v.baseModel || null,
       descriptionHtml: v.description || null,
       trainedWords: v.trainedWords || [], examples,
       downloadCount: v.stats?.downloadCount,
       fileName: this._primaryFile(v),
-      // Downloadable files, kept for the Workflows "load onto canvas" path.
+      // Early Access / buzz wall — load-bearing for the lightbox read (#1964).
+      // Kept from the pane's already-fetched model detail, not a second API call.
+      availability: v.availability || null,
+      earlyAccessEndsAt: v.earlyAccessEndsAt || null,
+      earlyAccessConfig: cfg ? {
+        timeframe: cfg.timeframe ?? null,
+        chargeForDownload: cfg.chargeForDownload ?? null,
+        downloadPrice: cfg.downloadPrice ?? null,
+      } : null,
+      // Downloadable files, kept for the Workflows "load onto canvas" path
+      // and the lightbox read (name / size / format / scan / hashes).
       // `format` rides in metadata (live shape: type:"Archive", metadata:{format:"Other"}).
       files: (v.files || []).map((f) => ({
         id: f.id, name: f.name || "", sizeKB: f.sizeKB ?? null,
         type: f.type || null, format: f.metadata?.format ?? null,
+        primary: f.primary === true,
+        pickleScanResult: f.pickleScanResult || null,
+        virusScanResult: f.virusScanResult || null,
+        hashes: f.hashes && typeof f.hashes === "object" ? { ...f.hashes } : null,
       })),
     };
   }

--- a/web/js/lib/civitai-lightbox-read.js
+++ b/web/js/lib/civitai-lightbox-read.js
@@ -1,0 +1,220 @@
+/**
+ * #1964 — serialize the LIVE CivitAI lightbox (what the user is looking at).
+ *
+ * `panel_civitai_open_lightbox` and the human "Ask agent to download" button
+ * already hand a download intent to an agent that cannot see the view it
+ * comes from: which of ~27 version pills is selected, the file on that pill
+ * (name / size / format / scan / Early Access), the creator's distribution
+ * note. The grid row only names the first version's "best match" file, so an
+ * agent that re-fetches CivitAI (or reads `civitai_results` items) cannot
+ * recover the lightbox. RED content is not on the public API at all (#1962).
+ *
+ * This module is the pane-path read: it copies the already-open lightbox's
+ * in-memory objects. It does not fetch, does not call CivitAI, and never
+ * carries image bytes. Wired into `panel_civitai_results` as `lightbox`.
+ */
+
+export const CIVITAI_NOTE_CAP = 4000;
+export const CIVITAI_LIGHTBOX_EXAMPLES = 12;
+
+/** Same map the model-detail download button uses (cmcp-civitai-ui SUBFOLDER). */
+const SUBFOLDER = {
+  LORA: "loras", Workflows: "workflows", TextualInversion: "embeddings",
+  VAE: "vae", Controlnet: "controlnet", Checkpoint: "checkpoints",
+};
+
+export function civitaiDownloadSubfolder(type) {
+  return SUBFOLDER[type] || "checkpoints";
+}
+
+/** Strip CivitAI description HTML to the text the lightbox shows. Pure — no DOM. */
+export function htmlToPlain(html) {
+  if (typeof html !== "string" || !html) return null;
+  const text = html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, "\"")
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+  return text || null;
+}
+
+function capNote(text) {
+  if (!text) return null;
+  return text.length > CIVITAI_NOTE_CAP ? text.slice(0, CIVITAI_NOTE_CAP) + "…" : text;
+}
+
+function copyHashes(h) {
+  if (!h || typeof h !== "object") return null;
+  const out = {};
+  for (const [k, v] of Object.entries(h)) {
+    if (typeof v === "string" && v) out[k] = v;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
+function serializeFile(f) {
+  if (!f) return null;
+  return {
+    id: f.id ?? null,
+    name: f.name || "",
+    sizeKB: f.sizeKB ?? null,
+    type: f.type || null,
+    format: f.format || null,
+    primary: f.primary === true,
+    pickleScanResult: f.pickleScanResult || null,
+    virusScanResult: f.virusScanResult || null,
+    hashes: copyHashes(f.hashes),
+  };
+}
+
+function earlyAccessFrom(v) {
+  if (!v) return null;
+  const cfg = v.earlyAccessConfig && typeof v.earlyAccessConfig === "object"
+    ? v.earlyAccessConfig : null;
+  return {
+    availability: v.availability || null,
+    endsAt: v.earlyAccessEndsAt || null,
+    chargeForDownload: cfg && typeof cfg.chargeForDownload === "boolean" ? cfg.chargeForDownload : null,
+    downloadPrice: cfg && cfg.downloadPrice != null ? cfg.downloadPrice : null,
+    timeframe: cfg && cfg.timeframe != null ? cfg.timeframe : null,
+  };
+}
+
+/** One media row — same gated contract as serializeCivitaiResults (mcp#623). */
+function serializeMediaItem(x) {
+  if (!x) return null;
+  const gated = x.gated === true || !x.thumbnailUrl;
+  return {
+    id: x.id,
+    kind: x.type === "video" ? "video" : "image",
+    creator: x.author || null,
+    baseModel: x.modelName || null,
+    type: x.type || null,
+    stats: { reactions: x.reactions ?? null },
+    urls: [x.thumbnailUrl, x.fullUrl].filter(Boolean),
+    gated,
+  };
+}
+
+function serializeVersionChip(v, selectedId) {
+  return {
+    id: v.id,
+    name: v.name || null,
+    baseModel: v.baseModel || null,
+    selected: v.id === selectedId,
+  };
+}
+
+function serializeSelectedVersion(v) {
+  if (!v) return null;
+  const files = Array.isArray(v.files) ? v.files.map(serializeFile).filter(Boolean) : [];
+  return {
+    id: v.id,
+    name: v.name || null,
+    baseModel: v.baseModel || null,
+    fileName: v.fileName || null,
+    trainedWords: Array.isArray(v.trainedWords) ? [...v.trainedWords] : [],
+    files,
+    earlyAccess: earlyAccessFrom(v),
+  };
+}
+
+function serializeModel(view, { forDownload } = {}) {
+  const detail = view.detail;
+  const version = view.version;
+  if (view.loading || !detail) {
+    return {
+      open: true,
+      kind: "model",
+      loading: true,
+      id: view.id ?? null,
+      title: view.title || null,
+      type: view.type || null,
+      creator: view.creator || null,
+      creatorNote: null,
+      versions: [],
+      selectedVersion: null,
+      downloadTarget: null,
+      examples: [],
+    };
+  }
+  const selected = version || (Array.isArray(detail.versions) ? detail.versions[0] : null);
+  const versions = Array.isArray(detail.versions)
+    ? detail.versions.map((v) => serializeVersionChip(v, selected?.id))
+    : [];
+  const noteHtml = selected?.descriptionHtml || detail.descriptionHtml || null;
+  const creatorNote = capNote(htmlToPlain(noteHtml));
+  const type = detail.type || null;
+  const out = {
+    open: true,
+    kind: "model",
+    loading: false,
+    id: detail.id,
+    title: detail.name || view.title || null,
+    type,
+    creator: detail.creator || view.creator || null,
+    creatorNote,
+    versions,
+    selectedVersion: serializeSelectedVersion(selected),
+    downloadTarget: selected ? {
+      model_id: detail.id,
+      model_version_id: selected.id,
+      versionName: selected.name || null,
+      type,
+      subfolder: civitaiDownloadSubfolder(type),
+      fileName: selected.fileName || null,
+    } : null,
+    examples: [],
+  };
+  if (!forDownload && selected && Array.isArray(selected.examples)) {
+    out.examples = selected.examples.slice(0, CIVITAI_LIGHTBOX_EXAMPLES).map(serializeMediaItem);
+  }
+  return out;
+}
+
+function serializeMedia(view) {
+  const item = view.item;
+  if (!item) {
+    return { open: true, kind: "media", loading: true, id: view.id ?? null, item: null };
+  }
+  return {
+    open: true,
+    kind: "media",
+    loading: false,
+    id: item.id,
+    title: item.author ? `@${item.author}` : null,
+    creator: item.author || null,
+    index: Number.isFinite(view.index) ? view.index : null,
+    total: Number.isFinite(view.total) ? view.total : null,
+    more: view.done === false,
+    item: serializeMediaItem(item),
+  };
+}
+
+/**
+ * Snapshot the live lightbox for the agent. `view` is the pane's in-memory
+ * object (`{open:false}` when nothing is open); never a CivitAI HTTP body.
+ *
+ * `forDownload: true` drops the examples grid — the "Ask agent to download"
+ * payload carries identity, version ladder, files, and the creator note
+ * (issue items 1–4), not the examples (item 5).
+ */
+export function serializeCivitaiLightbox(view, { forDownload = false } = {}) {
+  if (!view || view.open !== true) return { open: false };
+  if (view.kind === "media") return serializeMedia(view);
+  if (view.kind === "model") return serializeModel(view, { forDownload });
+  return { open: false };
+}


### PR DESCRIPTION
## Why

The CivitAI lightbox already has **Ask agent to download**, which hands a download intent to an agent that cannot see the view it comes from. If the user is looking at one of ~27 version pills, the agent gets a request whose context it cannot verify: which version is selected, what quant/precision it is, file size, Early Access / buzz, the creator's distribution note.

#1961/#1962 asked for pane-wide parity. This PR is the **lightbox read contract only** — a copy of the live pane view, not a public CivitAI API re-fetch (RED content is not on the API).

## What

- `panel_civitai_results` (`civitai_results`) now includes `lightbox`:
  - `{ open: false }` when nothing is open
  - model lightbox: title, creator note, full version ladder with the **active** pill, per-version files (name / size / format / scan / hashes / Early Access), download target, examples (same `gated` contract as the grid)
  - media lightbox: the open item + gating flag
- The live reader closes over the same `version` / `idx` the UI mutates, so a later results call sees the pill the user clicked.
- **Ask agent to download** appends items 1–4 of that view (identity, versions, files, creator note) so the click is no longer a request about a screen the agent has never seen.
- Serializer is pure: no `fetch`, no `civitai.com`. Tests fail if `driveGetResults` re-fetches model detail instead of copying pane state.

Closes #1964