### PR TITLE
fix: preserve browser stack for panel_run queue errors (#248)

### DIFF
--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -37,7 +37,11 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { dispatchScopedRun, createRunFetchInterceptor } from "../../web/js/lib/run-scope-guard.js";
+import {
+  dispatchScopedRun,
+  createRunFetchInterceptor,
+  invokeQueuePromptWithBrowserStack,
+} from "../../web/js/lib/run-scope-guard.js";
 import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import {
@@ -82,6 +86,7 @@ import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame
 import { createRunReconcileSweep } from "../../web/js/lib/run-reconcile-sweep.js";
 import { createRunReceiptOutbox } from "../../web/js/lib/run-receipt-outbox.js";
 import { createRehelloGate, routeIsStale } from "../../web/js/lib/rehello-gate.js";
+import { coerceMessageText } from "../../web/js/lib/chat-serialize.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -689,6 +694,7 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
       return dispatch ? dispatch(args) : { outcome: "unverified", queueMark: 1, verified: 0, error: "stub" };
     },
     createRunFetchInterceptor,
+    invokeQueuePromptWithBrowserStack,
     graphToPromptUnusable,
     unrunnableNodeIdsInScope,
     unserializableGraphRefusal,
@@ -738,6 +744,109 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
   );
   return { graph_run: factory(...names.map((n) => deps[n])), seen };
 }
+
+test("#248 production path: a scoped and full app.queuePrompt throw retains browser source context", async () => {
+  const stop = keepAlive();
+  try {
+    const browserStack = [
+      "TypeError: Cannot convert undefined or null to object",
+      "    at app.graphToPrompt (http://127.0.0.1:8188/extensions/tts_audio_suite/audio_analyzer_interface.js:102:24)",
+      "    at async ComfyApp.graphToPrompt (http://127.0.0.1:8188/extensions/comfyui-videohelpersuite/js/VHS.core.js:2349:23)",
+    ].join("\n");
+    const makeThrowingApp = () => {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const app = makeBusyDroppingFrontend({ apiTarget });
+      app.graph = { _nodes: [] };
+      app.queuePrompt = () => {
+        const error = new TypeError("Cannot convert undefined or null to object");
+        error.stack = browserStack;
+        return Promise.reject(error);
+      };
+      return { app, apiTarget, server };
+    };
+    const assertBrowserContext = (error) => {
+      assert.match(error.message, /^app\.queuePrompt failed:\n/);
+      assert.match(error.message, /Cannot convert undefined or null to object/);
+      assert.match(error.message, /tts_audio_suite\/audio_analyzer_interface\.js:102:24/);
+      assert.match(error.message, /comfyui-videohelpersuite\/js\/VHS\.core\.js:2349:23/);
+      return true;
+    };
+
+    const scoped = makeThrowingApp();
+    const scopedRun = realGraphRun({
+      app: scoped.app,
+      apiTarget: scoped.apiTarget,
+      budgetMs: 2000,
+      serializeMs: 500,
+      dispatch: (args) => dispatchScopedRun({ ...args, verifyTimeoutMs: 100 }),
+    });
+    await assert.rejects(() => scopedRun.graph_run({ to_node_id: 9 }), assertBrowserContext);
+    assert.equal(scoped.server.calls.length, 0, "the queue throw occurred before a POST");
+
+    const full = makeThrowingApp();
+    const fullRun = realGraphRun({
+      app: full.app,
+      apiTarget: full.apiTarget,
+      budgetMs: 2000,
+      serializeMs: 500,
+    });
+    await assert.rejects(() => fullRun.graph_run({}), assertBrowserContext);
+    assert.equal(full.server.calls.length, 0, "the queue throw occurred before a POST");
+  } finally {
+    stop();
+  }
+});
+
+test("#248 production path: a non-Error queue failure reaches the panel-visible reply unchanged", async () => {
+  const stop = keepAlive();
+  try {
+    assert.match(
+      panelSrc,
+      /error: coerceMessageText\(err\?\.message \?\? err\),/,
+      "the live bridge must serialize the executor failure through the panel message coercer",
+    );
+    const thrown = {
+      name: "QueueWrapperFailure",
+      message: "structured queue failure",
+      stack: "QueueWrapperFailure: structured queue failure\n    at extension://queue-wrapper.js:17:9",
+    };
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeBusyDroppingFrontend({ apiTarget });
+    app.graph = { _nodes: [] };
+    app.queuePrompt = () => Promise.reject(thrown);
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 2000,
+      serializeMs: 500,
+    });
+
+    await assert.rejects(
+      () => built.graph_run({}),
+      (received) => {
+        assert.equal(received, thrown, "graph_run must preserve the frontend's thrown object");
+        // This is the exact production bridge expression in panel.js: the
+        // panel-visible wire field prefers a structured error's message.
+        const reply = {
+          rid: "non-error-rid",
+          ok: false,
+          error: coerceMessageText(received?.message ?? received),
+        };
+        assert.deepEqual(reply, {
+          rid: "non-error-rid",
+          ok: false,
+          error: "structured queue failure",
+        });
+        return true;
+      },
+    );
+    assert.equal(server.calls.length, 0, "the queue failure occurred before a POST");
+  } finally {
+    stop();
+  }
+});
 
 test("#1565 CALL SITE: graph_run hands the dispatch its own command budget", async () => {
   const stop = keepAlive();

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -300,6 +300,39 @@ test("#248 a non-Error with a readable stack keeps its identity and message", as
   }
 });
 
