### PR TITLE
feat(1961): read the live CivitAI pane and dock/undock it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_civitai_results reports the live CivitAI lightbox (open model, version ladder + selection, files, creator note, download target) so "Ask agent to download" is no longer a request about a screen the agent cannot see (#1964)
 - CivitAI pane: Upscaler/Embeddings/Poses are real tabs (empty grids name types the current tab cannot see); sample URLs are the fetchable `/comfyui_mcp_panel/civitai/media` path plus a civitai.com pageUrl; open/clear echo applied tab/query/docked/cleared-count (#1958)
 - read-surface accuracy: query/view detail rows always include `mode` (including `active`) and surface writable `pinned`/`shape`; paste replies document that internal wires among the copied set are preserved; graph_serialize is one JSON `{workflow, node_count}` rather than two text blocks; auto-layout re-fit excludes pinned outliers so a skipped member cannot stretch a group over the canvas (#1957)
+- the agent can read what the live CivitAI pane is actually showing (painted grid cards, query, dock, overlay presence, optional contact-sheet of already-decoded thumbs) from the pane itself — not by re-fetching the public API, which never serves CivitAI RED — and can dock or undock the unified side panel after #1952's close (#1961, #1962)
 
 ## [0.15.121] - 2026-08-27
 

--- a/browser_tests/unit/pane-lifecycle.test.mjs
+++ b/browser_tests/unit/pane-lifecycle.test.mjs
@@ -1,0 +1,96 @@
+// #1961 — dock/undock remaining after #1952's close/dismiss.
+//
+// Close sheds the shell. The agent still could not undock a pane that
+// open_civitai docks by default. These tests drive the shipped setDocked path.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { setSidePanelDocked } from "../../web/js/lib/pane-lifecycle.js";
+
+const panelSrc = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+const sideSrc = readFileSync(new URL("../../web/js/cmcp-sidepanel-ui.js", import.meta.url), "utf8");
+
+function fakeHandle({ open = true, tab = "civitai", docked = true } = {}) {
+  let isOpen = open;
+  let isDocked = docked;
+  const calls = [];
+  return {
+    calls,
+    isOpen: () => isOpen,
+    activeTab: () => tab,
+    isDocked: () => isDocked,
+    setDocked(want) {
+      calls.push(want);
+      const changed = isDocked !== want;
+      isDocked = want;
+      return { ok: true, open: isOpen, changed, docked: isDocked, centered: !isDocked, tab };
+    },
+    close() { isOpen = false; },
+  };
+}
+
+test("#1961 setSidePanelDocked undocks an open docked pane", () => {
+  const h = fakeHandle({ docked: true, tab: "civitai" });
+  const r = setSidePanelDocked(h, false);
+  assert.deepEqual(r, { ok: true, open: true, changed: true, docked: false, centered: true, tab: "civitai" });
+  assert.deepEqual(h.calls, [false]);
+  assert.equal(h.isDocked(), false);
+});
+
+test("#1961 setSidePanelDocked re-docks an undocked pane", () => {
+  const h = fakeHandle({ docked: false, tab: "training" });
+  const r = setSidePanelDocked(h, true);
+  assert.equal(r.docked, true);
+  assert.equal(r.changed, true);
+  assert.equal(r.tab, "training");
+  assert.deepEqual(h.calls, [true]);
+});
+
+test("#1961 setSidePanelDocked is idempotent on an already-docked pane", () => {
+  const h = fakeHandle({ docked: true });
+  h.setDocked = (want) => {
+    h.calls.push(want);
+    return { ok: true, open: true, changed: false, docked: true, centered: false, tab: "civitai" };
+  };
+  const r = setSidePanelDocked(h, true);
+  assert.equal(r.changed, false);
+  assert.equal(r.docked, true);
+});
+
+test("#1961 a missing or closed handle is success, not an error", () => {
+  assert.deepEqual(setSidePanelDocked(null, false), {
+    ok: true, open: false, changed: false, docked: false, tab: null,
+  });
+  assert.deepEqual(setSidePanelDocked({}, true), {
+    ok: true, open: false, changed: false, docked: false, tab: null,
+  });
+  const closed = fakeHandle({ open: false });
+  assert.deepEqual(setSidePanelDocked(closed, false), {
+    ok: true, open: false, changed: false, docked: false, tab: null,
+  });
+  assert.deepEqual(closed.calls, [], "closed handle must not enter setDocked");
+});
+
+test("#1961 omitting docked is a caller error, not a silent no-op", () => {
+  assert.throws(() => setSidePanelDocked(fakeHandle(), undefined), /docked: true or false/);
+  assert.throws(() => setSidePanelDocked(fakeHandle(), "yes"), /docked: true or false/);
+});
+
+test("#1961 the panel imports and dispatches civitai_set_dock / training_set_dock on the shell, not the active tab", () => {
+  assert.match(
+    panelSrc,
+    /import \{\s*setSidePanelDocked,\s*\} from "\.\/lib\/pane-lifecycle\.js"/,
+  );
+  assert.match(panelSrc, /msg\.cmd === "civitai_set_dock"/);
+  assert.match(panelSrc, /msg\.cmd === "training_set_dock"/);
+  assert.match(panelSrc, /if \(msg\.cmd === "civitai_set_dock"\)/);
+  assert.match(panelSrc, /if \(msg\.cmd === "training_set_dock"\)/);
+  assert.match(panelSrc, /return setSidePanelDocked\(_sidePanelHandle, msg\.docked\)/);
+  assert.match(sideSrc, /setDocked,/);
+  assert.match(sideSrc, /const setDocked = \(docked\) => \{/);
+  // Same reason close is not gated: the dock mode is the SHELL's, and training
+  // content stays resident while CivitAI is the active tab.
+  const facade = sideSrc.slice(sideSrc.indexOf("const setDocked"), sideSrc.indexOf("const civitai"));
+  assert.doesNotMatch(facade, /_driveOf/);
+});

--- a/browser_tests/unit/pane-read.test.mjs
+++ b/browser_tests/unit/pane-read.test.mjs
@@ -1,0 +1,293 @@
+// #1961 / #1962 — live CivitAI pane read. The agent must observe the painted
+// grid (the authenticated surface, including RED content the public API never
+// serves), not a re-fetch of models. These tests drive the shipped helpers the
+// bridge dispatches; a fake screenshot or an items[] payload is not a pass.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  PANE_READ_SOURCE,
+  readCivitaiGridCards,
+  readPaneOverlayPresence,
+  captureLivePanePreview,
+  readLiveCivitaiPane,
+  readCivitaiPaneHandle,
+} from "../../web/js/lib/pane-read.js";
+
+const panelSrc = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+const civitaiSrc = readFileSync(new URL("../../web/js/cmcp-civitai-ui.js", import.meta.url), "utf8");
+const sideSrc = readFileSync(new URL("../../web/js/cmcp-sidepanel-ui.js", import.meta.url), "utf8");
+
+function card({
+  id,
+  kind = "media",
+  foot = "",
+  rating = "PG",
+  badge = "",
+  gated = false,
+  highlighted = false,
+  src = null,
+  hidden = false,
+  connected = true,
+  imgComplete = true,
+  imgSize = 64,
+} = {}) {
+  const classes = ["cmcp-cv-card"];
+  if (gated) classes.push("cmcp-cv-gated");
+  if (highlighted) classes.push("cmcp-agent-glow");
+  const img = src && !gated
+    ? {
+      tagName: "IMG",
+      src,
+      complete: imgComplete,
+      naturalWidth: imgComplete ? imgSize : 0,
+      naturalHeight: imgComplete ? imgSize : 0,
+      width: imgComplete ? imgSize : 0,
+      height: imgComplete ? imgSize : 0,
+    }
+    : null;
+  const children = {
+    ".cmcp-cv-cardfoot": foot ? { textContent: foot } : null,
+    ".cmcp-cv-rating": rating ? { textContent: rating } : null,
+    ".cmcp-cv-badge": badge ? { textContent: badge } : null,
+    img,
+  };
+  const el = {
+    className: classes.join(" "),
+    classList: { contains: (c) => classes.includes(c) },
+    dataset: { id: String(id), kind },
+    style: hidden ? { display: "none" } : {},
+    isConnected: connected,
+    querySelector(sel) { return children[sel] || null; },
+  };
+  return el;
+}
+
+function gridOf(cards, { connected = true } = {}) {
+  return {
+    isConnected: connected,
+    style: {},
+    querySelectorAll(sel) {
+      if (sel !== ".cmcp-cv-card") return [];
+      return cards;
+    },
+  };
+}
+
+test("#1961 readCivitaiGridCards reports painted cards, not an API payload", () => {
+  const a = card({
+    id: "2731187", kind: "model", foot: "Moody Krea 2 Mix\nSDXL · ⬇ 12",
+    rating: "X", badge: "Checkpoint", src: "/comfyui_mcp_panel/civitai/media?id=2731187",
+  });
+  const b = card({
+    id: "9", kind: "media", foot: "@alice  ♥ 4", rating: "XXX", gated: true,
+  });
+  const rows = readCivitaiGridCards(gridOf([a, b]));
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].id, "2731187");
+  assert.equal(rows[0].kind, "model");
+  assert.equal(rows[0].gated, false);
+  assert.equal(rows[0].src, "/comfyui_mcp_panel/civitai/media?id=2731187");
+  assert.match(rows[0].foot, /Moody Krea 2 Mix/);
+  assert.equal(rows[1].gated, true);
+  assert.equal(rows[1].src, null, "gated cards withhold the sample URL the grid itself withholds");
+  assert.equal(rows[1].rating, "XXX");
+});
+
+test("#1961 hidden or detached cards are not the user's view", () => {
+  const hidden = card({ id: "1", src: "/t/1", hidden: true });
+  const detached = card({ id: "2", src: "/t/2", connected: false });
+  const shown = card({ id: "3", src: "/t/3", foot: "@shown" });
+  assert.deepEqual(readCivitaiGridCards(gridOf([hidden, detached, shown])).map((r) => r.id), ["3"]);
+  assert.deepEqual(readCivitaiGridCards(gridOf([shown], { connected: false })), []);
+  assert.deepEqual(readCivitaiGridCards(null), []);
+});
+
+test("#1962 an items[] / API payload cannot populate visible — only the painted grid can", () => {
+  const apiItems = [
+    { id: 111, name: "from the public API", coverUrl: "https://civitai.com/x" },
+  ];
+  const out = readLiveCivitaiPane({
+    open: true,
+    showing: true,
+    shellTab: "civitai",
+    grid: gridOf([]),
+    state: { tab: "models", query: "moody", items: apiItems, models: apiItems },
+  });
+  assert.equal(out.source, PANE_READ_SOURCE);
+  assert.equal(out.count, 0);
+  assert.deepEqual(out.visible, []);
+  assert.equal(out.tab, "models");
+  assert.equal(out.query, "moody");
+});
+
+test("#1961 a closed pane is an empty live read, not a throw and not leftover cards", () => {
+  const leftover = card({ id: "keep", src: "/t/keep", connected: false });
+  const out = readLiveCivitaiPane({
+    open: false,
+    showing: true,
+    grid: gridOf([leftover], { connected: false }),
+    state: { tab: "images", query: "stale", items: [{ id: "keep" }] },
+  });
+  assert.equal(out.open, false);
+  assert.equal(out.showing, false);
+  assert.equal(out.source, PANE_READ_SOURCE);
+  assert.deepEqual(out.visible, []);
+});
+
+test("#1961 switching the shell away from CivitAI reports showing:false even if the grid still holds cards", () => {
+  const painted = card({ id: "5", src: "/t/5", highlighted: true });
+  const out = readLiveCivitaiPane({
+    open: true,
+    showing: false,
+    shellTab: "training",
+    docked: true,
+    grid: gridOf([painted]),
+    state: { tab: "images", query: "sdxl", signedIn: true },
+  });
+  assert.equal(out.open, true);
+  assert.equal(out.showing, false);
+  assert.equal(out.shell_tab, "training");
+  assert.equal(out.docked, true);
+  assert.equal(out.authenticated, true);
+  assert.deepEqual(out.visible, []);
+  assert.deepEqual(out.highlighted, []);
+});
+
+test("#1961 a showing pane returns live query box, glow, overlay presence, and no lightbox internals", () => {
+  const glow = card({ id: "7", src: "/proxy/7", highlighted: true, foot: "@bob  ♥ 1" });
+  const other = card({ id: "8", src: "/proxy/8", foot: "@cara  ♥ 2" });
+  const overlay = {
+    querySelector(sel) { return sel === ".cmcp-cv-lb" ? { isConnected: true, style: {} } : null; },
+  };
+  const out = readLiveCivitaiPane({
+    open: true,
+    showing: true,
+    shellTab: "civitai",
+    docked: true,
+    grid: gridOf([glow, other]),
+    searchEl: { value: "@alice sdxl" },
+    overlay,
+    state: {
+      tab: "images",
+      query: "sdxl",
+      loading: false,
+      done: true,
+      signedIn: true,
+      error: null,
+      filters: { browsingLevels: [1, 16] },
+    },
+  });
+  assert.equal(out.showing, true);
+  assert.equal(out.query, "sdxl");
+  assert.equal(out.query_box, "@alice sdxl");
+  assert.deepEqual(out.browsingLevels, [1, 16]);
+  assert.deepEqual(out.highlighted, ["7"]);
+  assert.equal(out.visible.length, 2);
+  assert.equal(out.overlay.lightbox, true);
+  assert.equal(Object.keys(out.overlay).join(","), "lightbox", "lightbox internals are #1964 — presence only");
+  assert.equal("title" in out.overlay, false);
+  assert.equal("prompt" in out.overlay, false);
+});
+
+test("#1961 overlay presence is false when no lightbox node is painted", () => {
+  assert.deepEqual(readPaneOverlayPresence(null), { lightbox: false });
+  assert.deepEqual(readPaneOverlayPresence({ querySelector: () => null }), { lightbox: false });
+  assert.deepEqual(
+    readPaneOverlayPresence({ querySelector: () => ({ isConnected: false }) }),
+    { lightbox: false },
+  );
+});
+
+test("#1961 captureLivePanePreview draws live decoded thumbs and never gated / unloaded ones", () => {
+  const draws = [];
+  const live = card({ id: "1", src: "/proxy/1", imgComplete: true });
+  const gated = card({ id: "2", gated: true, src: "/secret" });
+  const loading = card({ id: "3", src: "/proxy/3", imgComplete: false, imgSize: 0 });
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext() {
+      return {
+        drawImage(img, x, y, w, h) { draws.push({ src: img.src, x, y, w, h }); },
+      };
+    },
+    toDataURL() { return "data:image/png;base64,Qk0="; },
+  };
+  const visible = readCivitaiGridCards(gridOf([live, gated, loading]));
+  const preview = captureLivePanePreview(visible, {
+    createElement: () => canvas,
+    cell: 96,
+  });
+  assert.equal(preview.captured, true);
+  assert.equal(preview.source, PANE_READ_SOURCE);
+  assert.deepEqual(draws.map((d) => d.src), ["/proxy/1"]);
+  assert.equal(preview.cards, 1);
+  assert.equal(preview.image, "Qk0=");
+});
+
+test("#1961 captureLivePanePreview withholds under blind and refuses to invent a blank dump", () => {
+  const rows = readCivitaiGridCards(gridOf([card({ id: "1", src: "/t/1" })]));
+  assert.deepEqual(
+    captureLivePanePreview(rows, { blind: true }),
+    { captured: false, withheld: true, reason: "blind" },
+  );
+  assert.equal(captureLivePanePreview([], {}).reason, "no-decoded-thumbs");
+  assert.equal(captureLivePanePreview(rows, {}).reason, "no-canvas");
+});
+
+test("#1961 include_preview on a hidden pane is pane-not-showing, not a canvas dump", () => {
+  const out = readLiveCivitaiPane({
+    open: true,
+    showing: false,
+    shellTab: "training",
+    includePreview: true,
+    grid: gridOf([card({ id: "1", src: "/t/1" })]),
+  });
+  assert.deepEqual(out.preview, { captured: false, reason: "pane-not-showing" });
+});
+
+test("#1961 readCivitaiPaneHandle uses the handle's live read and treats a missing handle as closed", () => {
+  const closed = readCivitaiPaneHandle(null);
+  assert.equal(closed.open, false);
+  assert.equal(closed.showing, false);
+  assert.equal(closed.source, PANE_READ_SOURCE);
+  assert.deepEqual(closed.visible, []);
+
+  let called = 0;
+  const handle = {
+    readCivitai(opts) {
+      called += 1;
+      return readLiveCivitaiPane({
+        open: true,
+        showing: true,
+        shellTab: "civitai",
+        grid: gridOf([card({ id: "42", src: "/t/42", foot: "live" })]),
+        ...opts,
+      });
+    },
+  };
+  const live = readCivitaiPaneHandle(handle, { limit: 10 });
+  assert.equal(called, 1);
+  assert.equal(live.visible[0].id, "42");
+});
+
+test("#1961 the panel imports and dispatches the shipped live-pane read, not a results refetch", () => {
+  assert.match(
+    panelSrc,
+    /import \{\s*readCivitaiPaneHandle,\s*\} from "\.\/lib\/pane-read\.js"/,
+  );
+  assert.match(panelSrc, /msg\.cmd === "civitai_read"/);
+  assert.match(panelSrc, /if \(msg\.cmd === "civitai_read"\) return readCivitaiPaneHandle\(_sidePanelHandle/);
+  assert.match(panelSrc, /includePreview: msg\.include_preview === true/);
+  assert.match(panelSrc, /blind: AGENT_BLIND/);
+  assert.match(civitaiSrc, /read: driveRead/);
+  assert.match(civitaiSrc, /readLiveCivitaiPane\(/);
+  assert.match(sideSrc, /readCivitai,/);
+  assert.match(sideSrc, /const readCivitai = \(opts = \{\}\) => \{/);
+  // Must not go through _driveOf — a training-active shell still has a CivitAI
+  // pane to observe (showing:false), the way close does not gate on the tab.
+  const facade = sideSrc.slice(sideSrc.indexOf("const readCivitai"), sideSrc.indexOf("const civitai"));
+  assert.doesNotMatch(facade, /_driveOf/);
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -38,6 +38,7 @@ import { chipRow as filterChipRow, makeFilterButton } from "./cmcp-filter.js";
 import { coerceMessageText } from "./lib/chat-serialize.js";
 import { isImeComposing } from "./lib/ime.js";
 import { tr } from "./lib/i18n.js";
+import { readLiveCivitaiPane } from "./lib/pane-read.js";
 
 // `label` is a GETTER: this array is built at module scope, which runs at IMPORT time —
 // before setup() awaits loadCatalog() — so a plain value would freeze the English fallback
@@ -2428,6 +2429,28 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       }),
     };
   }
+  // Live pane observation (#1961/#1962): the painted grid, not a CivitAI refetch.
+  // `open`/`showing` come from the shell so a training-active unified panel still
+  // reports honestly (showing:false) instead of throwing "not open".
+  function driveRead(opts = {}) {
+    const open = opts.open ?? isOpen;
+    const showing = opts.showing ?? (open && isOpen && grid.isConnected);
+    return readLiveCivitaiPane({
+      open,
+      showing,
+      shellTab: opts.shellTab ?? "civitai",
+      docked: shell.isDocked(),
+      grid,
+      searchEl: search,
+      overlay: shell.overlay,
+      document: typeof document !== "undefined" ? document : null,
+      state,
+      limit: opts.limit,
+      includePreview: opts.includePreview === true,
+      blind: opts.blind === true,
+      createElement: opts.createElement,
+    });
+  }
   // The user-facing ✕ already called this (and teardown tears down the lightbox);
   // exposing it on drive is the agent inverse of open_civitai (#1952). Idempotent.
   function driveClose() {
@@ -2475,6 +2498,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       switchTab: driveSwitchTab, search: driveSearch, getResults: driveGetResults,
       highlight: driveHighlight, clearHighlight: driveClearHighlight,
       openLightbox: driveOpenLightbox, getState: driveGetState,
+      read: driveRead,
       close: driveClose,
     },
   };

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -19,6 +19,7 @@
 
 import { isImeComposing } from "./lib/ime.js";
 import { closeSidePanelHandle } from "./lib/resident-ui-close.js";
