### PR TITLE
Retry readable workflow-open when frontend normalization is still settling (#1898)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- retry one readable workflow-open normalization race while keeping persistent content mismatches fail-closed (#1898)
+
 ## [0.15.129] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -164,7 +164,11 @@ function productionExecutor(methodName, environment) {
   return factory(scope);
 }
 
-function productionReadableOpenEnvironment({ readableAfterRetry, readableButMismatched = false }) {
+function productionReadableOpenEnvironment({
+  readableAfterRetry,
+  readableButMismatched = false,
+  mismatchOnlyFirstLoad = false,
+}) {
   const previous = { path: "workflows/previous.json" };
   const target = {
     path: "workflows/target.json",
@@ -191,11 +195,12 @@ function productionReadableOpenEnvironment({ readableAfterRetry, readableButMism
     loadGraphData: async (state) => {
       loads += 1;
       root.extra = state.extra;
+      const mismatched = readableButMismatched && (!mismatchOnlyFirstLoad || loads === 1);
       root._nodes = [
         {
           id: 1,
           type: "KSampler",
-          widgets_values: [readableButMismatched ? "stale-value" : "target-value"],
+          widgets_values: [mismatched ? "stale-value" : "target-value"],
         },
       ];
     },
@@ -412,6 +417,59 @@ test("#1898 settles a readable outline after one normalization retry", async () 
   assert.equal(settleCalls, 4, "identity is settled before retry and after the final probe");
 });
 
+test("#1898 retries when a readable outline still lacks the final content proof", async () => {
+  const target = { path: "workflows/target.json" };
+  let outlineCalls = 0;
+  let settleCalls = 0;
+  let retries = 0;
+
+  const result = await settleOpenedWorkflowReadable({
+    settleActive: async () => {
+      settleCalls += 1;
+      return { status: "settled", active: target };
+    },
+    readGraphOutline: async () => {
+      outlineCalls += 1;
+      return { node_count: 8, outline: "8 nodes", detail_level: "full" };
+    },
+    shouldRetryNormalization: () => true,
+    retryNormalization: async () => {
+      retries += 1;
+      return true;
+    },
+  });
+
+  assert.equal(result.status, "settled-readable");
+  assert.equal(result.retried, true);
+  assert.equal(retries, 1, "a readable but unproven graph gets one bounded retry");
+  assert.equal(outlineCalls, 2, "the graph is re-probed after the retry");
+  assert.equal(settleCalls, 4, "identity is settled before and after the retry, then at return");
+});
+
+test("#1898 a readable outline does not retry when the caller declines", async () => {
+  const target = { path: "workflows/target.json" };
+  let retries = 0;
+  let outlineCalls = 0;
+
+  const result = await settleOpenedWorkflowReadable({
+    settleActive: async () => ({ status: "settled", active: target }),
+    readGraphOutline: async () => {
+      outlineCalls += 1;
+      return { node_count: 8, outline: "8 nodes", detail_level: "full" };
+    },
+    shouldRetryNormalization: () => false,
+    retryNormalization: async () => {
+      retries += 1;
+      return true;
+    },
+  });
+
+  assert.equal(result.status, "settled-readable");
+  assert.equal(result.retried, false);
+  assert.equal(retries, 0, "leftover-source or already-proven content must not reload");
+  assert.equal(outlineCalls, 1, "a declined retry keeps the first readable probe");
+});
+
 test("#1898 keeps an unreadable or unproven graph outcome unknown", async () => {
   const target = { path: "workflows/target.json" };
   let retries = 0;
@@ -612,6 +670,25 @@ test("#1898 production workflow_open accepts a settled readable outline after no
   assert.equal(panel.guard(), null, "the readable outcome releases the production reload guard");
 });
 
+test("#1898 production workflow_open retries a readable graph whose content is still normalizing", async () => {
+  const { target, counters, environment } = productionReadableOpenEnvironment({
+    readableAfterRetry: false,
+    readableButMismatched: true,
+    mismatchOnlyFirstLoad: true,
+  });
+  const panel = productionExecutor("workflow_open", environment);
+
+  const result = await panel.method({ path: target.path, rid: "readable-content-race" });
+
+  assert.equal(result.opened.path, target.path);
+  assert.deepEqual(
+    counters(),
+    { loads: 2, outlines: 2, contentProofs: 2 },
+    "a readable first outline still gets one bounded content-normalization retry",
+  );
+  assert.equal(panel.guard(), null, "the recovered outcome releases the production reload guard");
+});
+
 test("#1898 production workflow_open keeps a readable but mismatched graph unknown", async () => {
   const { target, counters, environment } = productionReadableOpenEnvironment({
     readableAfterRetry: false,
@@ -622,8 +699,8 @@ test("#1898 production workflow_open keeps a readable but mismatched graph unkno
   await assert.rejects(panel.method({ path: target.path, rid: "mismatched-readable-race" }), /content could not be verified/);
   assert.deepEqual(
     counters(),
-    { loads: 1, outlines: 1, contentProofs: 2 },
-    "readability cannot replace the final normalized node/value content proof",
+    { loads: 2, outlines: 2, contentProofs: 2 },
+    "a persistent mismatch remains unknown after the one bounded normalization retry",
   );
   assert.equal(panel.guard(), null, "the unknown outcome releases the production reload guard");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22529,9 +22529,10 @@ const GRAPH_TOOL_EXECUTORS = {
                 // #1898 — a graph can still be normalizing after the store has
                 // switched identity and `loadGraphData` has resolved. If the
                 // requested identity is already proven, let a real graph_outline
-                // probe settle that race; an unreadable probe gets exactly one
+                // probe settle that race; an unreadable probe, or a readable
+                // probe whose content is still unproven, gets exactly one
                 // normalization retry. The probe remains fail-closed: identity,
-                // readability and the final active settlement must all be proven.
+                // readability and the final content proof must all be proven.
                 if (
                   verdict.status === OPEN_REBIND_STATUS.CONTENT_UNVERIFIED &&
                   // #1283/#1089/#1215 — the readable-outline recovery is only
@@ -22561,6 +22562,12 @@ const GRAPH_TOOL_EXECUTORS = {
                         endStep: () => endWorkflowReloadStep(reloadGuardToken),
                       }),
                     readGraphOutline: () => GRAPH_TOOL_EXECUTORS.graph_outline({}),
+                    // A readable outline proves only that the graph is available. If the
+                    // first full content proof is still unproven, give the same bounded
+                    // normalization retry one opportunity even when the outline was
+                    // already readable. The final content proof below remains the gate,
+                    // so a persistent or structurally different graph still refuses.
+                    shouldRetryNormalization: () => !leftoverPreviousCanvas && !contentMatches,
                     retryNormalization: async () => {
                       if (!beginWorkflowReloadStep(reloadGuardToken)) return false;
                       try {

--- a/web/js/lib/settle-open-readable.js
+++ b/web/js/lib/settle-open-readable.js
@@ -2,7 +2,8 @@
  * #1898 — coordinate the open until the requested workflow is stable AND its
  * bound graph can be read. A store-level identity switch can settle before
  * graph normalization finishes, so give that normalization one retry when the
- * first outline probe is not readable. Callers must still verify graph content
+ * first outline probe is not readable or the caller's content proof says the
+ * readable graph is still settling. Callers must still verify graph content
  * before treating a readable result as proven.
  */
 
@@ -30,6 +31,7 @@ export async function settleOpenedWorkflowReadable({
   settleActive,
   readGraphOutline,
   retryNormalization,
+  shouldRetryNormalization,
 } = {}) {
   if (typeof settleActive !== "function" || typeof readGraphOutline !== "function") {
     return { status: "unknown", reason: "workflow identity or graph outline probe was unavailable" };
@@ -56,9 +58,10 @@ export async function settleOpenedWorkflowReadable({
 
   let probe = await read();
   let retried = false;
-  if (!probe.readable) {
+  const retryOnce = async () => {
     // Confirm the target still owns the canvas before retrying a load. A failed
-    // outline must not authorize normalization on a workflow that moved away.
+    // outline or an unproven content comparison must not authorize normalization
+    // on a workflow that moved away.
     active = await settle();
     if (active?.status !== "settled") return active ?? { status: "unknown" };
     if (typeof retryNormalization !== "function") {
@@ -74,6 +77,23 @@ export async function settleOpenedWorkflowReadable({
     if (active?.status !== "settled") return active ?? { status: "unknown" };
     probe = await read();
     if (!probe.readable) return { status: "unknown", reason: "bound graph outline remained unreadable after one retry" };
+    return null;
+  };
+  if (!probe.readable) {
+    const retryResult = await retryOnce();
+    if (retryResult) return retryResult;
+  } else if (typeof shouldRetryNormalization === "function") {
+    let shouldRetry = false;
+    try {
+      shouldRetry =
+        (await shouldRetryNormalization({ active: active.active, outline: probe.outline })) === true;
+    } catch {
+      shouldRetry = false;
+    }
+    if (shouldRetry) {
+      const retryResult = await retryOnce();
+      if (retryResult) return retryResult;
+    }
   }
 
   // The graph read itself is an await boundary in real frontends. Re-probe the


### PR DESCRIPTION
## Summary
- retry one workflow-open normalization even when the first `graph_outline` is already readable, if the content proof is still unproven
- skip that retry when the live canvas still looks like leftover SOURCE (#1215)
- keep a persistent mismatch fail-closed after the bounded retry
- drive the production `workflow_open` executor, not a mock of the helper

Fixes #1898

## Validation
- `node --test browser_tests/unit/open-active-settle.test.mjs`: 28 passed
- mutation: `shouldRetryNormalization: () => false` fails the new production tests
- `npm run test:unit`: 7443 passed, 0 failed, 1 todo

No merge or release performed.
