### PR TITLE
fix(2473): report host_links_reindexed on unexpose

### DIFF
--- a/browser_tests/unit/unexpose-boundary-slot.test.mjs
+++ b/browser_tests/unit/unexpose-boundary-slot.test.mjs
@@ -203,6 +203,7 @@ test("#1294 unexpose OUTPUT removes the named slot and reports what it dropped",
     slot: 0,
     interior_links_dropped: 1,
     host_links_dropped: 2,
+    host_links_reindexed: true,
   });
   assert.equal(res.warning, undefined);
 });
@@ -278,6 +279,7 @@ test("#1969 unexpose INPUT of a non-last slot reindexes remaining host links", (
   const { subgraph, host, rootGraph, imageLink, image1Link, vaeLink, hostCalls } = mkShiftedInputGraph();
   const res = buildExecutors(subgraph, rootGraph).graph_unexpose_subgraph_input({ name: "text" });
   assert.equal(res.removed.slot, 3);
+  assert.equal(res.removed.host_links_reindexed, true, "#2473 MCP must see that the panel reindexed");
   assert.equal(host.inputs.map((s) => s.name).join(","), "unet_name,clip_name,vae_name,image,image_1,noise_seed");
   // The live backlink still names the same wires — that is what query/outline see.
   assert.equal(host.inputs[3].link, 10);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23783,6 +23783,7 @@ const GRAPH_TOOL_EXECUTORS = {
         slot: slotIndex,
         interior_links_dropped: interiorLinks,
         host_links_dropped: hostLinks,
+        host_links_reindexed: true,
       },
       ...(removeErr
         ? {
@@ -23842,6 +23843,7 @@ const GRAPH_TOOL_EXECUTORS = {
         slot: slotIndex,
         interior_links_dropped: interiorLinks,
         host_links_dropped: hostLinks,
+        host_links_reindexed: true,
       },
       ...(removeErr
         ? {


### PR DESCRIPTION
Companion to artokun/comfyui-mcp#2473.

`graph_unexpose_subgraph_input/output` already call `reindexHostRailLinks` (#1969). Set `removed.host_links_reindexed: true` so MCP omits the stale remaining-piece warning.

Tests: `node --test browser_tests/unit/unexpose-boundary-slot.test.mjs browser_tests/unit/rail-slot.test.mjs` — 33 passed.