### PR TITLE
fix(1782): deliver scoped panel_run natively on frontend 1.49.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_run on frontend 1.49.6 delivers to_node_id natively when app.queuePrompt wrappers drop the third argument (#1782)
 - retry one readable workflow-open normalization race while keeping persistent content mismatches fail-closed (#1898)
 
 ## [0.15.129] - 2026-08-30

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -41,6 +41,9 @@ import {
   cancelPendingScopedQueueItem,
   dispatchScopedRun,
   invokeQueuePromptWithBrowserStack,
+  queueItemScopeIds,
+  unwrapExactScopeTargets,
+  withScopedQueueItemTargets,
 } from "../../web/js/lib/run-scope-guard.js";
 import { resolveRunToNodeTarget } from "../../web/js/lib/subgraph-scope.js";
 
@@ -234,6 +237,92 @@ function makeShadowedQueueFrontend({ dropArgs = false, apiTarget, output = OUR_O
   const app = new NativeApp();
   const nativeAppQueuePrompt = NativeApp.prototype.queuePrompt;
   app.queuePrompt = dropArgs
+    ? async function (number, batch) {
+        return nativeAppQueuePrompt.call(app, number, batch);
+      }
+    : async function (...args) {
+        return nativeAppQueuePrompt.apply(app, args);
+      };
+  return { app, api };
+}
+
+// Frontend 1.49.6 ComfyApp.queuePrompt: push {number, batchCount, queueNodeIds},
+// then the processor reads that array as partialExecutionTargets. An own-property
+// wrapper that calls through with only (number, batch) still reaches this loop —
+// it just pushes queueNodeIds: undefined. Filling the item (not bypassing the
+// wrapper) is how the panel delivers scope natively on that build (#1782).
+function makeFrontend1496({ dropAppArgs = false, dropApiArgs = false, apiTarget, output = OUR_OUTPUT } = {}) {
+  class NativeApi {
+    async queuePrompt(number, data, options) {
+      const targets = options?.partialExecutionTargets;
+      const body = frontendBody({
+        output: data?.output ?? output,
+        number,
+        targets: Array.isArray(targets) && targets.length ? targets : null,
+      });
+      api.posted.push(body);
+      await api.fetchApi("/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return { prompt_id: "native" };
+    }
+  }
+
+  const api = new NativeApi();
+  api.fetchApi = (...a) => apiTarget.fetchApi(...a);
+  api.posted = [];
+  const nativeApiQueuePrompt = NativeApi.prototype.queuePrompt;
+  api.queuePrompt = dropApiArgs
+    ? async function (number, data) {
+        return nativeApiQueuePrompt.call(api, number, data);
+      }
+    : async function (...args) {
+        return nativeApiQueuePrompt.apply(api, args);
+      };
+
+  class NativeApp {
+    constructor() {
+      this.api = api;
+      this.queueItems = [];
+      this.processingQueue = false;
+      this.graphToPrompt = async () => ({ output, workflow: {} });
+      this.graph = null;
+    }
+
+    async queuePrompt(number, batchCount = 1, optionsOrQueueNodeIds = {}) {
+      const options = Array.isArray(optionsOrQueueNodeIds)
+        ? { queueNodeIds: optionsOrQueueNodeIds }
+        : optionsOrQueueNodeIds && typeof optionsOrQueueNodeIds === "object"
+          ? optionsOrQueueNodeIds
+          : {};
+      this.queueItems.push({
+        number,
+        batchCount,
+        queueNodeIds: options.queueNodeIds,
+        requestId: 1,
+      });
+      if (this.processingQueue) return false;
+      this.processingQueue = true;
+      try {
+        while (this.queueItems.length) {
+          const item = this.queueItems.pop();
+          const p = await this.graphToPrompt();
+          await this.api.queuePrompt(item.number, p, {
+            partialExecutionTargets: item.queueNodeIds,
+          });
+        }
+      } finally {
+        this.processingQueue = false;
+      }
+      return true;
+    }
+  }
+
+  const app = new NativeApp();
+  const nativeAppQueuePrompt = NativeApp.prototype.queuePrompt;
+  app.queuePrompt = dropAppArgs
     ? async function (number, batch) {
         return nativeAppQueuePrompt.call(app, number, batch);
       }
@@ -4159,6 +4248,129 @@ test("#1782 actual queue path: shadowed forwarding preserves scope; dropping wra
       JSON.parse(droppingServer.calls[0].options.body).partial_execution_targets,
       ["14"],
     );
+  } finally {
+    stop();
+  }
+});
+
+test("#1782 queueItemScopeIds / unwrapExactScopeTargets: option objects are the same ids, not a different request", () => {
+  assert.deepEqual(queueItemScopeIds(["76:34"]), ["76:34"]);
+  assert.deepEqual(queueItemScopeIds({ queueNodeIds: ["76:34"] }), ["76:34"]);
+  assert.deepEqual(queueItemScopeIds({ partialExecutionTargets: ["76:34"] }), ["76:34"]);
+  assert.equal(queueItemScopeIds(null), null);
+  assert.equal(queueItemScopeIds("14"), null);
+  assert.equal(queueItemScopeIds({ queueNodeIds: [] }), null);
+  assert.deepEqual(unwrapExactScopeTargets({ queueNodeIds: ["14"] }, ["14"]), ["14"]);
+  assert.deepEqual(unwrapExactScopeTargets({ partialExecutionTargets: [14] }, ["14"]), ["14"]);
+  assert.equal(unwrapExactScopeTargets({ queueNodeIds: ["9"] }, ["14"]), null, "wrong ids stay a mismatch");
+  assert.equal(unwrapExactScopeTargets(["14", "9"], ["14"]), null, "extra ids stay a mismatch");
+  assert.equal(unwrapExactScopeTargets("14", ["14"]), null, "a bare string is not the option shape");
+});
+
+test("#1782 withScopedQueueItemTargets: a dropped 3rd arg is restored on THIS run's item only", async () => {
+  const items = [];
+  const app = { queueItems: items };
+  const execIds = ["14"];
+  const other = { number: MARK_B, requestId: 9, queueNodeIds: undefined };
+  items.push(other);
+  await withScopedQueueItemTargets(app, { queueMark: MARK_A, execIds }, () => {
+    items.push({ number: MARK_A, batchCount: 1, requestId: 1, queueNodeIds: undefined });
+    items.push({ number: MARK_A, requestId: 2, queueNodeIds: { queueNodeIds: ["14"] } });
+    items.push({ number: MARK_A, requestId: 3, queueNodeIds: ["9"] });
+    items.push({ number: MARK_A, queueNodeIds: undefined });
+  });
+  assert.deepEqual(items[0].queueNodeIds, undefined, "a different run's item is never touched");
+  assert.equal(items[1].queueNodeIds, execIds, "the missing array is restored by reference so the ownership tag survives");
+  assert.equal(items[2].queueNodeIds, execIds, "an options object naming the exact roots is flattened to the array 1.49.6 reads");
+  assert.deepEqual(items[3].queueNodeIds, ["9"], "a present array naming different roots is not overwritten");
+  assert.equal(items[4].queueNodeIds, undefined, "an item without ComfyApp's requestId is left for body repair");
+});
+
+test("#1782 frontend 1.49.6: dropping app.queuePrompt still delivers scope natively via queueItems", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const { app, api } = makeFrontend1496({
+      dropAppArgs: true,
+      apiTarget: { fetchApi: server },
+    });
+    assert.equal(Object.prototype.hasOwnProperty.call(app, "queuePrompt"), true);
+    const result = await dispatchScopedRun({
+      app,
+      apiTarget: api,
+      execIds: ["14"],
+      batch: 1,
+      toNodeId: 14,
+    });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(
+      result.scopeAppliedBy,
+      "frontend",
+      "1.49.6's own processor wrote partial_execution_targets after the item was restored — not request_body_repair",
+    );
+    assert.equal(result.repaired, 0);
+    assert.equal(server.calls.length, 1, "the first native attempt is enough");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#1782 frontend 1.49.6: a dropping api.queuePrompt still exact-target repairs rather than false-rejecting", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const { app, api } = makeFrontend1496({
+      dropAppArgs: true,
+      dropApiArgs: true,
+      apiTarget: { fetchApi: server },
+    });
+    const result = await dispatchScopedRun({
+      app,
+      apiTarget: api,
+      execIds: ["14"],
+      batch: 1,
+      toNodeId: 14,
+    });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.scopeAppliedBy, "request_body_repair");
+    assert.equal(result.repaired, 1);
+    assert.equal(server.calls.length, 1);
+    assert.deepEqual(
+      JSON.parse(server.calls[0].options.body).partial_execution_targets,
+      ["14"],
+      "the fallback still writes EXACTLY the requested roots, never a full-graph post",
+    );
+  } finally {
+    stop();
+  }
+});
+
+test("#1782 exact-target fallback: a store-layer options object in the body is rewritten, not false-rejected", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: server,
+      execIds: ["14"],
+      contentHash: OUR_HASH,
+      batch: 1,
+      toNodeId: 14,
+      queueMark: MARK_A,
+      repairScope: true,
+    });
+    const res = await guard(
+      ...promptPost({
+        prompt: OUR_OUTPUT,
+        client_id: "x",
+        number: MARK_A,
+        partial_execution_targets: { queueNodeIds: ["14"], partialExecutionTargets: ["14"] },
+      }),
+    );
+    assert.equal(res.status, 200, "exact ids in the store-layer shape are not a refusal");
+    assert.equal(guard.state.repaired, 1);
+    assert.equal(guard.state.dropped, null);
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
   } finally {
     stop();
   }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -896,6 +896,51 @@ function sameSet(a, b) {
 }
 
 /**
+ * IDs a queue item or a wrapped options object is already carrying.
+ *
+ * Frontend 1.49.6 stores `queueNodeIds` as a NodeExecutionId[] on the pending
+ * item. A wrapper that forwards the third argument verbatim can instead leave
+ * the store/API options object in that slot (or in `partial_execution_targets`).
+ * Those are the same IDs in another layer's shape, not a different request.
+ *
+ * @param {unknown} raw
+ * @returns {string[]|null}
+ */
+export function queueItemScopeIds(raw) {
+  if (Array.isArray(raw) && raw.length) return raw.map(String);
+  if (!raw || typeof raw !== "object") return null;
+  if (Array.isArray(raw.queueNodeIds) && raw.queueNodeIds.length) {
+    return raw.queueNodeIds.map(String);
+  }
+  if (Array.isArray(raw.partialExecutionTargets) && raw.partialExecutionTargets.length) {
+    return raw.partialExecutionTargets.map(String);
+  }
+  return null;
+}
+
+/**
+ * When a present-but-unusable `partial_execution_targets` value still names
+ * EXACTLY the requested execution roots, that is not a different request — it
+ * is the store/API option object copied into the body. Returning the expected
+ * ids lets the repair rewrite that shape into the array ComfyUI accepts
+ * instead of false-rejecting an exact-target payload (#1782).
+ *
+ * Wrong, extra, or empty ids return null: those remain a mismatch we do not
+ * overwrite.
+ *
+ * @param {unknown} raw
+ * @param {string[]} expected
+ * @returns {string[]|null}
+ */
+export function unwrapExactScopeTargets(raw, expected) {
+  const want = (expected ?? []).map(String);
+  if (!want.length) return null;
+  const got = queueItemScopeIds(raw);
+  if (!got || !sameSet(got, want)) return null;
+  return want.slice();
+}
+
+/**
  * Verify a POST /prompt request body carries EXACTLY the requested
  * partial-execution scope. Compared as string sets (server exec ids are strings;
  * a colon path like "76:34" for a subgraph-nested output must survive verbatim).
@@ -1629,20 +1674,22 @@ export function createScopedRunGuard({
     // overwrite; an unparseable body cannot be repaired. Both fall through to
     // the refusal below, exactly as before.
     let forwardOptions = options;
+    const exactWrapped = unwrapExactScopeTargets(scopeRead.raw, expected);
     if (
       repairScope &&
       contentOk &&
       !targets &&
-      // ONLY a genuinely ABSENT key (codex gate r7, P0-1). Previously `empty`
-      // and `not_a_list` were repaired too, which broke this module's own rule
-      // that a scope we did not put there is never overwritten. `[]`, `null`,
-      // `"14"`, and especially `{ queueNodeIds: [...] }` are PRESENT values in
-      // a shape we did not expect — the last looks like another layer's scope
-      // convention, not an absence. Absence is ours to fill; a present value we
-      // cannot interpret is someone else's data, and rewriting it would be
-      // executing our intent over a request that said something different.
-      // Those states now fall through to the refusal, which names what it saw.
-      scopeRead.state === "absent"
+      // Absence is ours to fill (codex gate r7, P0-1). `[]`, `null`, `"14"`,
+      // and a `{ queueNodeIds }` object naming SOME OTHER node are PRESENT
+      // values we cannot interpret — rewriting those would execute our intent
+      // over a request that said something different.
+      //
+      // #1782 — the exception is exact-target verified: a store/API options
+      // object that already names THIS run's roots is the same scope in
+      // another layer's shape (measured on 1.48.7 as a verbatim third-argument
+      // copy). That is not a different request, so refusing it was a false
+      // reject of a payload we can rewrite into the array ComfyUI accepts.
+      (scopeRead.state === "absent" || exactWrapped)
     ) {
       const repairedBody = repairScopeInBody(options?.body, expected);
       if (repairedBody != null) {
@@ -1883,6 +1930,116 @@ export function cancelPendingScopedQueueItem(app, { runTag, queueMark } = {}) {
     }
   }
   return { accessible: true, removed };
+}
+
+/**
+ * Restore `queueNodeIds` onto THIS run's pending frontend 1.49.6 queue item
+ * when a wrapper dropped the third argument of `app.queuePrompt`.
+ *
+ * ComfyApp 1.49.6 pushes `{ number, batchCount, queueNodeIds }` synchronously,
+ * then later reads that array for `isPartialExecution` and
+ * `api.queuePrompt(..., { partialExecutionTargets: queueNodeIds })`. An
+ * own-property wrapper that calls through with only `(number, batch)` still
+ * reaches that native loop — it just pushes `queueNodeIds: undefined`. Filling
+ * the missing array on the item lets the frontend write
+ * `partial_execution_targets` itself. The item's `number` must match this
+ * run's mark; a present array/object naming different roots is left untouched.
+ *
+ * Bypassing the wrapper entirely would skip its queue-time behaviour (seed
+ * capture, telemetry). This does not: it still calls through, then puts back
+ * the ids the native loop already knows how to honour.
+ *
+ * @param {object} app
+ * @param {{queueMark: number, execIds: string[]}} scope
+ * @param {() => *} invoke
+ */
+export function withScopedQueueItemTargets(app, { queueMark, execIds } = {}, invoke) {
+  const expected = (execIds ?? []).map(String);
+  const run = typeof invoke === "function" ? invoke : () => {};
+  let items;
+  try {
+    items = app?.queueItems;
+  } catch {
+    return run();
+  }
+  if (!Array.isArray(items) || typeof items.push !== "function" || !expected.length) {
+    return run();
+  }
+
+  const restoreItem = (item) => {
+    try {
+      if (!item || typeof item !== "object") return;
+      if (Number(item.number) !== queueMark) return;
+      // ComfyApp 1.49.6 stamps `requestId` on every queue item. Mock deferred
+      // items used by the fetch-chain tests share `queueItems` without that
+      // field; filling those would rewrite a fixture's stored third argument
+      // and hide a real retry. Absence of requestId means this is not the
+      // native processor's item, so leave it for the body-repair fallback.
+      if (!Object.prototype.hasOwnProperty.call(item, "requestId")) return;
+      const got = queueItemScopeIds(item.queueNodeIds);
+      if (got) {
+        // Already carrying the exact roots, but 1.49.6's `!!queueNodeIds?.length`
+        // and `partialExecutionTargets: queueNodeIds` need an ARRAY. An options
+        // object in that slot is the same scope in the wrong shape — flatten it.
+        if (sameSet(got, expected) && !Array.isArray(item.queueNodeIds)) {
+          item.queueNodeIds = execIds;
+        }
+        return;
+      }
+      item.queueNodeIds = execIds;
+    } catch {
+      // A hostile queue item cannot prevent the original push from running.
+    }
+  };
+
+  const origPush = items.push;
+  const push = function scopedQueueItemPush(...args) {
+    for (const arg of args) restoreItem(arg);
+    return origPush.apply(this, args);
+  };
+  try {
+    items.push = push;
+  } catch {
+    return run();
+  }
+
+  const restorePush = () => {
+    try {
+      if (items.push === push) items.push = origPush;
+    } catch {
+      // A hostile setter cannot prevent the invoke from having run.
+    }
+  };
+  const scanPending = () => {
+    try {
+      for (const item of items) restoreItem(item);
+    } catch {
+      // Reading a hostile queueItems entry must not replace the invoke result.
+    }
+  };
+
+  try {
+    const result = run();
+    if (result && typeof result.then === "function") {
+      return Promise.resolve(result).then(
+        (value) => {
+          scanPending();
+          restorePush();
+          return value;
+        },
+        (error) => {
+          restorePush();
+          throw error;
+        },
+      );
+    }
+    scanPending();
+    restorePush();
+    return result;
+  } catch (error) {
+    restorePush();
+    throw error;
+  }
 }
 
 /**
@@ -2240,7 +2397,9 @@ export async function dispatchScopedRun({
       // dispatched scopeless. An Error throw is decorated with its browser stack;
       // non-Error throws retain their existing identity.
       const queued = await boundedStep(
-        invokeQueuePromptWithBrowserStack(app, mark, batch, scopeArg),
+        withScopedQueueItemTargets(app, { queueMark: mark, execIds }, () =>
+          invokeQueuePromptWithBrowserStack(app, mark, batch, scopeArg),
+        ),
         boundedBy(attemptMs),
       );
       // `"error" in` rather than a truthiness test — a falsy thrown value still throws.


### PR DESCRIPTION
Fixes #1782

## Change
- restore `queueNodeIds` on ComfyApp 1.49.6 pending queue items when `app.queuePrompt` wrappers drop the third argument, so the native processor writes `partial_execution_targets` itself
- flatten an exact-target store/API options object already on the item into the array 1.49.6 reads (`!!queueNodeIds.length`)
- rewrite an exact-target options object in the `/prompt` body instead of false-rejecting it
- keep `request_body_repair` as the last-resort exact-target fallback when `api.queuePrompt` wrappers also drop extra arguments
- do not bypass queue wrappers (their queue-time behaviour still runs)

## Production path
`graph_run` resolves `to_node_id` into `partialTargets` and calls `dispatchScopedRun`. Each `app.queuePrompt` attempt now wraps `queueItems.push` for this run's mark. Frontend 1.49.6 pushes `{ number, batchCount, queueNodeIds, requestId }`; a dropping wrapper still reaches that push with `queueNodeIds: undefined`. Filling the missing array lets ComfyApp set `isPartialExecution` and pass `partialExecutionTargets` into `api.queuePrompt`. The fetch guard still verifies exact targets before the body leaves.

## Validation
- `node --test browser_tests/unit/run-scope-guard.test.mjs` — 153 passed
- `npm run test:unit` — 7436 passed, 1 existing todo
- `npm run typecheck` — passed (`npx tsc --noEmit`)
- `npm run check:scope` — passed
- `git diff --check` — passed

Do not merge automatically; this PR is implementation-only.