### PR TITLE
fix(#572): restamp scoped run after subgraph-exit settle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- scoped run-to-node no longer false-refuses after a finished subgraph edit: the graph stamp waits for pending canvas work to settle and restamps once if the revision moved before queue, without falling through to a full-graph run (#572)
 - resolve the 18+ consent card before the 300s tools/call deadline so an idle user gets a structured timeout instead of a transport hang (#390)
 
 ## [0.15.125] - 2026-08-30

--- a/browser_tests/unit/run-scope-stamp-settle.test.mjs
+++ b/browser_tests/unit/run-scope-stamp-settle.test.mjs
@@ -1,0 +1,289 @@
+/**
+ * #572 recurrence — a scoped run-to-node false-refuses as `graph CHANGED`
+ * after a finished subgraph edit (activate nested samplers, exit, then run).
+ *
+ * The shipped stamp used to run immediately, so a leftover nested `model`
+ * link (`135:29 model`) that rematerialises on the next turn / next
+ * graphToPrompt was treated as a user edit. These tests drive
+ * `dispatchScopedRun` — the same orchestration the panel run path runs —
+ * and must fail on that false reject while still refusing a real edit (#556).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  dispatchScopedRun,
+  graphStampBusy,
+  graphStampRevision,
+  sameGraphStampRevision,
+} from "../../web/js/lib/run-scope-guard.js";
+
+function jsonResponse(status, obj) {
+  return {
+    status,
+    clone() {
+      return { json: async () => JSON.parse(JSON.stringify(obj)) };
+    },
+    text: async () => JSON.stringify(obj),
+  };
+}
+
+function makeServer(responder) {
+  const calls = [];
+  const fetchApi = async (route, options) => {
+    calls.push({ route, options });
+    return responder ? responder(route, options) : jsonResponse(200, { prompt_id: `srv-${calls.length}` });
+  };
+  fetchApi.calls = calls;
+  return fetchApi;
+}
+
+const promptPost = (body) => [
+  "/prompt",
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  },
+];
+
+function keepAlive() {
+  const ka = setInterval(() => {}, 25);
+  return () => clearInterval(ka);
+}
+
+function frontendBody({ output, number, targets = null }) {
+  const body = { prompt: output, client_id: "x" };
+  if (targets) body.partial_execution_targets = targets;
+  if (number != 0) body.number = number;
+  return body;
+}
+
+// Nested KSampler inside subgraph instance 135 — leftover widget `model`
+// vs the rematerialised incoming link after subgraph-exit settle.
+const STALE_OUTPUT = {
+  "135:3": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "model.safetensors" } },
+  "135:29": { class_type: "KSampler", inputs: { model: "model.safetensors", seed: 1, steps: 20 } },
+  "34": { class_type: "PreviewImage", inputs: { images: ["135:29", 0] } },
+};
+const SETTLED_OUTPUT = {
+  "135:3": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "model.safetensors" } },
+  "135:29": { class_type: "KSampler", inputs: { model: ["135:3", 0], seed: 1, steps: 20 } },
+  "34": { class_type: "PreviewImage", inputs: { images: ["135:29", 0] } },
+};
+
+function queueFromPrompt(app, apiTarget) {
+  return async (number, _batch, arg) => {
+    const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+    const queued = await app.graphToPrompt();
+    const body = frontendBody({
+      output: queued.output,
+      number,
+      targets: targets?.length ? targets : null,
+    });
+    app.posted.push(body);
+    await apiTarget.fetchApi(...promptPost(body));
+    return true;
+  };
+}
+
+test("#572 graphStampRevision: unreadables are idle; a live transaction is busy", () => {
+  assert.equal(graphStampBusy(graphStampRevision({})), false);
+  assert.equal(graphStampBusy(graphStampRevision({ graph: {} })), false);
+  const busy = graphStampRevision({
+    graph: { changeTracker: { changeCount: 1 }, last_change_time: 4 },
+  });
+  assert.equal(graphStampBusy(busy), true);
+  assert.equal(busy.changeCount, 1);
+  assert.equal(busy.extra, 4);
+  const idle = graphStampRevision({
+    graph: { changeTracker: { changeCount: 0 }, last_change_time: 4 },
+  });
+  assert.equal(graphStampBusy(idle), false);
+  assert.equal(sameGraphStampRevision(busy, idle), false);
+});
+
+test("#572 settle: a pending subgraph-exit transaction is not a user edit — the scoped run dispatches", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const graph = {
+      last_change_time: 1,
+      changeTracker: { changeCount: 1, _restoringState: false },
+      _nodes: [],
+    };
+    const app = {
+      graph,
+      rootGraph: graph,
+      queueItems: [],
+      posted: [],
+      graphToPrompt: async () => ({
+        output: structuredClone(graph.changeTracker.changeCount > 0 ? STALE_OUTPUT : SETTLED_OUTPUT),
+        workflow: {},
+      }),
+    };
+    app.queuePrompt = async (number, batch, arg) => {
+      await new Promise((r) => setTimeout(r, 0));
+      return queueFromPrompt(app, apiTarget)(number, batch, arg);
+    };
+    setTimeout(() => {
+      graph.changeTracker.changeCount = 0;
+      graph.last_change_time = 2;
+    }, 0);
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["34"], batch: 1, toNodeId: 34, verifyTimeoutMs: 500,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "dispatched", "the leftover nested model link is settle, not drift");
+    assert.equal(result.verified, 1);
+    assert.deepEqual(ids, ["srv-1"]);
+    assert.equal(server.calls.length, 1, "the scoped prompt reached ComfyUI once");
+    const posted = JSON.parse(server.calls[0].options.body);
+    assert.deepEqual(posted.partial_execution_targets, ["34"]);
+    assert.deepEqual(posted.prompt["135:29"].inputs.model, ["135:3", 0]);
+  } finally {
+    stop();
+  }
+});
+
+test("#572 restamp: the first graphToPrompt rematerialising 135:29 model is OUR dispatch", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const graph = { last_change_time: 1, _nodes: [] };
+    let calls = 0;
+    const app = {
+      graph,
+      rootGraph: graph,
+      queueItems: [],
+      posted: [],
+      graphToPrompt: async () => {
+        calls += 1;
+        if (calls === 1) {
+          graph.last_change_time = 2;
+          return { output: structuredClone(STALE_OUTPUT), workflow: {} };
+        }
+        return { output: structuredClone(SETTLED_OUTPUT), workflow: {} };
+      },
+    };
+    app.queuePrompt = queueFromPrompt(app, apiTarget);
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["34"], batch: 1, toNodeId: 34, verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "dispatched", "a stale first serialization is restamped, not refused");
+    assert.equal(server.calls.length, 1);
+    assert.deepEqual(
+      JSON.parse(server.calls[0].options.body).prompt["135:29"].inputs.model,
+      ["135:3", 0],
+    );
+    assert.ok(calls >= 2, "the settled serialization was the one hashed");
+  } finally {
+    stop();
+  }
+});
+
+test("#572 graph_changed retry: a stale stamp whose refused body already matches the idle canvas dispatches once", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    let calls = 0;
+    const app = {
+      graph: { _nodes: [] },
+      queueItems: [],
+      posted: [],
+      graphToPrompt: async () => {
+        calls += 1;
+        return {
+          output: structuredClone(calls === 1 ? STALE_OUTPUT : SETTLED_OUTPUT),
+          workflow: {},
+        };
+      },
+    };
+    app.queuePrompt = queueFromPrompt(app, apiTarget);
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["34"], batch: 1, toNodeId: 34, verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "dispatched", "the in-command restamp closes the false graph CHANGED");
+    assert.equal(server.calls.length, 1, "the first drifted post never left; the settled one did");
+    const posted = JSON.parse(server.calls[0].options.body);
+    assert.deepEqual(posted.partial_execution_targets, ["34"]);
+    assert.deepEqual(posted.prompt["135:29"].inputs.model, ["135:3", 0]);
+    assert.equal(result.error, undefined);
+  } finally {
+    stop();
+  }
+});
+
+test("#572 #556: a real nested-model rewire after the stamp still refuses and queues nothing", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = {
+      graph: { _nodes: [] },
+      queueItems: [],
+      posted: [],
+      graphToPrompt: async () => ({ output: structuredClone(SETTLED_OUTPUT), workflow: {} }),
+      queuePrompt: async (number, _batch, arg) => {
+        const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+        const output = structuredClone(SETTLED_OUTPUT);
+        output["135:29"].inputs.model = ["99", 0];
+        const body = frontendBody({
+          output, number, targets: targets?.length ? targets : null,
+        });
+        app.posted.push(body);
+        await apiTarget.fetchApi(...promptPost(body));
+        return true;
+      },
+    };
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["34"], batch: 1, toNodeId: 34, verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "refused", "a genuine rewire is still drift");
+    assert.match(result.error, /graph CHANGED/i);
+    assert.match(result.error, /135:29 model/);
+    assert.match(result.error, /Nothing was queued/);
+    assert.match(result.error, /#556/);
+    assert.equal(server.calls.length, 0, "the edited workflow never left the tab");
+  } finally {
+    stop();
+  }
+});
+
+test("#572 #556: a sibling seed edit is still refused — settle does not license other drift", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = {
+      graph: { _nodes: [] },
+      queueItems: [],
+      posted: [],
+      graphToPrompt: async () => ({ output: structuredClone(SETTLED_OUTPUT), workflow: {} }),
+      queuePrompt: async (number, _batch, arg) => {
+        const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+        const output = structuredClone(SETTLED_OUTPUT);
+        output["135:29"].inputs.seed = 99;
+        const body = frontendBody({
+          output, number, targets: targets?.length ? targets : null,
+        });
+        await apiTarget.fetchApi(...promptPost(body));
+        return true;
+      },
+    };
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["34"], batch: 1, toNodeId: 34, verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "refused", "settle does not license a sibling user edit");
+    assert.match(result.error, /graph CHANGED/i);
+    assert.match(result.error, /135:29 seed/);
+    assert.doesNotMatch(result.error, /135:29 model/);
+    assert.equal(server.calls.length, 0);
+  } finally {
+    stop();
+  }
+});

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -1547,7 +1547,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, retired: false, dropped: null, droppedReason: null, failed: null, repairedFromKeys: null, prunedRetry: null };
+  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, retired: false, dropped: null, droppedReason: null, droppedBody: null, failed: null, repairedFromKeys: null, prunedRetry: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -1779,6 +1779,13 @@ export function createScopedRunGuard({
               bodyKeys: scopeRead.bodyKeys,
             };
       state.droppedReason = verdict.reason;
+      if (!contentOk) {
+        try {
+          state.droppedBody = typeof options?.body === "string" ? options.body : null;
+        } catch {
+          state.droppedBody = null;
+        }
+      }
       try {
         state.dropped = scopeDroppedError({ toNodeId, verdict });
       } catch {
@@ -1899,6 +1906,68 @@ export function cancelPendingScopedQueueItem(app, { runTag, queueMark } = {}) {
  *    (no fetchApi to observe through, or no prompt signature) — refused
  *    BEFORE dispatch, nothing queued.
  */
+
+/**
+ * The cheap canvas-revision signal the scoped-run stamp waits on (#572).
+ * `changeCount` / `_restoringState` / `isLoadingGraph` are ChangeTracker's
+ * own "do not snapshot yet" windows; `extra` is LiteGraph's last-change
+ * counter when the frontend exposes one. Unreadable fields count as idle.
+ */
+export function graphStampRevision(app) {
+  const graph = app?.rootGraph ?? app?.graph ?? null;
+  let tracker = null;
+  try {
+    tracker =
+      app?.extensionManager?.workflow?.activeWorkflow?.changeTracker ??
+      graph?.changeTracker ??
+      null;
+  } catch {
+    tracker = null;
+  }
+  let changeCount = 0;
+  let restoring = false;
+  let loading = false;
+  let extra = 0;
+  try {
+    const n = Number(tracker?.changeCount);
+    if (Number.isFinite(n) && n > 0) changeCount = n;
+  } catch {
+    /* unreadable tracker → treat as idle */
+  }
+  try {
+    restoring = !!tracker?._restoringState;
+  } catch {
+    restoring = false;
+  }
+  try {
+    loading = !!tracker?.constructor?.isLoadingGraph;
+  } catch {
+    loading = false;
+  }
+  try {
+    const n = Number(graph?.last_change_time ?? graph?._version);
+    if (Number.isFinite(n)) extra = n;
+  } catch {
+    extra = 0;
+  }
+  return { changeCount, restoring, loading, extra };
+}
+
+export function graphStampBusy(rev) {
+  return !!rev && (rev.changeCount > 0 || rev.restoring || rev.loading);
+}
+
+export function sameGraphStampRevision(a, b) {
+  return (
+    !!a &&
+    !!b &&
+    a.changeCount === b.changeCount &&
+    a.restoring === b.restoring &&
+    a.loading === b.loading &&
+    a.extra === b.extra
+  );
+}
+
 export async function dispatchScopedRun({
   app,
   apiTarget,
@@ -1912,7 +1981,7 @@ export async function dispatchScopedRun({
   onPromptId = null,
   onAcceptedNodeErrors = null,
 } = {}) {
-  const mark = queueMark ?? newScopedQueueMark();
+  let mark = queueMark ?? newScopedQueueMark();
   // #1565 — ONE DEADLINE FOR THE WHOLE DISPATCH, so the per-attempt bounds COMPOSE.
   //
   // Every wait in this function used to start its own fresh clock: four argument
@@ -2015,41 +2084,75 @@ export async function dispatchScopedRun({
   // No hash ⇒ no attribution ⇒ fail closed BEFORE dispatch. The canonical
   // form is RETAINED (contentCanon) so a graph_changed refusal can say WHAT
   // differed instead of asserting a cause (#659).
-  let contentHash = null;
-  let contentCanon = null;
-  let volatileInputs = null;
-  // #1571 — KEEP what was thrown. The refusal below is the only thing the caller sees,
-  // and without this the serializer's own message (which names the offending node) was
-  // discarded at exactly the moment it was needed.
-  let fingerprintCause = null;
-  try {
-    if (typeof app.graphToPrompt === "function") {
-      // This panel's live root is app.graph (r8) — app.rootGraph only as a
-      // fallback for frontends that expose it instead.
-      volatileInputs = collectVolatileInputs(app?.graph ?? app?.rootGraph ?? null);
-      // #1565 — BOUNDED. Serializing the whole workflow is the first thing the run path
-      // does that the read path never does, and an extension's serializeValue that never
-      // settles held the command open with no bound at all. A serializer that will not
-      // answer leaves no fingerprint, which is already the fail-closed state below:
-      // `unverifiable`, nothing queued, and the cause named.
-      const built = await boundedStep(app.graphToPrompt(), boundedBy(verifyTimeoutMs));
-      if (built === TIMED_OUT) {
-        throw new Error(
-          `app.graphToPrompt did not answer within this run's command budget — the ` +
-            `frontend could not serialize the workflow, so nothing was queued`,
-        );
+  //
+  // #572 recurrence — subgraph-exit / node-activate edits can still be
+  // flushing when this stamp runs (ChangeTracker.changeCount > 0, or the
+  // first graphToPrompt itself rematerialises a nested link). Snapshot after
+  // that window closes, and restamp once if the revision moved during the
+  // first fingerprint. A genuine mid-window user edit still mismatches and
+  // is refused (#556).
+  const fingerprintOnce = async () => {
+    let contentHash = null;
+    let contentCanon = null;
+    let volatileInputs = null;
+    let fingerprintCause = null;
+    try {
+      if (typeof app.graphToPrompt === "function") {
+        // Prefer the workflow root when the canvas is still inside a subgraph
+        // view: prompt keys are root-relative colon paths.
+        volatileInputs = collectVolatileInputs(app?.rootGraph ?? app?.graph ?? null);
+        // #1565 — BOUNDED. Serializing the whole workflow is the first thing the run path
+        // does that the read path never does, and an extension's serializeValue that never
+        // settles held the command open with no bound at all. A serializer that will not
+        // answer leaves no fingerprint, which is already the fail-closed state below:
+        // `unverifiable`, nothing queued, and the cause named.
+        const built = await boundedStep(app.graphToPrompt(), boundedBy(verifyTimeoutMs));
+        if (built === TIMED_OUT) {
+          throw new Error(
+            `app.graphToPrompt did not answer within this run's command budget — the ` +
+              `frontend could not serialize the workflow, so nothing was queued`,
+          );
+        }
+        // `"error" in` rather than a truthiness test: a falsy thrown value (`throw undefined`)
+        // used to propagate out of here, and a bound must not swallow it.
+        if ("error" in built) throw built.error;
+        contentCanon = canonicalizePrompt(built.value?.output, volatileInputs);
+        contentHash = contentCanon ? fnv1aHex(JSON.stringify(contentCanon)) : null;
       }
-      // `"error" in` rather than a truthiness test: a falsy thrown value (`throw undefined`)
-      // used to propagate out of here, and a bound must not swallow it.
-      if ("error" in built) throw built.error;
-      contentCanon = canonicalizePrompt(built.value?.output, volatileInputs);
-      contentHash = contentCanon ? fnv1aHex(JSON.stringify(contentCanon)) : null;
+    } catch (err) {
+      contentHash = null;
+      contentCanon = null;
+      fingerprintCause = err;
     }
-  } catch (err) {
-    contentHash = null;
-    contentCanon = null;
-    fingerprintCause = err;
+    return { contentHash, contentCanon, volatileInputs, fingerprintCause };
+  };
+  const yieldStampTurn = async () => {
+    if (hasBudget && typeof budget.exhausted === "function" && budget.exhausted()) return TIMED_OUT;
+    return boundedStep(new Promise((resolve) => setTimeout(resolve, 0)), boundedBy(1));
+  };
+
+  let rev = graphStampRevision(app);
+  await yieldStampTurn();
+  let revSettled = graphStampRevision(app);
+  if (graphStampBusy(revSettled) || !sameGraphStampRevision(rev, revSettled)) {
+    await yieldStampTurn();
+    revSettled = graphStampRevision(app);
   }
+
+  let fp = await fingerprintOnce();
+  const revAfterStamp = graphStampRevision(app);
+  if (
+    fp.contentHash &&
+    (!sameGraphStampRevision(revSettled, revAfterStamp) || graphStampBusy(revSettled))
+  ) {
+    const again = await fingerprintOnce();
+    if (again.contentHash) fp = again;
+  }
+
+  let contentHash = fp.contentHash;
+  let contentCanon = fp.contentCanon;
+  let volatileInputs = fp.volatileInputs;
+  const fingerprintCause = fp.fingerprintCause;
   if (!contentHash) {
     return {
       outcome: "unverifiable",
@@ -2063,7 +2166,7 @@ export async function dispatchScopedRun({
   // post-hash outcome so the caller can report the coverage gap truthfully
   // instead of implying full-graph drift proof (see collectVolatileInputs'
   // ACCEPTED RESIDUAL note).
-  const volatileList = volatileInputs ? [...volatileInputs].sort() : [];
+  let volatileList = volatileInputs ? [...volatileInputs].sort() : [];
   // Ownership tag for the timeout cancellation (see QUEUE_ITEM_TAG).
   const runTag = Symbol("cmcp-scoped-run");
   try {
@@ -2072,8 +2175,12 @@ export async function dispatchScopedRun({
     // non-extensible array — cancellation will report 0 and the sentinel covers it.
   }
   let dropped = null;
-  const attempts = queuePromptScopeAttempts(execIds);
-  for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
+  let restampUsed = false;
+  for (;;) {
+    let restampAgain = false;
+    dropped = null;
+    const attempts = queuePromptScopeAttempts(execIds);
+    for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
     const { arg: scopeArg, repair } = attempts[attemptIndex];
     const isLastAttempt = attemptIndex === attempts.length - 1;
     dropped = null;
@@ -2323,7 +2430,34 @@ export async function dispatchScopedRun({
     // r7 CONTENT DRIFT with ZERO verified posts is NOT an argument-shape
     // problem — retrying the other shape would produce the same drifted post.
     // Terminal refusal naming that the graph changed under the deferred item.
+    //
+    // #572 — one exception, and only this one: the refused body already equals
+    // a fresh serialization of the now-idle canvas. The first stamp was stale
+    // (subgraph-exit / node-activate still flushing); nothing was queued. Adopt
+    // the settled snapshot on a NEW mark so the closed first-attempt sentinel
+    // still blocks the old identity, and dispatch once. A live graph that does
+    // not match the refused body is a real concurrent edit and still refuses.
     if (guard.state.observed === 0 && guard.state.droppedReason === "graph_changed") {
+      if (!restampUsed) {
+        const live = await fingerprintOnce();
+        const bodyHash = live.contentHash
+          ? promptContentHashFromBody(guard.state.droppedBody, live.volatileInputs)
+          : null;
+        if (
+          live.contentHash &&
+          bodyHash === live.contentHash &&
+          !graphStampBusy(graphStampRevision(app))
+        ) {
+          restampUsed = true;
+          restampAgain = true;
+          contentHash = live.contentHash;
+          contentCanon = live.contentCanon;
+          volatileInputs = live.volatileInputs;
+          volatileList = volatileInputs ? [...volatileInputs].sort() : [];
+          mark = newScopedQueueMark();
+          break;
+        }
+      }
       return { outcome: "refused", queueMark: mark, verified: 0, volatileInputs: volatileList, error: guard.state.dropped };
     }
     // A corrupted post with ZERO verified posts means this argument SHAPE was
@@ -2353,6 +2487,8 @@ export async function dispatchScopedRun({
         graphChanged: guard.state.droppedReason === "graph_changed",
       }),
     };
+    }
+    if (restampAgain) continue;
+    return { outcome: "refused", queueMark: mark, verified: 0, volatileInputs: volatileList, error: dropped };
   }
-  return { outcome: "refused", queueMark: mark, verified: 0, volatileInputs: volatileList, error: dropped };
 }


### PR DESCRIPTION
## Summary

Fixes artokun/comfyui-mcp-panel#572 (recurrence after #576).

On current panel 0.15.124, activating sampler nodes inside a subgraph then exiting it still made a scoped run-to-node refuse with `graph CHANGED` and drift `135:29 model` — twice, including the command-level retry — with nothing queued and no concurrent user edit. The previous #572 fix excluded linked value-control widgets; this recurrence is a **stale stamp**, not another volatile input.

- Snapshot the scoped-run graph stamp **after** pending canvas work is idle (`changeCount` / restore / load windows).
- Restamp **once** if the revision moved during that first fingerprint (the serializer rematerialising a nested link).
- If the first post is still refused as `graph_changed` with zero verified prompts, and a fresh idle serialization **already equals the refused body**, retry once on a new queue mark. The closed first-attempt sentinel still blocks the stale identity.
- A real mid-window rewire or sibling edit still refuses and queues nothing (#556).

## Root cause

`dispatchScopedRun` fingerprinted immediately, then `queuePrompt` serialized later. Subgraph-exit / node-activate leftover settling (`135:29 model` leftover widget value → incoming link) landed between those two serializations. The #556 guard correctly refused its own drifted dispatch, but the drift was the canvas finishing the edit that had already completed, not a user mutation. The argument-shape retry does not re-fingerprint, so the command-level retry failed identically.

## Invariants preserved

- #556: a scope-dropped / corrupted / genuinely drifted dispatch is still refused before it leaves the browser. Only a refused body that already matches a fresh idle snapshot is retried, on a new mark, still scoped.
- No change to run-target resolution, unscoped runs, or the volatile-input exclusions from #576/#1331/#1124.

## Validation

- `node --test browser_tests/unit/run-scope-stamp-settle.test.mjs` — 6 pass (false reject after subgraph-exit settle, restamp on revision bump, graph_changed restamp, nested-model rewire still refused, sibling seed edit still refused)
- `node --test browser_tests/unit/run-scope-guard.test.mjs` — pass
- `node --test browser_tests/unit/scope-fingerprint-cause.test.mjs browser_tests/unit/run-command-budget.test.mjs` — pass
