### PR TITLE
fix(751): treat LIST as a core socket even with leftover widget defaults

### DIFF
--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -103,6 +103,43 @@ test("a forceInput declaration remains a wireable socket", () => {
   assert.deepEqual(requiredWidgetInputTypes(node), ["ZIPN_STYLE_GALLERY", "ZIPN_SPACER", "CLIP"]);
 });
 
+test("#751: LIST with leftover widget defaults is a core list-socket, not a pending widget", () => {
+  // TextEncodeQwenImageEditPlusCustom_lrzjason.configs is declared LIST (a
+  // link datatype) but INPUT_TYPES still stamps `default: []`. That is not a
+  // widget constructor; waiting 5s for one refuses a node that the stock
+  // frontend adds as a socket.
+  const node = {
+    constructor: {
+      nodeData: {
+        input: {
+          required: {
+            clip: ["CLIP", {}],
+            configs: ["LIST", { default: [] }],
+          },
+        },
+      },
+    },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(node, {}),
+    [],
+    "LIST + default must not wait for a widget constructor that will never register",
+  );
+  // A genuine custom widget with the same leftover-default shape still waits.
+  const custom = {
+    constructor: {
+      nodeData: {
+        input: {
+          required: { amount: ["ACME_VALUE", { default: 3 }] },
+        },
+      },
+    },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(custom, {}, new Set(["ACME_VALUE"])), [
+    "ACME_VALUE",
+  ]);
+});
+
 test("core MASK required input is a safe socket (#620 SetLatentNoiseMask)", () => {
   const node = {
     constructor: {

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -56,7 +56,10 @@ export function requiredWidgetInputTypes(nodeOrNodeData) {
 const SAFE_SOCKET_TYPES = new Set([
   "*", "ANY", "AUDIO", "BBOX", "CLIP", "CLIP_VISION", "CLIP_VISION_OUTPUT",
   "CONDITIONING", "CONTROL_NET", "GLIGEN", "GUIDER", "HOOKS", "IMAGE",
-  "IPADAPTER", "LATENT", "LATENT_OPERATION", "MASK", "MESH", "MODEL", "NOISE",
+  "IPADAPTER", "LATENT", "LATENT_OPERATION",
+  // #751 — LIST is ComfyUI's list-of-items socket. Packs often stamp leftover
+  // INPUT_TYPES `default: []` on it, which is not a widget constructor.
+  "LIST", "MASK", "MESH", "MODEL", "NOISE",
   "PHOTOMAKER", "SAMPLER", "SCHEDULER", "SIGMAS", "STYLE_MODEL", "UNET",
   "UPSCALE_MODEL", "VAE", "VOXEL",
 ]);


### PR DESCRIPTION
Closes #751

## Recurrence
`panel_add_node` rejected `TextEncodeQwenImageEditPlusCustom_lrzjason` because its required `configs` input is declared `LIST` (a link datatype) but also carries leftover `default: []` from INPUT_TYPES. The guard waited 5s for a widget constructor that never registers.

## Change
Add `LIST` to the core socket allowlist so a leftover default cannot keep a list-socket waiting. `#626` custom widgets with the same default shape still wait.

## Tests
`node --test browser_tests/unit/node-widget-materialization.test.mjs` — 75 passed, including the LIST+default recurrence.