### PR TITLE
fix(1931): drop SaveVideo orphan codec again at queue time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- SaveVideo DynamicCombo leftovers are cleaned again at queue time: a bare orphan `codec` next to nested `format.codec` is dropped before graphToPrompt, a first-serialize throw retries once, and the refusal names the node when it still fails (#1931)
+
 ## [0.15.126] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/dynamic-widget-reconcile.test.mjs
+++ b/browser_tests/unit/dynamic-widget-reconcile.test.mjs
@@ -12,6 +12,10 @@ import assert from "node:assert/strict";
 import {
   reconcileFreshDynamicWidgets,
   reconcileGraphDynamicWidgets,
+  nestedDynamicComboChildNames,
+  describeOrphanDynamicWidgets,
+  isDynamicWidgetMissingError,
+  installGraphToPromptDynamicReconcile,
 } from "../../web/js/lib/dynamic-widget-reconcile.js";
 
 const DYNAMIC = "COMFY_DYNAMICCOMBO_V3";
@@ -380,4 +384,125 @@ test("#2254: stale format.codec is still removed when codec is the required root
   assert.ok(result.relocated.includes("format.codec"));
   assert.equal(node.widgets.some((widget) => widget.name === "format.codec"), false);
   assert.equal(node.widgets.some((widget) => widget.name === "codec"), true);
+});
+
+test("#1931: nested DynamicCombo children are codec/encoding/crf, not top-level format", () => {
+  const names = nestedDynamicComboChildNames(nestedFormatDef());
+  assert.equal(names.has("codec"), true);
+  assert.equal(names.has("encoding"), true);
+  assert.equal(names.has("format"), false);
+  assert.equal(nestedDynamicComboChildNames(legacyCodecDef()).has("codec"), false);
+});
+
+test("#1931: describeOrphanDynamicWidgets names the SaveVideo duplicate set", () => {
+  const { node } = makeNode({
+    def: nestedFormatDef(),
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  const found = describeOrphanDynamicWidgets({ _nodes: [node] });
+  assert.equal(found.length, 1);
+  assert.equal(found[0].nodeId, 15);
+  assert.equal(found[0].nodeType, "SaveVideo");
+  assert.equal(found[0].orphan, "codec");
+  assert.equal(found[0].nested, "format.codec");
+});
+
+test("#1931: a loaded graph keyed on graph.nodes is still cleaned", () => {
+  const def = nestedFormatDef();
+  const { node, graphToPrompt } = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  assert.throws(graphToPrompt, /Dynamic widget doesn't exist on node/);
+  reconcileGraphDynamicWidgets({ nodes: [node] });
+  assert.equal(node.widgets.some((widget) => widget.name === "codec"), false);
+  assert.doesNotThrow(graphToPrompt);
+});
+
+test("#1931: a prototype value setter still counts as a dynamic root", () => {
+  const def = nestedFormatDef({ hiddenCodec: false });
+  const { node } = makeNode({ def });
+  const format = node.widgets.find((widget) => widget.name === "format");
+  const own = Object.getOwnPropertyDescriptor(format, "value");
+  delete format.value;
+  const proto = Object.create(Object.getPrototypeOf(format));
+  Object.defineProperty(proto, "value", own);
+  Object.setPrototypeOf(format, proto);
+  const result = reconcileFreshDynamicWidgets(node, def);
+  assert.equal(result.failures.length, 0);
+  assert.ok(result.replayed.includes("format"));
+});
+
+test("#1931: the serializer wrap drops the orphan before graphToPrompt", async () => {
+  const def = nestedFormatDef();
+  const { node, graphToPrompt } = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  const app = { graph: { _nodes: [node] }, graphToPrompt };
+  assert.equal(installGraphToPromptDynamicReconcile(app), true);
+  const prompt = await app.graphToPrompt();
+  assert.equal(node.widgets.some((widget) => widget.name === "codec"), false);
+  assert.equal(prompt.output[15].inputs.codec, "auto");
+});
+
+test("#1931: a first-serialize DynamicCombo throw is retried after reconcile", async () => {
+  const def = nestedFormatDef();
+  const { node, graphToPrompt } = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  let calls = 0;
+  const app = {
+    graph: { _nodes: [node] },
+    graphToPrompt() {
+      calls += 1;
+      if (calls === 1) throw new Error("Dynamic widget doesn't exist on node");
+      return graphToPrompt();
+    },
+  };
+  installGraphToPromptDynamicReconcile(app);
+  const prompt = await app.graphToPrompt();
+  assert.equal(calls, 2);
+  assert.equal(node.widgets.some((widget) => widget.name === "codec"), false);
+  assert.equal(prompt.output[15].inputs.codec, "auto");
+});
+
+test("#1931: a persistent serializer throw names the SaveVideo node and orphan", async () => {
+  const def = nestedFormatDef();
+  const { node } = makeNode({
+    def,
+    extraWidgets: [{ name: "codec", dynamic: true }],
+  });
+  const codec = node.widgets.find((widget) => widget.name === "codec");
+  Object.defineProperty(codec, "name", { configurable: true, writable: false, value: "codec" });
+  const app = {
+    graph: { _nodes: [node] },
+    graphToPrompt() {
+      throw new Error("Dynamic widget doesn't exist on node");
+    },
+  };
+  installGraphToPromptDynamicReconcile(app);
+  assert.throws(
+    () => app.graphToPrompt(),
+    (error) => {
+      assert.equal(isDynamicWidgetMissingError(error), true);
+      assert.match(error.message, /SaveVideo node 15/);
+      assert.match(error.message, /format\.codec/);
+      assert.match(error.message, /orphan codec/);
+      return true;
+    },
+  );
+});
+
+test("#1931: the serializer wrap is idempotent", () => {
+  const app = { graphToPrompt: async () => ({ output: {} }) };
+  const first = app.graphToPrompt;
+  assert.equal(installGraphToPromptDynamicReconcile(app), true);
+  const wrapped = app.graphToPrompt;
+  assert.notEqual(wrapped, first);
+  assert.equal(installGraphToPromptDynamicReconcile(app), true);
+  assert.equal(app.graphToPrompt, wrapped);
+  assert.equal(installGraphToPromptDynamicReconcile({}), false);
+  assert.equal(installGraphToPromptDynamicReconcile(null), false);
 });

--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -21,6 +21,7 @@ import test from "node:test";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
   unrunnableNodeIds,
@@ -61,6 +62,21 @@ test("#1654 a frontend serializer throw is preserved as a fail-closed refusal", 
   assert.match(msg, /Dynamic widget doesn't exist on node/);
   assert.match(msg, /Nothing was queued/);
   assert.match(msg, /frontend or an extension's serializer/);
+});
+
+test("#1931 an unnamed DynamicCombo throw does not send the caller to a named widget", () => {
+  const msg = graphToPromptFailureRefusal(new Error("Dynamic widget doesn't exist on node"));
+  assert.doesNotMatch(msg, /inspect the named widget/i);
+  assert.match(msg, /did not name a node or widget/);
+  assert.match(msg, /format\.codec/);
+});
+
+test("#1931 a named DynamicCombo throw keeps the inspect-the-named-widget remedy", () => {
+  const msg = graphToPromptFailureRefusal(
+    new Error("Dynamic widget doesn't exist on node: SaveVideo node 71 has format.codec and orphan codec"),
+  );
+  assert.match(msg, /inspect the named widget/i);
+  assert.match(msg, /SaveVideo node 71/);
 });
 
 test("#1654 serializer refusal rendering is total and bounded for hostile throws", () => {
@@ -129,6 +145,16 @@ test("#1565: a SYNCHRONOUS graphToPrompt still reaches the pre-flight — the bo
   });
   assert.notEqual(msg, "__NO_REFUSAL__", "the pre-flight must still refuse an unrunnable node");
   assert.match(msg, /^NOT queued:/);
+});
+
+test("#1931 graph_run installs the DynamicCombo reconcile wrap before preflight", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf-8");
+  const rec = src.indexOf("installGraphToPromptDynamicReconcile(app)");
+  const snapshot = src.indexOf("installGraphToPromptSnapshotBarrier(app)");
+  const preflight = src.indexOf("const preflightBuild = await withTimeout(");
+  assert.ok(rec > 0, "graph_run must install the DynamicCombo reconcile wrap");
+  assert.ok(snapshot > rec, "the snapshot barrier must stay outermost so cancel still throws synchronously");
+  assert.ok(preflight > snapshot, "both wraps must be installed before the pre-flight serialize");
 });
 
 test("#1582 the run path guards graphToPrompt BEFORE reading offenders", async () => {

--- a/browser_tests/unit/remove-widget.test.mjs
+++ b/browser_tests/unit/remove-widget.test.mjs
@@ -94,6 +94,37 @@ test("declaredInputNames reads required, optional AND hidden", () => {
   assert.deepEqual([...names].sort(), ["a", "b", "c"]);
 });
 
+test("#1931 nested DynamicCombo children are not top-level declared inputs", () => {
+  const names = declaredInputNames({
+    input: {
+      required: {
+        filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+        format: [
+          "COMFY_DYNAMICCOMBO_V3",
+          { options: [{ key: "auto", inputs: { required: { codec: ["COMFY_DYNAMICCOMBO_V3", { options: [] }] } } }] },
+        ],
+      },
+      optional: { codec: ["COMFY_DYNAMICCOMBO_V3", { options: [] }] },
+    },
+  });
+  assert.equal(names.has("format"), true);
+  assert.equal(names.has("filename_prefix"), true);
+  assert.equal(names.has("codec"), false, "flattened optional codec is a nested child of format");
+});
+
+test("#1931 a required DynamicCombo root stays declared even if another combo nests the same name", () => {
+  const names = declaredInputNames({
+    input: {
+      required: {
+        codec: ["COMFY_DYNAMICCOMBO_V3", { options: [{ key: "auto", inputs: {} }] }],
+        format: [["auto", "mp4"], { default: "auto" }],
+      },
+    },
+  });
+  assert.equal(names.has("codec"), true);
+  assert.equal(names.has("format"), true);
+});
+
 test("declaredInputNames returns NULL for a def it cannot read — not an empty set", () => {
   // The distinction is the whole safety story: an empty Set means "the backend declares
   // nothing, so every widget is dynamic", which would authorize removing ANY widget on a

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -54,6 +54,7 @@ import {
 } from "../../web/js/lib/missing-node-preflight.js";
 import { buildQueueAcceptResult, summarizePromptRejection } from "../../web/js/lib/queue-rejection.js";
 import { installGraphToPromptNullSafety } from "../../web/js/lib/widget-null-safety.js";
+import { installGraphToPromptDynamicReconcile } from "../../web/js/lib/dynamic-widget-reconcile.js";
 import {
   installGraphToPromptSnapshotBarrier,
   queuePromptWithGraphToPromptSnapshot,
@@ -703,6 +704,7 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
     describeUnrunnable,
     installGraphToPromptNullSafety,
     installGraphToPromptSnapshotBarrier,
+    installGraphToPromptDynamicReconcile,
     queuePromptWithGraphToPromptSnapshot,
     reserveGraphToPromptSnapshot,
     releaseGraphToPromptSnapshot,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -418,7 +418,11 @@ import {
   releaseReconnectScopePin,
 } from "./lib/reconnect-scope-fence.js";
 import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "./lib/set-widget.js";
-import { reconcileFreshDynamicWidgets, reconcileGraphDynamicWidgets } from "./lib/dynamic-widget-reconcile.js";
+import {
+  reconcileFreshDynamicWidgets,
+  reconcileGraphDynamicWidgets,
+  installGraphToPromptDynamicReconcile,
+} from "./lib/dynamic-widget-reconcile.js";
 import {
   createDeferredWidgetEditQueue,
   deferredWidgetQueueCounts,
@@ -19320,6 +19324,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // pre-flight is itself graphToPrompt and must not be the one serialization that
     // can still hit a null widget or establish a reservation before the guard exists.
     installGraphToPromptNullSafety(app);
+    // #1931 — SaveVideo can grow a bare `codec` next to `format.codec` after add/load
+    // (set_widget, restore, restart). Clean it on the serializer itself so preflight
+    // and the deferred queue-loop serialize see the same nested set. Installed before
+    // the snapshot barrier so a cancelled queue item still throws synchronously.
+    installGraphToPromptDynamicReconcile(app);
     installGraphToPromptSnapshotBarrier(app);
     try {
       // Inspect the SERIALIZED prompt, not the canvas. graphToPrompt has already

--- a/web/js/lib/dynamic-widget-reconcile.js
+++ b/web/js/lib/dynamic-widget-reconcile.js
@@ -1,11 +1,30 @@
 const DYNAMIC_COMBO_V3 = "COMFY_DYNAMICCOMBO_V3";
+const DYNAMIC_WIDGET_MISSING_RE = /Dynamic widget doesn't exist on node/i;
+const GRAPH_TO_PROMPT_RECONCILE = Symbol.for("comfyui-mcp.graphToPromptDynamicReconcile");
+const rawApply = Reflect.apply;
 
 function hasValueSetter(widget) {
   try {
-    return typeof Object.getOwnPropertyDescriptor(widget, "value")?.set === "function";
+    let proto = widget;
+    while (proto && proto !== Object.prototype) {
+      const desc = Object.getOwnPropertyDescriptor(proto, "value");
+      if (desc) return typeof desc.set === "function";
+      proto = Object.getPrototypeOf(proto);
+    }
+    return false;
   } catch {
     return false;
   }
+}
+
+function graphNodes(graph) {
+  if (Array.isArray(graph?._nodes) && graph._nodes.length) return graph._nodes;
+  if (Array.isArray(graph?.nodes)) return graph.nodes;
+  return [];
+}
+
+function nodeDef(node) {
+  return node?.constructor?.nodeData ?? node?.nodeData ?? null;
 }
 
 function readWidgetId(widget) {
@@ -50,6 +69,7 @@ function walkDynamicComboChildren(spec, visit) {
 
 function nestedChildNamesByRoot(required) {
   const byRoot = new Map();
+  if (!required || typeof required !== "object") return byRoot;
   for (const [name, spec] of Object.entries(required)) {
     if (!isDynamicComboSpec(spec)) continue;
     const children = new Set();
@@ -57,6 +77,26 @@ function nestedChildNamesByRoot(required) {
     if (children.size) byRoot.set(name, children);
   }
   return byRoot;
+}
+
+/**
+ * Bare names that exist only as children of a required DynamicCombo.
+ *
+ * SaveVideo's `codec` is declared under a chosen `format` option, not as its own
+ * top-level input. A flattened optional/hidden copy of that child is not a
+ * backend-declared row for remove_widget (#1931).
+ *
+ * @param {object} def
+ * @returns {Set<string>}
+ */
+export function nestedDynamicComboChildNames(def) {
+  const nested = new Set();
+  const required = def?.input?.required;
+  if (!required || typeof required !== "object") return nested;
+  for (const children of nestedChildNamesByRoot(required).values()) {
+    for (const name of children) nested.add(name);
+  }
+  return nested;
 }
 
 function isInternalRelocationName(name) {
@@ -324,11 +364,11 @@ export function reconcileFreshDynamicWidgets(node, currentDef) {
  * @returns {Array<object>}
  */
 export function reconcileGraphDynamicWidgets(graph) {
-  const nodes = Array.isArray(graph?._nodes) ? graph._nodes : [];
+  const nodes = graphNodes(graph);
   const results = [];
   for (const node of nodes) {
     try {
-      const def = node?.constructor?.nodeData;
+      const def = nodeDef(node);
       if (def) results.push(reconcileFreshDynamicWidgets(node, def));
       if (node?.subgraph) results.push(...reconcileGraphDynamicWidgets(node.subgraph));
     } catch (error) {
@@ -341,4 +381,139 @@ export function reconcileGraphDynamicWidgets(graph) {
     }
   }
   return results;
+}
+
+export function isDynamicWidgetMissingError(error) {
+  let raw = "";
+  try {
+    raw = error instanceof Error ? error.message : String(error ?? "");
+  } catch {
+    return false;
+  }
+  return DYNAMIC_WIDGET_MISSING_RE.test(raw);
+}
+
+/**
+ * Nodes that still carry a schema-verified DynamicCombo orphan (bare `codec`
+ * next to `format.codec` on SaveVideo). Used to name the serializer throw.
+ *
+ * @param {object} graph
+ * @returns {Array<{nodeId: unknown, nodeType: string, orphan: string, nested: string}>}
+ */
+export function describeOrphanDynamicWidgets(graph) {
+  const found = [];
+  for (const node of graphNodes(graph)) {
+    try {
+      const required = nodeDef(node)?.input?.required;
+      const nestedByRoot = nestedChildNamesByRoot(required);
+      if (!nestedByRoot.size) {
+        if (node?.subgraph) found.push(...describeOrphanDynamicWidgets(node.subgraph));
+        continue;
+      }
+      const widgets = Array.isArray(node.widgets) ? node.widgets : [];
+      const names = new Set();
+      for (const widget of widgets) {
+        if (typeof widget?.name === "string") names.add(widget.name);
+      }
+      for (const input of Array.isArray(node.inputs) ? node.inputs : []) {
+        if (typeof input?.name === "string") names.add(input.name);
+      }
+      for (const name of names) {
+        const root = orphanParentRoot(name, nestedByRoot, widgets);
+        if (!root) continue;
+        found.push({
+          nodeId: node.id,
+          nodeType: typeof node.type === "string" ? node.type : "node",
+          orphan: name,
+          nested: `${root}.${name.split(".")[0]}`,
+        });
+      }
+      if (node?.subgraph) found.push(...describeOrphanDynamicWidgets(node.subgraph));
+    } catch {
+      // A hostile node must not hide the rest of the graph.
+    }
+  }
+  return found;
+}
+
+function namedDynamicWidgetError(error, graph) {
+  const candidates = describeOrphanDynamicWidgets(graph);
+  let base = "";
+  try {
+    base = error instanceof Error ? error.message : String(error ?? "");
+  } catch {
+    base = "";
+  }
+  if (!candidates.length) {
+    return error instanceof Error ? error : new Error(base || "Dynamic widget doesn't exist on node");
+  }
+  const listed = candidates
+    .slice(0, 8)
+    .map((entry) => `${entry.nodeType} node ${entry.nodeId} has ${entry.nested} and orphan ${entry.orphan}`)
+    .join("; ");
+  const extra = candidates.length > 8 ? ` (${candidates.length - 8} more)` : "";
+  const message =
+    DYNAMIC_WIDGET_MISSING_RE.test(base) && !/\bnode\s+\d+/i.test(base)
+      ? `Dynamic widget doesn't exist on node: ${listed}${extra}`
+      : `${base} (${listed}${extra})`;
+  const named = new Error(message);
+  if (error instanceof Error) named.cause = error;
+  return named;
+}
+
+/**
+ * Reconcile nested DynamicCombo leftovers immediately before every prompt build,
+ * and retry once if the frontend still throws the unnamed SaveVideo serializer
+ * error. add_node/load already clean what they can; 0.15.124 recurrences still
+ * queued a graph that grew the orphan back (set_widget, restore, restart).
+ *
+ * @param {object} app
+ * @returns {boolean}
+ */
+export function installGraphToPromptDynamicReconcile(app) {
+  if (!app || typeof app.graphToPrompt !== "function") return false;
+  if (app[GRAPH_TO_PROMPT_RECONCILE]) return true;
+  const graphToPromptFn = app.graphToPrompt;
+  const orig = (...args) => rawApply(graphToPromptFn, app, args);
+  app.graphToPrompt = function reconcileThenGraphToPrompt(graph, ...rest) {
+    const target = graph ?? app.rootGraph ?? app.graph ?? null;
+    try {
+      reconcileGraphDynamicWidgets(target);
+    } catch {
+      // Best-effort: a hostile node must not block serialization.
+    }
+    const retry = (error) => {
+      if (!isDynamicWidgetMissingError(error)) throw error;
+      try {
+        reconcileGraphDynamicWidgets(target);
+      } catch {
+        // Retry with whatever state we could clean.
+      }
+      try {
+        const retried = orig(graph, ...rest);
+        if (retried && typeof retried.then === "function") {
+          return Promise.resolve(retried).then(
+            (value) => value,
+            (retryError) => {
+              throw namedDynamicWidgetError(retryError, target);
+            },
+          );
+        }
+        return retried;
+      } catch (retryError) {
+        throw namedDynamicWidgetError(retryError, target);
+      }
+    };
+    try {
+      const result = orig(graph, ...rest);
+      if (result && typeof result.then === "function") {
+        return Promise.resolve(result).then((value) => value, retry);
+      }
+      return result;
+    } catch (error) {
+      return retry(error);
+    }
+  };
+  app[GRAPH_TO_PROMPT_RECONCILE] = true;
+  return true;
 }

--- a/web/js/lib/missing-node-preflight.js
+++ b/web/js/lib/missing-node-preflight.js
@@ -151,11 +151,18 @@ export function graphToPromptFailureRefusal(error) {
   const cause = detail
     ? ` The frontend serializer reported: "${detail}".`
     : " The frontend did not provide an error detail.";
+  const namesAWidget = /\bnode\s+\d+/i.test(detail) || /orphan /i.test(detail);
+  const unnamedDynamic =
+    /Dynamic widget doesn't exist on node/i.test(detail) && !namesAWidget;
+  const inspect = unnamedDynamic
+    ? `The serializer did not name a node or widget; look for a DynamicCombo node that ` +
+      `carries both a nested child (format.codec) and a bare duplicate (codec).`
+    : `Inspect the named widget or extension before retrying.`;
   return (
     `NOT queued: this workflow could not be serialized into a prompt because ` +
     `graphToPrompt threw.${cause} Nothing was queued and the queue is untouched. ` +
     `This is the ComfyUI frontend or an extension's serializer error, not evidence that ` +
-    `a node type is missing; inspect the named widget or extension before retrying.`
+    `a node type is missing; ${inspect}`
   );
 }
 

--- a/web/js/lib/remove-widget.js
+++ b/web/js/lib/remove-widget.js
@@ -35,6 +35,7 @@ import { isControlAfterGenerateWidget } from "./control-after-generate.js";
 // than by type string. Reusing it keeps one answer to the question instead of two that
 // can drift — a subgraph node's `type` is a UUID, so a name test would never work anyway.
 import { isVirtualSubgraphContainer } from "./node-resolve.js";
+import { nestedDynamicComboChildNames } from "./dynamic-widget-reconcile.js";
 
 /** Widget names whose VALUE we never echo back, even in a "here is what I removed" reply. */
 const SECRETISH_NAME = /(api[_-]?key|secret|token|password|passwd|credential)/i;
@@ -60,10 +61,21 @@ export function declaredInputNames(def) {
   if (!def || typeof def !== "object") return null;
   const input = def.input;
   if (!input || typeof input !== "object") return null;
+  const required = input.required && typeof input.required === "object" ? input.required : null;
+  const nestedChildren = nestedDynamicComboChildNames(def);
   const names = new Set();
   for (const group of ["required", "optional", "hidden"]) {
     const g = input[group];
-    if (g && typeof g === "object") for (const k of Object.keys(g)) names.add(k);
+    if (!g || typeof g !== "object") continue;
+    for (const k of Object.keys(g)) {
+      // Nested DynamicCombo children are not top-level declared inputs. SaveVideo's
+      // `codec` exists only under a chosen `format` option; a flattened optional/hidden
+      // copy must not block panel_remove_widget of the orphan (#1931).
+      if (nestedChildren.has(k) && !(required && Object.prototype.hasOwnProperty.call(required, k))) {
+        continue;
+      }
+      names.add(k);
+    }
   }
   return names;
 }


### PR DESCRIPTION
## Summary

`panel_add_node("SaveVideo")` and load already keep nested `format.codec` (merged in #1970 / 0.15.119), but current-release 0.15.124 still failed `panel_run` with `Dynamic widget doesn't exist on node` after set_widget, restore, and restart. The frontend serializer trips on a bare orphan `codec` that grows back after the add/load cleanup.

This change:

- Reconciles nested DynamicCombo leftovers on `app.graphToPrompt` itself, so preflight and the deferred queue-loop serialize see the same nested set
- Retries once if the unnamed serializer throw still fires
- Names the SaveVideo node and orphan widget in the refusal when retry still fails
- Stops treating a flattened nested `codec` as a backend-declared input for `panel_remove_widget`

## Test plan

- [x] `node --test browser_tests/unit/dynamic-widget-reconcile.test.mjs` — wrap drops orphan before serialize; first-serialize throw retries; persistent throw names SaveVideo node 15; `#2254` inverse still holds
- [x] `node --test browser_tests/unit/add-node-schema-auto-refresh.test.mjs` — add_node still ships `filename_prefix, format, format.codec` only
- [x] `node --test browser_tests/unit/graph-to-prompt-failure.test.mjs` — unnamed throw no longer says inspect the named widget; wrap is installed before preflight
- [x] `node --test browser_tests/unit/remove-widget.test.mjs` — nested codec is not a declared input
- [x] `node --test browser_tests/unit/run-command-budget.test.mjs` — snapshot cancel still throws synchronously

Fixes #1931
