### PR TITLE
fix: preserve current untagged canvas capture

### DIFF
--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -1776,6 +1776,56 @@ test("#1911 production workflow_open without $subscribe captures already-current
   assert.equal(panel.guard(), null);
 });
 
+test("#1215 production workflow_open captures an already-current untagged canvas", async () => {
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  let captures = 0;
+  let captureDecisionInput;
+  const subscribers = [];
+  target.changeTracker = {
+    activeState: target.activeState,
+    checkState() {
+      captures += 1;
+    },
+  };
+  environment.activeWorkflowRef = () => target;
+  environment.document = workflowPiniaDocument({
+    $subscribe: (subscriber) => {
+      subscribers.push(subscriber);
+      return () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  });
+  environment.decideLiveCanvasCapture = (input) => {
+    captureDecisionInput = input;
+    return decideLiveCanvasCapture(input);
+  };
+  // Use the shipped classifier with an untagged root. The fixture's default
+  // matcher is bound-oriented for the older lifecycle cases; the production
+  // graph-binding matcher correctly answers false for this root, yielding unknown.
+  environment.graphRootWorkflowUuidMatches = graphRootWorkflowUuidMatches;
+  environment.graphRootWorkflowUuidMismatches = graphRootWorkflowUuidMismatches;
+  delete environment.describeLiveCanvasBinding;
+  environment.app.extensionManager.workflow.openWorkflow = async () => {};
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "already-current-untagged" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(captureDecisionInput.pointerMovedThisOpen, false);
+  assert.equal(captureDecisionInput.pointerProof, true, "the active pointer watch proves the target stayed current");
+  assert.equal(
+    captureDecisionInput.captureSourceProof,
+    true,
+    "an untagged but already-current canvas remains eligible for live capture",
+  );
+  assert.equal(captures, 1, "unknown binding must not revert node-written values to activeState");
+  assert.equal(subscribers.length, 0, "the production pointer watch is cleaned up after the open");
+  assert.equal(result.pointer_watch_unavailable, undefined);
+  assert.equal(panel.guard(), null);
+});
+
 test("#1911 production workflow_open without $subscribe skips switch capture, still flushes SOURCE, and discloses", async () => {
   const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
   let captures = 0;

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -1826,6 +1826,55 @@ test("#1215 production workflow_open captures an already-current untagged canvas
   assert.equal(panel.guard(), null);
 });
 
+test("#1215 production workflow_open discloses an unknown stale canvas when the pointer watch is unavailable", async () => {
+  const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
+  const staleValue = "stale-untagged-canvas";
+  let captures = 0;
+  let captureDecisionInput;
+  environment.app.graph._nodes = [{ id: 1, type: "KSampler", widgets_values: [staleValue] }];
+  target.changeTracker = {
+    activeState: target.activeState,
+    checkState() {
+      captures += 1;
+      const capturedState = {
+        ...structuredClone(this.activeState),
+        nodes: [{ ...this.activeState.nodes[0], widgets_values: [staleValue] }],
+      };
+      this.activeState = capturedState;
+      target.activeState = structuredClone(capturedState);
+    },
+  };
+  environment.activeWorkflowRef = () => target;
+  // No document or service subscription is supplied, so production cannot install
+  // its synchronous pointer watch. Use the shipped classifier against the untagged
+  // stale root; it must remain unknown rather than being treated as current by drift.
+  environment.graphRootWorkflowUuidMatches = graphRootWorkflowUuidMatches;
+  environment.graphRootWorkflowUuidMismatches = graphRootWorkflowUuidMismatches;
+  environment.graphRootReproducesStateContent = ({ rootGraph, state }) => ({
+    proven: rootGraph?._nodes?.[0]?.widgets_values?.[0] === state?.nodes?.[0]?.widgets_values?.[0],
+    presentationOnly: false,
+    normalizedOnly: false,
+  });
+  delete environment.describeLiveCanvasBinding;
+  environment.app.extensionManager.workflow.openWorkflow = async () => {};
+  environment.decideLiveCanvasCapture = (input) => {
+    captureDecisionInput = input;
+    return decideLiveCanvasCapture(input);
+  };
+
+  const panel = productionExecutor("workflow_open", environment);
+  const result = await panel.method({ path: target.path, rid: "unknown-stale-no-watch" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.equal(captureDecisionInput.pointerMovedThisOpen, false);
+  assert.equal(captureDecisionInput.pointerProof, false, "no watcher must not become pointer proof");
+  assert.equal(captureDecisionInput.captureSourceProof, false, "unknown binding needs positive proof");
+  assert.equal(captures, 0, "an unknown stale canvas must never be serialized into the target");
+  assert.equal(result.pointer_watch_unavailable, POINTER_WATCH_UNAVAILABLE_NOTICE);
+  assert.equal(environment.app.graph._nodes[0].widgets_values[0], "target-value");
+  assert.equal(panel.guard(), null);
+});
+
 test("#1911 production workflow_open without $subscribe skips switch capture, still flushes SOURCE, and discloses", async () => {
   const { target, environment } = productionReadableOpenEnvironment({ readableAfterRetry: true });
   let captures = 0;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21985,7 +21985,7 @@ const GRAPH_TOOL_EXECUTORS = {
           const targetBindingProof =
             captureBinding === "bound"
               ? true
-              : captureBinding === "unknown" && !pointerMovedThisOpen;
+              : captureBinding === "unknown" && !pointerMovedThisOpen && pointerProof;
           const captureSourceProof =
             targetBindingProof &&
             (!pointerMovedThisOpen || sourceBinding === "bound" || targetContentProof);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21977,8 +21977,17 @@ const GRAPH_TOOL_EXECUTORS = {
               targetContentProof = false;
             }
           }
+          // An untagged root is legitimately "unknown" on an already-current tab:
+          // the pointer proof says the canvas was not borrowed from another tab, so
+          // retain the #874 live-canvas capture for node-written values. After a tab
+          // switch, however, unknown remains insufficient; only a positive target
+          // binding plus independent source/target proof may authorize the write.
+          const targetBindingProof =
+            captureBinding === "bound"
+              ? true
+              : captureBinding === "unknown" && !pointerMovedThisOpen;
           const captureSourceProof =
-            captureBinding === "bound" &&
+            targetBindingProof &&
             (!pointerMovedThisOpen || sourceBinding === "bound" || targetContentProof);
           // #1575 — a state THIS command just read off disk is authoritative, and the
           // canvas mounted behind it is whatever the closed tab left there. Serializing


### PR DESCRIPTION
## Summary\n\n- keep live-canvas capture eligible for an already-current untagged root\n- retain fail-closed switched-canvas and stale TARGET-UUID protections\n- add a production-shaped regression using the shipped binding classifier and pointer watch\n\n## Validation\n\n- focused lifecycle checks: 93 passed\n- full unit suite: 7,422 passed, 1 todo\n- typecheck: passed\n- scope, i18n, vocabulary, and diff checks: passed\n\nFollow-up to merged Panel #2017/#1215.