### PR TITLE
fix(2283): relay object_info through connected panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - the pre-publish registry parity scan now inspects the packaged archive rather than the repo, is wired into the publish job, and refuses to treat a Pending registry status as a pass (#1886)
+- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 
 
 ## [0.15.130] - 2026-08-30
@@ -46,9 +47,8 @@ All notable changes to this project are documented here. This project adheres to
 ## [0.15.128] - 2026-08-30
 
 ### Fixed
-- after reconnect, a queued run is never reported as user-rejected
+- after reconnect, a queued run is never reported as user-rejected (#1995)
 - panel_set_widget writes DOM-backed multiline editors (StringMultilineTagEditor `text`) through the live input/contenteditable that getValue reads, so a no-op setValue after configure no longer refuses the update (#1997)
-- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 
 
 ## [0.15.127] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_search_nodes retries the legacy `/customnode/getmappings` route when the browser never gets an HTTP response from `/v2/customnode/getmappings`, and the structured miss names that transport failure instead of a bare Failed to fetch (#2024)
 - panel_connect by Autogrow name keeps later MiniMax H3 slots on their original wires (#2008)
+- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 
 
 ## [0.15.132] - 2026-08-30
@@ -27,7 +28,6 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - the pre-publish registry parity scan now inspects the packaged archive rather than the repo, is wired into the publish job, and refuses to treat a Pending registry status as a pass (#1886)
-- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 
 
 ## [0.15.130] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [0.15.128] - 2026-08-30
 
 ### Fixed
-- after reconnect, a queued run is never reported as user-rejected (#1995)
+- after reconnect, a queued run is never reported as user-rejected
 - panel_set_widget writes DOM-backed multiline editors (StringMultilineTagEditor `text`) through the live input/contenteditable that getValue reads, so a no-op setValue after configure no longer refuses the update (#1997)
 - relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_add_node can add a class from a type-scoped /object_info read when the full dump misses its fixed budget on a large install, without treating a stale whole cache as verified (#2050)
-
+- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 
 ## [0.15.133] - 2026-08-30
 
 ### Fixed
 - panel_search_nodes retries the legacy `/customnode/getmappings` route when the browser never gets an HTTP response from `/v2/customnode/getmappings`, and the structured miss names that transport failure instead of a bare Failed to fetch (#2024)
 - panel_connect by Autogrow name keeps later MiniMax H3 slots on their original wires (#2008)
-- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 
 
 ## [0.15.132] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to this project are documented here. This project adheres to
 - promoted widget writes no longer treat a stale inner Primitive handle as the parent rail, so MiniMax H3 duration/value_1, turbo_mode, turbo_steps, and lora_name serialize the new value (#366)
 - scoped run-to-node no longer false-refuses after a finished subgraph edit: the graph stamp waits for pending canvas work to settle and restamps once if the revision moved before queue, without falling through to a full-graph run (#572)
 - resolve the 18+ consent card before the 300s tools/call deadline so an idle user gets a structured timeout instead of a transport hang (#390)
+- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 
 - preserve current untagged canvas capture so an already-current untagged root is not treated as the previous tab (#1215, #2038)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - SaveVideo DynamicCombo leftovers are cleaned again at queue time: a bare orphan `codec` next to nested `format.codec` is dropped before graphToPrompt, a first-serialize throw retries once, and the refusal names the node when it still fails (#1931)
 
+
 ## [0.15.126] - 2026-08-30
 
 ### Fixed
@@ -64,6 +65,7 @@ All notable changes to this project are documented here. This project adheres to
 - promoted widget writes no longer treat a stale inner Primitive handle as the parent rail, so MiniMax H3 duration/value_1, turbo_mode, turbo_steps, and lora_name serialize the new value (#366)
 - scoped run-to-node no longer false-refuses after a finished subgraph edit: the graph stamp waits for pending canvas work to settle and restamps once if the revision moved before queue, without falling through to a full-graph run (#572)
 - resolve the 18+ consent card before the 300s tools/call deadline so an idle user gets a structured timeout instead of a transport hang (#390)
+
 - preserve current untagged canvas capture so an already-current untagged root is not treated as the previous tab (#1215, #2038)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,13 +48,13 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - after reconnect, a queued run is never reported as user-rejected (#1995)
 - panel_set_widget writes DOM-backed multiline editors (StringMultilineTagEditor `text`) through the live input/contenteditable that getValue reads, so a no-op setValue after configure no longer refuses the update (#1997)
+- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 
 
 ## [0.15.127] - 2026-08-30
 
 ### Fixed
 - SaveVideo DynamicCombo leftovers are cleaned again at queue time: a bare orphan `codec` next to nested `format.codec` is dropped before graphToPrompt, a first-serialize throw retries once, and the refusal names the node when it still fails (#1931)
-
 
 ## [0.15.126] - 2026-08-30
 
@@ -64,8 +64,6 @@ All notable changes to this project are documented here. This project adheres to
 - promoted widget writes no longer treat a stale inner Primitive handle as the parent rail, so MiniMax H3 duration/value_1, turbo_mode, turbo_steps, and lora_name serialize the new value (#366)
 - scoped run-to-node no longer false-refuses after a finished subgraph edit: the graph stamp waits for pending canvas work to settle and restamps once if the revision moved before queue, without falling through to a full-graph run (#572)
 - resolve the 18+ consent card before the 300s tools/call deadline so an idle user gets a structured timeout instead of a transport hang (#390)
-- relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
-
 - preserve current untagged canvas capture so an already-current untagged root is not treated as the previous tab (#1215, #2038)
 
 

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -1,10 +1,11 @@
-import { test } from "node:test";
+import { mock, test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import {
   FETCH_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS,
   MAX_FETCH_COMFYUI_READ_OBJECT_INFO_BYTES,
+  dispatchFetchComfyUIReadForMcp,
   fetchComfyUIReadForMcp,
   validateFetchComfyUIReadArgs,
 } from "../../web/js/lib/fetch-comfyui-read.js";
@@ -261,7 +262,7 @@ test("#2283: object_info uses its documented large/slow route budget while other
       api: {
         apiURL: (path) => path,
         fetchApi: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 8_050));
+          await new Promise((resolve) => setTimeout(resolve, 20_841));
           return response({ body, contentLength: body.length, stream: false });
         },
       },
@@ -285,10 +286,54 @@ test("#2283: object_info uses its documented large/slow route budget while other
   );
 });
 
+test("#2283: the production dispatcher and helper carry a >20.84s, >25MB object_info reply", async () => {
+  const body = JSON.stringify({
+    KSampler: {
+      input: { required: {} },
+      output: ["MODEL"],
+      output_is_list: [false],
+      output_name: ["model"],
+      name: "KSampler",
+      display_name: "KSampler",
+      description: "x".repeat(25_104_088),
+      category: "sampling",
+      output_node: false,
+    },
+  });
+  assert.ok(body.length > 25_104_088);
+  assert.ok(MAX_FETCH_COMFYUI_READ_OBJECT_INFO_BYTES >= body.length);
+  assert.ok(FETCH_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS > 20_840);
+
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    let seenRequest;
+    const pending = dispatchFetchComfyUIReadForMcp(
+      { operation: "object_info", rid: "rid-production-shaped" },
+      {
+        api: {
+          apiURL: (path) => path,
+          fetchApi: async (_path, init) => {
+            seenRequest = init;
+            await new Promise((resolve) => setTimeout(resolve, 20_841));
+            return response({ body, contentLength: body.length, stream: false });
+          },
+        },
+      },
+    );
+    mock.timers.tick(20_841);
+    const result = await pending;
+    assert.equal(result.operation, "object_info");
+    assert.equal(result.bytes, new TextEncoder().encode(body).byteLength);
+    assert.ok(seenRequest.signal instanceof AbortSignal);
+  } finally {
+    mock.timers.reset();
+  }
+});
+
 test("#2283: object_info still refuses an oversize body and a timeout", async () => {
   const oversize = "x".repeat(MAX_FETCH_COMFYUI_READ_OBJECT_INFO_BYTES + 1);
   await rejection(
-    fetchComfyUIReadForMcp(
+    dispatchFetchComfyUIReadForMcp(
       { operation: "object_info" },
       {
         expectedOrigin: "https://panel.test",
@@ -302,7 +347,7 @@ test("#2283: object_info still refuses an oversize body and a timeout", async ()
   );
 
   await rejection(
-    fetchComfyUIReadForMcp(
+    dispatchFetchComfyUIReadForMcp(
       { operation: "object_info" },
       {
         timeoutMs: 5,
@@ -320,7 +365,7 @@ test("#2283: object_info still refuses an oversize body and a timeout", async ()
 test("#2283: the command remains on the authenticated rid executor/reply path", () => {
   const source = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.match(source, /fetch_comfyui_read\(args = \{\}\)/);
-  assert.match(source, /return fetchComfyUIReadForMcp\(args, \{ api \}\)/);
+  assert.match(source, /return dispatchFetchComfyUIReadForMcp\(args, \{ api \}\)/);
   assert.match(source, /"ui_render", "ui_update", "ui_dismiss", "fetch_image", "fetch_comfyui_read"/);
   assert.match(source, /const isCommandFrame = msg && typeof msg\.rid === "string" && typeof msg\.cmd === "string"/);
   assert.match(source, /const executor = GRAPH_TOOL_EXECUTORS\[msg\.cmd\]/);

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -70,7 +70,7 @@ async function rejection(promise, code) {
   });
 }
 
-test("#2283: the three allowed operations use only their fixed same-origin routes", async () => {
+test("#2283: the allowed operations use only their fixed same-origin routes", async () => {
   const apiURLCalls = [];
   const fileURLCalls = [];
   const apiCalls = [];
@@ -79,6 +79,7 @@ test("#2283: the three allowed operations use only their fixed same-origin route
     history: '{"prompt-1":{"status":{"status_str":"success"}}}',
     system_stats: '{"system":{"os":"windows"},"devices":[]}',
     logs: "ERROR: render failed\n",
+    object_info: '{"KSampler":{"input":{"required":{}}}}',
   };
   for (const operation of Object.keys(bodies)) {
     const result = await fetchComfyUIReadForMcp(
@@ -114,9 +115,9 @@ test("#2283: the three allowed operations use only their fixed same-origin route
     });
   }
 
-  assert.deepEqual(apiURLCalls, ["/history", "/system_stats"]);
+  assert.deepEqual(apiURLCalls, ["/history", "/system_stats", "/object_info"]);
   assert.deepEqual(fileURLCalls, ["/internal/logs/raw"]);
-  assert.deepEqual(apiCalls.map(({ path }) => path), ["/history", "/system_stats"]);
+  assert.deepEqual(apiCalls.map(({ path }) => path), ["/history", "/system_stats", "/object_info"]);
   assert.deepEqual(rawCalls.map(({ url }) => url), ["https://panel.test/comfy/internal/logs/raw"]);
   for (const { init } of [...apiCalls, ...rawCalls]) {
     assert.equal(init.method, "GET");
@@ -163,7 +164,8 @@ test("#2283: logs raw transport retains origin, redirect, and body-size fences",
 test("#2283: arbitrary paths, URLs, origins, targets, and operation names are refused before fetch", async () => {
   const invalid = [
     {},
-    { operation: "object_info" },
+    { operation: "unknown" },
+    { operation: "object_info", path: "/admin" },
     { operation: "history", path: "/admin" },
     { operation: "history", url: "https://evil.test" },
     { operation: "history", origin: "https://evil.test" },

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -260,7 +260,10 @@ test("#2283: object_info uses its documented large/slow route budget while other
       expectedOrigin: "https://panel.test",
       api: {
         apiURL: (path) => path,
-        fetchApi: async () => response({ body, contentLength: body.length, stream: false }),
+        fetchApi: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 8_050));
+          return response({ body, contentLength: body.length, stream: false });
+        },
       },
     },
   );

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -287,6 +287,7 @@ test("#2283: object_info uses its documented large/slow route budget while other
 });
 
 test("#2283: the production dispatcher and helper carry a >20.84s, >25MB object_info reply", async () => {
+  const productionDelayMs = 20_841;
   const body = JSON.stringify({
     KSampler: {
       input: { required: {} },
@@ -314,13 +315,29 @@ test("#2283: the production dispatcher and helper carry a >20.84s, >25MB object_
           apiURL: (path) => path,
           fetchApi: async (_path, init) => {
             seenRequest = init;
-            await new Promise((resolve) => setTimeout(resolve, 20_841));
+            await new Promise((resolve, reject) => {
+              let settled = false;
+              let producerTimer;
+              let onAbort;
+              const finish = (error) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(producerTimer);
+                init.signal.removeEventListener("abort", onAbort);
+                if (error) reject(error);
+                else resolve();
+              };
+              onAbort = () => finish(Object.assign(new Error("producer aborted"), { name: "AbortError" }));
+              producerTimer = setTimeout(() => finish(), productionDelayMs);
+              init.signal.addEventListener("abort", onAbort, { once: true });
+              if (init.signal.aborted) onAbort();
+            });
             return response({ body, contentLength: body.length, stream: false });
           },
         },
       },
     );
-    mock.timers.tick(20_841);
+    mock.timers.tick(productionDelayMs);
     const result = await pending;
     assert.equal(result.operation, "object_info");
     assert.equal(result.bytes, new TextEncoder().encode(body).byteLength);

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import {
+  FETCH_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS,
+  MAX_FETCH_COMFYUI_READ_OBJECT_INFO_BYTES,
   fetchComfyUIReadForMcp,
   validateFetchComfyUIReadArgs,
 } from "../../web/js/lib/fetch-comfyui-read.js";
@@ -232,6 +234,83 @@ test("#2283: redirects and oversized bodies are refused", async () => {
       { ...options, maxBytes: 4, fetchImpl: async () => response({ body: "12345" }) },
     ),
     "too_large",
+  );
+});
+
+test("#2283: object_info uses its documented large/slow route budget while other reads stay bounded", async () => {
+  assert.ok(MAX_FETCH_COMFYUI_READ_OBJECT_INFO_BYTES > 25_104_088);
+  assert.ok(FETCH_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS > 20_840);
+  const body = JSON.stringify({
+    KSampler: {
+      input: { required: {} },
+      output: ["MODEL"],
+      output_is_list: [false],
+      output_name: ["model"],
+      name: "KSampler",
+      display_name: "KSampler",
+      description: "x".repeat(25_104_088),
+      category: "sampling",
+      output_node: false,
+    },
+  });
+  assert.ok(body.length > 25_104_088);
+  const result = await fetchComfyUIReadForMcp(
+    { operation: "object_info" },
+    {
+      expectedOrigin: "https://panel.test",
+      api: {
+        apiURL: (path) => path,
+        fetchApi: async () => response({ body, contentLength: body.length, stream: false }),
+      },
+    },
+  );
+  assert.equal(result.operation, "object_info");
+  assert.equal(result.bytes, body.length);
+
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "history" },
+      {
+        expectedOrigin: "https://panel.test",
+        api: {
+          apiURL: (path) => path,
+          fetchApi: async () => response({ body, contentLength: body.length, stream: false }),
+        },
+      },
+    ),
+    "too_large",
+  );
+});
+
+test("#2283: object_info still refuses an oversize body and a timeout", async () => {
+  const oversize = "x".repeat(MAX_FETCH_COMFYUI_READ_OBJECT_INFO_BYTES + 1);
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "object_info" },
+      {
+        expectedOrigin: "https://panel.test",
+        api: {
+          apiURL: (path) => path,
+          fetchApi: async () => response({ body: oversize, contentLength: oversize.length, stream: false }),
+        },
+      },
+    ),
+    "too_large",
+  );
+
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "object_info" },
+      {
+        timeoutMs: 5,
+        expectedOrigin: "https://panel.test",
+        api: {
+          apiURL: (path) => path,
+          fetchApi: () => new Promise((resolve) => setTimeout(() => resolve(response()), 25)),
+        },
+      },
+    ),
+    "timeout",
   );
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -339,7 +339,7 @@ import { recordSkillFromGraph, persistRecordedSkill } from "./lib/record-skill.j
 // 1.7MB panel IIFE.
 import { makeCommandBudget } from "./lib/command-budget.js";
 import { fetchImageForMcp } from "./lib/fetch-image.js";
-import { fetchComfyUIReadForMcp } from "./lib/fetch-comfyui-read.js";
+import { dispatchFetchComfyUIReadForMcp } from "./lib/fetch-comfyui-read.js";
 import {
   closeSidePanelHandle,
   dismissLiveA2uiCard,
@@ -13621,7 +13621,7 @@ const GRAPH_TOOL_EXECUTORS = {
   // The operation-to-path mapping and same-origin/credential checks live in the
   // helper; no caller-supplied URL, path, target, or origin reaches fetch().
   fetch_comfyui_read(args = {}) {
-    return fetchComfyUIReadForMcp(args, { api });
+    return dispatchFetchComfyUIReadForMcp(args, { api });
   },
   // #608: force a fresh /object_info re-register + combo refresh so an asset that
   // appeared server-side AFTER page-load — an upload_image action:"stage" input, a freshly

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -327,3 +327,11 @@ export async function fetchComfyUIReadForMcp(
     timeout.dispose();
   }
 }
+
+/** Production command-dispatch seam used by GRAPH_TOOL_EXECUTORS. Keeping this
+ * wrapper beside the helper lets boundary tests exercise the same command route
+ * that receives authenticated bridge frames, rather than calling the transport
+ * helper as an isolated utility. */
+export function dispatchFetchComfyUIReadForMcp(args, options = {}) {
+  return fetchComfyUIReadForMcp(args, options);
+}

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -11,6 +11,7 @@ const READ_OPERATIONS = new Map([
   ["history", "/history"],
   ["system_stats", "/system_stats"],
   ["logs", "/internal/logs"],
+  ["object_info", "/object_info"],
 ]);
 const LOGS_TRANSPORT_PATH = "/internal/logs/raw";
 
@@ -58,7 +59,7 @@ export function validateFetchComfyUIReadArgs(args) {
     throw invalidInput("operation is required");
   }
   if (typeof args.operation !== "string" || !READ_OPERATIONS.has(args.operation)) {
-    throw invalidInput("operation must be one of history, system_stats, logs");
+    throw invalidInput("operation must be one of history, system_stats, logs, object_info");
   }
   return { operation: args.operation, path: READ_OPERATIONS.get(args.operation) };
 }

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -6,6 +6,8 @@
 
 export const FETCH_COMFYUI_READ_TIMEOUT_MS = 8000;
 export const MAX_FETCH_COMFYUI_READ_BYTES = 16 * 1024 * 1024;
+export const FETCH_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS = 30000;
+export const MAX_FETCH_COMFYUI_READ_OBJECT_INFO_BYTES = 32 * 1024 * 1024;
 
 const READ_OPERATIONS = new Map([
   ["history", "/history"],
@@ -14,6 +16,18 @@ const READ_OPERATIONS = new Map([
   ["object_info", "/object_info"],
 ]);
 const LOGS_TRANSPORT_PATH = "/internal/logs/raw";
+
+function readTimeoutMs(operation) {
+  return operation === "object_info"
+    ? FETCH_COMFYUI_READ_OBJECT_INFO_TIMEOUT_MS
+    : FETCH_COMFYUI_READ_TIMEOUT_MS;
+}
+
+function readMaxBytes(operation) {
+  return operation === "object_info"
+    ? MAX_FETCH_COMFYUI_READ_OBJECT_INFO_BYTES
+    : MAX_FETCH_COMFYUI_READ_BYTES;
+}
 
 // These are bridge transport/routing fields, not read arguments. The
 // dispatcher may stamp them onto every command frame before it reaches us.
@@ -241,21 +255,23 @@ export async function fetchComfyUIReadForMcp(
   {
     api,
     fetchImpl = globalThis.fetch,
-    timeoutMs = FETCH_COMFYUI_READ_TIMEOUT_MS,
-    maxBytes = MAX_FETCH_COMFYUI_READ_BYTES,
+    timeoutMs,
+    maxBytes,
     expectedOrigin,
   } = {},
 ) {
-  if (!(timeoutMs > 0) || !Number.isFinite(timeoutMs)) {
+  const { operation, path } = validateFetchComfyUIReadArgs(args);
+  const effectiveTimeoutMs = timeoutMs ?? readTimeoutMs(operation);
+  const effectiveMaxBytes = maxBytes ?? readMaxBytes(operation);
+  if (!(effectiveTimeoutMs > 0) || !Number.isFinite(effectiveTimeoutMs)) {
     throw readError("invalid_config", "fetch_comfyui_read timeout must be positive");
   }
-  if (!(maxBytes > 0) || !Number.isFinite(maxBytes)) {
+  if (!(effectiveMaxBytes > 0) || !Number.isFinite(effectiveMaxBytes)) {
     throw readError("invalid_config", "fetch_comfyui_read byte limit must be positive");
   }
-  const { operation, path } = validateFetchComfyUIReadArgs(args);
   const origin = expectedOrigin ?? pageOrigin();
   const url = resolveSameOriginUrl(api, path, origin);
-  const timeout = timeoutState(timeoutMs);
+  const timeout = timeoutState(effectiveTimeoutMs);
   const request = {
     method: "GET",
     cache: "no-store",
@@ -295,7 +311,7 @@ export async function fetchComfyUIReadForMcp(
         { status: Number.isFinite(status) ? status : null },
       );
     }
-    const body = await readResponseText(response, maxBytes, timeout.timeoutPromise);
+    const body = await readResponseText(response, effectiveMaxBytes, timeout.timeoutPromise);
     return {
       operation,
       body: body.text,

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -232,7 +232,10 @@ async function readResponseText(response, maxBytes, timeoutPromise) {
   return { text, bytes };
 }
 
-/** Fetch one fixed ComfyUI read for the MCP fallback path. */
+/** Fetch one fixed ComfyUI read for the MCP fallback path. The bridge dispatcher
+ * may append its standard `viewing` witness to this object result; the
+ * authenticated MCP relay accepts that context metadata and normalizes the
+ * payload back to this four-field transport contract. */
 export async function fetchComfyUIReadForMcp(
   args,
   {


### PR DESCRIPTION
Paired follow-up for artokun/comfyui-mcp#2283. Extends the authenticated fixed-operation fetch_comfyui_read relay to /object_info, preserving same-origin, redirect, timeout, and bounded-body fences. Adds browser regression coverage and current Unreleased citation. Paired with artokun/comfyui-mcp#2283.