### PR TITLE
fix(1957): emit promised read fields and document actual paste/layout behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Added
 - panel_civitai_results reports the live CivitAI lightbox (open model, version ladder + selection, files, creator note, download target) so "Ask agent to download" is no longer a request about a screen the agent cannot see (#1964)
 - CivitAI pane: Upscaler/Embeddings/Poses are real tabs (empty grids name types the current tab cannot see); sample URLs are the fetchable `/comfyui_mcp_panel/civitai/media` path plus a civitai.com pageUrl; open/clear echo applied tab/query/docked/cleared-count (#1958)
+- read-surface accuracy: query/view detail rows always include `mode` (including `active`) and surface writable `pinned`/`shape`; paste replies document that internal wires among the copied set are preserved; graph_serialize is one JSON `{workflow, node_count}` rather than two text blocks; auto-layout re-fit excludes pinned outliers so a skipped member cannot stretch a group over the canvas (#1957)
 
 ## [0.15.121] - 2026-08-27
 

--- a/browser_tests/unit/auto-layout-subgraph.test.mjs
+++ b/browser_tests/unit/auto-layout-subgraph.test.mjs
@@ -193,6 +193,59 @@ test("#1328 a root-only apply with no captured subgraph still rearranges the roo
   assert.equal(moved, true);
 });
 
+test("#1957 group re-fit excludes a pinned outlier so the box cannot swallow the canvas", () => {
+  // Compact group at x=2000 with one PINNED member. Layout with anchor:"origin"
+  // moves the unpinned members to the origin and honestly skips the pin.
+  // Unfixed re-fit then wrapped the pin (still at 2000) AND the moved members
+  // into a ~2000px band that swallowed the unrelated node sitting in between.
+  const a = node(1, [2000, 0]);
+  const b = node(2, [2000, 150]);
+  const pinned = node(3, [2000, 300]);
+  pinned.flags = { pinned: true };
+  const outsider = node(4, [1000, 80]);
+  const g = {
+    id: 10,
+    title: "Sampler",
+    _bounding: boundsAroundNodes([a, b, pinned]),
+    recomputeInsideNodes() {},
+  };
+  const graph = attachGraphApi({
+    _nodes: [a, b, pinned, outsider],
+    _groups: [g],
+    links: { 1: { origin_id: 1, target_id: 2 } },
+  });
+  const canvas = { graph, setGraph() {}, setDirty() {} };
+  const layout = realAutoLayout(() => ({ graph, rootGraph: graph, canvas }));
+
+  const beforeMembers = groupMemberNodes(graph, g).map((n) => n.id).sort((x, y) => x - y);
+  assert.deepEqual(beforeMembers, [1, 2, 3], "the fixture starts as a compact group, not a canvas-wide band");
+  assert.equal(groupMemberNodes(graph, g).some((n) => n.id === 4), false, "the in-between node is not yet a member");
+
+  const opts = { node_ids: [1, 2, 3], mode: "flow_horizontal", groups: "preserve", anchor: "origin" };
+  const dry = layout({ ...opts, dry_run: true });
+  const dryBox = dry.groups?.find((row) => row.group_id === 10);
+  assert.ok(dryBox, "preserve mode reports the group");
+  assert.deepEqual(dryBox.re_fit_excluded_pinned, [3]);
+  assert.ok(
+    dryBox.bounds[2] < 800,
+    `dry_run re-fit must not span the pinned outlier at x=2000; got width ${dryBox.bounds[2]}`,
+  );
+
+  const applied = layout(opts);
+  const box = applied.groups?.find((row) => row.group_id === 10);
+  assert.ok(box);
+  assert.deepEqual(box.re_fit_excluded_pinned, [3]);
+  assert.ok(
+    box.bounds[2] < 800,
+    `applied re-fit must not keep the ~2000px band; got width ${box.bounds[2]}`,
+  );
+  const afterIds = groupMemberNodes(graph, g).map((n) => n.id);
+  assert.ok(!afterIds.includes(4), "an unrelated node must not be swallowed by re-fit");
+  assert.ok(!afterIds.includes(3), "the skipped pinned outlier is no longer a geometric member");
+  assert.ok(afterIds.includes(1) && afterIds.includes(2), "moved unpinned members stay in the group");
+  assert.ok(applied.skipped?.some((s) => s.node_id === 3 && s.reason === "pinned"));
+});
+
 test("#1328 apply refuses rather than writing root when the subgraph node count drifted", () => {
   const { inner, sub, root, rootNodes, canvas } = fixture();
   const originals = inner.slice();

--- a/browser_tests/unit/copy-paste-layout.test.mjs
+++ b/browser_tests/unit/copy-paste-layout.test.mjs
@@ -584,6 +584,12 @@ test("#1294 shipped copy+paste keeps groups and distinct branch y-positions", ()
   assert.equal(result.pasted_count, 10);
   assert.equal(result.copied_groups, 5);
   assert.equal(result.pasted_groups, 5, "groups survived paste");
+  assert.equal(result.connect_inputs, false);
+  assert.match(
+    result.note,
+    /Internal wires among the copied nodes are preserved/,
+    "#1957 the paste reply must document that internals survived, not promise a disconnected copy",
+  );
   assert.equal(dst.graph._groups.length, 5);
 
   const loraYs = result.pasted.filter((n) => n.type === LORA).map((n) => n.pos[1]);

--- a/browser_tests/unit/read-surface-accuracy.test.mjs
+++ b/browser_tests/unit/read-surface-accuracy.test.mjs
@@ -1,0 +1,226 @@
+/**
+ * #1957 — read-surface accuracy: promised fields that never appear, write-only
+ * attributes, and descriptions that undersell actual behaviour.
+ *
+ * Five gaps from a QA sweep (panel 0.15.114). None change fail-closed outcomes.
+ * Each test fails on the unfixed wording/missing field and passes on the shipped
+ * one. Drives the REAL summarizeNode / graph_serialize / graph_paste_nodes /
+ * graph_auto_layout seams, not a reimplementation.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { displayLabel, boundaryInputLabel, widgetLabelMap } from "../../web/js/lib/slot-labels.js";
+import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
+import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
+import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
+import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
+import { redactWidgetValue } from "../../web/js/lib/widget-secret-redaction.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const PANEL_SOURCE = readFileSync(PANEL_JS, "utf8");
+
+/** Brace-balanced extract so a later nested block cannot truncate the function. */
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  const open = src.indexOf(") {", start) + 2;
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
+function handlerBody(src, signature, { lead = 0 } = {}) {
+  const start = src.indexOf(signature);
+  if (start === -1) return null;
+  const from = Math.max(0, start - lead);
+  const after = start + signature.length;
+  const next = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  const end = next ? after + next.index : src.length;
+  return src.slice(from, end);
+}
+
+const summarizeNode = (() => {
+  const fn = namedFunctionSource(PANEL_SOURCE, "summarizeNode");
+  assert.ok(fn, "summarizeNode not found in panel source");
+  return new Function(
+    "virtualFedInputs",
+    "boundaryInputLabel",
+    "displayLabel",
+    "widgetLabelMap",
+    "duplicateWidgetRows",
+    "controlAfterGenerateModes",
+    "drivenWidgetsFor",
+    "redactWidgetValue",
+    `${fn}; return summarizeNode;`,
+  )(
+    virtualFedInputs,
+    boundaryInputLabel,
+    displayLabel,
+    widgetLabelMap,
+    duplicateWidgetRows,
+    controlAfterGenerateModes,
+    drivenWidgetsFor,
+    redactWidgetValue,
+  );
+})();
+
+function node(over = {}) {
+  return {
+    id: 1,
+    type: "KSampler",
+    title: "KSampler",
+    widgets: [],
+    inputs: [],
+    outputs: [],
+    pos: [10, 20],
+    size: [200, 100],
+    ...over,
+  };
+}
+
+test("#1957 detail rows always emit mode, including active (not omitted-as-default)", () => {
+  // The unfixed emit was `...(node.mode ? { mode } : {})`, so mode 0 (active)
+  // produced no field — the QA sweep never saw `mode` on any row.
+  const src = namedFunctionSource(PANEL_SOURCE, "summarizeNode");
+  assert.doesNotMatch(
+    src,
+    /\.\.\.\(node\.mode \? \{ mode:/,
+    "mode must not be omitted when the node is active",
+  );
+
+  const active = summarizeNode(node({ mode: 0 }));
+  assert.equal(active.mode, "active", "an ordinary node must name its mode");
+  assert.equal(Object.prototype.hasOwnProperty.call(active, "mode"), true);
+
+  const unset = summarizeNode(node());
+  assert.equal(unset.mode, "active", "a missing LiteGraph mode is active, not absent");
+
+  assert.equal(summarizeNode(node({ mode: 2 })).mode, "mute");
+  assert.equal(summarizeNode(node({ mode: 4 })).mode, "bypass");
+});
+
+test("#1957 pinned and shape surface on the same reads collapsed does", () => {
+  // view_selected / view_nodes_in_viewport / query_graph detail all map through
+  // summarizeNode. collapsed already rode on that payload; pinned and shape did not,
+  // so verifying a pin required a screenshot.
+  assert.match(
+    PANEL_SOURCE,
+    /nodes: picked\.slice\(0, MAX_STATE_NODES\)\.map\(summarizeNode\)/,
+    "view_selected must keep going through summarizeNode",
+  );
+  assert.match(
+    PANEL_SOURCE,
+    /const cap = visible\.slice\(0, MAX_STATE_NODES\)\.map\(summarizeNode\)/,
+    "view_nodes_in_viewport must keep going through summarizeNode",
+  );
+  assert.match(
+    PANEL_SOURCE,
+    /\.\.\.capSummaryWidgets\(summarizeNode\(n\), detailWidgetCap, maxChars\)/,
+    "query_graph detail must keep going through summarizeNode",
+  );
+
+  const pinned = summarizeNode(node({ flags: { pinned: true } }));
+  assert.equal(pinned.pinned, true);
+  const unpinned = summarizeNode(node({ flags: {} }));
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(unpinned, "pinned"),
+    false,
+    "unpinned is omitted like collapsed:false, not a write-only hole",
+  );
+
+  const both = summarizeNode(node({ flags: { collapsed: true, pinned: true } }));
+  assert.equal(both.collapsed, true);
+  assert.equal(both.pinned, true);
+
+  assert.equal(summarizeNode(node({ shape: "round" })).shape, "round");
+  assert.equal(summarizeNode(node({ shape: "card" })).shape, "card");
+  assert.equal(summarizeNode(node({ shape: 2 })).shape, "round", "numeric LiteGraph ROUND maps");
+  assert.equal(summarizeNode(node({ shape: 4 })).shape, "card", "numeric LiteGraph CARD maps");
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(summarizeNode(node()), "shape"),
+    false,
+    "default shape is omitted like collapsed:false",
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(summarizeNode(node({ shape: "default" })), "shape"),
+    false,
+  );
+});
+
+test("#1957 outline and compact rows tag a pinned node so a pin is visible without detail", () => {
+  const outline = handlerBody(PANEL_SOURCE, "graph_outline({");
+  const query = handlerBody(PANEL_SOURCE, "graph_query({");
+  assert.ok(outline, "graph_outline must exist");
+  assert.ok(query, "graph_query must exist");
+  const pinTag = /n\.flags && n\.flags\.pinned \? " \[pinned\]"/;
+  assert.match(outline, pinTag, "outline modeTag must mark pinned nodes");
+  assert.match(query, pinTag, "query compact modeTag must mark pinned nodes");
+});
+
+test("#1957 paste documents preserved internal wires — not a clean disconnected copy", () => {
+  const body = handlerBody(PANEL_SOURCE, "graph_paste_nodes({", { lead: 500 });
+  assert.ok(body, "graph_paste_nodes must exist");
+  assert.doesNotMatch(
+    body,
+    /drops a disconnected copy/,
+    "the unfixed wording told agents to re-wire internals that already survived",
+  );
+  assert.match(
+    body,
+    /Internal wires among the copied nodes are preserved/,
+    "the comment must name the actual behaviour",
+  );
+  assert.match(
+    body,
+    /note:\s*\n?\s*"Internal wires among the copied nodes are preserved/,
+    "the reply must carry the same claim so a description-only fix cannot silently regress",
+  );
+  assert.match(body, /connect_inputs: connect_inputs === true/, "echo the lever the note names");
+});
+
+test("#1957 graph_serialize is one JSON object, not two summary-then-graph blocks", () => {
+  // panel_strip_workflow converts this capture. The command itself returns a
+  // single `{ workflow, node_count }` — not the TWO text blocks the strip
+  // description used to promise. Pin the shipped contract so a later edit
+  // cannot reintroduce a two-block claim here.
+  const body = handlerBody(PANEL_SOURCE, "graph_serialize()", { lead: 600 });
+  assert.ok(body, "graph_serialize must exist");
+  assert.match(body, /ONE JSON object/, "the capture must be documented as one JSON object");
+  assert.match(body, /Not two blocks \(summary then graph\)/);
+  assert.doesNotMatch(
+    body,
+    /TWO blocks — the summary/,
+    "this command must not promise the strip tool's old two-block presentation",
+  );
+  assert.match(
+    body,
+    /return \{ workflow, node_count: workflow\?\.nodes\?\.length \?\? 0 \}/,
+    "the payload is one object with workflow + node_count",
+  );
+});
+
+test("#1957 auto-layout re-fit excludes pinned members rather than stretching the group", () => {
+  const body = handlerBody(PANEL_SOURCE, "graph_auto_layout({", { lead: 600 });
+  assert.ok(body, "graph_auto_layout must exist");
+  assert.match(
+    body,
+    /excluded from group re-fit/,
+    "the executor comment must name the pinned-outlier rule",
+  );
+  assert.match(
+    body,
+    /const movable = members\.filter\(\(n\) => !\(n\.flags && n\.flags\.pinned\)\)/,
+    "re-fit must drop pinned members when any unpinned member remains",
+  );
+  assert.match(
+    body,
+    /re_fit_excluded_pinned: excludedPinned/,
+    "the reply must name the pinned ids the box no longer wraps",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12215,8 +12215,10 @@ async function revertGraphSnapshotByMid(mid) {
 }
 
 /** Summarize one LiteGraph node for the agent — id, type, title, widget
- *  values, and input link sources. Deliberately NOT the full serialization
- *  (positions, colors, internal state) to keep token cost low. */
+ *  values, input link sources, and the presentation fields panel_edit_node
+ *  can write (mode always; pinned/shape/collapsed when not default).
+ *  Deliberately NOT the full serialization (positions, colors, internal
+ *  state beyond those) to keep token cost low. */
 function summarizeNode(node) {
   const widgets = {};
   for (const w of node.widgets ?? []) {
@@ -12328,9 +12330,22 @@ function summarizeNode(node) {
     size: node.size ? [Math.round(node.size[0]), Math.round(node.size[1])] : null,
     ...(fullHeight != null ? { full_height: fullHeight } : {}),
     ...(node.flags && node.flags.collapsed ? { collapsed: true } : {}),
-    // Execution mode — only emitted when NOT active so bypassed/muted nodes are
-    // clearly visible to the agent (LiteGraph: 2 = mute, 4 = bypass, 0 = active).
-    ...(node.mode ? { mode: { 2: "mute", 4: "bypass" }[node.mode] ?? `mode_${node.mode}` } : {}),
+    ...(node.flags && node.flags.pinned ? { pinned: true } : {}),
+    // Execution mode — ALWAYS emitted, including "active". Omitted-as-default
+    // for mode 0 made every ordinary node look like the field did not exist
+    // (#1957). LiteGraph: 0 = active, 2 = mute, 4 = bypass.
+    mode: { 0: "active", 2: "mute", 4: "bypass" }[Number(node.mode) || 0] ?? `mode_${node.mode}`,
+    // Shape is writeable via panel_edit_node; emit the named form when set so a
+    // round-trip does not require a screenshot. Numeric LiteGraph constants
+    // (BOX=1 ROUND=2 CIRCLE=3 CARD=4) map to the same names the write path
+    // accepts; unset/"default"/0 is omitted like collapsed:false.
+    ...(() => {
+      const s = node.shape;
+      if (s == null || s === "" || s === "default" || s === 0) return {};
+      if (s === "box" || s === "round" || s === "card" || s === "circle") return { shape: s };
+      const named = { 1: "box", 2: "round", 3: "circle", 4: "card" }[s];
+      return named ? { shape: named } : {};
+    })(),
     ...(node.color ? { color: node.color } : {}),
     ...(node.bgcolor ? { bgcolor: node.bgcolor } : {}),
     // OUTPUT nodes (SaveImage/PreviewImage/SaveVideo/…) are the only valid
@@ -13685,10 +13700,12 @@ const GRAPH_TOOL_EXECUTORS = {
         "The refresh did not complete and the panel could not determine why. Retry; if it persists, reload the ComfyUI tab.",
     };
   },
-  // Full-fidelity capture of the live canvas — the ROOT graph's serialized UI
-  // JSON (the same shape ComfyUI writes to disk on save), so the orchestrator
-  // can strip/slice/save what the user ACTUALLY has open without asking them to
-  // save to a file first. Read-only; subgraph defs ride along in `definitions`.
+  // Full-fidelity capture of the live canvas — ONE JSON object
+  // `{ workflow, node_count }` (the same UI-graph shape ComfyUI writes to disk
+  // on save). Not two blocks (summary then graph): this command is the capture
+  // panel_strip_workflow converts; that tool's own structuredContent.graph is
+  // the combined summary+graph form, not a second block from here. Read-only;
+  // subgraph defs ride along in workflow.definitions.
   graph_serialize() {
     const { rootGraph } = getGraphCtx();
     const workflow = rootGraph.serialize();
@@ -14162,7 +14179,8 @@ const GRAPH_TOOL_EXECUTORS = {
       // not doubled — and the closing quote cannot be swallowed by a trailing backslash.
       return `"${clipped.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
     };
-    const modeTag = (n) => ({ 2: " [mute]", 4: " [bypass]" }[n.mode] ?? "");
+    const modeTag = (n) =>
+      ({ 2: " [mute]", 4: " [bypass]" }[n.mode] ?? "") + (n.flags && n.flags.pinned ? " [pinned]" : "");
     const outTag = (n) => (n.constructor?.nodeData?.output_node ? " [OUTPUT]" : "");
 
     // #809: render the node block at ONE rung of the detail ladder. Every rung emits a
@@ -14713,7 +14731,8 @@ const GRAPH_TOOL_EXECUTORS = {
       const s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
       return s.length > n ? s.slice(0, n - 1) + "…" : s;
     };
-    const modeTag = (n) => ({ 2: " [mute]", 4: " [bypass]" }[n.mode] ?? "");
+    const modeTag = (n) =>
+      ({ 2: " [mute]", 4: " [bypass]" }[n.mode] ?? "") + (n.flags && n.flags.pinned ? " [pinned]" : "");
     const outTag = (n) => (n.constructor?.nodeData?.output_node ? " [OUTPUT]" : "");
     const header =
       `${matched.length} match(es) of ${candidates.length} in scope (viewing: ${total} nodes)` +
@@ -18695,7 +18714,9 @@ const GRAPH_TOOL_EXECUTORS = {
   // (unless dry_run) applies every position write in ONE beforeChange/afterChange
   // pair so a single Ctrl+Z restores the prior arrangement. Groups are re-fit
   // (preserve), moved rigidly (cluster), or left alone (ignore). Pinned nodes are
-  // never moved; the subgraph boundary rails (-10/-20) are excluded.
+  // never moved and are excluded from group re-fit so a skipped outlier cannot
+  // stretch the box over unrelated nodes. The subgraph boundary rails (-10/-20)
+  // are excluded.
   graph_auto_layout({
     node_ids,
     mode = "flow_horizontal",
@@ -18827,26 +18848,42 @@ const GRAPH_TOOL_EXECUTORS = {
     const predictGroupBounds = (memberIds) => {
       const members = memberIds
         .map((id) => nodeById.get(id))
-        .filter(Boolean)
-        .map((n) => {
-          const p = layout.positions.get(n.id);
-          return {
-            pos: p ? [p[0], p[1]] : [n.pos?.[0] ?? 0, n.pos?.[1] ?? 0],
-            size: [n.size?.[0] ?? 200, n.size?.[1] ?? 100],
-          };
-        });
-      return boundsAroundNodes(members);
+        .filter(Boolean);
+      // Pinned members are skipped by layout; including them in the re-fit
+      // stretches the box across the skipped outlier and any nodes that box
+      // now geometrically swallows (#1957). If every member is pinned, nothing
+      // moved, so keep the existing membership footprint.
+      const movable = members.filter((n) => !(n.flags && n.flags.pinned));
+      const fit = (movable.length ? movable : members).map((n) => {
+        const p = layout.positions.get(n.id);
+        return {
+          pos: p ? [p[0], p[1]] : [n.pos?.[0] ?? 0, n.pos?.[1] ?? 0],
+          size: [n.size?.[0] ?? 200, n.size?.[1] ?? 100],
+        };
+      });
+      return boundsAroundNodes(fit);
     };
     const groupResults =
       groups === "ignore"
         ? []
         : groupBoxes
             .filter((gb) => gb.memberIds.length)
-            .map((gb) => ({
-              group_id: gb.g.id != null ? gb.g.id : (graph._groups ?? []).indexOf(gb.g),
-              title: gb.g.title ?? "",
-              bounds: predictGroupBounds(gb.memberIds).map(Math.round),
-            }));
+            .map((gb) => {
+              const pinnedIds = gb.memberIds.filter((id) => {
+                const n = nodeById.get(id);
+                return n && n.flags && n.flags.pinned;
+              });
+              // Disclose only when the re-fit actually dropped a pinned member
+              // (a mixed group). An all-pinned group is a no-op footprint.
+              const excludedPinned =
+                pinnedIds.length && pinnedIds.length < gb.memberIds.length ? pinnedIds : [];
+              return {
+                group_id: gb.g.id != null ? gb.g.id : (graph._groups ?? []).indexOf(gb.g),
+                title: gb.g.title ?? "",
+                bounds: predictGroupBounds(gb.memberIds).map(Math.round),
+                ...(excludedPinned.length ? { re_fit_excluded_pinned: excludedPinned } : {}),
+              };
+            });
 
     if (dry_run) {
       return {
@@ -24137,8 +24174,10 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   // Paste the litegraph clipboard onto the CURRENT graph. Snapshots node ids
-  // before/after so the freshly-pasted node ids can be returned. connect_inputs
-  // false (default) drops a disconnected copy; pos places the paste anchor.
+  // before/after so the freshly-pasted node ids can be returned. Internal wires
+  // among the copied nodes are preserved. connect_inputs:false (default) drops
+  // only external feeds from nodes outside the copied set; pass true to also
+  // reconnect those. pos places the paste anchor.
   graph_paste_nodes({ pos, connect_inputs } = {}) {
     const { graph, canvas, LG } = getGraphCtx();
     if (!canvas) throw new Error("canvas unavailable");
@@ -24245,6 +24284,9 @@ const GRAPH_TOOL_EXECUTORS = {
       pasted,
       copied_groups: layout.groups.length,
       pasted_groups: groupsNow.length,
+      connect_inputs: connect_inputs === true,
+      note:
+        "Internal wires among the copied nodes are preserved. connect_inputs:false (default) drops only external feeds; pass true to also reconnect those.",
       ...(auxIdSanitizedCount ? { aux_id_sanitized: auxIdSanitizedCount } : {}),
     };
     if (groupsNow.length) {


### PR DESCRIPTION
Closes #1957

Read-surface accuracy from the QA sweep (panel 0.15.114). None of these change fail-closed outcomes.

- **mode:** `summarizeNode` always emits `mode` (`active`/`mute`/`bypass`). The old omitted-as-default for mode 0 made the promised field never appear on ordinary nodes.
- **pinned / shape:** the same payload (query_graph detail, view_selected, view_nodes_in_viewport) now surfaces `pinned` and named `shape` the way `collapsed` already did. Outline/compact rows also tag `[pinned]`.
- **paste:** the reply `note` documents that internal wires among the copied set are preserved; `connect_inputs:false` drops only external feeds.
- **serialize/strip:** `graph_serialize` is one JSON `{workflow, node_count}`, not two summary-then-graph text blocks.
- **auto-layout:** group re-fit excludes pinned members and reports `re_fit_excluded_pinned`, so a skipped outlier cannot stretch a group over unrelated nodes.

Tests drive the shipped functions. `npm run test:unit`: 7337 tests, 7336 pass, 0 fail, 1 todo.
