### PR TITLE
fix(248): reject dynamic error-tag proxies

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -333,6 +333,36 @@ test("#248 a non-Error with a spoofed Error toStringTag keeps its identity and m
   }
 });
 
+test("#248 a finite dynamic toStringTag Proxy keeps non-Error identity and message", async () => {
+  const thrown = new Proxy(
+    {},
+    {
+      get(target, property, receiver) {
+        if (property === Symbol.toStringTag) return "Error";
+        if (property === "message") return "structured dynamic proxy queue failure";
+        if (property === "stack") return "structured dynamic proxy stack";
+        return Reflect.get(target, property, receiver);
+      },
+    },
+  );
+  for (const queuePrompt of [
+    () => {
+      throw thrown;
+    },
+    () => Promise.reject(thrown),
+  ]) {
+    await assert.rejects(
+      () => invokeQueuePromptWithBrowserStack({ queuePrompt }),
+      (received) => {
+        assert.equal(received, thrown);
+        assert.equal(received.message, "structured dynamic proxy queue failure");
+        assert.equal(received.stack, "structured dynamic proxy stack");
+        return true;
+      },
+    );
+  }
+});
+
 test("#248 hostile or non-string stacks cannot mask the original queue failure", async () => {
   for (const stack of [Symbol("hostile stack"), { toString: () => { throw new Error("coercion"); } }]) {
     const error = new TypeError("Cannot convert undefined or null to object");

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -49,6 +49,7 @@ const objectToString = Object.prototype.toString;
 const hasOwn = Object.prototype.hasOwnProperty;
 const getPrototypeOf = Object.getPrototypeOf;
 const toStringTag = Symbol.toStringTag;
+const stackProperty = "stack";
 const BROWSER_ERROR_PROTO_MAX = 32;
 
 // `instanceof Error` rejects an Error created by the browser realm when this
@@ -78,7 +79,16 @@ function isBrowserError(value) {
       if (hasOwn.call(prototype, toStringTag)) return false;
       prototype = getPrototypeOf(prototype);
     }
-    return prototype === null;
+    if (prototype !== null) return false;
+
+    // JavaScript has no standard Proxy detector, and a Proxy can synthesize
+    // Symbol.toStringTag dynamically without exposing that tag through its
+    // own/prototype descriptors. Native browser Error instances do expose an
+    // own stack slot, including the cross-realm Errors this classifier exists
+    // to support. Requiring that independent witness keeps a finite tag-only
+    // Proxy fail-closed instead of replacing the thrown value and losing its
+    // identity/message surface.
+    return hasOwn.call(value, stackProperty);
   } catch {
     return false;
   }


### PR DESCRIPTION
Follow-up to merged PR #2013.

This hardens the browser Error classifier against a finite Proxy whose `get` trap dynamically synthesizes `Symbol.toStringTag = "Error"`. Such a value is conservatively kept as the original thrown object instead of being wrapped and losing its identity/message surface.

Checks completed locally:
- `node --test browser_tests/unit/run-scope-guard.test.mjs` — 148 passed
- `npm.cmd run test:unit` — 7,419 passed, 1 todo
- `npm.cmd run typecheck` — passed
- `git diff --check` — passed

Do not merge automatically.