### PR TITLE
fix(751): classify LIST leftover defaults as sockets, not pending widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_add_node no longer waits 5s then refuses a LIST-typed socket that carries leftover `{default: null}` / `{default: []}` widget metadata (TextEncodeQwenImageEditPlusCustom_lrzjason `configs`) (#751)
+
 ## [0.15.122] - 2026-08-27
 
 ### Fixed

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -7,6 +7,8 @@ import {
   driftedRequiredInputNames,
   missingRequiredWidgetMaterializations,
   declaredTypeMembers,
+  inputDeclaredAsSocket,
+  isComfyListSocketType,
   registeredSocketTypes,
   requiredWidgetInputTypes,
   unavailableRequiredCustomWidgetTypes,
@@ -103,28 +105,29 @@ test("a forceInput declaration remains a wireable socket", () => {
   assert.deepEqual(requiredWidgetInputTypes(node), ["ZIPN_STYLE_GALLERY", "ZIPN_SPACER", "CLIP"]);
 });
 
-test("#751: LIST with leftover widget defaults is a core list-socket, not a pending widget", () => {
-  // TextEncodeQwenImageEditPlusCustom_lrzjason.configs is declared LIST (a
-  // link datatype) but INPUT_TYPES still stamps `default: []`. That is not a
-  // widget constructor; waiting 5s for one refuses a node that the stock
-  // frontend adds as a socket.
-  const node = {
-    constructor: {
-      nodeData: {
-        input: {
-          required: {
-            clip: ["CLIP", {}],
-            configs: ["LIST", { default: [] }],
+test("#751: LIST with leftover widget defaults is a list-socket, not a pending widget", () => {
+  // Both leftover shapes packs actually emit: Python `None` (JSON null) and an
+  // empty list stamp. Neither is a widget constructor. LIST is proven as a
+  // list-socket, not by growing SAFE_SOCKET_TYPES' type-only shortcut.
+  for (const config of [{ default: null }, { default: [] }]) {
+    const node = {
+      constructor: {
+        nodeData: {
+          input: {
+            required: {
+              clip: ["CLIP", {}],
+              configs: ["LIST", config],
+            },
           },
         },
       },
-    },
-  };
-  assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(node, {}),
-    [],
-    "LIST + default must not wait for a widget constructor that will never register",
-  );
+    };
+    assert.deepEqual(
+      unavailableRequiredCustomWidgetTypes(node, {}),
+      [],
+      `LIST + ${JSON.stringify(config)} must not wait for a widget constructor that will never register`,
+    );
+  }
   // A genuine custom widget with the same leftover-default shape still waits.
   const custom = {
     constructor: {
@@ -1015,6 +1018,134 @@ test("#1062: a core 3D file input declaring a WIDGET value still waits for its c
   assert.deepEqual(unavailableRequiredCustomWidgetTypes(widgetish, {}, new Set(["MESH"]), widgetish), [
     "MESH,FILE_3D_GLB",
   ]);
+});
+
+// ---- #751: LIST sockets with leftover widget-value metadata -----------------------
+//
+// Recurrence of the original socket-vs-widget misread. `TextEncodeQwenImageEditPlusCustom_lrzjason`
+// declares `configs: ("LIST", {"default": None})` — a link datatype with leftover Python
+// `None` that `/object_info` serializes as `{default: null}`. Key presence made
+// `inputDeclaredAsSocket` return false, so `linkProven && socketDeclared` never fired,
+// and the add path waited 5s for a LIST widget constructor that will never register.
+//
+// LIST is NOT added to SAFE_SOCKET_TYPES: that set gets a type-only shortcut that would
+// waive a genuine LIST widget (`{default: [...]}`). The structural split is:
+//   * leftover `default: null` is not a widget declaration
+//   * LIST is a ComfyUI list-socket (link-proven like FILE_3D), still held to socket-shape
+//   * a real default / widgetType / min-max still waits (#580/#626/#788)
+
+/** Verbatim required inputs from the reporter's node (Comfyui-QwenEditUtils). */
+const QWEN_CUSTOM_DEF = {
+  input: {
+    required: {
+      clip: ["CLIP", {}],
+      vae: ["VAE", {}],
+      prompt: ["STRING", { multiline: true, dynamicPrompts: true }],
+      configs: ["LIST", { default: null }],
+    },
+  },
+};
+
+test("#751: leftover default:null does not make a LIST input widget-shaped", () => {
+  assert.equal(inputDeclaredAsSocket(["LIST", { default: null }]), true);
+  assert.equal(inputDeclaredAsSocket(["LIST", { default: null, tooltip: "Configs list" }]), true);
+  assert.equal(inputDeclaredAsSocket(["LIST", {}]), true);
+  assert.equal(inputDeclaredAsSocket(["LIST"]), true);
+  // Leftover empty-list stamp is the same as JSON null — not a widget value.
+  assert.equal(inputDeclaredAsSocket(["LIST", { default: [] }]), true);
+  // A REAL default / range is still a widget declaration — the #626 half.
+  assert.equal(inputDeclaredAsSocket(["LIST", { default: [1, 2] }]), false);
+  assert.equal(inputDeclaredAsSocket(["ACME_VALUE", { default: 3, min: 0, max: 10 }]), false);
+  // Empty object is a real DICT widget default (#1584), not leftover.
+  assert.equal(inputDeclaredAsSocket(["DICT", { default: {} }]), false);
+  assert.equal(isComfyListSocketType("LIST"), true);
+  assert.equal(isComfyListSocketType("list"), false);
+  assert.equal(isComfyListSocketType(" LIST "), false);
+});
+
+test("#751: TextEncodeQwenImageEditPlusCustom configs LIST+default:null is addable", () => {
+  // The reported dead end. No LIST constructor, and no output proof: the add path's
+  // single-class /object_info for this node only lists CONDITIONING/LATENT/ANY, so
+  // knownSocketTypes never contains LIST unless a sibling producer is widened in.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(QWEN_CUSTOM_DEF, { STRING: () => {} }, new Set(), QWEN_CUSTOM_DEF),
+    [],
+    "LIST with leftover default:null must not wait for a widget that never registers",
+  );
+  // The same node after a widen that DID find QwenEditConfigPreparer.output = LIST.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(
+      QWEN_CUSTOM_DEF,
+      { STRING: () => {} },
+      new Set(["LIST"]),
+      QWEN_CUSTOM_DEF,
+    ),
+    [],
+  );
+});
+
+test("#751: leftover default:null on a proven link type is a socket, not a widget wait", () => {
+  // The general rule, independent of LIST: a type the CURRENT backend outputs, carrying
+  // only JSON-null leftover metadata, is a socket. Presence of `default` used to block it.
+  const def = { input: { required: { configs: ["ACME_LIST", { default: null }] } } };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(["ACME_LIST"]), def), []);
+  // Without output proof it still fails closed — leftover keys do not invert #580.
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def), ["ACME_LIST"]);
+});
+
+test("#751 #626 INTACT: a LIST input that DECLARES a real value still waits", () => {
+  // A pack can register a LIST widget. A populated array default is that widget, and
+  // LIST's list-socket proof must not waive it the way SAFE_SOCKET_TYPES' type-only
+  // shortcut would.
+  const listWidget = { input: { required: { items: ["LIST", { default: [1, 2] }] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(listWidget, {}, new Set(["LIST"]), listWidget),
+    ["LIST"],
+  );
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(listWidget, { LIST: () => {} }, new Set(["LIST"]), listWidget),
+    [],
+  );
+});
+
+test("#751 #626 INTACT: a value-declaring custom widget is still not waived by output proof", () => {
+  const node = {
+    constructor: {
+      nodeData: { input: { required: { amount: ["ACME_VALUE", { default: 3, min: 0, max: 10 }] } } },
+    },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(node, {}, new Set(["ACME_VALUE"])),
+    ["ACME_VALUE"],
+  );
+});
+
+test("#751 #788 INTACT: a socket-union with widgetType+default:null still waits", () => {
+  const def = {
+    input: { required: { img: ["IMAGE,MASK", { widgetType: "IMAGE", default: null }] } },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["IMAGE", "MASK"]), def),
+    ["IMAGE,MASK"],
+  );
+});
+
+test("#751 #580 INTACT: an unproven custom widget with leftover default:null still waits", () => {
+  const def = { input: { required: { gallery: ["ZIPN_STYLE_GALLERY", { default: null }] } } };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def), [
+    "ZIPN_STYLE_GALLERY",
+  ]);
+});
+
+test("#751: a lookalike LIST spelling is not the list-socket", () => {
+  for (const type of ["list", " LIST ", "LISTS", "PyList"]) {
+    const def = { input: { required: { items: [type, { default: null }] } } };
+    assert.deepEqual(
+      unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def),
+      [type],
+      `${JSON.stringify(type)} must not be waived as LIST`,
+    );
+  }
 });
 
 test("#695: the report names the stuck INPUT and which of the two causes it is", () => {

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -56,10 +56,7 @@ export function requiredWidgetInputTypes(nodeOrNodeData) {
 const SAFE_SOCKET_TYPES = new Set([
   "*", "ANY", "AUDIO", "BBOX", "CLIP", "CLIP_VISION", "CLIP_VISION_OUTPUT",
   "CONDITIONING", "CONTROL_NET", "GLIGEN", "GUIDER", "HOOKS", "IMAGE",
-  "IPADAPTER", "LATENT", "LATENT_OPERATION",
-  // #751 — LIST is ComfyUI's list-of-items socket. Packs often stamp leftover
-  // INPUT_TYPES `default: []` on it, which is not a widget constructor.
-  "LIST", "MASK", "MESH", "MODEL", "NOISE",
+  "IPADAPTER", "LATENT", "LATENT_OPERATION", "MASK", "MESH", "MODEL", "NOISE",
   "PHOTOMAKER", "SAMPLER", "SCHEDULER", "SIGMAS", "STYLE_MODEL", "UNET",
   "UPSCALE_MODEL", "VAE", "VOXEL",
 ]);
@@ -224,10 +221,15 @@ export function unavailableRequiredWidgetReport(
     // output proof cannot see a core datatype that no INSTALLED node happens to emit; see
     // its own comment. The quantifier is still `every` — a proven member never vouches for
     // an unproven one.
+    // #751 — `isComfyListSocketType` is a FOURTH proof path for the same reason LIST is
+    // missing from SAFE_SOCKET_TYPES: it is a link socket (a Python list passed as one
+    // value), but adding it to the type-only shortcut would waive a genuine LIST widget.
+    // It still has to clear the input-level bar below.
     const linkProven = members.every(
       (member) =>
         SAFE_SOCKET_TYPES.has(member) ||
         isCore3dFileType(member) ||
+        isComfyListSocketType(member) ||
         knownSocketTypes?.has?.(member) === true ||
         wildcardOutputProven,
     );
@@ -491,6 +493,25 @@ export function isCore3dFileType(type) {
 }
 
 /**
+ * #751 — ComfyUI's LIST socket.
+ *
+ * Custom nodes pass a Python list as one link value by declaring type `LIST`. Core ComfyUI
+ * has no LIST widget (it is not in `IO` and not in `ComfyWidgets`); the stock UI renders
+ * `("LIST", {"default": None})` as a socket you wire. That is the shape
+ * `TextEncodeQwenImageEditPlusCustom_lrzjason.configs` and `QwenEditConfigPreparer` emit,
+ * and waiting for a constructor keyed `"LIST"` waits for evidence that cannot arrive.
+ *
+ * This is a link-datatype PROOF, the same role as `isCore3dFileType` — NOT membership in
+ * SAFE_SOCKET_TYPES. That set gets a type-only shortcut that ignores widget-value keys,
+ * and a pack can still register a LIST widget with a real default (an array). Those
+ * inputs stay widget-shaped and still wait (#626). Exact spelling, no normalisation:
+ * `"list"` and `" LIST "` are different identifiers everywhere else in this module.
+ */
+export function isComfyListSocketType(type) {
+  return type === "LIST";
+}
+
+/**
  * Whether a required input DECLARES itself as a link socket rather than a prompt value.
  *
  * This is the input-level half of the #626 waiver, and it is a POSITIVE reading of the
@@ -552,9 +573,27 @@ export function inputDeclaredAsSocket(spec) {
   if (config.forceInput || config.force_input || config.defaultInput || config.widget === false) {
     return true;
   }
-  return !WIDGET_VALUE_CONFIG_KEYS.some((key) =>
-    Object.prototype.hasOwnProperty.call(config, key),
-  );
+  return !WIDGET_VALUE_CONFIG_KEYS.some((key) => configKeyDeclaresWidgetValue(config, key));
+}
+
+/**
+ * #751 — leftover widget-value metadata is not a value a widget can honour.
+ *
+ * Python authors write `("LIST", {"default": None})` (JSON `null`) or stamp an empty
+ * list (`default: []`) on link sockets. Key *presence* used to flip the input to
+ * widget-shaped, so `linkProven && socketDeclared` never fired and the guard waited
+ * 5s for a constructor that will never register.
+ *
+ * A REAL default (`3`, `[1, 2]`, `{}`, `""`, `false`) is unchanged and still
+ * widget-shaped. `widgetType: "IMAGE"` is unchanged. Empty *object* `{}` is a real
+ * DICT widget default (#1584) and is NOT leftover.
+ */
+function configKeyDeclaresWidgetValue(config, key) {
+  if (!Object.prototype.hasOwnProperty.call(config, key)) return false;
+  const value = config[key];
+  if (value === null || value === undefined) return false;
+  if (Array.isArray(value) && value.length === 0) return false;
+  return true;
 }
 
 // Config keys that only a WIDGET can honour — their presence is the input declaring it


### PR DESCRIPTION
Closes #751

## Recurrence

`panel_add_node` rejected `TextEncodeQwenImageEditPlusCustom_lrzjason` because its required `configs` input is declared `LIST` (a link datatype) but also carries leftover widget metadata (`{default: null}` from Python `None`, or `{default: []}`). `inputDeclaredAsSocket` treated key *presence* as a widget declaration, so the `#626` waiver (`linkProven && socketDeclared`) never fired. The guard waited 5s for a LIST widget constructor that will never register. `panel_refresh_nodes` + retry could not help.

#1990 closed this by adding `LIST` to `SAFE_SOCKET_TYPES`. That set's type-only shortcut ignores widget-value keys entirely, so a genuine LIST widget (`{default: [1, 2]}`) would also skip the wait. Growing the allowlist is the class of fix #695 warned against.

## Change

Structural, not another name on the list:

- Leftover `default: null` / `default: []` is **not** a widget declaration. A real default (`3`, `[1, 2]`, `{}`, `""`, `false`) still is. Empty object `{}` stays a DICT widget default (#1584).
- `LIST` is a ComfyUI list-socket (`isComfyListSocketType`), the same *proof* role as `isCore3dFileType` — still held to socket-shape, not the SAFE_SOCKET_TYPES type-only shortcut.
- A type the current backend proves is an output (`knownSocketTypes`) with only leftover keys is a socket too.

`#580` unproven custom widgets, `#626` value-declaring inputs, and `#788` widget-bearing unions still wait.

## Tests

`node --test browser_tests/unit/node-widget-materialization.test.mjs` — 83 passed, including the reporter's `configs: ["LIST", {default: null}]` shape and the #580/#626/#788 intact cases.
