### PR TITLE
fix(366): write the host-keyed promoted rail, not a stale inner Primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- promoted widget writes no longer treat a stale inner Primitive handle as the parent rail, so MiniMax H3 duration/value_1, turbo_mode, turbo_steps, and lora_name serialize the new value (#366)
 - scoped run-to-node no longer false-refuses after a finished subgraph edit: the graph stamp waits for pending canvas work to settle and restamps once if the revision moved before queue, without falling through to a full-graph run (#572)
 - resolve the 18+ consent card before the 300s tools/call deadline so an idle user gets a structured timeout instead of a transport hang (#390)
 

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -594,6 +594,62 @@ test("#366 recurrence: production promoted write selects the host rail after a s
   assert.equal(set.promoted_from.value_scope, "instance");
 });
 
+test("#366 recurrence: stale inner _widget is rematerialized into the host-keyed rail through runSetWidget", async () => {
+  const reg = loadedRegistry();
+  const innerWidget = { name: "value", type: "INT", value: 5 };
+  const inner = {
+    id: 136,
+    type: "KSampler",
+    widgets: [innerWidget],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "136" ? inner : null) };
+  const store = { value: 5 };
+  const hostInput = {
+    name: "value_1",
+    label: "duration",
+    widgetId: "root:105:value_1",
+    widget: { name: "value_1" },
+    _widget: innerWidget,
+    _subgraphSlot: { name: "value_1", label: "duration" },
+  };
+  const parent = {
+    id: 105,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [hostInput],
+    get widgets() {
+      if (!hostInput._widget && hostInput.widgetId) {
+        const rail = {
+          name: "value_1",
+          label: "duration",
+          widgetId: hostInput.widgetId,
+          type: "INT",
+          get value() {
+            return store.value;
+          },
+          set value(next) {
+            store.value = next;
+          },
+        };
+        hostInput._widget = rail;
+      }
+      return hostInput._widget ? [hostInput._widget] : [];
+    },
+  };
+  const resolveSource = (_node, input) =>
+    input?.name === "value_1" ? { sourceNodeId: "136", sourceWidgetName: "value" } : null;
+
+  const { set } = await setViaHandler(reg, parent, "duration", 12, resolveSource);
+
+  assert.equal(store.value, 12, "the host-keyed rail store must receive the write");
+  assert.notEqual(hostInput._widget, innerWidget);
+  assert.equal(innerWidget.value, 5, "the inner Primitive-shaped widget is not the serializing rail");
+  assert.equal(set.node_id, 105);
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+  assert.equal(set.promoted_from.value_scope, "instance");
+});
+
 test("set_widget e2e: unreachable ⇒ REFUSE even for a would-be-core type, no mutation", async () => {
   const reg = unreachableRegistry();
   const node = { id: 1, type: "CheckpointLoaderSimple", widgets: [{ name: "ckpt_name", type: "text", value: "" }] };

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1915,6 +1915,170 @@ test("#366: a promoted STRING widget also syncs the parent rail (prompt text)", 
   assert.equal(set.promoted_from.parent_widget_synced, true);
 });
 
+/**
+ * MiniMax H3 / frontend 1.49+ shape: the host input is named `value_1` with
+ * display label `duration`, widgetId names this wrapper, and `_widget` still
+ * points at the INNER Primitive widget. SubgraphNode.widgets is a getter that
+ * returns `_widget` until that stale handle is dropped, then projects the
+ * store-backed rail queue compilation reads.
+ */
+function makeStaleInnerRailFixture({
+  innerId = 136,
+  innerType = "PrimitiveFloat",
+  innerWidgetType = "number",
+  innerValue = 5,
+  outerName = "value_1",
+  outerLabel = "duration",
+  parentId = 105,
+  comboValues = null,
+} = {}) {
+  const innerWidget = {
+    name: "value",
+    type: innerWidgetType,
+    value: innerValue,
+    ...(comboValues ? { options: { values: comboValues } } : {}),
+  };
+  const inner = { id: innerId, type: innerType, widgets: [innerWidget] };
+  const subgraph = {
+    _nodes: [inner],
+    getNodeById: (id) => (String(id) === String(innerId) ? inner : null),
+  };
+  const store = { value: innerValue };
+  const hostInput = {
+    name: outerName,
+    label: outerLabel,
+    widgetId: `root:${parentId}:${outerName}`,
+    widget: { name: outerName },
+    _widget: innerWidget,
+    _subgraphSlot: { name: outerName, label: outerLabel },
+  };
+  const parent = {
+    id: parentId,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [hostInput],
+    get widgets() {
+      if (!hostInput._widget && hostInput.widgetId) {
+        const rail = {
+          name: outerName,
+          label: outerLabel,
+          widgetId: hostInput.widgetId,
+          type: innerWidgetType,
+          get value() {
+            return store.value;
+          },
+          set value(next) {
+            store.value = next;
+          },
+          options: {
+            ...(comboValues ? { values: comboValues } : {}),
+            setValue(next) {
+              store.value = next;
+            },
+          },
+        };
+        hostInput._widget = rail;
+      }
+      return hostInput._widget ? [hostInput._widget] : [];
+    },
+  };
+  const resolveSource = (_node, subgraphInput) =>
+    subgraphInput?.name === outerName ? { sourceNodeId: String(innerId), sourceWidgetName: "value" } : null;
+  return { parent, inner, innerWidget, hostInput, store, resolveSource };
+}
+
+test("#366: writing the duration LABEL syncs the host-keyed rail, not the stale inner Primitive handle", () => {
+  const { parent, inner, innerWidget, hostInput, store, resolveSource } = makeStaleInnerRailFixture();
+
+  const set = applyWidgetWrite(parent, "duration", 12, { resolveSource });
+
+  assert.equal(store.value, 12, "the store-backed parent rail must hold the new duration");
+  assert.equal(hostInput._widget.value, 12);
+  assert.notEqual(hostInput._widget, innerWidget, "the inner Primitive must not remain the rail handle");
+  assert.equal(inner.widgets[0].value, 5, "the shared inner Primitive is not the serializing rail");
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+  assert.equal(set.promoted_from.value_scope, "instance");
+  assert.equal(set.promoted_from.subgraph_node_id, 105);
+  assert.equal(set.node_id, 105);
+});
+
+test("#366: writing value_1 (the programmatic name) also syncs that host-keyed duration rail", () => {
+  const { parent, store, resolveSource } = makeStaleInnerRailFixture();
+  const set = applyWidgetWrite(parent, "value_1", 8, { resolveSource });
+  assert.equal(store.value, 8);
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#366: a promoted BOOLEAN turbo_mode rail is synced when _widget still points at the inner toggle", () => {
+  const { parent, store, resolveSource } = makeStaleInnerRailFixture({
+    innerId: 140,
+    innerType: "PrimitiveBoolean",
+    innerWidgetType: "toggle",
+    innerValue: false,
+    outerName: "value",
+    outerLabel: "turbo_mode",
+  });
+  const set = applyWidgetWrite(parent, "turbo_mode", true, { resolveSource });
+  assert.equal(store.value, true);
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#366: a promoted COMBO lora_name rail is synced when _widget still points at the inner combo", () => {
+  const options = ["minimax_h3_fl2v_turbo_8step_v1.0_comfyui_bf16.safetensors", "other.safetensors"];
+  const { parent, store, resolveSource } = makeStaleInnerRailFixture({
+    innerId: 141,
+    innerType: "LoraLoader",
+    innerWidgetType: "combo",
+    innerValue: options[0],
+    outerName: "lora_name",
+    outerLabel: "lora_name",
+    comboValues: options,
+  });
+  const set = applyWidgetWrite(parent, "lora_name", options[1], { resolveSource });
+  assert.equal(store.value, options[1]);
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#366: options.setValue on the parent rail is driven so the serializing store updates", () => {
+  const store = { value: 5 };
+  const inner = { id: 136, type: "PrimitiveFloat", widgets: [{ name: "value", type: "number", value: 5 }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "136" ? inner : null) };
+  const railWidget = {
+    name: "value_1",
+    label: "duration",
+    widgetId: "root:105:value_1",
+    type: "number",
+    value: 5,
+    options: {
+      setValue(next) {
+        store.value = next;
+      },
+    },
+  };
+  const parent = {
+    id: 105,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [
+      {
+        name: "value_1",
+        label: "duration",
+        widgetId: "root:105:value_1",
+        _widget: railWidget,
+        widget: { name: "value_1" },
+        _subgraphSlot: { name: "value_1", label: "duration" },
+      },
+    ],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_1" ? { sourceNodeId: "136", sourceWidgetName: "value" } : null;
+
+  applyWidgetWrite(parent, "duration", 12, { resolveSource });
+  assert.equal(railWidget.value, 12);
+  assert.equal(store.value, 12, "the serializing store must update, not only the view property");
+});
+
 test("#366×#179: a promoted COMPOSITE write merges onto the RAIL's current object — the rail's unspecified fields are NOT clobbered by the stale inner", () => {
   // Inner (non-authoritative) and rail (authoritative) hold DIVERGENT composite
   // values. A partial write {strength:0.6} must preserve the RAIL's `lora`

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1357,6 +1357,66 @@ export function resolveHostPromotedWidgets(subgraphNode, hostInput) {
   return described.map((entry) => entry.widget);
 }
 
+function readHostWidgetId(hostInput) {
+  try {
+    const id = hostInput?.widgetId;
+    return typeof id === "string" && id.length > 0 ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * ComfyUI's SubgraphNode.widgets getter returns `_widget` first and never builds
+ * the host-keyed store projection while that handle still points at the INNER
+ * Primitive widget. Dropping that stale handle and re-reading widgets lets the
+ * getter materialize the rail queue compilation actually reads (#366).
+ */
+function rematerializeHostPromotedWidgets(subgraphNode, hostInput, innerWidget) {
+  if (!subgraphNode || !hostInput || !innerWidget) return [];
+  if (hostInput._widget !== innerWidget) return [];
+  if (!readHostWidgetId(hostInput)) return [];
+  const saved = hostInput._widget;
+  try {
+    hostInput._widget = undefined;
+    void subgraphNode.widgets;
+  } catch {
+    hostInput._widget = saved;
+    return [];
+  }
+  const next = resolveHostPromotedWidgets(subgraphNode, hostInput).filter(
+    (widget) => widget && widget !== innerWidget,
+  );
+  if (next.length) return next;
+  hostInput._widget = saved;
+  return [];
+}
+
+function liveHostPromotedWidgets(subgraphNode, hostInput, innerWidget) {
+  const current = resolveHostPromotedWidgets(subgraphNode, hostInput).filter(
+    (widget) => widget && widget !== innerWidget,
+  );
+  if (current.length) return current;
+  return rematerializeHostPromotedWidgets(subgraphNode, hostInput, innerWidget);
+}
+
+/** Assign a widget value and drive options.setValue when present (store-backed rails). */
+function assignWidgetValue(widget, coerced) {
+  widget.value = coerced;
+  let setValue;
+  try {
+    setValue = widget.options?.setValue;
+  } catch {
+    setValue = null;
+  }
+  if (typeof setValue !== "function") return;
+  try {
+    setValue.call(widget, coerced);
+  } catch {
+    /* verification below still decides whether the value stuck */
+  }
+}
+
 /**
  * The single AUTHORITATIVE parent rail widget for `hostInput` — the projection whose
  * value serializes at queue time (#366). This is the FIRST identity-authenticated
@@ -1525,7 +1585,9 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
   // (e.g. the widget is further promoted OUTWARD to an enclosing subgraph and is
   // exposed here as an input with no settable widget); the caller FAILS CLOSED on
   // null rather than write inner-only and render silently stale.
-  const parentWidgets = resolveHostPromotedWidgets(subgraphNode, input);
+  // The inner Primitive widget is never a parent rail, even when a stale `_widget`
+  // handle still points at it and the computed widgets getter therefore lists it.
+  const parentWidgets = liveHostPromotedWidgets(subgraphNode, input, innerWidget);
   const parentWidget = parentWidgets[0] ?? null;
   return { promoted: true, target: { node: innerNode, widget: innerWidget, input, parentWidget, parentWidgets } };
 }
@@ -1872,6 +1934,28 @@ export function applyWidgetWrite(
       // a stateful dynamic source can answer differently on a second call.
       out: coerceOutcome,
     });
+
+  // The rail object captured before /object_info may be a stale inner Primitive
+  // handle. Re-read the live host projections at write time so the store-backed
+  // rail (what serializes) is the one assigned.
+  if (promotedFrom && promotedHostInput) {
+    const liveRails = liveHostPromotedWidgets(node, promotedHostInput, w);
+    if (liveRails.length) {
+      promotedParentWidget = liveRails[0];
+      promotedParentWidgets = liveRails;
+    } else if (promotedParentWidget === w) {
+      throw new WidgetWriteError(
+        `promoted widget "${widgetName}" on subgraph node ${node.id} resolves to an inner ` +
+          `widget, but its AUTHORITATIVE parent rail widget could not be identified (the value ` +
+          `that serializes at queue time). This happens when the widget is further promoted to ` +
+          `an enclosing subgraph (fed by an outer link / exposed as an input, not a settable ` +
+          `widget), the promotion metadata is malformed, or its name is duplicated. Refusing to ` +
+          `write the inner widget alone, which would silently render the OLD value (#366). Edit ` +
+          `this widget from the outermost subgraph node, or disconnect the inner input to make ` +
+          `the inner value authoritative.`,
+      );
+    }
+  }
 
   // #366: for a promoted subgraph widget the AUTHORITATIVE value lives on the
   // parent's OWN rail widget (resolved by the promotion RELATIONSHIP in
@@ -2280,14 +2364,14 @@ export function applyWidgetWrite(
       if (fastBypasserAction) {
         Reflect.apply(fastBypasserAction.toggle, valueWidget, [fastBypasserAction.requested]);
       } else {
-        w.value = coerced;
+        assignWidgetValue(w, coerced);
       }
     }
-    if (parentWidget) parentWidget.value = coerced;
+    if (parentWidget) assignWidgetValue(parentWidget, coerced);
     // #477: sync the parent-facing DISPLAY proxies too. They are VIEWS of the same
     // promoted value (no semantic callback of their own — the inner target's fires
     // once below), so we assign their value directly, same as the rail.
-    for (const dw of displayWidgets) dw.value = coerced;
+    for (const dw of displayWidgets) assignWidgetValue(dw, coerced);
     // #1268 / comfyui-mcp#1658 — drive the BOUND PROPERTY, in litegraph's own position:
     // `BaseWidget.setValue` assigns the widget, then calls `node.setProperty(...)`, then
     // fires the callback. Placed here so a programmatic write leaves the node in the SAME


### PR DESCRIPTION
Fixes #366.

Previous merges (#383, #2016) still left MiniMax H3 / Seed Hunter promoted writes reporting success while the parent rail stayed stale. On current ComfyUI, `SubgraphNode.widgets` is a computed getter that returns `input._widget` first. When that handle still points at the inner Primitive widget, object-identity auth selected the inner node as the “parent rail”. Inner reads back the new value; queue compilation reads the host `widgetId` store, which never moved.

This change:
- Never treats the resolved inner widget as a parent rail
- Drops that stale `_widget` handle and rematerializes the host-keyed store projection (the value that serializes)
- Drives `options.setValue` on parent/display widgets so store-backed rails actually update
- Re-reads live host projections at write time so a rail captured before `/object_info` cannot stay stale

Tests drive `applyWidgetWrite` / `runSetWidget` against the MiniMax H3 shape (`duration`/`value_1`, `turbo_mode`, `lora_name`) and fail on the unfixed inner-as-rail behavior.
