### PR TITLE
fix: rebind workflow save after restart confirmation timeout (#1757)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- after a restart confirmation times out without rebooting, an in-place workflow save rebinds the same-origin userdata route and retries the write once, so a dirty tab is not stranded behind the browsers bare Failed to fetch; if the write still cannot land, the error names the userdata URL and any HTTP status/body (#1757)
 - promoted widget writes no longer treat a stale inner Primitive handle as the parent rail, so MiniMax H3 duration/value_1, turbo_mode, turbo_steps, and lora_name serialize the new value (#366)
 - scoped run-to-node no longer false-refuses after a finished subgraph edit: the graph stamp waits for pending canvas work to settle and restamps once if the revision moved before queue, without falling through to a full-graph run (#572)
 - resolve the 18+ consent card before the 300s tools/call deadline so an idle user gets a structured timeout instead of a transport hang (#390)

--- a/browser_tests/unit/save-route-retry.test.mjs
+++ b/browser_tests/unit/save-route-retry.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * #1757 recurrence — helpers behind the same-origin save rebind/retry.
+ * Behavioural coverage of the shipped write lives in save-transport-failure.test.mjs
+ * (it drives saveActiveWorkflow). These lock the flag, rebind, and probe shapes.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  classifySaveWriteLanded,
+  clearRestartConfirmTimeout,
+  consumeRestartConfirmTimeout,
+  noteRestartConfirmTimeout,
+  pageOrigin,
+  rebindSameOriginSaveRoute,
+  resolveSameOriginUserDataUrl,
+  restartConfirmTimeoutPending,
+  writeWithSameOriginRetry,
+} from "../../web/js/lib/save-route-retry.js";
+
+test("#1757 the restart-confirm timeout flag is one-shot", () => {
+  clearRestartConfirmTimeout();
+  assert.equal(restartConfirmTimeoutPending(), false);
+  noteRestartConfirmTimeout();
+  assert.equal(restartConfirmTimeoutPending(), true);
+  assert.equal(consumeRestartConfirmTimeout(), true);
+  assert.equal(restartConfirmTimeoutPending(), false);
+  assert.equal(consumeRestartConfirmTimeout(), false);
+});
+
+test("#1757 rebindSameOriginSaveRoute writes the page host onto api.api_host", () => {
+  const api = { api_host: "old.example:9" };
+  const result = rebindSameOriginSaveRoute({ api, origin: "http://127.0.0.1:8188/extra" });
+  assert.equal(result.rebound, true);
+  assert.equal(result.origin, "http://127.0.0.1:8188");
+  assert.equal(result.host, "127.0.0.1:8188");
+  assert.equal(api.api_host, "127.0.0.1:8188");
+});
+
+test("#1757 rebindSameOriginSaveRoute refuses a non-http origin rather than guessing", () => {
+  const api = { api_host: "old.example:9" };
+  const result = rebindSameOriginSaveRoute({ api, origin: "file:///C:/ComfyUI" });
+  assert.equal(result.rebound, false);
+  assert.equal(api.api_host, "old.example:9");
+});
+
+test("#1757 pageOrigin ignores the browser's string 'null'", () => {
+  assert.equal(pageOrigin({ origin: "null" }), null);
+  assert.equal(pageOrigin({ origin: "http://127.0.0.1:8188" }), "http://127.0.0.1:8188");
+});
+
+test("#1757 resolveSameOriginUserDataUrl prefers apiUrl, else origin+route", () => {
+  assert.equal(
+    resolveSameOriginUserDataUrl("workflows/Foo.json", {
+      apiUrl: (route) => `http://127.0.0.1:8188/api${route}`,
+    }),
+    "http://127.0.0.1:8188/api/userdata/workflows%2FFoo.json",
+  );
+  assert.equal(
+    resolveSameOriginUserDataUrl("workflows/Foo.json", { origin: "http://127.0.0.1:8188" }),
+    "http://127.0.0.1:8188/userdata/workflows%2FFoo.json",
+  );
+  assert.equal(resolveSameOriginUserDataUrl(""), null);
+});
+
+test("#1757 classifySaveWriteLanded reports missed / landed / unknown without guessing", async () => {
+  assert.equal(await classifySaveWriteLanded({ path: "workflows/Foo.json", existsOnDisk: async () => false }), "missed");
+  assert.equal(
+    await classifySaveWriteLanded({
+      path: "workflows/Foo.json",
+      existsOnDisk: async () => true,
+      expectedText: "{\"nodes\":[]}",
+      readDiskBytes: async () => "{\"nodes\":[]}",
+    }),
+    "landed",
+  );
+  assert.equal(
+    await classifySaveWriteLanded({
+      path: "workflows/Foo.json",
+      existsOnDisk: async () => true,
+      expectedText: "{\"nodes\":[]}",
+      readDiskBytes: async () => "{\"nodes\":[1]}",
+    }),
+    "missed",
+  );
+  assert.equal(await classifySaveWriteLanded({ path: "workflows/Foo.json" }), "unknown");
+  assert.equal(
+    await classifySaveWriteLanded({
+      path: "workflows/Foo.json",
+      existsOnDisk: async () => {
+        throw new Error("HEAD failed");
+      },
+    }),
+    "unknown",
+  );
+});
+
+test("#1757 writeWithSameOriginRetry does not retry a non-transport failure", async () => {
+  let writes = 0;
+  await assert.rejects(
+    () =>
+      writeWithSameOriginRetry(
+        async () => {
+          writes += 1;
+          throw new Error("Error storing user data file: 409 Conflict");
+        },
+        { allowUnknownRetry: true, afterRestartConfirmTimeout: true },
+      ),
+    /409 Conflict/,
+  );
+  assert.equal(writes, 1);
+});
+
+test("#1757 writeWithSameOriginRetry recovers when the probe says the write landed", async () => {
+  const recovered = await writeWithSameOriginRetry(
+    async () => {
+      throw new TypeError("Failed to fetch");
+    },
+    { probe: async () => "landed", recoveredValue: { path: "workflows/Foo.json" }, afterRestartConfirmTimeout: false },
+  );
+  assert.deepEqual(recovered, { path: "workflows/Foo.json" });
+});

--- a/browser_tests/unit/save-transport-failure.test.mjs
+++ b/browser_tests/unit/save-transport-failure.test.mjs
@@ -37,6 +37,13 @@ import {
   saveTransportFailureMessage,
   userDataRoute,
 } from "../../web/js/lib/save-transport-failure.js";
+import {
+  clearRestartConfirmTimeout,
+  noteRestartConfirmTimeout,
+  rebindSameOriginSaveRoute,
+  restartConfirmTimeoutPending,
+} from "../../web/js/lib/save-route-retry.js";
+import { linkDrivenWidgets } from "../../web/js/lib/graph-read.js";
 
 /** Exactly what Chrome throws when a fetch never completes. */
 const failedToFetch = () => new TypeError("Failed to fetch");
@@ -441,4 +448,136 @@ test("#1757 programmaticSave hands saveActiveWorkflow a LIVE socket observer", (
     /describeSaveBackendSocket\(\{[\s\S]*flaggedDown: comfyBackendSocketDown[\s\S]*socketReadyState: comfyBackendSocketReadyState\(\)/,
     "reading the same two observations the graph-mutation gate reads",
   );
+  assert.match(
+    call,
+    /rebindSaveRoute: \(\) =>/,
+    "the same-origin userdata rebind is installed on the production save",
+  );
+  assert.match(call, /rebindSameOriginSaveRoute\(\{[\s\S]*api,[\s\S]*origin:/);
+});
+
+function liveGraphNode() {
+  return {
+    graph: { links: { 7: { origin_id: 85, origin_slot: 0 } } },
+    widgets: [{ name: "steps", value: 30 }],
+    inputs: [{ name: "steps", type: "INT", link: 7 }],
+  };
+}
+
+test("#1757 recurrence: restart-confirm timeout → graph read still works → save succeeds after rebind", async () => {
+  clearRestartConfirmTimeout();
+  noteRestartConfirmTimeout();
+
+  const driven = linkDrivenWidgets(liveGraphNode());
+  assert.deepEqual(
+    driven,
+    { steps: { node_id: 85, output_slot: 0 } },
+    "in-memory graph reads keep working; they issue no HTTP",
+  );
+
+  const api = { api_host: "stale.example:9999" };
+  const active = persistedTab();
+  let writes = 0;
+  const svc = makeStore({
+    active,
+    disk: [active.path],
+    onSaveWorkflow: () => {
+      writes += 1;
+      if (api.api_host !== "127.0.0.1:8188") throw failedToFetch();
+    },
+  });
+
+  const saved = await saveActiveWorkflow(svc, undefined, {
+    existsOnDisk: async () => true,
+    rebindSaveRoute: () => rebindSameOriginSaveRoute({ api, origin: "http://127.0.0.1:8188" }),
+  });
+
+  assert.ok(saved, "the in-place save must persist after the same-origin rebind");
+  assert.equal(writes, 1, "rebind runs before the first write when the confirmation timed out");
+  assert.equal(api.api_host, "127.0.0.1:8188");
+  assert.equal(restartConfirmTimeoutPending(), false, "the save consumes the timeout flag");
+});
+
+test("#1757 recurrence: a missed in-place write is retried once and then succeeds", async () => {
+  clearRestartConfirmTimeout();
+  noteRestartConfirmTimeout();
+  assert.deepEqual(linkDrivenWidgets(liveGraphNode()).steps, { node_id: 85, output_slot: 0 });
+
+  const active = persistedTab();
+  let writes = 0;
+  let rebinds = 0;
+  const svc = makeStore({
+    active,
+    disk: [active.path],
+    onSaveWorkflow: () => {
+      writes += 1;
+      if (writes === 1) throw failedToFetch();
+    },
+  });
+
+  const saved = await saveActiveWorkflow(svc, undefined, {
+    existsOnDisk: async () => true,
+    probeSaveLanded: async () => "missed",
+    rebindSaveRoute: () => {
+      rebinds += 1;
+    },
+  });
+
+  assert.ok(saved);
+  assert.equal(writes, 2, "exactly one retry of the shipped store write");
+  assert.ok(rebinds >= 1, "the same-origin route is rebound before the retry");
+});
+
+test("#1757 recurrence: a still-failing save returns the userdata URL, not bare 'Failed to fetch'", async () => {
+  clearRestartConfirmTimeout();
+  noteRestartConfirmTimeout();
+  assert.ok(linkDrivenWidgets(liveGraphNode()).steps);
+
+  const active = persistedTab();
+  const svc = makeStore({
+    active,
+    disk: [active.path],
+    onSaveWorkflow: () => {
+      const err = failedToFetch();
+      err.status = 503;
+      err.body = "origin warming up";
+      throw err;
+    },
+  });
+
+  const err = await saveAndCatch(svc, undefined, {
+    existsOnDisk: async () => true,
+    probeSaveLanded: async () => "missed",
+    rebindSaveRoute: () => {},
+  });
+
+  assert.ok(err, "the save must still fail when the retry cannot persist");
+  assert.equal(err.message === "Failed to fetch", false, "the bare browser string is the defect");
+  assert.notEqual(err.message, "Failed to fetch");
+  assert.match(err.message, /Request URL:/);
+  assert.match(err.message, /\/userdata\/workflows%2FLTX%20EROS%20Extend\.json/);
+  assert.match(err.message, /HTTP status: 503/);
+  assert.match(err.message, /origin warming up/);
+});
+
+test("#1757 recurrence: a lost response whose write DID land is reported as success, not retried", async () => {
+  clearRestartConfirmTimeout();
+  const active = persistedTab();
+  let writes = 0;
+  const svc = makeStore({
+    active,
+    disk: [active.path],
+    onSaveWorkflow: () => {
+      writes += 1;
+      throw failedToFetch();
+    },
+  });
+
+  const saved = await saveActiveWorkflow(svc, undefined, {
+    existsOnDisk: async () => true,
+    probeSaveLanded: async () => "landed",
+  });
+
+  assert.ok(saved, "read-back proof that the bytes landed is success");
+  assert.equal(writes, 1, "must not retry a mutation the probe already found on disk");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -784,6 +784,10 @@ import {
 } from "./lib/workflow-save.js";
 import { describeSaveBackendSocket } from "./lib/save-transport-failure.js";
 import {
+  noteRestartConfirmTimeout,
+  rebindSameOriginSaveRoute,
+} from "./lib/save-route-retry.js";
+import {
   WORKFLOW_SAVE_COMMAND_BUDGET_MS,
   runBoundedWorkflowSave,
   workflowSaveTimeoutObservation,
@@ -7613,6 +7617,14 @@ async function programmaticSave(name) {
       describeSaveBackendSocket({
         flaggedDown: comfyBackendSocketDown,
         socketReadyState: comfyBackendSocketReadyState(),
+      }),
+    // #1757 — after a restart confirmation expires without rebooting, point the
+    // userdata write back at this page's origin before retrying the same-origin
+    // save. Evaluated at failure time so it describes the host that is live now.
+    rebindSaveRoute: () =>
+      rebindSameOriginSaveRoute({
+        api,
+        origin: globalThis.location?.origin,
       }),
   });
   if (details.mode === "in-place" && typeof clearWorkflowGraphProvenanceUnknown === "function") {
@@ -27970,7 +27982,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // the reply AND `settleRid` runs: without this the ledger keeps an
             // un-evictable in-flight entry whose replay would await a promise that can
             // never resolve, and answer nothing at all.
-            if (isAbandonedInteractive(result)) throw new Error(abandonedInteractiveError(msg.cmd));
+            if (isAbandonedInteractive(result)) {
+              // Withdrawn confirmation: the next in-place save rebinds the
+              // same-origin userdata route rather than inheriting a stale host.
+              noteRestartConfirmTimeout();
+              throw new Error(abandonedInteractiveError(msg.cmd));
+            }
           } else if (msg.cmd === "request_secret") {
             // Secure secret entry. The pasted value rides back to the
             // orchestrator (which writes it to config) and is the tool's reply;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -27982,12 +27982,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // the reply AND `settleRid` runs: without this the ledger keeps an
             // un-evictable in-flight entry whose replay would await a promise that can
             // never resolve, and answer nothing at all.
-            if (isAbandonedInteractive(result)) {
-              // Withdrawn confirmation: the next in-place save rebinds the
-              // same-origin userdata route rather than inheriting a stale host.
-              noteRestartConfirmTimeout();
-              throw new Error(abandonedInteractiveError(msg.cmd));
-            }
+            if (isAbandonedInteractive(result)) noteRestartConfirmTimeout();
+            if (isAbandonedInteractive(result)) throw new Error(abandonedInteractiveError(msg.cmd));
           } else if (msg.cmd === "request_secret") {
             // Secure secret entry. The pasted value rides back to the
             // orchestrator (which writes it to config) and is the tool's reply;

--- a/web/js/lib/save-route-retry.js
+++ b/web/js/lib/save-route-retry.js
@@ -1,0 +1,230 @@
+/**
+ * #1757 recurrence — a timed-out restart confirmation does not reboot ComfyUI,
+ * but the next in-place userdata write can still throw the browser's bare
+ * "Failed to fetch" while in-memory graph reads keep working.
+ *
+ * PR #1769 explained that transport failure. It did not rebind the same-origin
+ * userdata route or retry the write, so a dirty tab stayed unpersistable.
+ *
+ * In-place overwrite of the SAME graph bytes is idempotent, so one retry after
+ * a lost response cannot duplicate a distinct mutation. Save-as is not: the
+ * copy is created with overwrite:false, and a second attempt can 409. Callers
+ * set `allowUnknownRetry` only on the in-place path.
+ *
+ * A write is retried only when a read-back says it missed, or when the probe
+ * is unknown AND this is the in-place / restart-timeout path. Blind save-as
+ * retries are refused.
+ */
+
+import { isTransportFailure } from "./manager-fetch-failure.js";
+import { userDataRoute } from "./save-transport-failure.js";
+import { diskBytesEqualText } from "./workflow-open-staleness.js";
+
+let restartConfirmTimedOut = false;
+
+/** Record that a restart confirmation expired without rebooting. */
+export function noteRestartConfirmTimeout() {
+  restartConfirmTimedOut = true;
+}
+
+/** True if a restart confirmation has expired and has not yet been consumed. */
+export function restartConfirmTimeoutPending() {
+  return restartConfirmTimedOut === true;
+}
+
+/** Read-and-clear the restart-confirmation timeout flag. */
+export function consumeRestartConfirmTimeout() {
+  const was = restartConfirmTimedOut === true;
+  restartConfirmTimedOut = false;
+  return was;
+}
+
+/** Test hook: drop a leftover flag so cases cannot leak into each other. */
+export function clearRestartConfirmTimeout() {
+  restartConfirmTimedOut = false;
+}
+
+export function pageOrigin(locationLike = globalThis.location) {
+  const origin = locationLike?.origin;
+  if (typeof origin !== "string" || !origin || origin === "null") return null;
+  return origin;
+}
+
+/**
+ * Point ComfyUI's API host back at the page origin. A drifted `api_host` is
+ * how a same-origin userdata write starts targeting a host that will not
+ * answer while the in-memory graph is still live.
+ */
+export function rebindSameOriginSaveRoute({ api, origin } = {}) {
+  const raw = typeof origin === "string" && origin ? origin : pageOrigin();
+  if (!raw || raw === "null") return { rebound: false, origin: null, host: null };
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return { rebound: false, origin: null, host: null };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { rebound: false, origin: null, host: null };
+  }
+  if (!parsed.host) return { rebound: false, origin: null, host: null };
+  if (api && typeof api === "object") {
+    try {
+      api.api_host = parsed.host;
+    } catch {
+      /* frozen host — the write still goes out, just without a rebind */
+    }
+  }
+  return { rebound: true, origin: parsed.origin, host: parsed.host };
+}
+
+/** Absolute userdata URL a reader can match against the network panel. */
+export function resolveSameOriginUserDataUrl(path, { origin, apiUrl } = {}) {
+  const route = userDataRoute(path);
+  if (!route) return null;
+  if (typeof apiUrl === "function") {
+    try {
+      const resolved = apiUrl(route);
+      if (typeof resolved === "string" && resolved) return resolved;
+    } catch {
+      /* fall through to origin+route */
+    }
+  }
+  const base = typeof origin === "string" && origin && origin !== "null" ? origin : pageOrigin();
+  if (!base) return route;
+  try {
+    return new URL(route, base.endsWith("/") ? base : `${base}/`).href;
+  } catch {
+    return route;
+  }
+}
+
+/**
+ * Did the userdata write land despite a lost HTTP response?
+ * `"landed"` / `"missed"` / `"unknown"` — never a guess presented as fact.
+ */
+export async function classifySaveWriteLanded({
+  path,
+  expectedText,
+  existsOnDisk,
+  readDiskBytes,
+} = {}) {
+  if (typeof path !== "string" || !path) return "unknown";
+  if (typeof existsOnDisk === "function") {
+    let exists;
+    try {
+      exists = await existsOnDisk(path);
+    } catch {
+      return "unknown";
+    }
+    if (exists === false) return "missed";
+    if (exists !== true) return "unknown";
+  }
+  if (typeof readDiskBytes !== "function") return "unknown";
+  if (typeof expectedText !== "string") return "unknown";
+  let disk;
+  try {
+    disk = await readDiskBytes(path);
+  } catch {
+    return "unknown";
+  }
+  if (disk == null) return "unknown";
+  if (typeof disk === "string") return disk === expectedText ? "landed" : "missed";
+  return diskBytesEqualText(disk, expectedText) ? "landed" : "missed";
+}
+
+function attachUrl(err, url) {
+  if (!(err instanceof Error) || typeof url !== "string" || !url) return;
+  if (typeof err.url === "string" && err.url) return;
+  try {
+    err.url = url;
+  } catch {
+    /* frozen error */
+  }
+}
+
+async function safeRebind(rebind) {
+  if (typeof rebind !== "function") return;
+  try {
+    await rebind();
+  } catch {
+    /* rebind is best-effort; the write's own error is the one that matters */
+  }
+}
+
+async function classifyProbe(probe) {
+  if (typeof probe !== "function") return "unknown";
+  try {
+    const result = await probe();
+    if (result === true || result === "landed") return "landed";
+    if (result === false || result === "missed") return "missed";
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Run `write` once. On a transport failure, probe whether it landed, rebind
+ * the same-origin userdata route, and retry at most once when that is safe.
+ *
+ * @param {() => Promise<unknown>} write
+ * @param {object} [opts]
+ * @param {() => unknown} [opts.rebind]
+ * @param {() => Promise<unknown>} [opts.probe]
+ * @param {unknown} [opts.recoveredValue] returned when the probe says the write landed
+ * @param {boolean} [opts.allowUnknownRetry] in-place only: overwrite of the same bytes
+ * @param {boolean} [opts.afterRestartConfirmTimeout] skip the module flag; tests inject this
+ * @param {() => boolean} [opts.consumeTimeout]
+ * @param {string} [opts.url] userdata URL attached to a final transport error
+ */
+export async function writeWithSameOriginRetry(write, opts = {}) {
+  const rebind = opts.rebind;
+  const probe = opts.probe;
+  const recoveredValue = opts.recoveredValue;
+  const allowUnknownRetry = opts.allowUnknownRetry === true;
+  const url = typeof opts.url === "string" && opts.url ? opts.url : null;
+  const consumeTimeout =
+    typeof opts.consumeTimeout === "function" ? opts.consumeTimeout : consumeRestartConfirmTimeout;
+  const timedOut =
+    opts.afterRestartConfirmTimeout === true ||
+    (opts.afterRestartConfirmTimeout !== false && consumeTimeout());
+
+  if (timedOut) await safeRebind(rebind);
+
+  try {
+    return await write();
+  } catch (err) {
+    if (!isTransportFailure(err)) throw err;
+    attachUrl(err, url);
+
+    const landed = await classifyProbe(probe);
+    if (landed === "landed") return recoveredValue;
+
+    const retryUnknown = landed === "unknown" && (timedOut || allowUnknownRetry);
+    if (landed !== "missed" && !retryUnknown) throw err;
+
+    await safeRebind(rebind);
+
+    if (landed === "unknown") {
+      const landedAgain = await classifyProbe(probe);
+      if (landedAgain === "landed") return recoveredValue;
+      if (landedAgain === "missed") {
+        try {
+          return await write();
+        } catch (err2) {
+          attachUrl(err2, url);
+          throw err2;
+        }
+      }
+      if (!timedOut && !allowUnknownRetry) throw err;
+    }
+
+    try {
+      return await write();
+    } catch (err2) {
+      attachUrl(err2, url);
+      throw err2;
+    }
+  }
+}

--- a/web/js/lib/save-transport-failure.js
+++ b/web/js/lib/save-transport-failure.js
@@ -162,8 +162,11 @@ const OPERATIONS = {
  * @param {"in-place"|"save-as"} ctx.operation  which write was attempted
  * @param {string}  ctx.path     the workflow's store path ("workflows/Foo.json")
  * @param {"down"|"open"|undefined} ctx.backendSocket  see describeSaveBackendSocket
+ * @param {string}  [ctx.url]    absolute request URL when one was observed
+ * @param {number}  [ctx.status] HTTP status when a response DID arrive
+ * @param {string}  [ctx.body]   bounded response body when a response DID arrive
  */
-export function saveTransportFailureMessage(err, { operation, path, backendSocket } = {}) {
+export function saveTransportFailureMessage(err, { operation, path, backendSocket, url, status, body } = {}) {
   if (!isTransportFailure(err)) return null;
   const raw = (err instanceof Error ? err.message : String(err ?? "")).trim();
   const op = OPERATIONS[operation] || { verb: "the save of", state: "" };
@@ -172,16 +175,44 @@ export function saveTransportFailureMessage(err, { operation, path, backendSocke
   const where = route
     ? `ComfyUI's same-origin userdata route (${route})`
     : `ComfyUI's same-origin userdata route`;
+  const observed = observedSaveResponse(err, { url, status, body });
+  const responseClause = observed.hasStatus
+    ? `failed ${op.verb} ${target} against ${where}.${observed.text}`
+    : `${op.verb} ${target} received NO HTTP response from ${where}, so there is no status code and no response body to report — they do not exist (#1757).${observed.text}`;
   return (
-    `${raw || "the request failed"} — ${op.verb} ${target} received NO HTTP response from ` +
-    `${where}, so there is no status code and no response body to ` +
-    `report — they do not exist (#1757).${socketNote(backendSocket)} This does NOT establish ` +
+    `${raw || "the request failed"} — ${responseClause}${socketNote(backendSocket)} This does NOT establish ` +
     `that nothing was written: a reply lost after the request was delivered looks exactly like ` +
     `this from the browser, so read the file back before retrying rather than assuming either ` +
     `outcome.${op.state} Finally: graph reads, layout edits and panel_list_workflows keep ` +
     `succeeding right through this, because they run against the in-memory graph and issue no ` +
     `HTTP at all — their success is not evidence that ComfyUI is up.`
   );
+}
+
+/** Extra URL/status/body the throw carried. `hasStatus` means a response line existed. */
+function observedSaveResponse(err, { url, status, body }) {
+  let failUrl = typeof url === "string" && url ? url : "";
+  if (!failUrl && err && typeof err === "object" && typeof err.url === "string" && err.url) {
+    failUrl = err.url;
+  }
+  let failStatus;
+  if (typeof status === "number" && Number.isFinite(status)) failStatus = status;
+  else if (err && typeof err === "object" && typeof err.status === "number" && Number.isFinite(err.status)) {
+    failStatus = err.status;
+  }
+  let failBody = typeof body === "string" ? body.trim() : "";
+  if (!failBody && err && typeof err === "object" && typeof err.body === "string") {
+    failBody = err.body.trim();
+  }
+  if (failBody.length > 200) failBody = `${failBody.slice(0, 200)}…`;
+  const parts = [];
+  if (failUrl) parts.push(`Request URL: ${failUrl}`);
+  if (typeof failStatus === "number") parts.push(`HTTP status: ${failStatus}`);
+  if (failBody) parts.push(`body: ${failBody}`);
+  return {
+    hasStatus: typeof failStatus === "number",
+    text: parts.length === 0 ? "" : ` ${parts.join("; ")}.`,
+  };
 }
 
 /**

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -10,6 +10,11 @@ import {
   isSaveTransportFailure,
   readBackendSocket,
 } from "./save-transport-failure.js";
+import {
+  classifySaveWriteLanded,
+  resolveSameOriginUserDataUrl,
+  writeWithSameOriginRetry,
+} from "./save-route-retry.js";
 
 // Programmatic workflow saving — shared by the panel and unit tests.
 //
@@ -674,6 +679,13 @@ export async function saveActiveWorkflow(
     // moment. Omitted by a caller that cannot observe it ⇒ the message says nothing
     // about the socket, which is the honest answer.
     describeBackendSocket,
+    // #1757 recurrence — re-point the userdata write at the page origin after a
+    // timed-out restart confirmation (or any transport miss). Injected as a
+    // function so tests drive the shipped write without a live `api` object.
+    rebindSaveRoute,
+    // Optional override for the post-transport read-back. Omitted ⇒ built from
+    // existsOnDisk / readDiskBytes against the bytes this write was about to send.
+    probeSaveLanded,
     // Optional production hook used for persisted Save-As copies. It must return true
     // only after the destination-stamped copy is proven live on the shared canvas.
     repaintCanvas,
@@ -1388,7 +1400,15 @@ export async function saveActiveWorkflow(
   }
   if (inPlace === "authorize") markPersistedForOverwrite(wf); // sync (post-assert) ⇒ no leak window
   recordOutcome(details, "in-place", { sourcePath: currentPath, targetPath: finalTargetPath });
-  const savedRecord = await saveInPlace(svc, wf, { readSaveFailureCause, path: finalTargetPath, describeBackendSocket });
+  const savedRecord = await saveInPlace(svc, wf, {
+    readSaveFailureCause,
+    path: finalTargetPath,
+    describeBackendSocket,
+    rebindSaveRoute,
+    probeSaveLanded,
+    existsOnDisk,
+    readDiskBytes,
+  });
   // r10 — thread the save API's own produced record (when it returns one) through
   // details, so the identity carry can prove succession from the replacement
   // EVENT. An empty/non-object return simply carries no thread (fail safe).
@@ -2303,14 +2323,53 @@ export function explainUserDataStoreFailure(message) {
   );
 }
 
-async function saveInPlace(svc, wf, { readSaveFailureCause, path, describeBackendSocket } = {}) {
+async function saveInPlace(svc, wf, {
+  readSaveFailureCause,
+  path,
+  describeBackendSocket,
+  rebindSaveRoute,
+  probeSaveLanded,
+  existsOnDisk,
+  readDiskBytes,
+} = {}) {
   // Return the save API's own result: when it yields the workflow record it
   // PRODUCED (a re-registered successor object), that is the one unambiguous
   // replacement-event thread the identity carry can use (r10) — path occupancy
   // proves nothing (a close→reopen occupies the same path with a new identity).
+  const hasStoreWrite = typeof svc?.saveWorkflow === "function";
+  const hasRecordWrite = typeof wf?.save === "function";
+  if (!hasStoreWrite && !hasRecordWrite) {
+    throw new Error("workflow save API unavailable on this frontend");
+  }
+  const write = () => (hasStoreWrite ? svc.saveWorkflow(wf) : wf.save());
+  let expectedText;
   try {
-    if (typeof svc.saveWorkflow === "function") return await svc.saveWorkflow(wf);
-    if (typeof wf.save === "function") return await wf.save();
+    if (typeof wf?.content === "string" && wf.content) expectedText = wf.content;
+    else if (wf?.activeState != null) expectedText = JSON.stringify(wf.activeState);
+  } catch {
+    expectedText = undefined;
+  }
+  const probe =
+    typeof probeSaveLanded === "function"
+      ? probeSaveLanded
+      : () =>
+          classifySaveWriteLanded({
+            path,
+            expectedText,
+            existsOnDisk,
+            readDiskBytes,
+          });
+  const url = resolveSameOriginUserDataUrl(path);
+  try {
+    // In-place overwrite of the same graph bytes is idempotent, so one retry
+    // after a lost response cannot apply a distinct mutation twice.
+    return await writeWithSameOriginRetry(write, {
+      rebind: rebindSaveRoute,
+      probe,
+      recoveredValue: wf,
+      allowUnknownRetry: true,
+      url,
+    });
   } catch (err) {
     // #1757 — FIRST, because it is the shape that carries no status at all. A
     // transport failure never produced an HTTP response, so `explainUserDataStoreFailure`
@@ -2320,6 +2379,9 @@ async function saveInPlace(svc, wf, { readSaveFailureCause, path, describeBacken
     const decorated = decorateSaveTransportFailure(err, {
       operation: "in-place",
       path,
+      url,
+      status: err && typeof err === "object" && typeof err.status === "number" ? err.status : undefined,
+      body: err && typeof err === "object" && typeof err.body === "string" ? err.body : undefined,
       // Read HERE, not at entry: the socket state that matters is the one at the moment
       // the write failed, and the write is what we just awaited.
       backendSocket: readBackendSocket(describeBackendSocket),
@@ -2341,7 +2403,6 @@ async function saveInPlace(svc, wf, { readSaveFailureCause, path, describeBacken
     }
     throw err;
   }
-  throw new Error("workflow save API unavailable on this frontend");
 }
 
 /** True when `err` is a name-collision (HTTP 409) from the userdata write — the


### PR DESCRIPTION
Fixes #1757.

## Recurrence

PR #1769 explained a lost `/userdata` write as a transport failure (URL, no status/body, websocket observation). It did **not** rebind or retry the same-origin save route. After a restart confirmation timed out without rebooting, live graph reads still worked and the workflow stayed `modified: true`, but the in-place save kept returning the browser's bare `Failed to fetch`. Duplicate report 2026-08-29 on panel 0.15.102 saw the same no-response userdata write with the panel websocket still open.

## What this does

1. After a withdrawn/timed-out restart confirmation, rebind ComfyUI's API host to the page origin before the next in-place write.
2. If the write still throws a transport error, probe whether the bytes landed; retry the shipped store `saveWorkflow` **once** when the probe says missed (in-place overwrite of the same graph is idempotent).
3. If it still cannot persist, keep the userdata URL and any HTTP status/body on the error instead of the generic fetch exception.

Save-as is unchanged: overwrite:false is not idempotent, so unknown probes are not retried there.

## Tests

```
node --test browser_tests/unit/save-transport-failure.test.mjs browser_tests/unit/save-route-retry.test.mjs
```

Regression drives `saveActiveWorkflow` (not a reimplementation): restart-confirm timeout → in-memory graph read still works → save either succeeds after rebind/retry or returns URL/status, never bare `Failed to fetch`. 27/27 pass.