+test("#248 a non-Error with a spoofed Error toStringTag keeps its identity and message", async () => {
+  for (const thrown of [
+    {
+      [Symbol.toStringTag]: "Error",
+      name: "SpoofedQueueFailure",
+      message: "structured spoofed queue failure",
+      stack: "SpoofedQueueFailure: structured spoofed queue failure\n    at extension://queue-wrapper.js:23:9",
+    },
+    Object.assign(Object.create({ [Symbol.toStringTag]: "Error" }), {
+      name: "InheritedSpoofedQueueFailure",
+      message: "structured inherited spoofed queue failure",
+      stack: "InheritedSpoofedQueueFailure: structured inherited spoofed queue failure\n    at extension://queue-wrapper.js:29:9",
+    }),
+  ]) {
+    for (const queuePrompt of [
+      () => {
+        throw thrown;
+      },
+      () => Promise.reject(thrown),
+    ]) {
+      await assert.rejects(
+        () => invokeQueuePromptWithBrowserStack({ queuePrompt }),
+        (received) => {
+          assert.equal(received, thrown);
+          assert.equal(received.message, thrown.message);
+          assert.equal(received.stack, thrown.stack);
+          return true;
+        },
+      );
+    }
+  }
+});
+
 test("#248 hostile or non-string stacks cannot mask the original queue failure", async () => {
   for (const stack of [Symbol("hostile stack"), { toString: () => { throw new Error("coercion"); } }]) {
     const error = new TypeError("Cannot convert undefined or null to object");

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -14,6 +14,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync, statSync } from "node:fs";
+import { runInNewContext } from "node:vm";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -39,6 +40,7 @@ import {
   readScopeFromBody,
   cancelPendingScopedQueueItem,
   dispatchScopedRun,
+  invokeQueuePromptWithBrowserStack,
 } from "../../web/js/lib/run-scope-guard.js";
 import { resolveRunToNodeTarget } from "../../web/js/lib/subgraph-scope.js";
 
@@ -244,6 +246,131 @@ function makeShadowedQueueFrontend({ dropArgs = false, apiTarget, output = OUR_O
 // ---------------------------------------------------------------------------
 // Pure helpers
 // ---------------------------------------------------------------------------
+
+test("#248 queuePrompt invocation keeps the original browser stack for sync and async throws", async () => {
+  const browserStack = [
+    "TypeError: Cannot convert undefined or null to object",
+    "    at app.queuePrompt (http://127.0.0.1:8188/extensions/tts_audio_suite/audio_analyzer_interface.js:102:24)",
+  ].join("\n");
+  for (const queuePrompt of [
+    () => {
+      const error = new TypeError("Cannot convert undefined or null to object");
+      error.stack = browserStack;
+      throw error;
+    },
+    () => {
+      const error = new TypeError("Cannot convert undefined or null to object");
+      error.stack = browserStack;
+      return Promise.reject(error);
+    },
+  ]) {
+    await assert.rejects(
+      () => invokeQueuePromptWithBrowserStack({ queuePrompt }, 0, 1, undefined),
+      (error) => {
+        assert.match(error.message, /^app\.queuePrompt failed:\n/);
+        assert.match(error.message, /Cannot convert undefined or null to object/);
+        assert.match(error.message, /tts_audio_suite\/audio_analyzer_interface\.js:102:24/);
+        return true;
+      },
+    );
+  }
+});
+
+test("#248 a non-Error with a readable stack keeps its identity and message", async () => {
+  const thrown = {
+    name: "QueueWrapperFailure",
+    message: "structured queue failure",
+    stack: "QueueWrapperFailure: structured queue failure\n    at extension://queue-wrapper.js:17:9",
+  };
+  for (const queuePrompt of [
+    () => {
+      throw thrown;
+    },
+    () => Promise.reject(thrown),
+  ]) {
+    await assert.rejects(
+      () => invokeQueuePromptWithBrowserStack({ queuePrompt }),
+      (received) => {
+        assert.equal(received, thrown);
+        assert.equal(received.message, thrown.message);
+        assert.equal(received.stack, thrown.stack);
+        return true;
+      },
+    );
+  }
+});
+
+test("#248 hostile or non-string stacks cannot mask the original queue failure", async () => {
+  for (const stack of [Symbol("hostile stack"), { toString: () => { throw new Error("coercion"); } }]) {
+    const error = new TypeError("Cannot convert undefined or null to object");
+    error.stack = stack;
+    await assert.rejects(
+      () => invokeQueuePromptWithBrowserStack({ queuePrompt: () => Promise.reject(error) }),
+      (received) => {
+        assert.equal(received, error);
+        assert.equal(received.message, "Cannot convert undefined or null to object");
+        return true;
+      },
+    );
+  }
+});
+
+test("#248 huge stacks are bounded and credential-shaped text is redacted", async () => {
+  const error = new TypeError("Cannot convert undefined or null to object");
+  error.stack = [
+    error.message,
+    "    at app.graphToPrompt (http://127.0.0.1:8188/extensions/tts_audio_suite/audio_analyzer_interface.js:102:24)",
+    `    at fetch (https://example.test/?opaque=${"a".repeat(64)})`,
+    "    at noisy-frame ".repeat(100_000),
+  ].join("\n");
+  await assert.rejects(
+    () => invokeQueuePromptWithBrowserStack({ queuePrompt: () => Promise.reject(error) }),
+    (wrapped) => {
+      assert.ok(wrapped.message.length <= 4096, `message must be bounded, got ${wrapped.message.length}`);
+      assert.match(wrapped.message, /tts_audio_suite\/audio_analyzer_interface\.js:102:24/);
+      assert.match(wrapped.message, /browser stack truncated/);
+      assert.match(wrapped.message, /«redacted»/);
+      assert.doesNotMatch(wrapped.message, /opaque=aaaa/);
+      return true;
+    },
+  );
+});
+
+test("#248 a Proxy getPrototypeOf trap cannot replace the original thrown value", async () => {
+  let prototypeReads = 0;
+  const hostile = new Proxy({}, {
+    getPrototypeOf() {
+      prototypeReads += 1;
+      throw new Error("getPrototypeOf trap should not run");
+    },
+  });
+  await assert.rejects(
+    () => invokeQueuePromptWithBrowserStack({ queuePrompt: () => Promise.reject(hostile) }),
+    (received) => {
+      assert.equal(received, hostile);
+      return true;
+    },
+  );
+  assert.equal(prototypeReads, 0);
+});
+
+test("#248 cross-realm Error-shaped values retain their browser stack", async () => {
+  const crossRealmError = runInNewContext(`(() => {
+    const error = new TypeError("Cannot convert undefined or null to object");
+    error.stack = "TypeError: Cannot convert undefined or null to object\\n" +
+      "    at app.graphToPrompt (http://127.0.0.1:8188/extensions/tts_audio_suite/audio_analyzer_interface.js:102:24)";
+    return error;
+  })()`);
+  await assert.rejects(
+    () => invokeQueuePromptWithBrowserStack({ queuePrompt: () => Promise.reject(crossRealmError) }),
+    (wrapped) => {
+      assert.match(wrapped.message, /^app\.queuePrompt failed:\n/);
+      assert.match(wrapped.message, /Cannot convert undefined or null to object/);
+      assert.match(wrapped.message, /tts_audio_suite\/audio_analyzer_interface\.js:102:24/);
+      return true;
+    },
+  );
+});
 
 test("#1782 queuePromptScopeArgs: no scope ⇒ [undefined]; 1.49.6 options carry both queue layers", () => {
   assert.deepEqual(queuePromptScopeArgs(undefined), [undefined]);

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -387,6 +387,52 @@ test("#248 a Proxy getPrototypeOf trap cannot replace the original thrown value"
   assert.equal(prototypeReads, 0);
 });
 
+test("#248 a Proxy cannot hang or spoof Error classification through a cyclic prototype", async () => {
+  let prototypeReads = 0;
+  let hostile;
+  hostile = new Proxy({}, {
+    get(target, property, receiver) {
+      if (property === Symbol.toStringTag) return "Error";
+      return Reflect.get(target, property, receiver);
+    },
+    getPrototypeOf() {
+      prototypeReads += 1;
+      return hostile;
+    },
+  });
+  await assert.rejects(
+    () => invokeQueuePromptWithBrowserStack({ queuePrompt: () => Promise.reject(hostile) }),
+    (received) => {
+      assert.equal(received, hostile);
+      return true;
+    },
+  );
+  assert.equal(prototypeReads, 1);
+});
+
+test("#248 a Proxy cannot force an unbounded Error prototype scan", async () => {
+  let prototypeReads = 0;
+  const handler = {
+    get(target, property, receiver) {
+      if (property === Symbol.toStringTag) return "Error";
+      return Reflect.get(target, property, receiver);
+    },
+    getPrototypeOf() {
+      prototypeReads += 1;
+      return new Proxy({}, handler);
+    },
+  };
+  const hostile = new Proxy({}, handler);
+  await assert.rejects(
+    () => invokeQueuePromptWithBrowserStack({ queuePrompt: () => Promise.reject(hostile) }),
+    (received) => {
+      assert.equal(received, hostile);
+      return true;
+    },
+  );
+  assert.equal(prototypeReads, 33);
+});
+
 test("#248 cross-realm Error-shaped values retain their browser stack", async () => {
   const crossRealmError = runInNewContext(`(() => {
     const error = new TypeError("Cannot convert undefined or null to object");

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -157,12 +157,12 @@ test("#988 (codex) source guard: the scan runs BEFORE dispatch, not after", () =
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const scan = src.indexOf("repeatingControls = findRepeatingControlWidgets(");
   // #1565 — the unscoped dispatch is BOUNDED by the command budget now, so the literal is
-  // no longer a bare `await`. The anchor follows the call; the ordering property it guards
-  // is unchanged, and the assertion below pins that it is still the bounded call.
-  const dispatch = src.indexOf("app.queuePrompt(0, batch, undefined)");
+  // no longer a bare `await`. #248 routes the queue call through the browser-stack
+  // decorator; anchor the production invocation instead of reaching into that helper.
+  const dispatch = src.indexOf("invokeQueuePromptWithBrowserStack(app, 0, batch, undefined)");
   assert.match(
     src.slice(Math.max(0, dispatch - 200), dispatch + 200),
-    /Promise\.resolve\(\s*queuePromptWithGraphToPromptSnapshot\([\s\S]*?app\.queuePrompt\(0, batch, undefined\)/,
+    /Promise\.resolve\(\s*queuePromptWithGraphToPromptSnapshot\([\s\S]*?invokeQueuePromptWithBrowserStack\(app, 0, batch, undefined\)/,
     "the unscoped dispatch must stay bounded — an unbounded one hangs past the relay window",
   );
   const scopedDispatch = src.indexOf("runScopeResult = await dispatchScopedRun({");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -834,7 +834,11 @@ import {
   contentProofExclusiveAmongOpen,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
-import { createRunFetchInterceptor, dispatchScopedRun } from "./lib/run-scope-guard.js";
+import {
+  createRunFetchInterceptor,
+  dispatchScopedRun,
+  invokeQueuePromptWithBrowserStack,
+} from "./lib/run-scope-guard.js";
 import { prunedRetryNote } from "./lib/partial-run-prune.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import { collectNodeOutputMedia } from "./lib/node-output-media.js";
@@ -19559,7 +19563,7 @@ const GRAPH_TOOL_EXECUTORS = {
         const queued = await withTimeout(
           Promise.resolve(
             queuePromptWithGraphToPromptSnapshot(app, promptSnapshotReservation, () =>
-              app.queuePrompt(0, batch, undefined),
+              invokeQueuePromptWithBrowserStack(app, 0, batch, undefined),
             ),
           ).then(
             (value) => ({ value }),

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -32,12 +32,90 @@ import { controlAfterGenerateEntries } from "./control-after-generate.js";
 // timeout helper is how this repo keeps producing near-duplicate bugs (bounded-step's
 // own header), so there is not one.
 import { withTimeout } from "./bounded-step.js";
+import { scrubSecretShapedText } from "./http-failure.js";
 
 // #1854 — the intrinsic captured ONCE at module load. Invoking through a
 // per-call property lookup on the function object would read an overrideable
 // own property, so a shadowed one could throw before the original ran; this
 // reads nothing off the target at call time.
 const rawApply = Reflect.apply;
+
+const QUEUE_PROMPT_ERROR_PREFIX = "app.queuePrompt failed:\n";
+const QUEUE_PROMPT_ERROR_MESSAGE_MAX = 4096;
+const QUEUE_PROMPT_ERROR_DETAIL_MAX =
+  QUEUE_PROMPT_ERROR_MESSAGE_MAX - QUEUE_PROMPT_ERROR_PREFIX.length;
+const QUEUE_PROMPT_ERROR_TRUNCATION = "\n… [browser stack truncated]";
+const objectToString = Object.prototype.toString;
+
+// `instanceof Error` rejects an Error created by the browser realm when this
+// module runs in another realm. The object tag keeps that existing browser
+// behaviour without walking a hostile Proxy prototype chain.
+function isBrowserError(value) {
+  try {
+    return objectToString.call(value) === "[object Error]";
+  } catch {
+    return false;
+  }
+}
+
+function formatQueuePromptStack(stack) {
+  const truncated = stack.length > QUEUE_PROMPT_ERROR_DETAIL_MAX;
+  const raw = truncated
+    ? `${stack.slice(0, QUEUE_PROMPT_ERROR_DETAIL_MAX - QUEUE_PROMPT_ERROR_TRUNCATION.length)}${QUEUE_PROMPT_ERROR_TRUNCATION}`
+    : stack;
+  // Keep stack newlines for source readability, but do not carry control bytes
+  // into the bridge. Redaction runs only after the bounded slice.
+  const clean = raw.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ");
+  const redacted = scrubSecretShapedText(clean);
+  return redacted.length <= QUEUE_PROMPT_ERROR_DETAIL_MAX
+    ? redacted
+    : `${redacted.slice(0, QUEUE_PROMPT_ERROR_DETAIL_MAX - 1)}…`;
+}
+
+/**
+ * #248 — Preserve the browser-side source context when the frontend's queue
+ * wrapper throws. The bridge serializes an executor failure from `message`,
+ * not `stack`, so passing the original Error through loses the extension URL
+ * and line that identify the broken graph serializer. Keep a bounded, redacted
+ * browser stack inside the message for both synchronous throws and rejected
+ * promises.
+ */
+function queuePromptFailureError(error) {
+  // Preserve JavaScript's existing contract for non-Error throws (including
+  // `throw undefined`) and values whose object surface is hostile. In
+  // particular, a frontend can throw a structured non-Error with its own
+  // readable `message` and `stack`; wrapping it would discard that object's
+  // identity and hand the bridge a different message surface.
+  if (error === null || typeof error !== "object" || !isBrowserError(error)) return error;
+  let stack;
+  try {
+    // Some browser Error-like objects expose a hostile or non-string stack
+    // value. Keep native string stacks verbatim; never interpolate arbitrary
+    // values because Symbol() and throwing coercers can mask the queue error.
+    stack = error.stack;
+  } catch {
+    // A throwing stack accessor means the original value is the only safe one.
+    return error;
+  }
+  // A non-string or absent stack is left for the bridge's ordinary message
+  // serializer; there is no safe browser context to add here.
+  if (typeof stack !== "string" || !stack) return error;
+  return new Error(`${QUEUE_PROMPT_ERROR_PREFIX}${formatQueuePromptStack(stack)}`);
+}
+
+/** Invoke the live frontend queue while preserving its browser diagnostics. */
+export function invokeQueuePromptWithBrowserStack(app, ...args) {
+  let result;
+  try {
+    result = app.queuePrompt(...args);
+  } catch (error) {
+    return Promise.reject(queuePromptFailureError(error));
+  }
+  return Promise.resolve(result).catch((error) => {
+    throw queuePromptFailureError(error);
+  });
+}
+
 // #556 — panel_run's to_node_id ("run to node") must NEVER silently fall through
 // to a FULL-graph execution. A scoped run can fail open on two channels:
 //
@@ -2016,8 +2094,12 @@ export async function dispatchScopedRun({
       // is the state the give-up path below already exists for — it cancels the still-
       // pending queue item and, either way, CLOSES this guard, so a post the abandoned
       // queuePrompt emits later still meets the fence and is refused rather than
-      // dispatched scopeless. A throw is re-thrown unchanged (boundedStep keeps it).
-      const queued = await boundedStep(app.queuePrompt(mark, batch, scopeArg), boundedBy(attemptMs));
+      // dispatched scopeless. An Error throw is decorated with its browser stack;
+      // non-Error throws retain their existing identity.
+      const queued = await boundedStep(
+        invokeQueuePromptWithBrowserStack(app, mark, batch, scopeArg),
+        boundedBy(attemptMs),
+      );
       // `"error" in` rather than a truthiness test — a falsy thrown value still throws.
       if (queued !== TIMED_OUT && "error" in queued) throw queued.error;
       if (!guard.verdictReached()) {

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -49,6 +49,7 @@ const objectToString = Object.prototype.toString;
 const hasOwn = Object.prototype.hasOwnProperty;
 const getPrototypeOf = Object.getPrototypeOf;
 const toStringTag = Symbol.toStringTag;
+const BROWSER_ERROR_PROTO_MAX = 32;
 
 // `instanceof Error` rejects an Error created by the browser realm when this
 // module runs in another realm. The object tag keeps that existing browser
@@ -66,12 +67,18 @@ function isBrowserError(value) {
 
     // A spoof can put the tag on a custom prototype instead of the thrown
     // object itself. Genuine Error prototype chains do not define it, so
-    // reject any candidate that does. Proxies and other hostile objects remain
-    // fail-closed through the surrounding catch.
-    for (let prototype = getPrototypeOf(value); prototype !== null; prototype = getPrototypeOf(prototype)) {
+    // reject any candidate that does. Proxies can return themselves or an
+    // unbounded stream of fresh objects from getPrototypeOf; bound both cases
+    // so classification remains synchronous and fail-closed.
+    const seen = new WeakSet([value]);
+    let prototype = getPrototypeOf(value);
+    for (let depth = 0; prototype !== null && depth < BROWSER_ERROR_PROTO_MAX; depth += 1) {
+      if (seen.has(prototype)) return false;
+      seen.add(prototype);
       if (hasOwn.call(prototype, toStringTag)) return false;
+      prototype = getPrototypeOf(prototype);
     }
-    return true;
+    return prototype === null;
   } catch {
     return false;
   }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -46,13 +46,32 @@ const QUEUE_PROMPT_ERROR_DETAIL_MAX =
   QUEUE_PROMPT_ERROR_MESSAGE_MAX - QUEUE_PROMPT_ERROR_PREFIX.length;
 const QUEUE_PROMPT_ERROR_TRUNCATION = "\n… [browser stack truncated]";
 const objectToString = Object.prototype.toString;
+const hasOwn = Object.prototype.hasOwnProperty;
+const getPrototypeOf = Object.getPrototypeOf;
+const toStringTag = Symbol.toStringTag;
 
 // `instanceof Error` rejects an Error created by the browser realm when this
 // module runs in another realm. The object tag keeps that existing browser
-// behaviour without walking a hostile Proxy prototype chain.
+// behaviour; the prototype walk rejects inherited toStringTag spoofs while
+// remaining behind the object-tag check for ordinary hostile values.
 function isBrowserError(value) {
   try {
-    return objectToString.call(value) === "[object Error]";
+    // Object.prototype.toString gives objects control over this result through
+    // Symbol.toStringTag. A thrown structured value can therefore impersonate
+    // an Error unless its own tag is excluded before relying on the cross-realm
+    // brand check. Ordinary same- and cross-realm Errors do not define an own
+    // toStringTag and continue through to the existing decoration path.
+    if (hasOwn.call(value, toStringTag)) return false;
+    if (objectToString.call(value) !== "[object Error]") return false;
+
+    // A spoof can put the tag on a custom prototype instead of the thrown
+    // object itself. Genuine Error prototype chains do not define it, so
+    // reject any candidate that does. Proxies and other hostile objects remain
+    // fail-closed through the surrounding catch.
+    for (let prototype = getPrototypeOf(value); prototype !== null; prototype = getPrototypeOf(prototype)) {
+      if (hasOwn.call(prototype, toStringTag)) return false;
+    }
+    return true;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- Preserve useful browser source context when panel_run app.queuePrompt rejects or throws.
- Apply the diagnostic boundary to both scoped and full graph_run paths; the bridge serializes error.message, so a safely read browser stack is embedded there.
- Avoid instanceof and String(error): non-Error values, hostile proxies, and non-string or unreadable stacks retain their original thrown identity.
- Bound the complete diagnostic message at 4,096 characters, preserve stack line breaks, remove control bytes, and reuse the existing credential redactor.
- Update the existing bounded-dispatch source guard for the helper call.

## Evidence

- Issue #248 current recurrence is the panel scoped to_node_id path. The older MCP detectRunRejection fix can classify and forward a panel rejection but cannot reconstruct a stack discarded by Panel.
- Regression coverage exercises the extracted production graph_run path for both scoped and full runs and asserts the extension URL and source lines survive before any POST.
- Regression coverage covers huge stacks, credential-shaped text, Symbol and throwing-coercion stacks, a throwing Proxy getPrototypeOf trap, and a cross-realm native Error.
- No init.py or apps_routes.py changes.

## Checks

- npm.cmd run check:scope
- npm.cmd run check:changelog
- npm.cmd run typecheck
- npm.cmd run test:unit: 7405 tests, 7404 passed, 0 failed, 1 todo
- Full run-scope-guard suite: 142 passed
- Full run-command-budget suite: 41 passed
- Focused #248 tests passed

Do not merge automatically.