+import { readLiveCivitaiPane } from "./lib/pane-read.js";
 import { createCivitaiContent } from "./cmcp-civitai-ui.js";
 import { createAppsContent } from "./cmcp-apps-ui.js";
 import { createTrainingContent } from "./cmcp-training-ui.js";
@@ -217,8 +218,9 @@ export function openSidePanel(ctx = {}, opts = {}) {
 
   // ── docked mode ─────────────────────────────────────────────────────────────
   applyDock.centered = false;
+  let dockEnabled = !!opts.dock;
   function applyDock() {
-    if (!opts.dock) { setCentered(); return; }
+    if (!dockEnabled) { setCentered(); return; }
     const geo = _dockGeometry();
     if (geo?.status === "detached") { overlay.style.display = "none"; return; }
     overlay.style.display = "";
@@ -337,7 +339,7 @@ export function openSidePanel(ctx = {}, opts = {}) {
 
   // ── go: mount the initial tab, then wire the dock + slide-in ──────────────────
   activate(initialKey);
-  if (opts.dock) {
+  if (dockEnabled) {
     applyDock();
     if (typeof ctx.watchDock === "function") {
       try { _dockDispose = ctx.watchDock(applyDock); } catch { _dockDispose = null; }
@@ -363,6 +365,53 @@ export function openSidePanel(ctx = {}, opts = {}) {
     isOpen: () => isOpen,
     activeTab: () => activeKey,
   });
+  // Dock mode is the SHELL's, not the active tab's. A tab-gated undock would
+  // refuse while Training is showing — the same accumulation trap close
+  // already refuses to walk into.
+  const setDocked = (docked) => {
+    if (!isOpen) return { ok: true, open: false, changed: false, docked: false, tab: null };
+    const want = !!docked;
+    const was = shell.isDocked();
+    dockEnabled = want;
+    if (want) {
+      applyDock();
+      overlay.classList.add("cmcp-dock-in");
+    } else {
+      setCentered();
+      overlay.classList.add("cmcp-dock-in");
+    }
+    const now = shell.isDocked();
+    return {
+      ok: true,
+      open: true,
+      changed: was !== now,
+      docked: now,
+      centered: shell.isCentered(),
+      tab: activeKey,
+    };
+  };
+  const readCivitai = (opts = {}) => {
+    const c = contents.get("civitai");
+    const showing = isOpen && activeKey === "civitai";
+    if (c && c.drive && typeof c.drive.read === "function") {
+      return c.drive.read({
+        ...opts,
+        open: isOpen,
+        showing,
+        shellTab: activeKey,
+      });
+    }
+    return readLiveCivitaiPane({
+      open: isOpen,
+      showing: false,
+      shellTab: activeKey,
+      docked: shell.isDocked(),
+      limit: opts.limit,
+      includePreview: opts.includePreview === true,
+      blind: opts.blind === true,
+      createElement: opts.createElement,
+    });
+  };
   const civitai = {
     getResults: (a) => _driveOf("civitai", "civitai browser not open", "getResults", [a]),
     highlight: (ids, o) => _driveOf("civitai", "civitai browser not open", "highlight", [ids, o]),
@@ -371,6 +420,7 @@ export function openSidePanel(ctx = {}, opts = {}) {
     search: (a) => _driveOf("civitai", "civitai browser not open", "search", [a]),
     openLightbox: (id, o) => _driveOf("civitai", "civitai browser not open", "openLightbox", [id, o]),
     getState: () => _driveOf("civitai", "civitai browser not open", "getState", []),
+    read: (o) => readCivitai(o),
     close: closeResident,
   };
   const training = {
@@ -387,6 +437,9 @@ export function openSidePanel(ctx = {}, opts = {}) {
     close,
     isOpen: () => isOpen,
     activeTab: () => activeKey,
+    isDocked: () => shell.isDocked(),
+    setDocked,
+    readCivitai,
     focus: () => { try { if (searchEl.style.display !== "none") searchEl.focus(); } catch { /* detached */ } },
     // RunPod status frames → re-render the active content (no-op unless Local).
     update: () => { const c = contents.get(activeKey); if (c && typeof c.update === "function") { try { c.update(); } catch { /* ignore */ } } },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -339,6 +339,12 @@ import {
   dismissAllLiveA2uiCards,
   unloadChatMediaCards,
 } from "./lib/resident-ui-close.js";
+import {
+  readCivitaiPaneHandle,
+} from "./lib/pane-read.js";
+import {
+  setSidePanelDocked,
+} from "./lib/pane-lifecycle.js";
 // #1184 — the ORDER a backend switch commits in. A module because the defect is an
 // ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
 import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
@@ -27857,7 +27863,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             msg.cmd === "civitai_results" || msg.cmd === "civitai_highlight" ||
             msg.cmd === "civitai_clear_highlight" || msg.cmd === "civitai_switch_tab" ||
             msg.cmd === "civitai_search" || msg.cmd === "civitai_open_lightbox" ||
-            msg.cmd === "civitai_close"
+            msg.cmd === "civitai_close" || msg.cmd === "civitai_read" ||
+            msg.cmd === "civitai_set_dock"
           ) {
             // Agent DRIVES the already-open CivitAI browser. onCivitaiCmd throws
             // an honest "civitai browser not open" when the modal isn't live, which
@@ -27868,7 +27875,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             msg.cmd === "open_training" || msg.cmd === "training_get_state" ||
             msg.cmd === "training_set_field" || msg.cmd === "training_goto_step" ||
             msg.cmd === "training_set_target" || msg.cmd === "training_highlight" ||
-            msg.cmd === "training_close"
+            msg.cmd === "training_close" || msg.cmd === "training_set_dock"
           ) {
             if (!onTrainingCmd) throw new Error("This panel build can't drive the training wizard.");
             result = await onTrainingCmd(msg);
@@ -28228,10 +28235,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           "ui_render", "ui_update", "ui_dismiss", "fetch_image", "fetch_comfyui_read",
           "civitai_results", "civitai_highlight", "civitai_clear_highlight",
           "civitai_switch_tab", "civitai_search", "civitai_open_lightbox",
-          "civitai_close",
+          "civitai_close", "civitai_read", "civitai_set_dock",
           "open_training", "training_get_state", "training_set_field",
           "training_goto_step", "training_set_target", "training_highlight",
-          "training_close",
+          "training_close", "training_set_dock",
         ]);
         if (!SILENT_CMDS.has(msg.cmd)) {
           onCommand?.(msg.cmd, msg, reply);
@@ -38971,6 +38978,12 @@ function buildPanel() {
     // (guard here, plus the facade re-checks the active tab).
     onCivitaiCmd(msg) {
       if (msg.cmd === "civitai_close") return closeSidePanelHandle(_sidePanelHandle);
+      if (msg.cmd === "civitai_read") return readCivitaiPaneHandle(_sidePanelHandle, {
+        limit: msg.limit,
+        includePreview: msg.include_preview === true,
+        blind: AGENT_BLIND,
+      });
+      if (msg.cmd === "civitai_set_dock") return setSidePanelDocked(_sidePanelHandle, msg.docked);
       const h = _sidePanelHandle;
       if (!h) throw new Error("civitai browser not open");
       switch (msg.cmd) {
@@ -38990,6 +39003,7 @@ function buildPanel() {
         return { ok: true };
       }
       if (msg.cmd === "training_close") return closeSidePanelHandle(_sidePanelHandle);
+      if (msg.cmd === "training_set_dock") return setSidePanelDocked(_sidePanelHandle, msg.docked);
       const h = _sidePanelHandle;
       if (!h) throw new Error("training wizard not open");
       switch (msg.cmd) {

--- a/web/js/lib/pane-lifecycle.js
+++ b/web/js/lib/pane-lifecycle.js
@@ -1,0 +1,25 @@
+// Remaining pane lifecycle after close/dismiss (#1952, #1961).
+//
+// Close already sheds the unified shell. The agent still could not undock /
+// re-dock it, so a long session that opened the pane docked (the open_civitai
+// default) had no inverse short of closing. These functions ARE that inverse.
+
+/**
+ * Dock or undock the unified side panel.
+ *
+ * Idempotent: a missing/closed handle is success with `open:false`. Already in
+ * the requested mode is success with `changed:false`. `docked` must be a
+ * boolean — a missing value is a caller error, not a no-op, so an omitted
+ * argument cannot be read as "leave it".
+ */
+export function setSidePanelDocked(handle, docked) {
+  if (typeof docked !== "boolean") {
+    throw new Error("set_dock requires docked: true or false");
+  }
+  if (!handle || typeof handle.setDocked !== "function") {
+    return { ok: true, open: false, changed: false, docked: false, tab: null };
+  }
+  const open = typeof handle.isOpen === "function" ? !!handle.isOpen() : true;
+  if (!open) return { ok: true, open: false, changed: false, docked: false, tab: null };
+  return handle.setDocked(docked);
+}

--- a/web/js/lib/pane-read.js
+++ b/web/js/lib/pane-read.js
@@ -1,0 +1,258 @@
+// Live CivitAI pane read (#1961, #1962).
+//
+// The agent must see what the USER sees in the docked pane. That is the
+// authenticated grid currently painted in the renderer — including CivitAI RED
+// content the public REST API never serves. Re-fetching models from the API is
+// therefore not a substitute: a card the grid is showing and a card the API
+// would return are different sets.
+//
+// These helpers inspect the live overlay/grid DOM (and the pane's own in-memory
+// state that painted it). They never call CivitAI. Overlay presence is reported
+// as a boolean only; lightbox internals are a separate contract (#1964).
+
+export const PANE_READ_SOURCE = "live-pane";
+
+const DEFAULT_LIMIT = 40;
+const PREVIEW_MAX_CARDS = 6;
+const PREVIEW_CELL = 96;
+
+function clampLimit(limit) {
+  const n = Number(limit);
+  return Number.isFinite(n) && n > 0 ? Math.min(Math.floor(n), 200) : DEFAULT_LIMIT;
+}
+
+function classHas(el, name) {
+  if (!el) return false;
+  if (el.classList && typeof el.classList.contains === "function") {
+    try { return !!el.classList.contains(name); } catch { /* fall through */ }
+  }
+  const cls = typeof el.className === "string" ? el.className : "";
+  return (` ${cls} `).includes(` ${name} `);
+}
+
+function textOf(el) {
+  if (!el) return "";
+  const t = el.textContent;
+  return typeof t === "string" ? t.replace(/\s+/g, " ").trim() : "";
+}
+
+function childByClass(el, cls) {
+  if (!el || typeof el.querySelector !== "function") return null;
+  try { return el.querySelector(`.${cls}`); } catch { return null; }
+}
+
+function isPainted(el) {
+  if (!el) return false;
+  if (el.isConnected === false) return false;
+  const display = el.style && el.style.display;
+  if (display === "none") return false;
+  return true;
+}
+
+/**
+ * Cards currently painted in the CivitAI grid. Source of truth is the live
+ * `.cmcp-cv-card` nodes, not an items[] payload and not a network call.
+ */
+export function readCivitaiGridCards(grid, { limit = DEFAULT_LIMIT } = {}) {
+  const lim = clampLimit(limit);
+  if (!grid || typeof grid.querySelectorAll !== "function" || !isPainted(grid)) {
+    return [];
+  }
+  let nodes;
+  try { nodes = grid.querySelectorAll(".cmcp-cv-card"); } catch { return []; }
+  const rows = [];
+  for (const card of nodes || []) {
+    if (!isPainted(card)) continue;
+    const id = card.dataset && card.dataset.id != null ? String(card.dataset.id) : "";
+    if (!id) continue;
+    const gated = classHas(card, "cmcp-cv-gated");
+    const highlighted = classHas(card, "cmcp-agent-glow");
+    const img = typeof card.querySelector === "function" ? card.querySelector("img") : null;
+    const src = !gated && img && typeof img.src === "string" && img.src ? img.src : null;
+    rows.push({
+      id,
+      kind: (card.dataset && card.dataset.kind) || "media",
+      foot: textOf(childByClass(card, "cmcp-cv-cardfoot")) || null,
+      rating: textOf(childByClass(card, "cmcp-cv-rating")) || null,
+      badge: textOf(childByClass(card, "cmcp-cv-badge")) || null,
+      gated,
+      highlighted,
+      src,
+      el: card,
+    });
+    if (rows.length >= lim) break;
+  }
+  return rows;
+}
+
+/** Overlay presence only. Lightbox body/media are #1964. */
+export function readPaneOverlayPresence(root) {
+  if (!root || typeof root.querySelector !== "function") {
+    return { lightbox: false };
+  }
+  let lb = null;
+  try { lb = root.querySelector(".cmcp-cv-lb"); } catch { lb = null; }
+  return { lightbox: !!(lb && isPainted(lb)) };
+}
+
+/**
+ * Contact-sheet preview of thumbs ALREADY decoded in the live grid.
+ *
+ * Draws the painted <img> elements. Does not fetch URLs, does not sample
+ * gated cards, and does not fall back to the ComfyUI canvas. Missing canvas
+ * support or no decoded thumbs is `captured:false` with a reason — never a
+ * blank PNG that could be mistaken for "the pane is empty".
+ */
+export function captureLivePanePreview(visibleCards, {
+  blind = false,
+  createElement,
+  maxCards = PREVIEW_MAX_CARDS,
+  cell = PREVIEW_CELL,
+} = {}) {
+  if (blind) return { captured: false, withheld: true, reason: "blind" };
+
+  const cap = Number.isFinite(maxCards) && maxCards > 0 ? Math.min(Math.floor(maxCards), 12) : PREVIEW_MAX_CARDS;
+  const size = Number.isFinite(cell) && cell > 0 ? Math.min(Math.floor(cell), 256) : PREVIEW_CELL;
+  const imgs = [];
+  for (const row of Array.isArray(visibleCards) ? visibleCards : []) {
+    if (!row || row.gated) continue;
+    const el = row.el;
+    const img = el && typeof el.querySelector === "function" ? el.querySelector("img") : null;
+    if (!img || typeof img.src !== "string" || !img.src) continue;
+    if (img.complete === false) continue;
+    const w = Number(img.naturalWidth) || Number(img.width) || 0;
+    const h = Number(img.naturalHeight) || Number(img.height) || 0;
+    if (w < 1 || h < 1) continue;
+    imgs.push(img);
+    if (imgs.length >= cap) break;
+  }
+  if (!imgs.length) return { captured: false, reason: "no-decoded-thumbs" };
+
+  const make =
+    typeof createElement === "function"
+      ? createElement
+      : (typeof document !== "undefined" && typeof document.createElement === "function"
+        ? (tag) => document.createElement(tag)
+        : null);
+  if (!make) return { captured: false, reason: "no-canvas" };
+
+  let canvas;
+  try { canvas = make("canvas"); } catch { canvas = null; }
+  if (!canvas || typeof canvas.getContext !== "function") {
+    return { captured: false, reason: "no-canvas" };
+  }
+  const cols = Math.min(4, imgs.length);
+  const rows = Math.ceil(imgs.length / cols);
+  canvas.width = cols * size;
+  canvas.height = rows * size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx || typeof ctx.drawImage !== "function") {
+    return { captured: false, reason: "no-canvas" };
+  }
+  let drawn = 0;
+  imgs.forEach((img, i) => {
+    const x = (i % cols) * size;
+    const y = Math.floor(i / cols) * size;
+    try {
+      ctx.drawImage(img, x, y, size, size);
+      drawn += 1;
+    } catch { /* tainted / detached */ }
+  });
+  if (!drawn) return { captured: false, reason: "draw-failed" };
+  if (typeof canvas.toDataURL !== "function") return { captured: false, reason: "no-canvas" };
+  let dataUrl;
+  try { dataUrl = canvas.toDataURL("image/png"); } catch {
+    return { captured: false, reason: "tainted-canvas" };
+  }
+  if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:image/png")) {
+    return { captured: false, reason: "empty-capture" };
+  }
+  const comma = dataUrl.indexOf(",");
+  return {
+    captured: true,
+    source: PANE_READ_SOURCE,
+    mimeType: "image/png",
+    width: canvas.width,
+    height: canvas.height,
+    cards: drawn,
+    image: comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl,
+  };
+}
+
+function copyLevels(filters) {
+  const levels = filters && Array.isArray(filters.browsingLevels) ? filters.browsingLevels : null;
+  return levels ? levels.map((n) => n) : null;
+}
+
+/**
+ * What the live CivitAI pane is showing right now.
+ *
+ * `items` / API payloads are ignored: `visible` is populated only from painted
+ * grid cards. A closed or hidden pane returns `open`/`showing` honestly and an
+ * empty `visible` list — leftover detached cards are not the user's view.
+ */
+export function readLiveCivitaiPane({
+  open = false,
+  showing = false,
+  shellTab = null,
+  docked = false,
+  grid = null,
+  searchEl = null,
+  overlay = null,
+  document: doc = null,
+  state = null,
+  limit = DEFAULT_LIMIT,
+  includePreview = false,
+  blind = false,
+  createElement = undefined,
+} = {}) {
+  const isOpen = !!open;
+  const isShowing = isOpen && !!showing && isPainted(grid);
+  const visible = isShowing ? readCivitaiGridCards(grid, { limit }) : [];
+  const overlayRoot = overlay || doc || null;
+  const out = {
+    ok: true,
+    open: isOpen,
+    showing: isShowing,
+    source: PANE_READ_SOURCE,
+    surface: "civitai",
+    shell_tab: shellTab ?? null,
+    docked: !!docked,
+    tab: state && typeof state.tab === "string" ? state.tab : null,
+    query: state && typeof state.query === "string" ? state.query : null,
+    query_box: searchEl && typeof searchEl.value === "string" ? searchEl.value : null,
+    loading: !!(state && state.loading),
+    done: !!(state && state.done),
+    authenticated: !!(state && state.signedIn),
+    error: (state && state.error) || null,
+    browsingLevels: copyLevels(state && state.filters),
+    highlighted: isShowing ? visible.filter((c) => c.highlighted).map((c) => c.id) : [],
+    overlay: readPaneOverlayPresence(overlayRoot),
+    visible: visible.map(({ el, ...rest }) => rest),
+    count: visible.length,
+  };
+  if (includePreview) {
+    out.preview = isShowing
+      ? captureLivePanePreview(visible, { blind, createElement })
+      : { captured: false, reason: isOpen ? "pane-not-showing" : "pane-closed" };
+  }
+  return out;
+}
+
+/**
+ * Read through the side-panel handle. A missing/closed handle is an empty
+ * live-pane result, not a throw — absence is the observation.
+ */
+export function readCivitaiPaneHandle(handle, opts = {}) {
+  if (handle && typeof handle.readCivitai === "function") {
+    return handle.readCivitai(opts);
+  }
+  const open = !!(handle && typeof handle.isOpen === "function" && handle.isOpen());
+  return readLiveCivitaiPane({
+    open,
+    showing: false,
+    shellTab: handle && typeof handle.activeTab === "function" ? handle.activeTab() : null,
+    docked: !!(handle && typeof handle.isDocked === "function" && handle.isDocked()),
+    ...opts,
+  });
+}


### PR DESCRIPTION
## Why

#1961: agents must SEE what the user sees in the CivitAI pane and control the full pane lifecycle. #1962 forbids answering with "use the CivitAI REST API instead" — RED/X/XXX is not served by the API; the authenticated pane is the only panel surface that shows it.

#1952 already shipped close/dismiss. This is the first real slice on the **shipped pane path**: a live read of what the pane is painting, plus the dock/undock inverse that close did not cover.

## What

- `civitai_read` inspects the **painted** `.cmcp-cv-card` grid (query box, sub-tab, dock, glow, gated/blurred, overlay presence). `source: "live-pane"`. An `items[]` / public-API payload cannot populate `visible`. Leftover detached cards while Training is showing are not the user's view.
- Optional `include_preview: true` draws a contact sheet from **already-decoded** live thumbs. Gated cards and Blind mode withhold pixels. Never falls back to the ComfyUI canvas.
- `civitai_set_dock` / `training_set_dock` undock or re-dock the unified shell. Not gated on the active tab (same reason close is not).

Lightbox internals stay out — that is #1964.

## Tests

`npm run test:unit`: 7347 pass / 0 fail / 1 todo. New files drive the shipped helpers and pin dispatcher wiring:
- `browser_tests/unit/pane-read.test.mjs`
- `browser_tests/unit/pane-lifecycle.test.mjs`

## Remaining on #1961

- Lightbox content contract (#1964)
- `panel_screenshot` `target` for panel / training / full chrome
- `panel_civitai_results` promised inline IMAGE blocks (#1958)
- Training visual/DOM read (`training_get_state` already exists)
- Orchestrator MCP names for the new bridge cmds (panel accepts them the same way #1952 shipped `civitai_close` ahead of vocab)

Refs #1961. Closes #1962.