### PR TITLE
fix(1215): keep additive source edits out of target state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ All notable changes to this project are documented here. This project adheres to
 - raise default render stall threshold for long nodes
 - report host_links_reindexed on unexpose so MCP can skip the stale warning (#1993)
 
-
 ## [0.15.123] - 2026-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented here. This project adheres to
 - raise default render stall threshold for long nodes
 - report host_links_reindexed on unexpose so MCP can skip the stale warning (#1993)
 
+
 ## [0.15.123] - 2026-08-28
 
 ### Fixed

--- a/browser_tests/unit/flush-source-before-switch.test.mjs
+++ b/browser_tests/unit/flush-source-before-switch.test.mjs
@@ -309,10 +309,11 @@ test("#1295: the #1215 TARGET capture gate still skips an untagged switch — th
   assert.ok(flushAt < gateAt, "source flush is BEFORE the switch; target capture is AFTER");
   const gate = SRC.slice(gateAt, SRC.indexOf("await target.changeTracker?.checkState?.()", gateAt));
   assert.match(gate, /!pointerMovedThisOpen/);
-  assert.match(gate, /captureBinding !== "foreign"/);
+  assert.match(gate, /sourceBinding === "bound"/);
+  assert.match(gate, /graphRootMatchesState\(/);
   assert.doesNotMatch(
     gate,
-    /if \(captureBinding !== "foreign"\)/,
-    '"not foreign" alone was the #1215 hole — the source flush must not bring it back',
+    /captureBinding === "bound"\s*\|\|/,
+    'a TARGET tag alone must not reopen the #1215 capture hole',
   );
 });

--- a/browser_tests/unit/live-canvas-capture-gate.test.mjs
+++ b/browser_tests/unit/live-canvas-capture-gate.test.mjs
@@ -255,7 +255,7 @@ test("#1911: a missing watcher is named on the success reply, not swallowed", ()
   assert.match(SRC, /if \(!activePointerWatchAvailable\) pointerWatchUnavailable = true/);
 });
 
-test("#1911: TARGET capture still requires the #1215 already-current / not-foreign proof", () => {
+test("#1911: TARGET capture still requires independent #1215 proof after a switch", () => {
   const gateAt = SRC.indexOf("const captureBinding = describeLiveCanvasBinding(target);");
   assert.notEqual(gateAt, -1);
   const captureAt = SRC.indexOf("await target.changeTracker?.checkState?.()", gateAt);
@@ -263,11 +263,12 @@ test("#1911: TARGET capture still requires the #1215 already-current / not-forei
   const gate = SRC.slice(gateAt, captureAt);
   assert.match(gate, /pointerMovedThisOpen = !sameWorkflowObject\(activeBefore, target\)/);
   assert.match(gate, /!pointerMovedThisOpen/);
-  assert.match(gate, /captureBinding !== "foreign"/);
+  assert.match(gate, /sourceBinding === "bound"/);
+  assert.match(gate, /graphRootMatchesState\(/);
   assert.match(gate, /decideLiveCanvasCapture/);
   assert.doesNotMatch(
     gate,
-    /if \(captureBinding !== "foreign"\)/,
-    '"not foreign" alone was the #1215 hole — the missing-watch path must not bring it back',
+    /captureBinding === "bound"\s*\|\|/,
+    "a TARGET tag alone must not be treated as independent proof",
   );
 });

--- a/browser_tests/unit/live-canvas-capture-gate.test.mjs
+++ b/browser_tests/unit/live-canvas-capture-gate.test.mjs
@@ -74,6 +74,19 @@ test("#1911: watch available + unproven pointer skips capture without pretending
   assert.equal(decision.reason, "unproven-pointer");
 });
 
+test("#1215: a positively proven SOURCE canvas blocks capture before TARGET proof", () => {
+  const decision = decideLiveCanvasCapture({
+    watchAvailable: true,
+    captureSourceProof: false,
+    pointerProof: false,
+    pointerMovedThisOpen: true,
+    sourceCanvasStillMounted: true,
+  });
+  assert.equal(decision.capture, false);
+  assert.equal(decision.disclose, false);
+  assert.equal(decision.reason, "source-canvas-still-mounted");
+});
+
 test("#1911: $subscribe absent + tab switch does NOT capture TARGET (that is the #1215 poison) and DISCLOSES", () => {
   const decision = decideLiveCanvasCapture({
     watchAvailable: false,
@@ -208,6 +221,7 @@ test("#1911: workflow_open imports and calls the shipped capture-gate helper", (
   assert.match(SRC, /decideLiveCanvasCapture\(\{/);
   assert.match(SRC, /watchAvailable:\s*activePointerWatchAvailable/);
   assert.match(SRC, /pointerMovedThisOpen/);
+  assert.match(SRC, /sourceCanvasStillMounted/);
 });
 
 test("#1911: SOURCE flush is NOT gated on the Pinia watch — that is the #1215/#1295 invariant", () => {

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -20,6 +20,7 @@ import {
   installActivePointerWatch,
   POINTER_WATCH_UNAVAILABLE_NOTICE,
 } from "../../web/js/lib/live-canvas-capture-gate.js";
+import { graphRootStructureExtendsActiveWorkflow } from "../../web/js/lib/graph-binding.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
@@ -857,7 +858,7 @@ test("#1639 production workflow_open preserves proven-bound capture after a legi
   assert.equal(panel.guard(), null, "the production open releases its reload guard");
 });
 
-test("#1215 production workflow_open does not capture a still-mounted previous canvas even when the Pinia watch proves the tab move", async () => {
+test("#1215 production workflow_open does not capture a still-mounted previous canvas with an uncaptured SOURCE node addition", async () => {
   const uuid = "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
   const previousState = {
     nodes: [{ id: 1, type: "KSampler", widgets_values: ["previous-value"] }],
@@ -885,9 +886,21 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
     },
   };
   const root = {
-    _nodes: [{ id: 1, type: "KSampler", widgets_values: ["previous-value"] }],
+    // The outgoing tab has a live, manually-added node that its tracker has not
+    // captured yet. The exact #1951 source proof must therefore be false even
+    // though this is still visibly the outgoing canvas.
+    _nodes: [
+      { id: 1, type: "KSampler", widgets_values: ["previous-value"] },
+      { id: 566, type: "PreviewImage", widgets_values: [] },
+    ],
     extra: { comfyui_mcp: { workflow_uuid: uuid } },
   };
+  root.serialize = () => ({
+    nodes: root._nodes.map((node) => ({ ...node })),
+    links: [],
+    groups: [],
+    extra: root.extra,
+  });
   const previous = {
     path: "workflows/previous.json",
     changeTracker: { activeState: structuredClone(previousState) },
@@ -969,10 +982,13 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
     graphRootCarriesOpenProof: () => true,
     graphRootWorkflowUuidMatches: () => true,
     graphRootReproducesStateContent: ({ rootGraph, state }) => ({
-      proven: rootGraph?._nodes?.[0]?.widgets_values?.[0] === state?.nodes?.[0]?.widgets_values?.[0],
+      proven:
+        rootGraph?._nodes?.length === state?.nodes?.length &&
+        rootGraph?._nodes?.[0]?.widgets_values?.[0] === state?.nodes?.[0]?.widgets_values?.[0],
       presentationOnly: false,
       normalizedOnly: false,
     }),
+    graphRootStructureExtendsActiveWorkflow,
     describeGraphStateDifference: () => ({ comparable: true, surfaces: ["nodes"], accountedSurfaces: [], nodeDifference: null }),
     openContentDifferenceIsDefinitionsOnly: () => false,
     resolveOpenRebindVerdict: ({ contentMatches }) =>
@@ -994,9 +1010,10 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
   const result = await panel.method({ path: "target.json", rid: "still-mounted-source" });
 
   assert.equal(result.opened.path, target.path);
-  assert.equal(captured, 0, "a proven pointer move is not proof the still-mounted canvas belongs to TARGET");
+  assert.equal(captured, 0, "a source edit that the tracker missed is not proof the visible root belongs to TARGET");
   assert.equal(loadedValue, "target-value", "the repaint must use TARGET's tracker, not the previous canvas");
   assert.equal(root._nodes[0].widgets_values[0], "target-value");
+  assert.equal(root._nodes.some((node) => node.id === 566), false, "the previous tab's added node must not reach TARGET");
   assert.equal(panel.guard(), null, "the production open releases its reload guard");
 });
 

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -21,6 +21,7 @@ import {
   POINTER_WATCH_UNAVAILABLE_NOTICE,
 } from "../../web/js/lib/live-canvas-capture-gate.js";
 import {
+  graphRootMatchesState,
   graphRootStructureExtendsActiveWorkflow,
   graphRootWorkflowUuidMatches,
   graphRootWorkflowUuidMismatches,
@@ -147,6 +148,9 @@ function productionExecutor(methodName, environment) {
     POINTER_WATCH_UNAVAILABLE_NOTICE,
     workflowOpenReadinessRefusalError,
     readWorkflowOpenReadinessRefusal,
+    graphRootMatchesState,
+    graphRootWorkflowUuidMatches,
+    graphRootWorkflowUuidMismatches,
     describeLiveCanvasBinding: productionDescribeLiveCanvasBinding(environment),
     ...environment,
   };
@@ -1226,6 +1230,95 @@ test("#1215 production workflow_open does not treat a TARGET graph containing SO
   assert.equal(loadedValue, "target-value");
   assert.equal(root._nodes[0].widgets_values[0], "frontend-normalized");
   assert.equal(root._nodes.some((node) => node.id === 566), true, "the valid TARGET addition must survive the open");
+  assert.equal(panel.guard(), null, "the production open releases its reload guard");
+});
+
+test("#1215 production workflow_open does not capture a SOURCE root carrying the TARGET UUID", async () => {
+  const sourceUuid = "source-3b5f6d7e-6a89-4b9f-a58c-ff48a2eb7e95";
+  const targetUuid = "target-3b5f6d7e-6a89-4b9f-a58c-ff48a2eb7e95";
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  const sourceState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: ["source-value"] }],
+    links: [],
+    groups: [],
+    last_node_id: 1,
+    extra: { comfyui_mcp: { workflow_uuid: sourceUuid } },
+  };
+  const targetState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: ["target-value"] }],
+    links: [],
+    groups: [],
+    last_node_id: 1,
+    extra: { comfyui_mcp: { workflow_uuid: targetUuid } },
+  };
+  const source = {
+    path: "workflows/source.json",
+    changeTracker: { activeState: structuredClone(sourceState) },
+  };
+  let active = source;
+  let captures = 0;
+  let captureDecisionInput;
+  const subscribers = [];
+  target.activeState = structuredClone(targetState);
+  target.changeTracker = {
+    activeState: structuredClone(targetState),
+    checkState() {
+      captures += 1;
+    },
+  };
+  const root = environment.app.graph;
+  root._nodes = [
+    { id: 1, type: "KSampler", widgets_values: ["source-value"] },
+    { id: 566, type: "PreviewImage", widgets_values: [] },
+  ];
+  root.extra = { comfyui_mcp: { workflow_uuid: targetUuid } };
+  root.serialize = () => ({
+    nodes: root._nodes.map((node) => ({ ...node })),
+    links: [],
+    groups: [],
+    last_node_id: 566,
+    extra: root.extra,
+  });
+  environment.document = workflowPiniaDocument({
+    $subscribe: (subscriber) => {
+      subscribers.push(subscriber);
+      return () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  });
+  environment.activeWorkflowRef = () => active;
+  environment.workflowObjectUuid = (workflow) => (workflow === source ? sourceUuid : targetUuid);
+  environment.workflowStableUuid = (workflow) => (workflow === source ? sourceUuid : targetUuid);
+  delete environment.describeLiveCanvasBinding;
+  delete environment.graphRootWorkflowUuidMatches;
+  environment.app.extensionManager.workflow.openWorkflow = async () => {
+    active = target;
+  };
+  environment.getGraphCtx = () => ({ graph: root, rootGraph: root });
+  environment.decideLiveCanvasCapture = (input) => {
+    captureDecisionInput = input;
+    return decideLiveCanvasCapture(input);
+  };
+  environment.graphRootReproducesStateContent = ({ rootGraph, state }) => ({
+    // The mounted SOURCE has a user edit beyond the source tracker, so the exact
+    // source-content proof is intentionally unavailable; identity must still fail closed.
+    proven: rootGraph?._nodes?.length === state?.nodes?.length &&
+      rootGraph?._nodes?.[0]?.widgets_values?.[0] === state?.nodes?.[0]?.widgets_values?.[0],
+    presentationOnly: false,
+    normalizedOnly: false,
+  });
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "target-tagged-source-root" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(captureDecisionInput.captureSourceProof, false, "a TARGET tag on SOURCE is not independent capture proof");
+  assert.equal(captureDecisionInput.sourceCanvasStillMounted, false, "the stale root must reach the fail-closed gate");
+  assert.equal(captures, 0, "the stale SOURCE root must never be serialized into TARGET");
+  assert.equal(environment.app.graph._nodes[0].widgets_values[0], "target-value");
+  assert.equal(environment.app.graph._nodes.some((node) => node.id === 566), false);
   assert.equal(panel.guard(), null, "the production open releases its reload guard");
 });
 

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -20,7 +20,11 @@ import {
   installActivePointerWatch,
   POINTER_WATCH_UNAVAILABLE_NOTICE,
 } from "../../web/js/lib/live-canvas-capture-gate.js";
-import { graphRootStructureExtendsActiveWorkflow } from "../../web/js/lib/graph-binding.js";
+import {
+  graphRootStructureExtendsActiveWorkflow,
+  graphRootWorkflowUuidMatches,
+  graphRootWorkflowUuidMismatches,
+} from "../../web/js/lib/graph-binding.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
@@ -91,6 +95,31 @@ function balancedFrom(src, marker, openAt = null) {
 }
 
 const PINIA_STORE_HELPER_SOURCE = balancedFrom(SRC, "function getPiniaStore(id)");
+const LIVE_CANVAS_BINDING_SOURCE = balancedFrom(SRC, "function describeLiveCanvasBinding(wf)");
+
+function productionDescribeLiveCanvasBinding(environment) {
+  const factory = new Function(
+    "app",
+    "workflowObjectUuid",
+    "workflowStableUuid",
+    "graphRootWorkflowUuidMatches",
+    "graphRootWorkflowUuidMismatches",
+    "workflowOwnsRootUuidTag",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${LIVE_CANVAS_BINDING_SOURCE}\nreturn describeLiveCanvasBinding;`,
+  );
+  return factory(
+    environment.app,
+    environment.workflowObjectUuid,
+    environment.workflowStableUuid,
+    environment.graphRootWorkflowUuidMatches ?? graphRootWorkflowUuidMatches,
+    environment.graphRootWorkflowUuidMismatches ?? graphRootWorkflowUuidMismatches,
+    environment.workflowOwnsRootUuidTag,
+    environment.WORKFLOW_META_NAMESPACE,
+    environment.WORKFLOW_UUID_FIELD,
+  );
+}
 
 // Execute a shipped executor body with the shipped reload guard and proof helper.
 // The frontend-facing services are supplied by each lifecycle test, but the operation
@@ -118,6 +147,7 @@ function productionExecutor(methodName, environment) {
     POINTER_WATCH_UNAVAILABLE_NOTICE,
     workflowOpenReadinessRefusalError,
     readWorkflowOpenReadinessRefusal,
+    describeLiveCanvasBinding: productionDescribeLiveCanvasBinding(environment),
     ...environment,
   };
   const scope = new Proxy(sandbox, {
@@ -875,6 +905,7 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
   };
   let active;
   let captured = 0;
+  let captureDecisionInput;
   let loadedValue;
   const subscribers = [];
   const workflowStore = {
@@ -975,7 +1006,10 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
     retryNodeRestores: async () => ({ restored: [], failed: [], recovered: [] }),
     liteGraphGlobal: () => null,
     getGraphCtx: () => ({ graph: root, rootGraph: root }),
-    describeLiveCanvasBinding: () => "bound",
+    decideLiveCanvasCapture: (input) => {
+      captureDecisionInput = input;
+      return decideLiveCanvasCapture(input);
+    },
     applySavedNodePresentation: () => {},
     applySavedSubgraphHostWidgets: () => {},
     decideOpenStaleness: () => ({ stale: false, reload: false }),
@@ -1012,6 +1046,9 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
   const result = await panel.method({ path: "target.json", rid: "still-mounted-source" });
 
   assert.equal(result.opened.path, target.path);
+  assert.equal(captureDecisionInput.captureSourceProof, false, "the production TARGET classifier must see SOURCE's root as foreign");
+  assert.equal(captureDecisionInput.sourceCanvasStillMounted, true, "the production SOURCE classifier must reach the capture decision");
+  assert.equal(captureDecisionInput.sourceCanvasStillMounted && captureDecisionInput.pointerMovedThisOpen, true);
   assert.equal(captured, 0, "a source edit that the tracker missed is not proof the visible root belongs to TARGET");
   assert.equal(loadedValue, "target-value", "the repaint must use TARGET's tracker, not the previous canvas");
   assert.equal(root._nodes[0].widgets_values[0], "target-value");
@@ -1039,6 +1076,7 @@ test("#1215 production workflow_open does not treat a TARGET graph containing SO
   };
   let active;
   let captures = 0;
+  let captureDecisionInput;
   let loadedValue;
   const subscribers = [];
   const workflowStore = {
@@ -1138,7 +1176,10 @@ test("#1215 production workflow_open does not treat a TARGET graph containing SO
     retryNodeRestores: async () => ({ restored: [], failed: [], recovered: [] }),
     liteGraphGlobal: () => null,
     getGraphCtx: () => ({ graph: root, rootGraph: root }),
-    describeLiveCanvasBinding: () => "bound",
+    decideLiveCanvasCapture: (input) => {
+      captureDecisionInput = input;
+      return decideLiveCanvasCapture(input);
+    },
     applySavedNodePresentation: () => {},
     applySavedSubgraphHostWidgets: () => {},
     decideOpenStaleness: () => ({ stale: false, reload: false }),
@@ -1179,6 +1220,8 @@ test("#1215 production workflow_open does not treat a TARGET graph containing SO
   const result = await panel.method({ path: target.path, rid: "target-plus-source-addition" });
 
   assert.equal(result.opened.path, target.path);
+  assert.equal(captureDecisionInput.captureSourceProof, true, "the production TARGET classifier must see TARGET's root as bound");
+  assert.equal(captureDecisionInput.sourceCanvasStillMounted, false, "the SOURCE proof must not reject a valid TARGET graph");
   assert.equal(captures, 1, "a target-tagged graph must not bypass TARGET checkState on SOURCE containment alone");
   assert.equal(loadedValue, "target-value");
   assert.equal(root._nodes[0].widgets_values[0], "frontend-normalized");

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -859,18 +859,19 @@ test("#1639 production workflow_open preserves proven-bound capture after a legi
 });
 
 test("#1215 production workflow_open does not capture a still-mounted previous canvas with an uncaptured SOURCE node addition", async () => {
-  const uuid = "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
+  const sourceUuid = "source-c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
+  const targetUuid = "target-c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
   const previousState = {
     nodes: [{ id: 1, type: "KSampler", widgets_values: ["previous-value"] }],
     links: [],
     groups: [],
-    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+    extra: { comfyui_mcp: { workflow_uuid: sourceUuid } },
   };
   const targetState = {
     nodes: [{ id: 1, type: "KSampler", widgets_values: ["target-value"] }],
     links: [],
     groups: [],
-    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+    extra: { comfyui_mcp: { workflow_uuid: targetUuid } },
   };
   let active;
   let captured = 0;
@@ -893,7 +894,7 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
       { id: 1, type: "KSampler", widgets_values: ["previous-value"] },
       { id: 566, type: "PreviewImage", widgets_values: [] },
     ],
-    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+    extra: { comfyui_mcp: { workflow_uuid: sourceUuid } },
   };
   root.serialize = () => ({
     nodes: root._nodes.map((node) => ({ ...node })),
@@ -952,8 +953,8 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
     WORKFLOW_UUID_FIELD: "workflow_uuid",
     WORKFLOW_PATH_FIELD: "workflow_path",
     OPEN_PROOF_FIELD: "open_proof",
-    workflowObjectUuid: () => uuid,
-    workflowStableUuid: () => uuid,
+    workflowObjectUuid: (workflow) => (workflow === previous ? sourceUuid : targetUuid),
+    workflowStableUuid: (workflow) => (workflow === previous ? sourceUuid : targetUuid),
     workflowOwnsRootUuidTag: () => false,
     workflowUuidOwner: () => null,
     getWorkflowTitle: () => "Target",
@@ -980,7 +981,8 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
     decideOpenStaleness: () => ({ stale: false, reload: false }),
     describeRepaintSourceBinding: () => "unknown",
     graphRootCarriesOpenProof: () => true,
-    graphRootWorkflowUuidMatches: () => true,
+    graphRootWorkflowUuidMatches: ({ rootGraph, activeWorkflowUuid }) =>
+      rootGraph?.extra?.comfyui_mcp?.workflow_uuid === activeWorkflowUuid,
     graphRootReproducesStateContent: ({ rootGraph, state }) => ({
       proven:
         rootGraph?._nodes?.length === state?.nodes?.length &&
@@ -1000,7 +1002,7 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
     settleOwnedOpenedWorkflowActive,
     noteOpenAttempt: () => ({ seq: 1 }),
     backendSocketReplyFields: () => ({}),
-    activeWorkflowUuidForOpenReply: () => uuid,
+    activeWorkflowUuidForOpenReply: () => targetUuid,
     describeOpenActiveBinding: () => ({ active_matches_target: true }),
     canvasFileDivergenceNote: () => null,
     failOpenRebindUnknown: (error) => error,
@@ -1014,6 +1016,173 @@ test("#1215 production workflow_open does not capture a still-mounted previous c
   assert.equal(loadedValue, "target-value", "the repaint must use TARGET's tracker, not the previous canvas");
   assert.equal(root._nodes[0].widgets_values[0], "target-value");
   assert.equal(root._nodes.some((node) => node.id === 566), false, "the previous tab's added node must not reach TARGET");
+  assert.equal(panel.guard(), null, "the production open releases its reload guard");
+});
+
+test("#1215 production workflow_open does not treat a TARGET graph containing SOURCE plus an added node as SOURCE", async () => {
+  const sourceUuid = "source-9a9b1c2d-6a89-4b9f-a58c-ff48a2eb7e95";
+  const targetUuid = "target-9a9b1c2d-6a89-4b9f-a58c-ff48a2eb7e95";
+  const sourceState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: ["previous-value"] }],
+    links: [],
+    groups: [],
+    extra: { comfyui_mcp: { workflow_uuid: sourceUuid } },
+  };
+  const targetState = {
+    nodes: [
+      { id: 1, type: "KSampler", widgets_values: ["target-value"] },
+      { id: 566, type: "PreviewImage", widgets_values: [] },
+    ],
+    links: [],
+    groups: [],
+    extra: { comfyui_mcp: { workflow_uuid: targetUuid } },
+  };
+  let active;
+  let captures = 0;
+  let loadedValue;
+  const subscribers = [];
+  const workflowStore = {
+    $subscribe: (subscriber) => {
+      subscribers.push(subscriber);
+      return () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  };
+  const root = {
+    // This is a valid TARGET graph: it contains all SOURCE nodes and one additional
+    // node, but its target identity must prevent the SOURCE-containment heuristic.
+    _nodes: targetState.nodes.map((node) => ({ ...node })),
+    extra: targetState.extra,
+  };
+  root.serialize = () => ({
+    nodes: root._nodes.map((node) => ({ ...node })),
+    links: [],
+    groups: [],
+    extra: root.extra,
+  });
+  const previous = {
+    path: "workflows/previous.json",
+    changeTracker: { activeState: structuredClone(sourceState) },
+  };
+  const target = {
+    path: "workflows/target-with-addition.json",
+    filename: "target-with-addition.json",
+    isModified: false,
+    changeTracker: {
+      activeState: structuredClone(targetState),
+      checkState() {
+        captures += 1;
+        this.activeState = structuredClone(targetState);
+      },
+    },
+  };
+  active = previous;
+  const app = {
+    rootGraph: root,
+    graph: root,
+    canvas: { graph: root },
+    loadGraphData: async (state) => {
+      loadedValue = state?.nodes?.[0]?.widgets_values?.[0];
+      root.extra = state.extra;
+      root._nodes = state.nodes.map((node) => ({ ...node }));
+      // A completed TARGET restore can normalize a widget while retaining its
+      // valid node set. This must not be called leftover SOURCE state.
+      root._nodes[0].widgets_values[0] = "frontend-normalized";
+    },
+    extensionManager: {
+      workflow: {
+        openWorkflows: [target],
+        workflows: [],
+        getWorkflowByPath: () => target,
+        openWorkflow: async () => {
+          active = target;
+        },
+      },
+    },
+  };
+  const status = { PROVEN: "proven", CONTENT_UNVERIFIED: "content-unverified", UNPROVEN: "unproven" };
+  const panel = productionExecutor("workflow_open", {
+    backendReconnectEpoch: 4,
+    activeWorkflowResyncEpoch: 4,
+    postReconnectBindingProofEpoch: 4,
+    app,
+    document: workflowPiniaDocument(workflowStore),
+    activeWorkflowRef: () => active,
+    sameWorkflowObject: (a, b) => a === b,
+    workflowTabId: (workflow) => `wf:${workflow.path}`,
+    WORKFLOW_META_NAMESPACE: "comfyui_mcp",
+    WORKFLOW_UUID_FIELD: "workflow_uuid",
+    WORKFLOW_PATH_FIELD: "workflow_path",
+    OPEN_PROOF_FIELD: "open_proof",
+    workflowObjectUuid: (workflow) => (workflow === previous ? sourceUuid : targetUuid),
+    workflowStableUuid: (workflow) => (workflow === previous ? sourceUuid : targetUuid),
+    workflowOwnsRootUuidTag: () => false,
+    workflowUuidOwner: () => null,
+    getWorkflowTitle: () => "Target with addition",
+    waitForReconnectHandshakeBeforeOpen: async () => {},
+    comfyBackendIsDown: () => false,
+    postReconnectBindingSettleWindow: () => false,
+    nodeDefRefreshInFlight: null,
+    flushSourceCanvasBeforeSwitch: async () => {},
+    claimActiveWorkflowMove: () => {},
+    acquireCanvasInteractionLock: () => null,
+    releaseCanvasInteractionLock: () => {},
+    MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+    settleOpenedWorkflowTarget: async () => ({ target, loaded: false }),
+    workflowRecordMatchesSelector: () => true,
+    installNodeConfigureIsolation: () => ({ failures: [], restore: () => {} }),
+    installGraphConfigureWatch: () => ({ restore: () => {} }),
+    loadRestoreCompleted: () => true,
+    retryNodeRestores: async () => ({ restored: [], failed: [], recovered: [] }),
+    liteGraphGlobal: () => null,
+    getGraphCtx: () => ({ graph: root, rootGraph: root }),
+    describeLiveCanvasBinding: () => "bound",
+    applySavedNodePresentation: () => {},
+    applySavedSubgraphHostWidgets: () => {},
+    decideOpenStaleness: () => ({ stale: false, reload: false }),
+    describeRepaintSourceBinding: () => "unknown",
+    graphRootCarriesOpenProof: () => true,
+    graphRootWorkflowUuidMatches: ({ rootGraph, activeWorkflowUuid }) =>
+      rootGraph?.extra?.comfyui_mcp?.workflow_uuid === activeWorkflowUuid,
+    graphRootReproducesStateContent: ({ rootGraph, state }) => {
+      const sameShape = rootGraph?._nodes?.length === state?.nodes?.length;
+      const sameWidget = rootGraph?._nodes?.[0]?.widgets_values?.[0] === state?.nodes?.[0]?.widgets_values?.[0];
+      const exact = sameShape && sameWidget;
+      return {
+        proven: exact,
+        presentationOnly: false,
+        normalizedOnly: sameShape && !sameWidget,
+        normalizedFields: sameShape && !sameWidget ? ["widgets_values"] : [],
+      };
+    },
+    graphRootStructureExtendsActiveWorkflow,
+    describeGraphStateDifference: () => ({ comparable: true, surfaces: ["nodes"], accountedSurfaces: [], nodeDifference: null }),
+    openContentDifferenceIsDefinitionsOnly: () => false,
+    resolveOpenRebindVerdict: ({ contentMatches }) =>
+      contentMatches ? { status: status.PROVEN } : { status: status.CONTENT_UNVERIFIED },
+    describeOpenRebindOutcome: () => "content could not be verified",
+    OPEN_REBIND_STATUS: status,
+    GRAPH_TOOL_EXECUTORS: { graph_outline: () => ({ node_count: 2, outline: "1 KSampler, 566 PreviewImage", detail_level: "full" }) },
+    settleOpenedWorkflowReadable,
+    settleOwnedOpenedWorkflowActive,
+    noteOpenAttempt: () => ({ seq: 1 }),
+    backendSocketReplyFields: () => ({}),
+    activeWorkflowUuidForOpenReply: () => targetUuid,
+    describeOpenActiveBinding: () => ({ active_matches_target: true }),
+    canvasFileDivergenceNote: () => null,
+    failOpenRebindUnknown: (error) => error,
+    coerceMessageText: (value) => String(value),
+  });
+
+  const result = await panel.method({ path: target.path, rid: "target-plus-source-addition" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(captures, 1, "a target-tagged graph must not bypass TARGET checkState on SOURCE containment alone");
+  assert.equal(loadedValue, "target-value");
+  assert.equal(root._nodes[0].widgets_values[0], "frontend-normalized");
+  assert.equal(root._nodes.some((node) => node.id === 566), true, "the valid TARGET addition must survive the open");
   assert.equal(panel.guard(), null, "the production open releases its reload guard");
 });
 

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -1154,6 +1154,11 @@ test("#1215: an untagged root admits the capture only in the already-current cas
     /!liveCanvasStillSource\(app\?\.graph\)/,
     "a still-mounted SOURCE canvas must not be captured into TARGET even when bound",
   );
+  assert.match(
+    gate,
+    /graphRootStructureExtendsActiveWorkflow\(\{[\s\S]*activeWorkflow: activeBefore/,
+    "an uncaptured additive SOURCE edit must still identify the mounted graph as SOURCE",
+  );
 });
 
 test("#1215: an untagged repaint source on a tab switch is DISCLOSED, not silently served", () => {

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -1132,7 +1132,7 @@ test("#1215: the pre-switch active workflow is snapshotted BEFORE the pointer mo
   assert.ok(snapAt < switchAt, "…before openWorkflow, which is what changes the answer");
 });
 
-test("#1215: an untagged root admits the capture only in the already-current case", () => {
+test("#1215: a switched capture needs independent source or exact target proof", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const gateAt = src.indexOf("const captureBinding = describeLiveCanvasBinding(target);");
   assert.notEqual(gateAt, -1, "the capture must stay gated on the live-canvas binding");
@@ -1140,15 +1140,14 @@ test("#1215: an untagged root admits the capture only in the already-current cas
   assert.notEqual(captureAt, -1);
   const gate = src.slice(gateAt, captureAt);
   assert.match(gate, /pointerMovedThisOpen = !sameWorkflowObject\(activeBefore, target\)/);
-  // A capture is allowed only when the active pointer did not move. A stale root
-  // carrying the target UUID is not independent canvas proof after a tab switch.
-  assert.match(gate, /!pointerMovedThisOpen/);
-  assert.match(gate, /captureBinding !== "foreign"/);
-  assert.doesNotMatch(
-    gate,
-    /if \(captureBinding !== "foreign"\)/,
-    '"not foreign" alone was the #1215 hole — it must not come back',
-  );
+  // A TARGET UUID alone is not independent canvas proof after a tab switch: the
+  // outgoing SOURCE can carry that stale tag. The positive switched arms must be
+  // explicit and fail closed when neither proof is available.
+  assert.match(gate, /const sourceBinding = pointerMovedThisOpen\s*\?\s*describeLiveCanvasBinding\(activeBefore\)/);
+  assert.match(gate, /captureBinding === "bound"/);
+  assert.match(gate, /sourceBinding === "bound"/);
+  assert.match(gate, /graphRootMatchesState\(/);
+  assert.match(gate, /targetContentProof/);
   assert.match(
     gate,
     /const sourceCanvasStillMounted = liveCanvasStillSource\(app\?\.graph\)/,

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -1159,6 +1159,11 @@ test("#1215: an untagged root admits the capture only in the already-current cas
     /graphRootStructureExtendsActiveWorkflow\(\{[\s\S]*activeWorkflow: activeBefore/,
     "an uncaptured additive SOURCE edit must still identify the mounted graph as SOURCE",
   );
+  assert.match(
+    gate,
+    /graphRootWorkflowUuidMatches\(\{[\s\S]*activeWorkflowUuid: sourceWorkflowUuid/,
+    "structural SOURCE containment must be paired with an exact root-blind SOURCE identity",
+  );
 });
 
 test("#1215: an untagged repaint source on a tab switch is DISCLOSED, not silently served", () => {

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -1151,8 +1151,8 @@ test("#1215: an untagged root admits the capture only in the already-current cas
   );
   assert.match(
     gate,
-    /!liveCanvasStillSource\(app\?\.graph\)/,
-    "a still-mounted SOURCE canvas must not be captured into TARGET even when bound",
+    /const sourceCanvasStillMounted = liveCanvasStillSource\(app\?\.graph\)/,
+    "a still-mounted SOURCE canvas must be evaluated before the capture decision",
   );
   assert.match(
     gate,
@@ -1161,8 +1161,13 @@ test("#1215: an untagged root admits the capture only in the already-current cas
   );
   assert.match(
     gate,
-    /graphRootWorkflowUuidMatches\(\{[\s\S]*activeWorkflowUuid: sourceWorkflowUuid/,
-    "structural SOURCE containment must be paired with an exact root-blind SOURCE identity",
+    /describeLiveCanvasBinding\(activeBefore\) !== "bound"/,
+    "structural SOURCE containment must use the production classifier for SOURCE identity",
+  );
+  assert.match(
+    gate,
+    /sourceCanvasStillMounted,/,
+    "the SOURCE proof must reach the capture decision instead of being short-circuited",
   );
 });
 

--- a/browser_tests/unit/settle-open-target.test.mjs
+++ b/browser_tests/unit/settle-open-target.test.mjs
@@ -548,7 +548,8 @@ test("#1575: a state just read off DISK is not overwritten by the still-mounted 
   );
   // #1295's own pins must survive this change.
   assert.match(gate, /!pointerMovedThisOpen/);
-  assert.match(gate, /captureBinding !== "foreign"/);
+  assert.match(gate, /sourceBinding === "bound"/);
+  assert.match(gate, /graphRootMatchesState\(/);
 });
 
 test("#1575: a repaired open DISCLOSES that the canvas is the on-disk copy", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21952,8 +21952,30 @@ const GRAPH_TOOL_EXECUTORS = {
             activePointerEpochAtOpen !== null &&
             activePointerEpoch === activePointerEpochAtOpen &&
             activeIdentityAtCapture;
+          // A TARGET UUID on the root is not independent proof after a pointer move:
+          // the outgoing SOURCE can retain a stale/shared stamp while the source
+          // classifier correctly answers "foreign". In that shape, capturing would
+          // serialize SOURCE into TARGET. Keep the proven-bound recurrence, and admit
+          // the already-repainted TARGET only when its complete state matches the
+          // target tracker; an unproven or drifted root fails closed.
+          const sourceBinding = pointerMovedThisOpen
+            ? describeLiveCanvasBinding(activeBefore)
+            : "bound";
+          let targetContentProof = false;
+          if (pointerMovedThisOpen && sourceBinding === "foreign") {
+            try {
+              targetContentProof =
+                graphRootMatchesState({
+                  rootGraph: app?.graph,
+                  state: target?.changeTracker?.activeState ?? target?.activeState,
+                }) === true;
+            } catch {
+              targetContentProof = false;
+            }
+          }
           const captureSourceProof =
-            captureBinding === "bound" || (captureBinding !== "foreign" && !pointerMovedThisOpen);
+            captureBinding === "bound" &&
+            (!pointerMovedThisOpen || sourceBinding === "bound" || targetContentProof);
           // #1575 — a state THIS command just read off disk is authoritative, and the
           // canvas mounted behind it is whatever the closed tab left there. Serializing
           // that over the fresh state is the #1215/#968 poisoning through a new entry

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22013,6 +22013,32 @@ const GRAPH_TOOL_EXECUTORS = {
               // whose widget values differ, and would regress #1639's proven-bound
               // capture. A count-short graph is deliberately not a source proof
               // because it could already have been rebuilt for TARGET.
+              // Containment is content evidence, not ownership evidence. Resolve both
+              // live workflow objects without consulting the mounted root, then require
+              // the root to carry the SOURCE's exact identity. The identities must also
+              // differ: a duplicate tab with a copied UUID is not an independent source
+              // proof, even if the frontend has temporarily exposed both objects.
+              const sourceWorkflowUuid = workflowObjectUuid(activeBefore) || workflowStableUuid(activeBefore, {
+                embed: false,
+                commit: false,
+              });
+              const targetWorkflowUuid = workflowObjectUuid(target) || workflowStableUuid(target, {
+                embed: false,
+                commit: false,
+              });
+              if (
+                typeof sourceWorkflowUuid !== "string" ||
+                !sourceWorkflowUuid ||
+                typeof targetWorkflowUuid !== "string" ||
+                !targetWorkflowUuid ||
+                sourceWorkflowUuid === targetWorkflowUuid ||
+                !graphRootWorkflowUuidMatches({
+                  rootGraph,
+                  activeWorkflowUuid: sourceWorkflowUuid,
+                })
+              ) {
+                return false;
+              }
               const liveNodes = rootGraph?._nodes;
               const sourceNodeCount = Array.from(sourceStateForSwitch.nodes).length;
               const liveNodeCount = Array.isArray(liveNodes) ? Array.from(liveNodes).length : 0;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -811,6 +811,7 @@ import {
   graphRootWorkflowUuidMatches,
   graphRootMatchesState,
   graphRootReproducesStateContent,
+  graphRootStructureExtendsActiveWorkflow,
   applySavedNodePresentation,
   describeRepaintSourceBinding,
   graphCommandBindingBar,
@@ -21982,8 +21983,11 @@ const GRAPH_TOOL_EXECUTORS = {
           // tab, and checkState() then serializes that previous canvas into TARGET.
           // Related workflows (same node ids/types, different widgets) are the shape
           // that then publishes TARGET's fence over SOURCE's values.
-          // proven/presentationOnly only: normalizedOnly would treat those related
-          // graphs as a match, which is the silent serve this closes.
+          // The source probe accepts proven/presentationOnly, plus the narrower
+          // additive-node containment case below: an uncaptured SOURCE edit can
+          // otherwise make the exact proof false while the root is still SOURCE.
+          // normalizedOnly would treat related graphs as a match, which is the
+          // silent serve this closes.
           const sourceStateForSwitch = pointerMovedThisOpen
             ? (activeBefore?.changeTracker?.activeState ?? activeBefore?.activeState)
             : null;
@@ -21998,7 +22002,28 @@ const GRAPH_TOOL_EXECUTORS = {
                 rootGraph,
                 state: sourceStateForSwitch,
               });
-              return proof?.proven === true || proof?.presentationOnly === true;
+              if (proof?.proven === true || proof?.presentationOnly === true) return true;
+              // A user edit can make SOURCE's live graph differ from its last
+              // ChangeTracker capture without making it cease to be SOURCE. In
+              // particular, an added node makes the exact proof above false; the
+              // old #1951 gate then allowed checkState() to copy that still-mounted
+              // graph into TARGET. Only take this fallback for the reported
+              // additive-node shape. Without that positive count increase,
+              // structural containment also matches a correctly-mounted TARGET
+              // whose widget values differ, and would regress #1639's proven-bound
+              // capture. A count-short graph is deliberately not a source proof
+              // because it could already have been rebuilt for TARGET.
+              const liveNodes = rootGraph?._nodes;
+              const sourceNodeCount = Array.from(sourceStateForSwitch.nodes).length;
+              const liveNodeCount = Array.isArray(liveNodes) ? Array.from(liveNodes).length : 0;
+              if (sourceNodeCount === 0 || liveNodeCount <= sourceNodeCount) {
+                return false;
+              }
+              const sourceStructureContainsLive = graphRootStructureExtendsActiveWorkflow({
+                rootGraph,
+                activeWorkflow: activeBefore,
+              });
+              return sourceStructureContainsLive === true;
             } catch {
               return false;
             }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21969,14 +21969,6 @@ const GRAPH_TOOL_EXECUTORS = {
           // information. The helper either uses the pre-watch already-current proof
           // or skips a switch capture and DISCLOSES. Silent skip is the remaining
           // #1215 path (SOURCE widget values surviving onto TARGET).
-          const captureDecision = decideLiveCanvasCapture({
-            watchAvailable: activePointerWatchAvailable,
-            openLoaded: openSettled?.loaded === true,
-            captureSourceProof,
-            pointerProof,
-            pointerMovedThisOpen,
-          });
-          if (captureDecision.disclose) pointerWatchUnavailable = true;
           // #1215 (2026-08-27 recurrence) — DISTINCT from #1911. The Pinia watch
           // proves the POINTER moved; it does not prove the canvas swapped. A stale
           // or shared root UUID still answers "bound" while app.graph is the outgoing
@@ -21987,7 +21979,10 @@ const GRAPH_TOOL_EXECUTORS = {
           // additive-node containment case below: an uncaptured SOURCE edit can
           // otherwise make the exact proof false while the root is still SOURCE.
           // normalizedOnly would treat related graphs as a match, which is the
-          // silent serve this closes.
+          // silent serve this closes. This probe must run BEFORE
+          // decideLiveCanvasCapture: the production classifier correctly reports
+          // TARGET as foreign while the mounted root is SOURCE, so captureSourceProof
+          // cannot be the only route by which this fact reaches the decision.
           const sourceStateForSwitch = pointerMovedThisOpen
             ? (activeBefore?.changeTracker?.activeState ?? activeBefore?.activeState)
             : null;
@@ -22015,9 +22010,9 @@ const GRAPH_TOOL_EXECUTORS = {
               // because it could already have been rebuilt for TARGET.
               // Containment is content evidence, not ownership evidence. Resolve both
               // live workflow objects without consulting the mounted root, then require
-              // the root to carry the SOURCE's exact identity. The identities must also
-              // differ: a duplicate tab with a copied UUID is not an independent source
-              // proof, even if the frontend has temporarily exposed both objects.
+              // the production classifier to prove that the root belongs to SOURCE.
+              // The identities must also differ: a duplicate tab with a copied UUID is
+              // not an independent source proof, even if both objects are exposed.
               const sourceWorkflowUuid = workflowObjectUuid(activeBefore) || workflowStableUuid(activeBefore, {
                 embed: false,
                 commit: false,
@@ -22032,10 +22027,7 @@ const GRAPH_TOOL_EXECUTORS = {
                 typeof targetWorkflowUuid !== "string" ||
                 !targetWorkflowUuid ||
                 sourceWorkflowUuid === targetWorkflowUuid ||
-                !graphRootWorkflowUuidMatches({
-                  rootGraph,
-                  activeWorkflowUuid: sourceWorkflowUuid,
-                })
+                describeLiveCanvasBinding(activeBefore) !== "bound"
               ) {
                 return false;
               }
@@ -22054,10 +22046,19 @@ const GRAPH_TOOL_EXECUTORS = {
               return false;
             }
           };
+          const sourceCanvasStillMounted = liveCanvasStillSource(app?.graph);
+          const captureDecision = decideLiveCanvasCapture({
+            watchAvailable: activePointerWatchAvailable,
+            openLoaded: openSettled?.loaded === true,
+            captureSourceProof,
+            pointerProof,
+            pointerMovedThisOpen,
+            sourceCanvasStillMounted,
+          });
+          if (captureDecision.disclose) pointerWatchUnavailable = true;
           if (
             openSettled?.loaded !== true &&
-            captureDecision.capture &&
-            !liveCanvasStillSource(app?.graph)
+            captureDecision.capture
           ) {
             try {
               // AWAITED (codex). A frontend whose tracker captures asynchronously would

--- a/web/js/lib/live-canvas-capture-gate.js
+++ b/web/js/lib/live-canvas-capture-gate.js
@@ -67,6 +67,7 @@ export function installActivePointerWatch(observer, stores = []) {
  *   captureSourceProof?: boolean,
  *   pointerProof?: boolean,
  *   pointerMovedThisOpen?: boolean,
+ *   sourceCanvasStillMounted?: boolean,
  * }} [input]
  * @returns {{
  *   capture: boolean,
@@ -81,6 +82,7 @@ export function decideLiveCanvasCapture({
   captureSourceProof = false,
   pointerProof = false,
   pointerMovedThisOpen = false,
+  sourceCanvasStillMounted = false,
 } = {}) {
   const discloseMissingWatch = watchAvailable !== true;
   const withNotice = (capture, reason) =>
@@ -96,6 +98,14 @@ export function decideLiveCanvasCapture({
   // A state this command just read off disk holds no node-written values to
   // save, and the canvas behind it is whatever the closed tab left there.
   if (openLoaded === true) return withNotice(false, "loaded-from-disk");
+
+  // A positive SOURCE identity/content proof is stronger than the TARGET
+  // capture proof. The classifier quite correctly answers "foreign" for TARGET
+  // while this root is still SOURCE, so the caller must surface this fact before
+  // the normal capture decision can short-circuit it.
+  if (sourceCanvasStillMounted === true) {
+    return withNotice(false, "source-canvas-still-mounted");
+  }
 
   if (watchAvailable === true) {
     if (pointerProof === true && captureSourceProof === true) {


### PR DESCRIPTION
## Summary

- Treat a still-mounted outgoing canvas with an uncaptured additive node as SOURCE only when its root carries the distinct, exact root-blind SOURCE identity.
- Prevent the #1951 capture gate from serializing that SOURCE canvas into TARGET.
- Apply the same identity-gated helper to repaint/admission so a valid TARGET graph containing SOURCE nodes plus an addition is not rejected as leftover SOURCE.
- Add production-path regressions for both directions and retain the #1639 proven-bound capture control.
- No changes to `init.py` or `apps_routes.py`.

## Tests

- `npm.cmd run test:unit` — 7,399 passed, 0 failed, 1 todo
- Focused workflow/capture/graph-binding tests — 221 passed
- `frontend-contract.test.mjs` — 9 passed
- `npm.cmd run typecheck`
- `npm.cmd run check:scope`
- `npm.cmd run i18n:check`
- `npm.cmd run check:changelog`
- `git diff --check`

## Remaining evidence

- The behavioral tests exercise the production `workflow_open` executor, including capture and completed-load admission.
- No live browser/ComfyUI reproduction was available in this worktree.
- The fallback is deliberately limited to positive additive-node containment plus distinct exact SOURCE identity; widget-only, deletion, and equal-count replacement drift remain governed by existing proof/refusal paths.

This PR is intentionally not merged.