### PR TITLE
fix(panel): fence same-id node replacement at widget write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- preserve and synchronously fence node-incarnation witnesses across deferred replays and custom LTX/PromptRelay/Ideogram/MiniMax writes (#2021, #2478)
+
 ## [0.15.124] - 2026-08-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - preserve and synchronously fence node-incarnation witnesses across deferred replays and custom LTX/PromptRelay/Ideogram/MiniMax writes (#2021, #2478)
-
 ## [0.15.124] - 2026-08-29
 
 ### Fixed
@@ -209,7 +208,6 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - a connect that renames its target says so, instead of leaving the caller a stale title (#1856)
-
 
 ## [0.15.101] - 2026-08-26
 

--- a/browser_tests/unit/deferred-widget-edit.test.mjs
+++ b/browser_tests/unit/deferred-widget-edit.test.mjs
@@ -16,6 +16,7 @@ import {
   sameDeferredWidgetValue,
 } from "../../web/js/lib/deferred-widget-edit.js";
 import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
+import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 
 const panelSource = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(/\r\n/g, "\n");
 const scopedBatchSeedSource = readFileSync(
@@ -201,14 +202,21 @@ function buildProductionDeferredSafety() {
   return { safety, branch };
 }
 
-function runProductionDeferredBranch({ node, queuePayload, expected = "old", value = "new" }) {
+function runProductionDeferredBranch({
+  node,
+  queuePayload,
+  expected = "old",
+  value = "new",
+  expectedNodeIdentity,
+}) {
   const { safety, branch } = buildProductionDeferredSafety();
   let currentQueuePayload = queuePayload;
+  let liveNode = node;
   const timers = [];
   const applyCalls = [];
   const graph = {
     _nodes: [node],
-    getNodeById: (id) => (id === node.id ? node : null),
+    getNodeById: (id) => (id === node.id ? liveNode : null),
   };
   const deferredQueue = createDeferredWidgetEditQueue({
     readQueue: async () => currentQueuePayload,
@@ -249,7 +257,7 @@ function runProductionDeferredBranch({ node, queuePayload, expected = "old", val
     {
       graph_set_widget: async (args) => {
         applyCalls.push(args);
-        node.widgets[0].value = value;
+        liveNode.widgets[0].value = value;
         return { applied: true };
       },
     },
@@ -262,13 +270,20 @@ function runProductionDeferredBranch({ node, queuePayload, expected = "old", val
     setQueue: (next) => {
       currentQueuePayload = next;
     },
-    call: () => executor({
-      node_id: node.id,
-      widget: "text",
-      value,
-      expected_value: expected,
-      defer_until_idle: true,
-    }),
+    replaceNode: (replacement) => {
+      liveNode = replacement;
+    },
+    call: () => {
+      const args = {
+        node_id: node.id,
+        widget: "text",
+        value,
+        expected_value: expected,
+        defer_until_idle: true,
+      };
+      if (expectedNodeIdentity !== undefined) args.expected_node_identity = expectedNodeIdentity;
+      return executor(args);
+    },
   };
 }
 
@@ -288,9 +303,11 @@ test("#1716 production graph_set_widget parks a safe scalar edit while render is
 
 test("#1716 production graph_set_widget replays the parked edit after the queue drains", async () => {
   const node = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "old" }] };
+  const expectedNodeIdentity = nodeInstanceIdentity(node);
   const run = runProductionDeferredBranch({
     node,
     queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+    expectedNodeIdentity,
   });
   const parked = await run.call();
   assert.equal(parked.deferred, true);
@@ -303,8 +320,77 @@ test("#1716 production graph_set_widget replays the parked edit after the queue 
   assert.equal(node.widgets[0].value, "new");
   assert.equal(run.applyCalls.length, 1, "the production executor must be called once at drain");
   assert.equal(run.applyCalls[0].defer_replay, true);
+  assert.equal(run.applyCalls[0].expected_node_identity, expectedNodeIdentity);
+  assert.equal(Object.hasOwn(run.applyCalls[0], "expected_node_identity"), true);
   assert.equal(run.deferredQueue.pending(), 0);
   run.deferredQueue.close();
+});
+
+test("#2478 production deferred replay preserves legacy omission and refuses same-type replacement", async () => {
+  const node = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "old" }] };
+  const run = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+  });
+  await run.call();
+  run.setQueue({ queue_running: [], queue_pending: [] });
+  run.timers.shift()();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(Object.hasOwn(run.applyCalls[0], "expected_node_identity"), false);
+  run.deferredQueue.close();
+
+  const guardedNode = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "old" }] };
+  const replacement = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "old" }] };
+  const identity = nodeInstanceIdentity(guardedNode);
+  const guarded = runProductionDeferredBranch({
+    node: guardedNode,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+    expectedNodeIdentity: identity,
+  });
+  await guarded.call();
+  guarded.replaceNode(replacement);
+  guarded.setQueue({ queue_running: [], queue_pending: [] });
+  guarded.timers.shift()();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(guarded.applyCalls.length, 0, "replacement must be refused before the replay executor");
+  assert.equal(replacement.widgets[0].value, "old");
+  guarded.deferredQueue.close();
+});
+
+test("#2478 production deferred path rejects malformed identities but still accepts an omitted identity", async () => {
+  const node = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "old" }] };
+  for (const malformed of ["", 42, "x".repeat(257)]) {
+    const run = runProductionDeferredBranch({
+      node,
+      queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+      expectedNodeIdentity: malformed,
+    });
+    await assert.rejects(run.call(), /expected_node_identity must be a non-empty string/);
+    assert.equal(run.deferredQueue.pending(), 0);
+    run.deferredQueue.close();
+  }
+  const legacy = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: ["render-1"], queue_pending: [] },
+  });
+  await assert.doesNotReject(legacy.call());
+  assert.equal(legacy.deferredQueue.pending(), 1);
+  legacy.deferredQueue.close();
+});
+
+test("#2478 production idle replay forwards the identity witness", async () => {
+  const node = { id: 7, type: "KSampler", widgets: [{ name: "text", value: "old" }] };
+  const expectedNodeIdentity = nodeInstanceIdentity(node);
+  const run = runProductionDeferredBranch({
+    node,
+    queuePayload: { queue_running: [], queue_pending: [] },
+    expectedNodeIdentity,
+  });
+  const result = await run.call();
+  assert.equal(result.applied, true);
+  assert.equal(run.applyCalls.length, 1);
+  assert.equal(run.applyCalls[0].defer_replay, true);
+  assert.equal(run.applyCalls[0].expected_node_identity, expectedNodeIdentity);
 });
 
 test("#1716 production graph_set_widget refuses callback-driven widgets before parking", async () => {

--- a/browser_tests/unit/graph-find-nodes.test.mjs
+++ b/browser_tests/unit/graph-find-nodes.test.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "../../web/js/lib/slot-labels.js";
 import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
 import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
+import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
 import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
 import { redactWidgetValue } from "../../web/js/lib/widget-secret-redaction.js";
@@ -56,6 +57,7 @@ const summarizeNode = (() => {
     "controlAfterGenerateModes",
     "drivenWidgetsFor",
     "redactWidgetValue",
+    "nodeInstanceIdentity",
     `${source}; return summarizeNode;`,
   )(
     virtualFedInputs,
@@ -66,6 +68,7 @@ const summarizeNode = (() => {
     controlAfterGenerateModes,
     drivenWidgetsFor,
     redactWidgetValue,
+    nodeInstanceIdentity,
   );
 })();
 

--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -24,6 +24,7 @@ import {
   truncationTail,
 } from "../../web/js/lib/graph-read.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
+import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 
 const PANEL_JS = join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js");
 const source = readFileSync(PANEL_JS, "utf8");
@@ -101,16 +102,22 @@ const graph = {
 
 // summarizeNode is kept deliberately small because its own production dependencies are
 // unrelated to this budget seam. The graph_query method itself is the shipped source.
-const summarizeNode = (node) => ({
-  id: node.id,
-  type: node.type,
-  title: node.title,
-  widgets: Object.fromEntries((node.widgets ?? []).map((w) => [w.name, w.value])),
-  // Production summarizeNode also emits inputs/outputs; those are what push a
-  // fully-capped detail row past max_chars and into fitDetailLine (#2436).
-  ...(Array.isArray(node.inputs) && node.inputs.length ? { inputs: node.inputs } : {}),
-  ...(Array.isArray(node.outputs) && node.outputs.length ? { outputs: node.outputs } : {}),
-});
+const summarizeNode = (node) => {
+  // Use the same panel-owned per-object identity source as the shipped bundle.
+  // The identity is deliberately not copied from a synthetic serialized field.
+  const nodeIdentity = nodeInstanceIdentity(node);
+  return {
+    id: node.id,
+    ...(nodeIdentity ? { node_identity: nodeIdentity } : {}),
+    type: node.type,
+    title: node.title,
+    widgets: Object.fromEntries((node.widgets ?? []).map((w) => [w.name, w.value])),
+    // Production summarizeNode also emits inputs/outputs; those are what push a
+    // fully-capped detail row past max_chars and into fitDetailLine (#2436).
+    ...(Array.isArray(node.inputs) && node.inputs.length ? { inputs: node.inputs } : {}),
+    ...(Array.isArray(node.outputs) && node.outputs.length ? { outputs: node.outputs } : {}),
+  };
+};
 
 const graphQuerySource = methodSource(source, "graph_query({");
 const dependencyNames = [
@@ -268,6 +275,34 @@ test("#2314 detail rows explicitly classify ordinary and promoted nodes", () => 
     assert.equal(row.is_subgraph, true);
     assert.equal(result.nodes?.[0]?.is_subgraph, true, "#1925 pinpoint detail must publish a structured subgraph row");
     assert.equal(result.nodes?.[0]?.id, 83);
+  } finally {
+    graph._nodes.pop();
+  }
+});
+
+test("#2478 one-ID compact probes publish a bounded identity-bearing witness", () => {
+  const node = {
+    id: 84,
+    type: "PrimitiveStringMultiline",
+    title: "Prompt",
+    widgets: [{ name: "text", value: "new" }],
+    inputs: [],
+    outputs: [],
+  };
+  graph._nodes.push(node);
+  try {
+    const result = query({ ids: [84], fields: "compact", max_chars: 500 });
+    const expectedIdentity = nodeInstanceIdentity(node);
+    assert.match(result.text, /#84 PrimitiveStringMultiline/);
+    assert.deepEqual(result.nodes, [
+      {
+        id: 84,
+        type: "PrimitiveStringMultiline",
+        node_identity: expectedIdentity,
+        is_subgraph: false,
+      },
+    ]);
+    assert.ok(JSON.stringify(result.nodes).length <= 500, "identity witness must remain bounded");
   } finally {
     graph._nodes.pop();
   }

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -4,6 +4,23 @@ import { readFileSync } from "node:fs";
 import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
 import { findSubgraphOwner } from "../../web/js/lib/subgraph-scope.js";
 import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
+import { classifyLtxTimelineWrite, applyLtxTimelineWrite, derivedTimelineRefusal } from "../../web/js/lib/ltx-director.js";
+import {
+  classifyPromptRelayTimelineWrite,
+  applyPromptRelayTimelineWrite,
+  promptRelayDerivedRefusal,
+} from "../../web/js/lib/prompt-relay-timeline.js";
+import { classifyRgthreeFastGroupsWrite, rgthreeFastGroupsRefusal } from "../../web/js/lib/rgthree-fast-groups.js";
+import {
+  classifyIdeogram4PromptBuilderWrite,
+  applyIdeogram4PromptBuilderWrite,
+  ideogram4PromptBuilderRefusal,
+} from "../../web/js/lib/ideogram4-prompt-builder.js";
+import {
+  classifyMiniMaxH3PromptBuilderWrite,
+  applyMiniMaxH3PromptBuilderWrite,
+} from "../../web/js/lib/minimax-h3-prompt-builder.js";
+import { classifyMiniMaxH3DirectorWrite, miniMaxH3DirectorPromptRefusal } from "../../web/js/lib/minimax-h3-director.js";
 
 // This tree is CRLF; CI checks out LF. Every source pin below anchors on a BLANK LINE,
 // and a literal two-newline anchor never matches a CRLF blank line — so these four fence
@@ -45,6 +62,79 @@ function extractShippingMethod(signature) {
     if (ch === "}" && --depth === 0) return PANEL_SRC.slice(start, i + 1);
   }
   throw new Error(`unterminated method: ${signature}`);
+}
+
+function extractTargetFenceProperty() {
+  const start = PANEL_SRC.indexOf("const assertGraphSetWidgetTargetStillCurrent = () => {");
+  const end = PANEL_SRC.indexOf("\n    // #314:", start);
+  assert.ok(start >= 0 && end > start, "production graph_set_widget fence not found");
+  const bodyStart = PANEL_SRC.indexOf("{", start) + 1;
+  const bodyEnd = PANEL_SRC.lastIndexOf("\n    };", end);
+  assert.ok(bodyStart > 0 && bodyEnd > bodyStart, "production graph_set_widget fence body not found");
+  return `assertTargetStillCurrent: () => {${PANEL_SRC.slice(bodyStart, bodyEnd)}\n      }`;
+}
+
+function makeProductionTargetFence({ node, graph, expectedNodeType, expectedNodeIdentity }) {
+  const fenceProperty = extractTargetFenceProperty();
+  const makeFence = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "assertActiveWorkflowCommandTarget",
+    "assertExpectedPromotedScope",
+    "WORKFLOW_UUID_FIELD",
+    "nodeInstanceIdentity",
+    `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay, expected_node_identity) {
+      const enforceDeferredExpected = defer_replay === true;
+      return ({ ${fenceProperty} }).assertTargetStillCurrent;
+    };`,
+  );
+  let liveTarget = node;
+  const fence = makeFence(
+    () => ({ graph, rootGraph: graph }),
+    () => liveTarget,
+    () => {},
+    () => {},
+    "workflow_uuid",
+    nodeInstanceIdentity,
+  )(node.id, expectedNodeType, undefined, undefined, node, undefined, expectedNodeIdentity);
+  return {
+    fence,
+    replaceNode: (replacement) => {
+      liveTarget = replacement;
+    },
+  };
+}
+
+function makeProductionCustomRoute() {
+  const start = PANEL_SRC.indexOf("    const ltxKind = classifyLtxTimelineWrite(node, widget);");
+  const end = PANEL_SRC.indexOf("    // #458:", start);
+  assert.ok(start >= 0 && end > start, "production custom graph_set_widget routes not found");
+  return new Function(
+    "node",
+    "widget",
+    "value",
+    "builder_state",
+    "graph",
+    "assertGraphSetWidgetTargetStillCurrent",
+    "classifyLtxTimelineWrite",
+    "applyLtxTimelineWrite",
+    "derivedTimelineRefusal",
+    "classifyPromptRelayTimelineWrite",
+    "applyPromptRelayTimelineWrite",
+    "promptRelayDerivedRefusal",
+    "classifyRgthreeFastGroupsWrite",
+    "rgthreeFastGroupsRefusal",
+    "classifyIdeogram4PromptBuilderWrite",
+    "applyIdeogram4PromptBuilderWrite",
+    "ideogram4PromptBuilderRefusal",
+    "classifyMiniMaxH3PromptBuilderWrite",
+    "applyMiniMaxH3PromptBuilderWrite",
+    "classifyMiniMaxH3DirectorWrite",
+    "miniMaxH3DirectorPromptRefusal",
+    `return async function runCustomRoute() {
+      ${PANEL_SRC.slice(start, end)}
+    };`,
+  );
 }
 
 test("graph_set_widget enforces expected_node_type at the synchronous write boundary", () => {
@@ -99,13 +189,151 @@ test("the command bridge forwards the complete identity-bearing message to the p
   assert.match(PANEL_SRC.slice(dispatchStart, dispatchEnd + "result = await executor(msg);".length), /executor\(msg\)/);
 });
 
+test("#2478 every custom mutation route fences a same-ID same-type replacement before mutation", async () => {
+  const runCustomRoute = makeProductionCustomRoute();
+  const promptRelayTimeline = { segments: [{ prompt: "old", length: 24, color: "#fff" }] };
+  const minimaxState = {
+    version: 1,
+    mode: "T2VA",
+    off: {},
+    duration: 5,
+    p2Shot: 1,
+    lastShot: 1,
+    imd: "old",
+    soundscape: "",
+    music: "N/A",
+    ref: {
+      subjectDefs: [],
+      summaryTypes: ["reference generation"],
+      summaryText: "",
+      retention: [],
+      styleLine: "",
+      detail: "",
+      soundscape: "",
+      music: "N/A",
+    },
+  };
+  const cases = [
+    {
+      label: "LTXDirector",
+      widget: "timeline_data",
+      value: { segments: [{ start: 0, length: 24, prompt: "new", type: "text" }] },
+      makeNode: () => {
+        const node = {
+          id: 7,
+          type: "LTXDirector",
+          _timelineEditor: {
+            timelineDataWidget: { value: JSON.stringify({ segments: [{ start: 0, length: 24, prompt: "old", type: "text" }] }) },
+            _applyLoadedTimeline() {
+              throw new Error("custom mutation was reached");
+            },
+          },
+        };
+        return node;
+      },
+    },
+    {
+      label: "PromptRelayEncodeTimeline",
+      widget: "timeline_data",
+      value: { segments: [{ prompt: "new", length: 24, color: "#fff" }] },
+      makeNode: () => ({
+        id: 7,
+        type: "PromptRelayEncodeTimeline",
+        widgets: [
+          { name: "timeline_data", value: JSON.stringify(promptRelayTimeline) },
+          { name: "local_prompts", value: "old" },
+          { name: "segment_lengths", value: "24" },
+        ],
+      }),
+    },
+    {
+      label: "Ideogram4PromptBuilderKJ",
+      widget: "elements_data",
+      value: [{ x: 0.1, y: 0.2, w: 0.3, h: 0.4, type: "text", text: "new", desc: "new region", palette: ["#abc"] }],
+      makeNode: () => {
+        const currentBoxes = [{ x: 0, y: 0, w: 0.2, h: 0.2, type: "obj", text: "", desc: "old", palette: [] }];
+        const node = {
+          id: 7,
+          type: "Ideogram4PromptBuilderKJ",
+          _boxes: currentBoxes,
+          widgets: [],
+        };
+        node.widgets.push({
+          name: "elements_data",
+          value: JSON.stringify(currentBoxes),
+          serializeValue: () => JSON.stringify(node._boxes),
+        });
+        node.onExecuted = () => {
+          throw new Error("custom mutation was reached");
+        };
+        return node;
+      },
+    },
+    {
+      label: "MiniMaxH3PromptBuilder",
+      widget: "prompt_text",
+      value: "new prompt",
+      makeNode: () => ({
+        id: 7,
+        type: "MiniMaxH3PromptBuilder",
+        widgets: [
+          { name: "prompt_text", value: "old prompt" },
+          { name: "builder_state", value: JSON.stringify(minimaxState) },
+        ],
+      }),
+    },
+  ];
+
+  for (const item of cases) {
+    const node = item.makeNode();
+    const replacement = { id: node.id, type: node.type, widgets: [] };
+    const graph = {
+      beforeChange() {
+        fence.replaceNode(replacement);
+      },
+      afterChange() {},
+      setDirtyCanvas() {},
+    };
+    const fence = makeProductionTargetFence({
+      node,
+      graph,
+      expectedNodeType: node.type,
+      expectedNodeIdentity: nodeInstanceIdentity(node),
+    });
+    await assert.rejects(
+      runCustomRoute(
+        node,
+        item.widget,
+        item.value,
+        undefined,
+        graph,
+        fence.fence,
+        classifyLtxTimelineWrite,
+        applyLtxTimelineWrite,
+        derivedTimelineRefusal,
+        classifyPromptRelayTimelineWrite,
+        applyPromptRelayTimelineWrite,
+        promptRelayDerivedRefusal,
+        classifyRgthreeFastGroupsWrite,
+        rgthreeFastGroupsRefusal,
+        classifyIdeogram4PromptBuilderWrite,
+        applyIdeogram4PromptBuilderWrite,
+        ideogram4PromptBuilderRefusal,
+        classifyMiniMaxH3PromptBuilderWrite,
+        applyMiniMaxH3PromptBuilderWrite,
+        classifyMiniMaxH3DirectorWrite,
+        miniMaxH3DirectorPromptRefusal,
+      ),
+      /target (?:identity )?changed before dispatch/,
+      item.label,
+    );
+    assert.equal(node.id, replacement.id, `${item.label} node remains addressable`);
+    assert.equal(node.type, replacement.type, `${item.label} replacement used the same type`);
+  }
+});
+
 test("the production write fence accepts legacy writes, rejects missing-shape identities, and blocks same-type reuse", () => {
-  const start = PANEL_SRC.indexOf("async graph_set_widget({");
-  const fenceStart = PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", start);
-  const fenceTail = PANEL_SRC.slice(fenceStart).match(/\r?\n      \},\r?\n      \/\/ Stale-combo retry/);
-  const fenceEnd = fenceTail?.index == null ? -1 : fenceStart + fenceTail.index;
-  assert.ok(fenceStart >= 0 && fenceEnd > fenceStart, "production graph_set_widget fence not found");
-  const fenceProperty = PANEL_SRC.slice(fenceStart, fenceEnd) + "\n      }";
+  const fenceProperty = extractTargetFenceProperty();
   const makeFence = new Function(
     "getGraphCtx",
     "resolveNode",
@@ -141,15 +369,7 @@ test("the production write fence accepts legacy writes, rejects missing-shape id
 });
 
 test("the shipped target fence rejects replacement objects and preserves qualified ids", () => {
-  const start = PANEL_SRC.indexOf("async graph_set_widget({");
-  const end = PANEL_SRC.indexOf("\n  // artokun/comfyui-mcp#938", start);
-  const handler = PANEL_SRC.slice(start, end);
-  const fenceStart = handler.indexOf("assertTargetStillCurrent: () => {");
-  const fenceTail = handler.slice(fenceStart).match(/\r?\n      \},\r?\n      \/\/ Stale-combo retry/);
-  const fenceEnd = fenceTail?.index == null ? -1 : fenceStart + fenceTail.index;
-  assert.ok(fenceStart >= 0, "production target fence not found");
-  assert.ok(fenceEnd > fenceStart, "production target fence boundary not found");
-  const fenceProperty = handler.slice(fenceStart, fenceEnd) + "\n      }";
+  const fenceProperty = extractTargetFenceProperty();
 
   const original = { id: 7, type: "OtherLoraLoader" };
   let liveTarget = original;
@@ -220,12 +440,10 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
   let writes = 0;
   let liveTarget = { id: 76, type: "OrdinaryNode" };
   const currentCtx = () => ({ graph: currentGraph, rootGraph });
+  const fenceProperty = extractTargetFenceProperty();
   const factorySource = `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay, expected_node_identity) {
       const enforceDeferredExpected = defer_replay === true;
-      return ({ ${PANEL_SRC.slice(
-        PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", PANEL_SRC.indexOf("async graph_set_widget({")),
-        PANEL_SRC.indexOf("\n      // Stale-combo retry", PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", PANEL_SRC.indexOf("async graph_set_widget({"))),
-      )} }).assertTargetStillCurrent;
+      return ({ ${fenceProperty} }).assertTargetStillCurrent;
     };`;
   const makeFence = new Function(
     "getGraphCtx",
@@ -374,12 +592,7 @@ test("#2314 production graph_enter_subgraph -> graph_set_widget fence refuses a 
   const enterReply = await enter({ node_id: 78 });
   assert.equal(enterReply.settled, true, "the production enter path must settle on the child graph");
 
-  const handlerStart = PANEL_SRC.indexOf("async graph_set_widget({");
-  const fenceStart = PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", handlerStart);
-  const fenceTail = PANEL_SRC.slice(fenceStart).match(/\r?\n      \},\r?\n      \/\/ Stale-combo retry/);
-  const fenceEnd = fenceTail?.index == null ? -1 : fenceStart + fenceTail.index;
-  assert.ok(fenceStart >= 0 && fenceEnd > fenceStart, "production graph_set_widget fence not found");
-  const fenceProperty = PANEL_SRC.slice(fenceStart, fenceEnd) + "\n      }";
+  const fenceProperty = extractTargetFenceProperty();
   const makeFence = new Function(
     "getGraphCtx",
     "resolveNode",

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
 import { findSubgraphOwner } from "../../web/js/lib/subgraph-scope.js";
+import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 
 // This tree is CRLF; CI checks out LF. Every source pin below anchors on a BLANK LINE,
 // and a literal two-newline anchor never matches a CRLF blank line — so these four fence
@@ -56,12 +57,87 @@ test("graph_set_widget enforces expected_node_type at the synchronous write boun
   const expectedArg = handler.indexOf("expected_node_type");
   const targetCheck = handler.indexOf("liveTarget.type !== expected_node_type");
   const identityCheck = handler.indexOf("liveTarget !== node");
+  const expectedIdentity = handler.indexOf("expected_node_identity");
+  const identityWitnessCheck = handler.indexOf("nodeInstanceIdentity(liveTarget)");
   const runSet = handler.indexOf("runSetWidget(node, widget, value, setWidgetOpts)");
   assert.ok(expectedArg >= 0, "handler does not accept expected_node_type");
   assert.ok(targetCheck >= 0, "handler does not verify the live target type");
+  assert.ok(expectedIdentity >= 0, "handler does not accept expected_node_identity");
+  assert.ok(identityWitnessCheck >= 0, "handler does not verify the live node identity");
   assert.ok(identityCheck >= 0, "handler does not reject a same-type replacement object");
   assert.ok(runSet > targetCheck, "target type must be checked before runSetWidget");
+  assert.ok(runSet > identityWitnessCheck, "target identity must be checked before runSetWidget");
   assert.ok(runSet > identityCheck, "target identity must be checked before runSetWidget");
+});
+
+test("node detail identity is panel-owned, stable per object, and changes on replacement", () => {
+  const original = { id: 78, type: "OrdinaryNode", node_identity: "forged" };
+  const replacement = { id: 78, type: "OrdinaryNode", node_identity: "forged" };
+  const first = nodeInstanceIdentity(original);
+  assert.match(first, /^node-incarnation:/);
+  assert.equal(nodeInstanceIdentity(original), first);
+  assert.notEqual(nodeInstanceIdentity(replacement), first);
+  assert.equal(nodeInstanceIdentity(null), null);
+  assert.equal(nodeInstanceIdentity("not a node"), null);
+});
+
+test("structured production projections carry the same node identity witness", () => {
+  const summaryStart = PANEL_SRC.indexOf("function summarizeNode(node) {");
+  const summaryEnd = PANEL_SRC.indexOf("function nodeDescription(node)", summaryStart);
+  assert.ok(summaryStart >= 0 && summaryEnd > summaryStart, "production node summarizer not found");
+  const summary = PANEL_SRC.slice(summaryStart, summaryEnd);
+  assert.match(summary, /nodeInstanceIdentity\(node\)/);
+  assert.match(summary, /node_identity/);
+  assert.match(PANEL_SRC, /nodes: inner\.slice\(0, MAX_STATE_NODES\)\.map\(summarizeNode\)/);
+  assert.match(PANEL_SRC, /capSummaryWidgets\(summarizeNode\(n\)/);
+});
+
+test("the command bridge forwards the complete identity-bearing message to the production executor", () => {
+  const dispatchStart = PANEL_SRC.indexOf("const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];");
+  const dispatchEnd = PANEL_SRC.indexOf("result = await executor(msg);", dispatchStart);
+  assert.ok(dispatchStart >= 0 && dispatchEnd > dispatchStart, "production command bridge dispatch not found");
+  assert.match(PANEL_SRC.slice(dispatchStart, dispatchEnd + "result = await executor(msg);".length), /executor\(msg\)/);
+});
+
+test("the production write fence accepts legacy writes, rejects missing-shape identities, and blocks same-type reuse", () => {
+  const start = PANEL_SRC.indexOf("async graph_set_widget({");
+  const fenceStart = PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", start);
+  const fenceTail = PANEL_SRC.slice(fenceStart).match(/\r?\n      \},\r?\n      \/\/ Stale-combo retry/);
+  const fenceEnd = fenceTail?.index == null ? -1 : fenceStart + fenceTail.index;
+  assert.ok(fenceStart >= 0 && fenceEnd > fenceStart, "production graph_set_widget fence not found");
+  const fenceProperty = PANEL_SRC.slice(fenceStart, fenceEnd) + "\n      }";
+  const makeFence = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "assertActiveWorkflowCommandTarget",
+    "assertExpectedPromotedScope",
+    "WORKFLOW_UUID_FIELD",
+    "nodeInstanceIdentity",
+    `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay, expected_node_identity) {
+      const enforceDeferredExpected = defer_replay === true;
+      return ({ ${fenceProperty} }).assertTargetStillCurrent;
+    };`,
+  );
+  const original = { id: 78, type: "OrdinaryNode" };
+  let liveTarget = original;
+  const make = (identity) =>
+    makeFence(
+      () => ({ graph: {} }),
+      () => liveTarget,
+      () => {},
+      () => {},
+      "workflow_uuid",
+      nodeInstanceIdentity,
+    )(78, undefined, undefined, undefined, original, undefined, identity);
+
+  const run = (identity) => make(identity)();
+  assert.doesNotThrow(() => run(undefined), "omitting the optional field preserves legacy writes");
+  assert.throws(() => run(""), /expected_node_identity must be a non-empty string/);
+  assert.throws(() => run(42), /expected_node_identity must be a non-empty string/);
+  const identity = nodeInstanceIdentity(original);
+  assert.doesNotThrow(() => run(identity));
+  liveTarget = { id: 78, type: "OrdinaryNode" };
+  assert.throws(() => run(identity), /target identity changed before dispatch/);
 });
 
 test("the shipped target fence rejects replacement objects and preserves qualified ids", () => {
@@ -78,7 +154,7 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
   const original = { id: 7, type: "OtherLoraLoader" };
   let liveTarget = original;
   let resolvedId;
-  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay) {
+  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay, expected_node_identity) {
       const enforceDeferredExpected = defer_replay === true;
       return ({ ${fenceProperty} }).assertTargetStillCurrent;
     };`;
@@ -90,6 +166,7 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
     "assertActiveWorkflowCommandTarget",
     "assertExpectedPromotedScope",
     "WORKFLOW_UUID_FIELD",
+    "nodeInstanceIdentity",
     factorySource,
     );
   } catch (err) {
@@ -104,6 +181,7 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
     () => {},
     () => {},
     "workflow_uuid",
+    nodeInstanceIdentity,
   )("7:subgraph", "OtherLoraLoader", undefined, undefined, original, undefined);
 
   fence();
@@ -118,7 +196,7 @@ test("the shipped target fence rejects replacement objects and preserves qualifi
 
 test("#2314 production scope fence refuses receiver navigation after graph_query reply", () => {
   const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
-  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  const helperEnd = PANEL_SRC.indexOf("\n// ---- per-turn graph snapshots", helperStart);
   assert.ok(helperStart >= 0, "production promoted-scope helper not found");
   assert.ok(helperEnd > helperStart, "production promoted-scope helper boundary not found");
   const helperSource = PANEL_SRC.slice(helperStart, helperEnd);
@@ -142,7 +220,7 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
   let writes = 0;
   let liveTarget = { id: 76, type: "OrdinaryNode" };
   const currentCtx = () => ({ graph: currentGraph, rootGraph });
-  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay) {
+  const factorySource = `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay, expected_node_identity) {
       const enforceDeferredExpected = defer_replay === true;
       return ({ ${PANEL_SRC.slice(
         PANEL_SRC.indexOf("assertTargetStillCurrent: () => {", PANEL_SRC.indexOf("async graph_set_widget({")),
@@ -155,6 +233,7 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
     "assertActiveWorkflowCommandTarget",
     "assertExpectedPromotedScope",
     "WORKFLOW_UUID_FIELD",
+    "nodeInstanceIdentity",
     factorySource,
   );
   const fence = makeFence(
@@ -163,6 +242,7 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
     () => {},
     assertScope,
     "workflow_uuid",
+    nodeInstanceIdentity,
   )(
     76,
     "OrdinaryNode",
@@ -202,7 +282,7 @@ test("#2314 production scope fence refuses receiver navigation after graph_query
 
 test("#2314 production graph_enter_subgraph -> graph_set_widget fence refuses a parent-rail relink", async () => {
   const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
-  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  const helperEnd = PANEL_SRC.indexOf("\n// ---- per-turn graph snapshots", helperStart);
   assert.ok(helperStart >= 0 && helperEnd > helperStart, "production scope helper boundary not found");
   const promotionStart = PANEL_SRC.indexOf("function resolveSubgraphLink(");
   const promotionEnd = PANEL_SRC.indexOf("\nfunction findPromotedHostInput", promotionStart);
@@ -306,7 +386,8 @@ test("#2314 production graph_enter_subgraph -> graph_set_widget fence refuses a 
     "assertActiveWorkflowCommandTarget",
     "assertExpectedPromotedScope",
     "WORKFLOW_UUID_FIELD",
-    `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay) {
+    "nodeInstanceIdentity",
+    `return function (node_id, expected_node_type, workflow_uuid, expected_scope, node, defer_replay, expected_node_identity) {
       const enforceDeferredExpected = defer_replay === true;
       return ({ ${fenceProperty} }).assertTargetStillCurrent;
     };`,
@@ -329,6 +410,7 @@ test("#2314 production graph_enter_subgraph -> graph_set_widget fence refuses a 
     () => {},
     assertScope(describeActiveGraph, findSubgraphOwner, resolvePromotedInnerTarget, sourceForSubgraphInput),
     "workflow_uuid",
+    nodeInstanceIdentity,
   )(76, "PrimitiveStringMultiline", "workflow-a", expectedScope, inner, undefined);
 
   assert.doesNotThrow(() => fence(), "the entered, still-authoritative promotion is writable");
@@ -346,7 +428,7 @@ test("#2314 production graph_enter_subgraph -> graph_set_widget fence refuses a 
 
 test("#2314 same owner id in a different graph is refused at the shipped fence", () => {
   const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
-  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  const helperEnd = PANEL_SRC.indexOf("\n// ---- per-turn graph snapshots", helperStart);
   const helperSource = PANEL_SRC.slice(helperStart, helperEnd);
   const assertScope = new Function(
     "describeActiveGraph",
@@ -378,7 +460,7 @@ test("#2314 same owner id in a different graph is refused at the shipped fence",
 
 test("#2314 terminal endpoint is part of the shipped receiver fence", () => {
   const helperStart = PANEL_SRC.indexOf("function canonicalExpectedPromotedOwner");
-  const helperEnd = PANEL_SRC.indexOf("\n\n// ---- per-turn graph snapshots", helperStart);
+  const helperEnd = PANEL_SRC.indexOf("\n// ---- per-turn graph snapshots", helperStart);
   assert.ok(helperStart >= 0 && helperEnd > helperStart, "production scope helper boundary not found");
   const assertScope = new Function(
     "describeActiveGraph",

--- a/browser_tests/unit/ltx-director.test.mjs
+++ b/browser_tests/unit/ltx-director.test.mjs
@@ -584,7 +584,7 @@ const PANEL_SRC = readFileSync(
 ).replace(/\r\n/g, "\n");
 
 const LTX_SET_WIDGET_BRANCH = PANEL_SRC.match(
-  /const ltxKind = classifyLtxTimelineWrite\(node, widget\);\n    if \(ltxKind === "derived"\) \{[\s\S]*?setDirty: \(\) => graph\.setDirtyCanvas\(true, true\),\n      \}\);\n    \}/,
+  /const ltxKind = classifyLtxTimelineWrite\(node, widget\);\n    if \(ltxKind === "derived"\) \{[\s\S]*?assertTargetStillCurrent: assertGraphSetWidgetTargetStillCurrent,\n      \}\);\n    \}/,
 );
 
 test("graph_set_widget still routes LTXDirector timeline_data through applyLtxTimelineWrite", () => {
@@ -619,6 +619,7 @@ test("shipped graph_set_widget authors an LTXDirector timeline without a live ed
     "widget",
     "value",
     "graph",
+    "assertGraphSetWidgetTargetStillCurrent",
     `return (function () { ${LTX_SET_WIDGET_BRANCH[0]} })();`,
   );
   const res = run(
@@ -629,6 +630,7 @@ test("shipped graph_set_widget authors an LTXDirector timeline without a live ed
     LTX_TIMELINE_MASTER_WIDGET,
     { global_prompt: "g", segments: [seg({ prompt: "shipped" })] },
     graph,
+    () => {},
   );
   assert.equal(res.ltx_timeline.fallback, true);
   assert.equal(res.ltx_timeline.driven, true);

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -1527,6 +1527,7 @@ test("graph_set_widget routes master → apply, derived → refusal, everything 
       "widget",
       "value",
       "graph",
+      "assertGraphSetWidgetTargetStillCurrent",
       `return () => { ${relayBranch[0]}\n return "fell-through"; };`,
     );
     const fn = factory(
@@ -1540,13 +1541,14 @@ test("graph_set_widget routes master → apply, derived → refusal, everything 
       "timeline_data",
       { segments: [] },
       { beforeChange() {}, afterChange() {}, setDirtyCanvas() {} },
+      () => {},
     );
     return { fn, calls };
   };
 
   const master = run("master");
   assert.deepEqual(master.fn(), { applied: true });
-  assert.deepEqual(master.calls[0].hooks, ["afterChange", "beforeChange", "setDirty"]);
+  assert.deepEqual(master.calls[0].hooks, ["afterChange", "assertTargetStillCurrent", "beforeChange", "setDirty"]);
 
   const derived = run("derived");
   assert.throws(() => derived.fn(), /refused timeline_data on 3/);

--- a/browser_tests/unit/read-surface-accuracy.test.mjs
+++ b/browser_tests/unit/read-surface-accuracy.test.mjs
@@ -18,6 +18,7 @@ import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
 import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
 import { redactWidgetValue } from "../../web/js/lib/widget-secret-redaction.js";
+import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const PANEL_SOURCE = readFileSync(PANEL_JS, "utf8");
@@ -57,6 +58,7 @@ const summarizeNode = (() => {
     "controlAfterGenerateModes",
     "drivenWidgetsFor",
     "redactWidgetValue",
+    "nodeInstanceIdentity",
     `${fn}; return summarizeNode;`,
   )(
     virtualFedInputs,
@@ -67,6 +69,7 @@ const summarizeNode = (() => {
     controlAfterGenerateModes,
     drivenWidgetsFor,
     redactWidgetValue,
+    nodeInstanceIdentity,
   );
 })();
 

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -285,6 +285,7 @@ test("#570/#718: hello ALWAYS advertises both workflow-stamp fences so the orche
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp_at_write, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_expected_node_type_at_write, true);
+  assert.equal(buildHelloPayload({ tabId: "t" }).enforces_expected_node_identity_at_write, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).publishes_promoted_terminal_witnesses, true);
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_promoted_parent_rail_at_write, true);
   assert.equal(
@@ -297,6 +298,10 @@ test("#570/#718: hello ALWAYS advertises both workflow-stamp fences so the orche
   );
   assert.equal(
     buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_expected_node_type_at_write,
+    true,
+  );
+  assert.equal(
+    buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_expected_node_identity_at_write,
     true,
   );
 });

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -239,8 +239,17 @@ test("#718 wiring: graph_set_widget passes the execution-time workflow fence int
   const body = src.slice(start, end);
   assert.match(
     body,
-    /assertTargetStillCurrent:\s*\(\)\s*=>\s*\{[\s\S]*assertActiveWorkflowCommandTarget\([\s\S]*workflow_uuid/,
-    "the post-await write boundary must recheck the exact command stamp",
+    /assertTargetStillCurrent:\s*assertGraphSetWidgetTargetStillCurrent/,
+    "the post-await write boundary must be wired into the normal write path",
+  );
+  const fenceStart = src.indexOf("const assertGraphSetWidgetTargetStillCurrent = () => {");
+  const fenceEnd = src.indexOf("\n    // #314", fenceStart);
+  assert.notEqual(fenceStart, -1, "the shared graph_set_widget fence must exist");
+  assert.notEqual(fenceEnd, -1, "the shared graph_set_widget fence boundary must exist");
+  assert.match(
+    src.slice(fenceStart, fenceEnd),
+    /assertActiveWorkflowCommandTarget\([\s\S]*workflow_uuid/,
+    "the shared write boundary must recheck the exact command stamp",
   );
 });
 

--- a/browser_tests/unit/summarize-duplicate-widgets.test.mjs
+++ b/browser_tests/unit/summarize-duplicate-widgets.test.mjs
@@ -24,6 +24,7 @@ import { fileURLToPath } from "node:url";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "../../web/js/lib/slot-labels.js";
 import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
 import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
+import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
 import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
@@ -58,6 +59,7 @@ const summarizeNode = (() => {
     "controlAfterGenerateModes",
     "drivenWidgetsFor",
     "redactWidgetValue",
+    "nodeInstanceIdentity",
     `${fn}; return summarizeNode;`,
   )(
     virtualFedInputs,
@@ -68,6 +70,7 @@ const summarizeNode = (() => {
     controlAfterGenerateModes,
     drivenWidgetsFor,
     redactWidgetValue,
+    nodeInstanceIdentity,
   );
 })();
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17279,6 +17279,16 @@ const GRAPH_TOOL_EXECUTORS = {
     const expected_node_identity =
       arguments[0] && typeof arguments[0] === "object" ? arguments[0].expected_node_identity : undefined;
     const { defer_until_idle, expected_value, defer_replay } = arguments[0] ?? {};
+    if (
+      expected_node_identity !== undefined &&
+      (typeof expected_node_identity !== "string" ||
+        expected_node_identity.length === 0 ||
+        expected_node_identity.length > 256)
+    ) {
+      throw new Error(
+        "graph_set_widget expected_node_identity must be a non-empty string of at most 256 characters",
+      );
+    }
     // #1413 — ONE deadline for the whole command, taken BEFORE anything awaits, so the
     // bounded steps inside it compose instead of adding (#1192, #671). The step this
     // exists for is the stale-combo recovery's refresh join below: reached only after
@@ -17349,6 +17359,7 @@ const GRAPH_TOOL_EXECUTORS = {
           builder_state,
           expected_node_type: node.type,
           expected_scope,
+          ...(expected_node_identity !== undefined ? { expected_node_identity } : {}),
           expected_value,
           defer_replay: true,
         });
@@ -17391,6 +17402,7 @@ const GRAPH_TOOL_EXECUTORS = {
             builder_state,
             expected_node_type: deferredNode.type,
             expected_scope,
+            ...(expected_node_identity !== undefined ? { expected_node_identity } : {}),
             expected_value,
             defer_replay: true,
           }),
@@ -17442,6 +17454,114 @@ const GRAPH_TOOL_EXECUTORS = {
     // refresh and an upload probe between reading the schema and deciding, and a
     // classification computed before those awaits can be superseded during them.
     let setWidgetSchemaProvenance = () => "none";
+    // Every graph_set_widget mutation, including the custom editor routes below, must
+    // cross the same final synchronous boundary. Keep this callback in the handler scope
+    // so custom writers can invoke it after their undo envelope opens but immediately
+    // before their first graph/editor mutation. Optional witnesses remain optional for
+    // legacy callers; when present, all validation is fail-closed and identity is compared
+    // against the live object rather than a serialized node field.
+    const assertGraphSetWidgetTargetStillCurrent = () => {
+      assertActiveWorkflowCommandTarget({
+        cmd: "graph_set_widget",
+        [WORKFLOW_UUID_FIELD]: workflow_uuid,
+      });
+      if (
+        expected_scope === undefined &&
+        expected_node_type === undefined &&
+        expected_node_identity === undefined &&
+        !enforceDeferredExpected
+      ) return;
+      const current = getGraphCtx();
+      assertExpectedPromotedScope(current, expected_scope, () => {
+        let terminalNode = node;
+        let terminalWidget = node?.widgets?.find((candidate) => candidate?.name === widget) ?? null;
+        let depth = 0;
+        if (node?.subgraph) {
+          const resolved = resolvePromotedInnerTarget(node, widget, sourceForSubgraphInput);
+          if (!resolved?.promoted || !resolved.target) return null;
+          const reached = followPromotionToConcrete(resolved.target, sourceForSubgraphInput);
+          if (
+            !reached?.node ||
+            !reached.widget ||
+            reached.cycle ||
+            reached.error ||
+            reached.terminalVirtual ||
+            reached.node.subgraph
+          ) {
+            return null;
+          }
+          terminalNode = reached.node;
+          terminalWidget = reached.widget;
+          depth = reached.depth;
+        }
+        const inputs = terminalPromotionShape(terminalNode);
+        if (
+          !terminalNode ||
+          !terminalWidget ||
+          !inputs ||
+          (typeof terminalNode.id !== "number" && typeof terminalNode.id !== "string") ||
+          typeof terminalNode.type !== "string" ||
+          typeof terminalWidget.name !== "string"
+        ) {
+          return null;
+        }
+        return {
+          node_id: terminalNode.id,
+          type: terminalNode.type,
+          widget: terminalWidget.name,
+          inputs,
+          depth,
+        };
+      });
+      const liveTarget = resolveNode(current.graph, node_id);
+      if (
+        expected_node_type !== undefined &&
+        (typeof expected_node_type !== "string" || !expected_node_type)
+      ) {
+        throw new Error("graph_set_widget expected_node_type must be a non-empty string");
+      }
+      if (
+        expected_node_type !== undefined &&
+        (!liveTarget || liveTarget !== node || liveTarget.type !== expected_node_type)
+      ) {
+        throw new Error(
+          `panel_set_widget target changed before dispatch: expected ${expected_node_type}, ` +
+            `found ${liveTarget?.type ?? "missing"}`,
+        );
+      }
+      if (
+        expected_node_identity !== undefined &&
+        (typeof expected_node_identity !== "string" ||
+          expected_node_identity.length === 0 ||
+          expected_node_identity.length > 256)
+      ) {
+        throw new Error(
+          "graph_set_widget expected_node_identity must be a non-empty string of at most 256 characters",
+        );
+      }
+      const liveIdentity =
+        expected_node_identity !== undefined ? nodeInstanceIdentity(liveTarget) : null;
+      if (expected_node_identity !== undefined && liveIdentity !== expected_node_identity) {
+        throw new Error(
+          `panel_set_widget target identity changed before dispatch: expected ${expected_node_identity}, ` +
+            `found ${liveIdentity ?? "missing"}`,
+        );
+      }
+      if (enforceDeferredExpected) {
+        const liveWidget = liveTarget?.widgets?.find((candidate) => candidate?.name === widget);
+        if (
+          !liveTarget ||
+          liveTarget !== node ||
+          !liveWidget ||
+          !sameDeferredWidgetValue(liveWidget.value, expected_value)
+        ) {
+          throw new Error(
+            `panel_set_widget deferred replay refused "${widget}" on node ${node_id}: ` +
+              "the widget changed before the write boundary; nothing was applied",
+          );
+        }
+      }
+    };
     // #314: the LTXDirector custom node owns its timeline widgets through an in-browser
     // TimelineEditor whose in-memory `this.timeline` is the source of truth. A raw widget
     // write "succeeds" (panel_query_graph shows it) but never reaches the editor/UI and is
@@ -17461,6 +17581,7 @@ const GRAPH_TOOL_EXECUTORS = {
         beforeChange: () => graph.beforeChange(),
         afterChange: () => graph.afterChange(),
         setDirty: () => graph.setDirtyCanvas(true, true),
+        assertTargetStillCurrent: assertGraphSetWidgetTargetStillCurrent,
       });
     }
     // #506: the ComfyUI-PromptRelay "PromptRelayEncodeTimeline" node has the same shape of
@@ -17480,6 +17601,7 @@ const GRAPH_TOOL_EXECUTORS = {
         beforeChange: () => graph.beforeChange(),
         afterChange: () => graph.afterChange(),
         setDirty: () => graph.setDirtyCanvas(true, true),
+        assertTargetStillCurrent: assertGraphSetWidgetTargetStillCurrent,
       });
     }
     // #983: rgthree's Fast Groups Muter toggle rows are DERIVED READOUTS of whether the matched
@@ -17504,6 +17626,7 @@ const GRAPH_TOOL_EXECUTORS = {
           beforeChange: () => graph.beforeChange(),
           afterChange: () => graph.afterChange(),
           setDirty: () => graph.setDirtyCanvas(true, true),
+          assertTargetStillCurrent: assertGraphSetWidgetTargetStillCurrent,
         });
       }
       throw new Error(ideogram4PromptBuilderRefusal(widget, node.id));
@@ -17519,6 +17642,7 @@ const GRAPH_TOOL_EXECUTORS = {
         beforeChange: () => graph.beforeChange(),
         afterChange: () => graph.afterChange(),
         setDirty: () => graph.setDirtyCanvas(true, true),
+        assertTargetStillCurrent: assertGraphSetWidgetTargetStillCurrent,
       });
     }
     // #458: WAIT for the startup baseline history seed to land before authorizing, so a
@@ -17969,112 +18093,9 @@ const GRAPH_TOOL_EXECUTORS = {
           },
         };
       },
-      // #718: the first command-handler fence ran before awaitObjectInfoHistorySeed()
-      // and the fresh /object_info request. A user can switch workflows while either
-      // promise is pending, so re-read the ACTIVE uuid at the exact shared write
-      // boundary. runSetWidget calls this synchronously before every write path.
-      assertTargetStillCurrent: () => {
-        assertActiveWorkflowCommandTarget({
-          cmd: "graph_set_widget",
-          [WORKFLOW_UUID_FIELD]: workflow_uuid,
-        });
-        if (
-          expected_scope === undefined &&
-          expected_node_type === undefined &&
-          expected_node_identity === undefined &&
-          !enforceDeferredExpected
-        ) return;
-        const current = getGraphCtx();
-        assertExpectedPromotedScope(current, expected_scope, () => {
-          let terminalNode = node;
-          let terminalWidget = node?.widgets?.find((candidate) => candidate?.name === widget) ?? null;
-          let depth = 0;
-          if (node?.subgraph) {
-            const resolved = resolvePromotedInnerTarget(node, widget, sourceForSubgraphInput);
-            if (!resolved?.promoted || !resolved.target) return null;
-            const reached = followPromotionToConcrete(resolved.target, sourceForSubgraphInput);
-            if (
-              !reached?.node ||
-              !reached.widget ||
-              reached.cycle ||
-              reached.error ||
-              reached.terminalVirtual ||
-              reached.node.subgraph
-            ) {
-              return null;
-            }
-            terminalNode = reached.node;
-            terminalWidget = reached.widget;
-            depth = reached.depth;
-          }
-          const inputs = terminalPromotionShape(terminalNode);
-          if (
-            !terminalNode ||
-            !terminalWidget ||
-            !inputs ||
-            (typeof terminalNode.id !== "number" && typeof terminalNode.id !== "string") ||
-            typeof terminalNode.type !== "string" ||
-            typeof terminalWidget.name !== "string"
-          ) {
-            return null;
-          }
-          return {
-            node_id: terminalNode.id,
-            type: terminalNode.type,
-            widget: terminalWidget.name,
-            inputs,
-            depth,
-          };
-        });
-        const liveTarget = resolveNode(current.graph, node_id);
-        if (
-          expected_node_type !== undefined &&
-          (typeof expected_node_type !== "string" || !expected_node_type)
-        ) {
-          throw new Error("graph_set_widget expected_node_type must be a non-empty string");
-        }
-        if (
-          expected_node_type !== undefined &&
-          (!liveTarget || liveTarget !== node || liveTarget.type !== expected_node_type)
-        ) {
-          throw new Error(
-            `panel_set_widget target changed before dispatch: expected ${expected_node_type}, ` +
-              `found ${liveTarget?.type ?? "missing"}`,
-          );
-        }
-        if (
-          expected_node_identity !== undefined &&
-          (typeof expected_node_identity !== "string" ||
-            expected_node_identity.length === 0 ||
-            expected_node_identity.length > 256)
-        ) {
-          throw new Error(
-            "graph_set_widget expected_node_identity must be a non-empty string of at most 256 characters",
-          );
-        }
-        const liveIdentity =
-          expected_node_identity !== undefined ? nodeInstanceIdentity(liveTarget) : null;
-        if (expected_node_identity !== undefined && liveIdentity !== expected_node_identity) {
-          throw new Error(
-            `panel_set_widget target identity changed before dispatch: expected ${expected_node_identity}, ` +
-              `found ${liveIdentity ?? "missing"}`,
-          );
-        }
-        if (enforceDeferredExpected) {
-          const liveWidget = liveTarget?.widgets?.find((candidate) => candidate?.name === widget);
-          if (
-            !liveTarget ||
-            liveTarget !== node ||
-            !liveWidget ||
-            !sameDeferredWidgetValue(liveWidget.value, expected_value)
-          ) {
-            throw new Error(
-              `panel_set_widget deferred replay refused "${widget}" on node ${node_id}: ` +
-                "the widget changed before the write boundary; nothing was applied",
-            );
-          }
-        }
-      },
+      // #718/#2478: the handler's one final workflow/scope/type/identity fence. Custom
+      // editor routes use the same callback at their own synchronous mutation boundary.
+      assertTargetStillCurrent: assertGraphSetWidgetTargetStillCurrent,
       // Stale-combo retry: reuse the /object_info already fetched for authorization
       // (passed by runSetWidget) to refresh THIS target's combo option lists in place
       // — a single fetch total (#458 P2). When a payload IS present we NEVER re-fetch,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -72,6 +72,7 @@ import {
 } from "./lib/widget-write.js";
 import { missingWidgetMessage } from "./lib/missing-widget.js";
 import { freeVramSuccessResult, readVramOccupancy } from "./lib/vram-occupancy.js";
+import { nodeInstanceIdentity } from "./lib/node-identity.js";
 import { describeVoiceError } from "./lib/voice-error.js";
 import { voiceRecognitionLang } from "./lib/voice-language.js";
 import { isEmbeddedDesktopShell, voiceInputSupport } from "./lib/voice-support.js";
@@ -12236,6 +12237,7 @@ async function revertGraphSnapshotByMid(mid) {
  *  Deliberately NOT the full serialization (positions, colors, internal
  *  state beyond those) to keep token cost low. */
 function summarizeNode(node) {
+  const nodeIdentity = nodeInstanceIdentity(node);
   const widgets = {};
   for (const w of node.widgets ?? []) {
     if (w && typeof w.name === "string") widgets[w.name] = redactWidgetValue(w.name, w.value);
@@ -12340,6 +12342,10 @@ function summarizeNode(node) {
   }
   const summary = {
     id: node.id,
+    // #2478 — this is an opaque identity of THIS live node object, not a
+    // serialized node field. The MCP preflight carries it to graph_set_widget
+    // so same-id, same-type replacement cannot satisfy a stale write.
+    ...(nodeIdentity ? { node_identity: nodeIdentity } : {}),
     type: node.type,
     title: node.title,
     pos: node.pos ? [Math.round(node.pos[0]), Math.round(node.pos[1])] : null,
@@ -17270,6 +17276,8 @@ const GRAPH_TOOL_EXECUTORS = {
     // positional arguments.
     const expected_scope =
       arguments[0] && typeof arguments[0] === "object" ? arguments[0].expected_scope : undefined;
+    const expected_node_identity =
+      arguments[0] && typeof arguments[0] === "object" ? arguments[0].expected_node_identity : undefined;
     const { defer_until_idle, expected_value, defer_replay } = arguments[0] ?? {};
     // #1413 — ONE deadline for the whole command, taken BEFORE anything awaits, so the
     // bounded steps inside it compose instead of adding (#1192, #671). The step this
@@ -17970,7 +17978,12 @@ const GRAPH_TOOL_EXECUTORS = {
           cmd: "graph_set_widget",
           [WORKFLOW_UUID_FIELD]: workflow_uuid,
         });
-        if (expected_scope === undefined && expected_node_type === undefined && !enforceDeferredExpected) return;
+        if (
+          expected_scope === undefined &&
+          expected_node_type === undefined &&
+          expected_node_identity === undefined &&
+          !enforceDeferredExpected
+        ) return;
         const current = getGraphCtx();
         assertExpectedPromotedScope(current, expected_scope, () => {
           let terminalNode = node;
@@ -18027,6 +18040,24 @@ const GRAPH_TOOL_EXECUTORS = {
           throw new Error(
             `panel_set_widget target changed before dispatch: expected ${expected_node_type}, ` +
               `found ${liveTarget?.type ?? "missing"}`,
+          );
+        }
+        if (
+          expected_node_identity !== undefined &&
+          (typeof expected_node_identity !== "string" ||
+            expected_node_identity.length === 0 ||
+            expected_node_identity.length > 256)
+        ) {
+          throw new Error(
+            "graph_set_widget expected_node_identity must be a non-empty string of at most 256 characters",
+          );
+        }
+        const liveIdentity =
+          expected_node_identity !== undefined ? nodeInstanceIdentity(liveTarget) : null;
+        if (expected_node_identity !== undefined && liveIdentity !== expected_node_identity) {
+          throw new Error(
+            `panel_set_widget target identity changed before dispatch: expected ${expected_node_identity}, ` +
+              `found ${liveIdentity ?? "missing"}`,
           );
         }
         if (enforceDeferredExpected) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14862,24 +14862,47 @@ const GRAPH_TOOL_EXECUTORS = {
       truncatedBy = "max_chars";
       text = assemble();
     }
-    // #1925 — a pinpoint detail read is the orchestrator's promoted-scope probe.
-    // That classifier prefers a structured `nodes` row with a boolean
-    // `is_subgraph`; `text` alone is a fallback. Publish the row beside the
-    // survey line so a verified-stable root subgraph instance is classifiable.
+    // #1925/#2478 — a pinpoint read is the orchestrator's promoted-scope and
+    // node-incarnation probe. That classifier prefers a structured `nodes` row
+    // with a boolean `is_subgraph` and, for current panels, the opaque
+    // `node_identity`; `text` alone is a legacy fallback. Publish a minimal
+    // bounded witness for an explicit one-ID compact read too. Broad compact
+    // reads keep their historical text-only shape and never expose a large
+    // structured summary for every node.
     // #1941 — fit the structured row the same way as the survey line. An
     // uncapped VHS/high-fan-in summary used to dwarf `max_chars` while the
     // text stub stayed bounded; a timed-out/truncated probe then fell through
     // to graph_get_subgraph and refused a root node as an unclassifiable
     // promoted container.
     const pinpointNodes = (() => {
-      if (!(pinpoint && proj === "detail" && shown === 1 && matched[0])) return null;
-      const summary = {
-        ...capSummaryWidgets(summarizeNode(matched[0]), detailWidgetCap, maxChars),
-        is_subgraph: !!matched[0].subgraph,
-      };
+      if (!(pinpoint && (proj === "detail" || proj === "compact") && shown === 1 && matched[0])) return null;
+      const summarized = summarizeNode(matched[0]);
+      const summary =
+        proj === "compact"
+          ? {
+              id: summarized.id,
+              type: summarized.type,
+              ...(typeof summarized.node_identity === "string"
+                ? { node_identity: summarized.node_identity }
+                : {}),
+              is_subgraph: !!matched[0].subgraph,
+            }
+          : {
+              ...capSummaryWidgets(summarized, detailWidgetCap, maxChars),
+              is_subgraph: !!matched[0].subgraph,
+            };
       const fitted = fitDetailLine(
         JSON.stringify(summary),
-        { id: summary.id, type: summary.type, title: summary.title, is_subgraph: summary.is_subgraph },
+        proj === "compact"
+          ? {
+              id: summary.id,
+              type: summary.type,
+              ...(typeof summary.node_identity === "string"
+                ? { node_identity: summary.node_identity }
+                : {}),
+              is_subgraph: summary.is_subgraph,
+            }
+          : { id: summary.id, type: summary.type, title: summary.title, is_subgraph: summary.is_subgraph },
         maxChars,
       );
       try {
@@ -14889,6 +14912,9 @@ const GRAPH_TOOL_EXECUTORS = {
           {
             id: summary.id,
             type: summary.type,
+            ...(typeof summary.node_identity === "string"
+              ? { node_identity: summary.node_identity }
+              : {}),
             is_subgraph: !!matched[0].subgraph,
           },
         ];

--- a/web/js/lib/ideogram4-prompt-builder.js
+++ b/web/js/lib/ideogram4-prompt-builder.js
@@ -352,7 +352,7 @@ function readSerializedRegions(elementsWidget) {
 export function applyIdeogram4PromptBuilderWrite(
   node,
   value,
-  { beforeChange, afterChange, setDirty } = {},
+  { beforeChange, afterChange, setDirty, assertTargetStillCurrent } = {},
 ) {
   if (classifyIdeogram4PromptBuilderWrite(node, IDEOGRAM4_ELEMENTS_WIDGET) !== "derived") {
     throw new Error(
@@ -400,6 +400,7 @@ export function applyIdeogram4PromptBuilderWrite(
   const previousSize = Array.isArray(node.size) ? [...node.size] : null;
   beforeChange?.();
   try {
+    assertTargetStillCurrent?.();
     node.onExecuted({ caption: [JSON.stringify(currentCaptionForRegions(node, boxes))] });
     // The callback is the mutation boundary. Verify the exact semantic fields that
     // the caption format carries before reporting success; a callback that exists but

--- a/web/js/lib/ltx-director.js
+++ b/web/js/lib/ltx-director.js
@@ -416,7 +416,11 @@ export function derivedTimelineRefusal(widgetName, nodeId) {
  * clean current-timeline snapshot, so anything they don't mention is PRESERVED. An explicit
  * empty array (e.g. `motionSegments: []`) still clears that track; only OMISSION preserves.
  */
-function applySerializedLtxTimeline(node, merged, { beforeChange, afterChange, setDirty, preservedTracks, mergedOntoCurrent }) {
+function applySerializedLtxTimeline(
+  node,
+  merged,
+  { beforeChange, afterChange, setDirty, assertTargetStillCurrent, preservedTracks, mergedOntoCurrent },
+) {
   const missing = FALLBACK_REQUIRED_WIDGETS.filter((name) => !findWidget(node, name));
   if (missing.length) {
     throw new LtxTimelineWriteError(
@@ -437,6 +441,7 @@ function applySerializedLtxTimeline(node, merged, { beforeChange, afterChange, s
 
   beforeChange?.();
   try {
+    assertTargetStillCurrent?.();
     findWidget(node, LTX_TIMELINE_MASTER_WIDGET).value = JSON.stringify(merged);
     for (const name of LTX_DERIVED_TIMELINE_WIDGETS) {
       findWidget(node, name).value = derived[name];
@@ -474,7 +479,11 @@ function applySerializedLtxTimeline(node, merged, { beforeChange, afterChange, s
   };
 }
 
-export function applyLtxTimelineWrite(node, value, { getEditor, beforeChange, afterChange, setDirty } = {}) {
+export function applyLtxTimelineWrite(
+  node,
+  value,
+  { getEditor, beforeChange, afterChange, setDirty, assertTargetStillCurrent } = {},
+) {
   const { timeline } = normalizeLtxTimelineValue(value);
   const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
   const overlay = effectiveTimeline(timeline);
@@ -488,6 +497,7 @@ export function applyLtxTimelineWrite(node, value, { getEditor, beforeChange, af
     );
     beforeChange?.();
     try {
+      assertTargetStillCurrent?.();
       editor._applyLoadedTimeline(JSON.stringify(merged), null);
     } finally {
       afterChange?.();
@@ -519,6 +529,7 @@ export function applyLtxTimelineWrite(node, value, { getEditor, beforeChange, af
       beforeChange,
       afterChange,
       setDirty,
+      assertTargetStillCurrent,
       preservedTracks,
       mergedOntoCurrent,
     });

--- a/web/js/lib/minimax-h3-prompt-builder.js
+++ b/web/js/lib/minimax-h3-prompt-builder.js
@@ -517,7 +517,7 @@ export function applyMiniMaxH3PromptBuilderWrite(
   node,
   widgetName,
   value,
-  { builder_state: companionState, beforeChange, afterChange, setDirty } = {},
+  { builder_state: companionState, beforeChange, afterChange, setDirty, assertTargetStillCurrent } = {},
 ) {
   const promptWidget = findWidget(node, MINIMAX_H3_PROMPT_TEXT_WIDGET);
   const stateWidget = findWidget(node, MINIMAX_H3_BUILDER_STATE_WIDGET);
@@ -535,6 +535,7 @@ export function applyMiniMaxH3PromptBuilderWrite(
 
   beforeChange?.();
   try {
+    assertTargetStillCurrent?.();
     promptWidget.value = pair.prompt;
     stateWidget.value = serializedState;
     if (node && typeof node === "object") node._mmh3Draft = null;

--- a/web/js/lib/node-identity.js
+++ b/web/js/lib/node-identity.js
@@ -1,0 +1,42 @@
+// Per-object node incarnation identity for graph read/write fences (#2478).
+//
+// The identity deliberately lives outside LiteGraph node data. A workflow can
+// contain arbitrary serialized fields, so a value copied from the node itself
+// would not prove that the panel is still holding the same live object. A
+// WeakMap gives one stable token to one live node object and necessarily gives
+// a replacement object a different token, even when its id and type are equal.
+// This is a local correctness witness, not an attestation or security boundary.
+
+const NODE_IDENTITIES = new WeakMap();
+let fallbackCounter = 0;
+
+function randomIdentity() {
+  try {
+    const cryptoApi = globalThis.crypto;
+    if (typeof cryptoApi?.randomUUID === "function") {
+      const uuid = cryptoApi.randomUUID();
+      if (typeof uuid === "string" && uuid) return `node-incarnation:${uuid}`;
+    }
+    if (typeof cryptoApi?.getRandomValues === "function") {
+      const bytes = cryptoApi.getRandomValues(new Uint8Array(16));
+      const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
+      if (hex) return `node-incarnation:${hex}`;
+    }
+  } catch {
+    // A local fallback still gives stable per-object identity when the host's
+    // randomness API is unavailable or temporarily throws.
+  }
+  fallbackCounter += 1;
+  return `node-incarnation:${Date.now().toString(36)}:${fallbackCounter.toString(36)}`;
+}
+
+/** Return the panel-owned identity of a live node object, or null for bad input. */
+export function nodeInstanceIdentity(node) {
+  if ((typeof node !== "object" || node === null) && typeof node !== "function") return null;
+  let identity = NODE_IDENTITIES.get(node);
+  if (!identity) {
+    identity = randomIdentity();
+    NODE_IDENTITIES.set(node, identity);
+  }
+  return identity;
+}

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -735,7 +735,7 @@ export function promptRelayDerivedRefusal(widgetName, nodeId) {
 export function applyPromptRelayTimelineWrite(
   node,
   value,
-  { getEditor, beforeChange, afterChange, setDirty, now = Date.now } = {},
+  { getEditor, beforeChange, afterChange, setDirty, assertTargetStillCurrent, now = Date.now } = {},
 ) {
   const overlay = normalizePromptRelayTimelineValue(value);
 
@@ -971,6 +971,7 @@ export function applyPromptRelayTimelineWrite(
   let editorSynced = false;
   let uiRefreshError = null;
   try {
+    assertTargetStillCurrent?.();
     widgets[PROMPT_RELAY_MASTER_WIDGET].value = timelineJson;
     widgets.local_prompts.value = derived.local_prompts;
     widgets.segment_lengths.value = derived.segment_lengths;

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -799,6 +799,9 @@ export function buildHelloPayload({
     // synchronous write boundary, so the orchestrator can fence a node
     // replacement between its final identity probe and mutation.
     enforces_expected_node_type_at_write: true,
+    // #2478: graph_set_widget also honors the opaque per-node incarnation
+    // identity emitted by graph reads at the same synchronous write boundary.
+    enforces_expected_node_identity_at_write: true,
     // #2314: graph_set_widget validates an optional promoted subgraph owner and
     // workflow witness against the LIVE canvas at the same synchronous boundary.
     enforces_expected_scope_at_write: true,


### PR DESCRIPTION
## Summary

- Emit an opaque, page-local per-object node incarnation identity from the production node detail summarizer, including graph query detail and subgraph projections.
- Advertise enforces_expected_node_identity_at_write in every Panel hello.
- Validate and consume expected_node_identity at the final synchronous graph_set_widget fence before runSetWidget/applyWidgetWrite, rejecting malformed values and same-ID/same-type replacement objects while preserving omission for legacy callers.
- Extend production-path tests for normal writes, legacy omission, malformed identity, forged serialized identity, and same-ID/same-type replacement; update summarizeNode harnesses to inject the real helper.

Fixes Artokun/comfyui-mcp#2478
Pairs with Artokun/comfyui-mcp#2513

## Validation

- npm.cmd ci
- 225-file node --check scan
- npm.cmd run typecheck
- npm.cmd run test:unit with installed comfyui_frontend_package: 6,980 passed, 0 failed, 1 todo
- python -m py_compile __init__.py
- Python comfy-cli parity, Bandit, published-archive YARA, pack-content, and version checks
- npm.cmd run test:e2e:list: 98 tests listed; live ComfyUI E2E execution not run

Do not merge this PR.