### PR TITLE
fix(390): resolve 18+ consent card before the tools/call deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- resolve the 18+ consent card before the 300s tools/call deadline so an idle user gets a structured timeout instead of a transport hang (#390)
+
 ## [0.15.125] - 2026-08-30
 
 ### Fixed
@@ -19,7 +22,6 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Changed
 - record node identity fence (#2021)
-
 
 ## [0.15.124] - 2026-08-29
 

--- a/browser_tests/unit/adult-consent-wait.test.mjs
+++ b/browser_tests/unit/adult-consent-wait.test.mjs
@@ -1,0 +1,314 @@
+/**
+ * #390 — an unanswered 18+ consent card must resolve the command before the
+ * enclosing tools/call dies, instead of holding the rid until the transport
+ * kills it.
+ *
+ * The original orchestrator clamp still waited hundreds of seconds (under
+ * 300s, past the nested SDK's 60s default). The panel owns the blocking card,
+ * so the bound lives on the real question painter's wait — not a copy of it.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  CONSENT_HEADER,
+  CONSENT_NESTED_CALL_BUDGET_MS,
+  CONSENT_NO_LABEL,
+  CONSENT_TRANSPORT_DEADLINE_MS,
+  CONSENT_WAIT_MS,
+  CONSENT_YES_LABEL,
+  adultConsentTimeoutResult,
+  isAdultConsentCard,
+  waitForAdultConsentAnswer,
+} from "../../web/js/lib/adult-consent-wait.js";
+
+const PANEL = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const source = readFileSync(PANEL, "utf8").replace(/\r\n/g, "\n");
+
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} not found`);
+  const signatureEnd = src.indexOf(") {", start);
+  assert.notEqual(signatureEnd, -1, `${name} body not found`);
+  const open = signatureEnd + 2;
+  let depth = 1;
+  let quote = null;
+  let lineComment = false;
+  let blockComment = false;
+  for (let i = open + 1; i < src.length; i += 1) {
+    const c = src[i];
+    const n = src[i + 1];
+    if (lineComment) {
+      if (c === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (c === "*" && n === "/") {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (c === "\\") i += 1;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === "/" && n === "/") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+    if (c === "/" && n === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      continue;
+    }
+    if (c === "{") depth += 1;
+    else if (c === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  assert.fail(`could not close ${name}`);
+}
+
+function consentMsg(overrides = {}) {
+  return {
+    header: CONSENT_HEADER,
+    question: "Adult-content gate — please confirm BOTH that you are at least 18.",
+    ask_id: "ask-consent-1",
+    options: [
+      { label: CONSENT_YES_LABEL, description: "Enable adult content for this session" },
+      { label: CONSENT_NO_LABEL, description: "Stay in safe-for-work mode" },
+    ],
+    ...overrides,
+  };
+}
+
+function manualTimers() {
+  let fire = null;
+  let delay = null;
+  let armed = false;
+  let didClear = false;
+  return {
+    timers: {
+      setTimer: (fn, ms) => {
+        fire = fn;
+        delay = ms;
+        armed = true;
+        return 1;
+      },
+      clearTimer: () => {
+        didClear = true;
+        fire = null;
+      },
+    },
+    expire: () => {
+      assert.ok(fire, "no timer was armed — the bound is not in effect");
+      fire();
+    },
+    delay: () => delay,
+    cleared: () => armed && didClear,
+  };
+}
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.children = [];
+    this.listeners = new Map();
+    this.className = "";
+    this.classList = { add() {}, remove() {} };
+    this.style = {};
+    this.value = "";
+    this.hidden = false;
+    this.disabled = false;
+    this.textContent = "";
+  }
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+  replaceChildren(...children) {
+    this.children = children;
+  }
+  addEventListener(name, fn) {
+    this.listeners.set(name, fn);
+  }
+  scrollIntoView() {}
+}
+
+function makeQuestionPainter({
+  wait = waitForAdultConsentAnswer,
+  record = () => {},
+} = {}) {
+  const log = new FakeElement("log");
+  const newMsgBtn = new FakeElement("button");
+  const document = { createElement: (tag) => new FakeElement(tag) };
+  const paintQuestion = new Function(
+    "document",
+    "log",
+    "newMsgBtn",
+    "clearEmpty",
+    "record",
+    "scrollLog",
+    "revealInteractiveCard",
+    "openSidebarTab",
+    "stickToBottom",
+    "coerceMessageText",
+    "renderRichText",
+    "isImeComposing",
+    "registerInteractiveCard",
+    "retireInteractiveCard",
+    "tr",
+    "INTERACTIVE_ABANDONED",
+    "waitForAdultConsentAnswer",
+    `${namedFunctionSource(source, "paintQuestion")}; return paintQuestion;`,
+  )(
+    document,
+    log,
+    newMsgBtn,
+    () => {},
+    record,
+    () => {},
+    () => {},
+    () => {},
+    false,
+    (value) => String(value ?? ""),
+    (el, text) => { el.textContent = String(text); },
+    () => false,
+    () => () => {},
+    () => {},
+    (key, fallback) => fallback,
+    Symbol("abandoned"),
+    wait,
+  );
+  return { log, paintQuestion };
+}
+
+const CONSENT_CARD = consentMsg();
+const RESTART_CARD = {
+  question: "Restart ComfyUI now?",
+  options: [{ label: "Yes, go ahead" }, { label: "No, cancel" }],
+};
+
+test("#390 the shipped wait sits inside both transport budgets", () => {
+  assert.ok(CONSENT_WAIT_MS > 0, "a non-positive bound is no bound");
+  assert.ok(
+    CONSENT_WAIT_MS < CONSENT_TRANSPORT_DEADLINE_MS,
+    "must resolve before the 300s tools/call kill",
+  );
+  assert.ok(
+    CONSENT_WAIT_MS < CONSENT_NESTED_CALL_BUDGET_MS,
+    "must also beat the 60s nested-SDK default the recurrence died on",
+  );
+  assert.equal(CONSENT_TRANSPORT_DEADLINE_MS, 300_000);
+});
+
+test("#390 only the 18+ consent card is bounded — a restart confirm is not", () => {
+  assert.equal(isAdultConsentCard(CONSENT_CARD), true);
+  assert.equal(isAdultConsentCard(consentMsg({ header: undefined })), true, "option identity is enough");
+  assert.equal(isAdultConsentCard(RESTART_CARD), false);
+  assert.equal(isAdultConsentCard({ header: CONSENT_HEADER }), true);
+  assert.equal(isAdultConsentCard(null), false);
+  assert.equal(isAdultConsentCard("yes"), false);
+});
+
+test("#390 a timeout result never grants adult mode", () => {
+  const out = adultConsentTimeoutResult("ask-consent-1");
+  assert.equal(out.nsfw_allowed, false);
+  assert.equal(out.timed_out, true);
+  assert.equal(out.request_id, "ask-consent-1");
+  assert.deepEqual(adultConsentTimeoutResult(""), { nsfw_allowed: false, timed_out: true });
+});
+
+test("#390 unanswered consent wait resolves structured timeout instead of hanging", async () => {
+  const never = new Promise(() => {});
+  const { timers, expire, delay } = manualTimers();
+  const pending = waitForAdultConsentAnswer(CONSENT_CARD, never, { timers });
+  let settled = false;
+  pending.then(() => { settled = true; });
+  await Promise.resolve();
+  assert.equal(settled, false, "must not resolve before the bound fires");
+  assert.equal(delay(), CONSENT_WAIT_MS, "the shipped wait, not a guessed one");
+  expire();
+  const out = await pending;
+  assert.equal(out.nsfw_allowed, false);
+  assert.equal(out.timed_out, true);
+  assert.equal(out.request_id, "ask-consent-1");
+});
+
+test("#390 a click before the bound is the answer, not a timeout", async () => {
+  const { timers, cleared } = manualTimers();
+  let resolveAnswer;
+  const answer = new Promise((res) => { resolveAnswer = res; });
+  const pending = waitForAdultConsentAnswer(CONSENT_CARD, answer, { timers });
+  resolveAnswer(CONSENT_YES_LABEL);
+  assert.equal(await pending, CONSENT_YES_LABEL);
+  assert.equal(cleared(), true, "the bound must not fire after a real pick");
+});
+
+test("#390 a non-consent question is returned UNCHANGED — no bound is armed", async () => {
+  const { timers, delay } = manualTimers();
+  const original = Promise.resolve("Yes, go ahead");
+  const out = waitForAdultConsentAnswer(RESTART_CARD, original, { timers });
+  assert.equal(out, original, "same promise object — not wrapped");
+  assert.equal(delay(), null, "no timer");
+  assert.equal(await out, "Yes, go ahead");
+});
+
+test("#390 the painter imports and returns the shipped consent wait", () => {
+  assert.match(
+    source,
+    /import \{ waitForAdultConsentAnswer \} from "\.\/lib\/adult-consent-wait\.js";/,
+  );
+  const paint = namedFunctionSource(source, "paintQuestion");
+  assert.match(paint, /waitForAdultConsentAnswer\(msg, promise,/);
+  assert.match(paint, /handedToCaller\.then\(unregister, unregister\)/);
+  assert.match(paint, /return handedToCaller;/);
+  assert.match(
+    namedFunctionSource(source, "createBridgeClient"),
+    /result = await onAsk\(msg, thisSock\.__cmcpSocketId \?\? null\)/,
+    "the executor still awaits the painter's promise — that is the command duration",
+  );
+});
+
+test("#390 the REAL painter's unanswered consent card settles before the transport deadline", { timeout: 1000 }, async () => {
+  const { timers, expire, delay } = manualTimers();
+  const wait = (msg, promise, opts = {}) =>
+    waitForAdultConsentAnswer(msg, promise, { ...opts, timers, waitMs: opts.waitMs ?? CONSENT_WAIT_MS });
+  const { log, paintQuestion } = makeQuestionPainter({ wait });
+  const pending = paintQuestion(CONSENT_CARD, "socket-390");
+  let settled = false;
+  pending.then(() => { settled = true; });
+  await Promise.resolve();
+  assert.equal(settled, false, "unfixed hang: the painter returned an unbounded promise");
+  assert.ok(log.children.length >= 1, "the gate still rendered");
+  assert.equal(delay(), CONSENT_WAIT_MS);
+  expire();
+  const out = await pending;
+  assert.equal(out.nsfw_allowed, false, "timeout must not grant");
+  assert.equal(out.timed_out, true);
+  assert.equal(out.request_id, "ask-consent-1");
+  assert.ok(
+    log.children[0].children.some((c) => /No answer in time/.test(c.textContent)),
+    "the card says the wait ended, so a late click is not a silent no-op",
+  );
+});
+
+test("#390 the REAL painter still hands a consent click through as the option label", { timeout: 1000 }, async () => {
+  const { timers } = manualTimers();
+  const wait = (msg, promise, opts = {}) =>
+    waitForAdultConsentAnswer(msg, promise, { ...opts, timers });
+  const { log, paintQuestion } = makeQuestionPainter({ wait });
+  const pending = paintQuestion(CONSENT_CARD, "socket-390-yes");
+  const card = log.children[0];
+  const btnRow = card.children.find((el) => el.children.some((c) => c.tagName === "button"));
+  const yes = btnRow.children[0];
+  yes.listeners.get("click")();
+  assert.equal(await pending, CONSENT_YES_LABEL);
+});

--- a/browser_tests/unit/restart-confirmation-transport.test.mjs
+++ b/browser_tests/unit/restart-confirmation-transport.test.mjs
@@ -9,6 +9,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { waitForAdultConsentAnswer } from "../../web/js/lib/adult-consent-wait.js";
 
 const PANEL = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const source = readFileSync(PANEL, "utf8").replace(/\r\n/g, "\n");
@@ -107,6 +108,7 @@ function makeQuestionPainter({ record = () => {}, onReveal = () => {} } = {}) {
     "retireInteractiveCard",
     "tr",
     "INTERACTIVE_ABANDONED",
+    "waitForAdultConsentAnswer",
     `${namedFunctionSource(source, "paintQuestion")}; return paintQuestion;`,
   )(
     document,
@@ -125,6 +127,7 @@ function makeQuestionPainter({ record = () => {}, onReveal = () => {} } = {}) {
     () => {},
     (key, fallback) => fallback,
     Symbol("abandoned"),
+    waitForAdultConsentAnswer,
   );
   return { log, paintQuestion };
 }

--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -140,7 +140,7 @@ test("#952 source guard: a question card registers itself and unregisters when a
     "registered at paint, and ONLY when a command painted it",
   );
   assert.match(paint, /alreadyAnswered: \(\) => done,/, "so an answered card is skipped");
-  assert.match(paint, /promise\.then\(unregister, unregister\)/, "and dropped once it settles, either way");
+  assert.match(paint, /handedToCaller\.then\(unregister, unregister\)/, "and dropped once the caller-facing wait settles, either way");
 });
 
 test("#952 (codex) a SECRET card is retired too, with secret-safe wording", () => {

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -627,6 +627,7 @@
       "new_messages": "New messages",
       "next": "Next",
       "no_agent_is_listening_on_the_bridge": "No agent is listening on the bridge ({bridge}). This ComfyUI won’t start one — run the agent on YOUR machine, then click Connect:\n    {command}",
+      "no_answer_in_time_adult_content_stays": "No answer in time — adult content stays as it was.",
       "no_chats_match_this_search": "No chats match this search.",
       "no_credential_slots": "No credential slots.",
       "no_errors_recorded_since_the_last_execution": "no errors recorded since the last execution start",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -769,6 +769,7 @@ import {
   refusedInteractiveCardError,
 } from "./lib/interactive-card-fence.js";
 import { revealInteractiveCard } from "./lib/interactive-card-reveal.js";
+import { waitForAdultConsentAnswer } from "./lib/adult-consent-wait.js";
 import {
   saveActiveWorkflow,
   shouldGroundBeforeTurn,
@@ -36464,8 +36465,33 @@ function buildPanel() {
         }),
       abandon,
     });
-    promise.then(unregister, unregister);
-    return promise;
+    // #390 — the 18+ consent card is the one question whose idle wait used to
+    // outlive the enclosing tools/call. Bound HERE, on the promise the
+    // executor awaits, so an unanswered gate resolves with a structured
+    // timeout instead of holding the rid until the transport kills it.
+    // Non-consent questions (restart confirm, generic asks) pass through.
+    const handedToCaller = waitForAdultConsentAnswer(msg, promise, {
+      onTimeout: () => {
+        if (done || abandoned) return;
+        done = true;
+        try {
+          const note = document.createElement("div");
+          note.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8615);opacity:0.7;margin-top:0.4rem;";
+          note.textContent = tr(
+            "panel.no_answer_in_time_adult_content_stays",
+            "No answer in time — adult content stays as it was.",
+          );
+          card.appendChild(note);
+          for (const el of [...btnRow.children, other, submit]) {
+            try { el.disabled = true; } catch { /* presentation-only */ }
+          }
+        } catch (error) {
+          console.warn("[comfyui-mcp-panel] couldn't present consent-card timeout:", error?.message ?? error);
+        }
+      },
+    });
+    handedToCaller.then(unregister, unregister);
+    return handedToCaller;
   }
 
   /**

--- a/web/js/lib/adult-consent-wait.js
+++ b/web/js/lib/adult-consent-wait.js
@@ -1,0 +1,105 @@
+// #390 — the 18+ consent card must not hold the enclosing tools/call until
+// the transport kills it.
+//
+// The card is painted by the same `ask_user` path as any other question, and
+// that path blocks until a human clicks. An idle user therefore leaves the
+// command in flight until the ~300s tools/call deadline (and nested MCP SDK
+// clients often die at the 60s default), which surfaces as a transport error
+// even though nothing failed. The original orchestrator clamp still waits
+// hundreds of seconds; this bound lives on the card the panel owns.
+//
+// Detection is option-identity plus the card header the orchestrator sends,
+// never a loose heuristic: a restart confirm must keep waiting on a person.
+// On timeout the command resolves with a structured result that does NOT
+// grant adult mode. Persistent consent is unchanged and remains queryable.
+
+import { withTimeout } from "./bounded-step.js";
+
+/** Exact affirmative option the orchestrator paints on the consent card. */
+export const CONSENT_YES_LABEL = "Yes — I'm 18+ and it's legal in my region";
+/** Exact decline option the orchestrator paints on the consent card. */
+export const CONSENT_NO_LABEL = "No — keep it SFW";
+/** Header the orchestrator stamps on the consent card. */
+export const CONSENT_HEADER = "18+ consent";
+
+/**
+ * How long the consent card may block the command.
+ *
+ * Must finish well inside both the 60s nested-SDK default (the recurrence
+ * died after ~50s) and the 300s tools/call kill. An attentive click still
+ * wins this race; an idle user gets a structured timeout, not a hang.
+ */
+export const CONSENT_WAIT_MS = 20_000;
+
+/** Enclosing tools/call budget this wait must beat. */
+export const CONSENT_TRANSPORT_DEADLINE_MS = 300_000;
+
+/** Nested MCP SDK default that killed the recurrence's nested call. */
+export const CONSENT_NESTED_CALL_BUDGET_MS = 60_000;
+
+/**
+ * Structured command result when the card is not answered in time.
+ * Does not grant adult mode. `request_id` is the card's ask_id when present
+ * so a later content-mode read can be correlated with this gate.
+ *
+ * @param {string} [askId]
+ */
+export function adultConsentTimeoutResult(askId) {
+  const result = { nsfw_allowed: false, timed_out: true };
+  if (typeof askId === "string" && askId) result.request_id = askId;
+  return result;
+}
+
+function optionLabel(opt) {
+  if (typeof opt === "string") return opt;
+  if (opt && typeof opt === "object" && typeof opt.label === "string") return opt.label;
+  return "";
+}
+
+/**
+ * True only for the 18+ consent card. Other question cards (restart confirm,
+ * generic asks) must keep blocking on a person.
+ *
+ * @param {any} msg
+ */
+export function isAdultConsentCard(msg) {
+  if (!msg || typeof msg !== "object") return false;
+  if (msg.header === CONSENT_HEADER) return true;
+  const opts = Array.isArray(msg.options) ? msg.options : [];
+  const labels = opts.map(optionLabel);
+  return labels.includes(CONSENT_YES_LABEL) && labels.includes(CONSENT_NO_LABEL);
+}
+
+/**
+ * Bound the consent-card wait. Non-consent questions are returned unchanged.
+ *
+ * Uses the repo's one `withTimeout` primitive — a second timer helper is how
+ * this class of hang keeps coming back.
+ *
+ * @param {any} msg
+ * @param {Promise<any>} answerPromise
+ * @param {{
+ *   waitMs?: number,
+ *   onTimeout?: () => void,
+ *   timers?: { setTimer?: Function, clearTimer?: Function },
+ * }} [opts]
+ * @returns {Promise<any>}
+ */
+export function waitForAdultConsentAnswer(msg, answerPromise, opts = {}) {
+  if (!isAdultConsentCard(msg)) return answerPromise;
+  const waitMs = Number.isFinite(opts.waitMs) && opts.waitMs > 0 ? opts.waitMs : CONSENT_WAIT_MS;
+  const askId = typeof msg.ask_id === "string" ? msg.ask_id : "";
+  return withTimeout(
+    answerPromise,
+    waitMs,
+    () => {
+      try {
+        opts.onTimeout?.();
+      } catch {
+        /* card presentation is best-effort; the command still has to settle */
+      }
+      return adultConsentTimeoutResult(askId);
+    },
+    opts.timers,
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #390 (recurrence). The original orchestrator clamp (`getAskTiming`, ~240s + grace) still left the nested tools/call waiting on the panel's unbounded `ask_user` card, so an idle 18+ consent gate died as a transport timeout instead of a structured result.

The panel owns that wait. `paintQuestion` now routes the consent card through `waitForAdultConsentAnswer`, which resolves in 20s (well under the 60s nested-SDK default and the 300s tools/call kill) with `{ nsfw_allowed: false, timed_out: true }` and does **not** grant adult mode. A real click still wins. Persistent consent stays queryable.

## Test plan

- [x] `node --test browser_tests/unit/adult-consent-wait.test.mjs` — 9/9 pass
- [x] `node --test browser_tests/unit/restart-confirmation-transport.test.mjs browser_tests/unit/stale-interactive-card.test.mjs` — existing painters still extract
- Tests drive the shipped helper **and** the real `paintQuestion` body; an unanswered consent card that returned an unbounded promise would hang the 1s test timeout
