### PR TITLE
fix: paint Codex generated-image results in sidebar chat (#1994)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- Codex generatedImage results paint as chat attachments (#1994)
 - panel_run on frontend 1.49.6 delivers to_node_id natively when app.queuePrompt wrappers drop the third argument (#1782)
 - retry one readable workflow-open normalization race while keeping persistent content mismatches fail-closed (#1898)
 

--- a/browser_tests/unit/generated-image-chat.test.mjs
+++ b/browser_tests/unit/generated-image-chat.test.mjs
@@ -1,0 +1,196 @@
+// #1994 — a Codex generatedImage result must become a chat attachment.
+//
+// The backend already wrote the PNG and emitted generatedImage(result). The
+// panel kept the text half of that payload and never handed the bytes to the
+// media painter, so the sidebar stayed empty until a manual show-media call.
+// These tests drive the shipped converter and the shipped message-handler
+// handoff: a completed result must paint; a missing result must not.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  generatedImageDataUrl,
+  generatedImageMediaItems,
+  generatedImageRemainderText,
+  isGeneratedImagePayload,
+  presentGeneratedImage,
+} from "../../web/js/lib/generated-image.js";
+import { composeShowMediaReply } from "../../web/js/lib/media-preview.js";
+import { coerceMessageText } from "../../web/js/lib/chat-serialize.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+// 1×1 PNG. Magic prefix is what the converter uses to pick image/png.
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+function paintHarness() {
+  const painted = [];
+  const showMedia = (items) =>
+    composeShowMediaReply(items, {
+      paintImage: (url, caption) => painted.push({ url, caption }),
+      paintVideo: () => {},
+      paintAudio: () => {},
+      paintFileLink: () => {},
+      imageViewUrl: () => null,
+      coerceMessageText,
+    });
+  return { painted, showMedia };
+}
+
+function shippedHandoffSource() {
+  const start = panelSrc.indexOf("const generatedItems = generatedImageMediaItems(msg);");
+  assert.ok(start > 0, "the shipped message handler must call generatedImageMediaItems");
+  const end = panelSrc.indexOf('if (msg && msg.type === "stream" && typeof msg.id === "string")', start);
+  assert.ok(end > start, "could not bound the generated-image say handoff");
+  return panelSrc.slice(start, end);
+}
+
+function shippedHandoffRunner() {
+  const slice = shippedHandoffSource();
+  return new Function(
+    "generatedImageMediaItems",
+    "generatedImageRemainderText",
+    "coerceMessageText",
+    "onShowMedia",
+    "onSay",
+    "msg",
+    `return (async () => {\n${slice}\n})();`,
+  );
+}
+
+test("#1994: a completed generatedImage result becomes a show-media image item", () => {
+  const items = generatedImageMediaItems({
+    type: "generatedImage",
+    result: PNG_B64,
+    savedPath: "C:\\\\Users\\\\x\\\\.codex\\\\generated_images\\\\ig_1.png",
+  });
+  assert.equal(items.length, 1, "a completed result must produce an attachment");
+  assert.equal(items[0].kind, "image");
+  assert.equal(items[0].dataUrl, `data:image/png;base64,${PNG_B64}`);
+  assert.equal(items[0].filename, "ig_1.png");
+});
+
+test("#1994: imageGeneration with a data URL result is accepted as-is", () => {
+  const dataUrl = `data:image/png;base64,${PNG_B64}`;
+  const items = generatedImageMediaItems({
+    type: "imageGeneration",
+    status: "completed",
+    result: dataUrl,
+  });
+  assert.equal(items.length, 1);
+  assert.equal(items[0].dataUrl, dataUrl);
+});
+
+test("#1994: in-progress or result-less payloads produce no attachment", () => {
+  assert.deepEqual(
+    generatedImageMediaItems({ type: "generatedImage", status: "in_progress" }),
+    [],
+  );
+  assert.deepEqual(generatedImageMediaItems({ type: "generatedImage", result: "" }), []);
+  assert.deepEqual(generatedImageMediaItems({ type: "say", text: "hello" }), []);
+  assert.deepEqual(generatedImageMediaItems({ result: "ok" }), []);
+});
+
+test("#1994: presentGeneratedImage paints through the shipped media renderer", async () => {
+  const { painted, showMedia } = paintHarness();
+  const out = await presentGeneratedImage(
+    { type: "generatedImage", result: PNG_B64, savedPath: "/tmp/ig_1.png" },
+    showMedia,
+  );
+  assert.equal(out.painted, 1, "a successful generate must report a painted card");
+  assert.equal(painted.length, 1, "the chat painter must receive the attachment");
+  assert.equal(painted[0].url, `data:image/png;base64,${PNG_B64}`);
+  assert.equal(painted[0].caption, "ig_1.png");
+});
+
+test("#1994: a missing result fails closed — zero painted cards", async () => {
+  const { painted, showMedia } = paintHarness();
+  const out = await presentGeneratedImage({ type: "generatedImage" }, showMedia);
+  assert.equal(out.painted, 0);
+  assert.equal(painted.length, 0, "no bytes means no attachment");
+});
+
+test("#1994: image-only remainder is empty so the bubble does not dump base64", () => {
+  const payload = { type: "generatedImage", result: PNG_B64 };
+  assert.equal(isGeneratedImagePayload(payload), true);
+  assert.equal(generatedImageRemainderText(payload), "");
+  const dumped = coerceMessageText(payload);
+  assert.ok(dumped.includes(PNG_B64.slice(0, 12)), "the old text path would have dumped the bytes");
+});
+
+test("#1994: a say wrapping prose plus a generated image keeps the prose", () => {
+  const msg = {
+    type: "say",
+    text: "here is the edit",
+    generatedImage: { type: "generatedImage", result: PNG_B64 },
+  };
+  const items = generatedImageMediaItems(msg);
+  assert.equal(items.length, 1);
+  assert.equal(generatedImageRemainderText(msg, items), "here is the edit");
+});
+
+test("#1994: generatedImage(result) as a raw string field still paints", async () => {
+  const { painted, showMedia } = paintHarness();
+  const out = await presentGeneratedImage({ generatedImage: PNG_B64 }, showMedia);
+  assert.equal(out.painted, 1);
+  assert.equal(painted.length, 1);
+  assert.equal(painted[0].url, generatedImageDataUrl(PNG_B64));
+});
+
+test("#1994: the shipped dispatcher imports and runs the generated-image handoff", async () => {
+  assert.match(
+    panelSrc,
+    /import \{ generatedImageMediaItems, generatedImageRemainderText \} from "\.\/lib\/generated-image\.js";/,
+    "the panel must import the converter, not a replica",
+  );
+  const slice = shippedHandoffSource();
+  assert.match(slice, /await onShowMedia\(generatedItems\)/, "the handoff must paint through onShowMedia");
+  assert.match(slice, /generatedImageRemainderText\(msg, generatedItems\)/, "prose must come from the remainder helper");
+
+  const { painted, showMedia } = paintHarness();
+  const said = [];
+  const run = shippedHandoffRunner();
+  await run(
+    generatedImageMediaItems,
+    generatedImageRemainderText,
+    coerceMessageText,
+    showMedia,
+    (text) => said.push(text),
+    { type: "generatedImage", result: PNG_B64, savedPath: "out.png" },
+  );
+  assert.equal(painted.length, 1, "the shipped handler must hand the result to the painter");
+  assert.equal(painted[0].url, generatedImageDataUrl(PNG_B64));
+  assert.equal(painted[0].caption, "out.png");
+  assert.deepEqual(said, [], "an image-only frame must not also emit a JSON bubble");
+});
+
+test("#1994: the shipped say path paints the attachment and keeps leftover text", async () => {
+  const { painted, showMedia } = paintHarness();
+  const said = [];
+  const run = shippedHandoffRunner();
+  await run(
+    generatedImageMediaItems,
+    generatedImageRemainderText,
+    coerceMessageText,
+    showMedia,
+    (text, meta) => said.push({ text, meta }),
+    {
+      type: "say",
+      id: "m-img",
+      streamed: true,
+      text: "done",
+      item: { type: "imageGeneration", status: "completed", result: PNG_B64, savedPath: "edit.png" },
+    },
+  );
+  assert.equal(painted.length, 1, "the say frame must still surface the generated attachment");
+  assert.equal(painted[0].url, generatedImageDataUrl(PNG_B64));
+  assert.equal(painted[0].caption, "edit.png");
+  assert.equal(said.length, 1);
+  assert.equal(said[0].text, "done");
+  assert.equal(said[0].meta.id, "m-img");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -632,6 +632,7 @@ import { settleOpenedWorkflowTarget } from "./lib/settle-open-target.js";
 import { settleOwnedOpenedWorkflowActive } from "./lib/settle-open-active.js";
 import { settleOpenedWorkflowReadable } from "./lib/settle-open-readable.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext, stripAgentDirectedBlocks } from "./lib/chat-serialize.js";
+import { generatedImageMediaItems, generatedImageRemainderText } from "./lib/generated-image.js";
 import {
   applyCurrentDefWidgetValues,
   driftedRequiredInputNames,
@@ -28500,13 +28501,28 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         queueHiddenAgentNote(coerceMessageText(msg.text));
         return;
       }
+      // Codex generatedImage / imageGeneration: paint the bytes, then leftover prose.
+      // Array.isArray: extracted bridge-client tests stub missing helpers as noop.
+      const generatedItems = generatedImageMediaItems(msg);
+      if (Array.isArray(generatedItems) && generatedItems.length && onShowMedia) {
+        try {
+          await onShowMedia(generatedItems);
+        } catch {
+          /* a fenced turn must not surface as a transport error */
+        }
+      }
       if (msg && msg.type === "say" && msg.text != null) {
         // A completed render/output frame can arrive as a structured payload,
         // not a bare string (#238). Route it through the SAME serializer the
         // A2UI/replay paths use so the sidebar shows readable text instead of a
         // dropped frame or an "[object Object]" bubble.
         // `id` reconciles this committed reply with its live streaming preview.
-        onSay(coerceMessageText(msg.text), { id: msg.id, streamed: !!msg.streamed });
+        const sayText = Array.isArray(generatedItems) && generatedItems.length
+          ? generatedImageRemainderText(msg, generatedItems)
+          : coerceMessageText(msg.text);
+        if (sayText || !Array.isArray(generatedItems) || !generatedItems.length) {
+          onSay(sayText, { id: msg.id, streamed: !!msg.streamed });
+        }
       }
       // Live streaming deltas: incremental thinking / reply text before the final
       // `say` commits. phase: "think" | "text" | "end".

--- a/web/js/lib/generated-image.js
+++ b/web/js/lib/generated-image.js
@@ -1,0 +1,244 @@
+// Codex built-in image generation lands as a generatedImage / imageGeneration
+// item with a base64 `result`. The chat renderer used to keep only the text
+// half of that payload, so a successful generate never became a media card.
+
+const IMAGE_ITEM_TYPES = new Set([
+  "generatedimage",
+  "imagegeneration",
+  "image_generation",
+  "image_generation_call",
+]);
+
+const COMPLETE_STATUSES = new Set(["", "completed", "complete", "success", "done"]);
+const PNG_MAGIC = "iVBORw0KGgo";
+const JPEG_MAGIC = "/9j/";
+const GIF_MAGIC = "R0lGOD";
+const WEBP_MAGIC = "UklGR";
+const MIN_BASE64_CHARS = 32;
+const WALK_DEPTH = 4;
+
+function asRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value;
+}
+
+function asNonEmptyString(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function typeKey(value) {
+  const raw = asNonEmptyString(value);
+  return raw ? raw.replace(/[-]/g, "_").toLowerCase() : "";
+}
+
+function isImageItemType(value) {
+  return IMAGE_ITEM_TYPES.has(typeKey(value));
+}
+
+function statusAllowsPaint(status) {
+  if (status == null) return true;
+  if (typeof status !== "string") return false;
+  return COMPLETE_STATUSES.has(status.trim().toLowerCase());
+}
+
+function mimeFromBase64(body) {
+  if (body.startsWith(PNG_MAGIC)) return "image/png";
+  if (body.startsWith(JPEG_MAGIC)) return "image/jpeg";
+  if (body.startsWith(GIF_MAGIC)) return "image/gif";
+  if (body.startsWith(WEBP_MAGIC)) return "image/webp";
+  return "image/png";
+}
+
+function compactBase64(value) {
+  return value.replace(/[\t\n\f\r ]/g, "");
+}
+
+/** A data:image URL the chat <img> can load, or null when `result` is not image bytes. */
+export function generatedImageDataUrl(result) {
+  const raw = asNonEmptyString(result);
+  if (!raw) return null;
+  if (/^data:image\//i.test(raw)) return raw;
+  const body = compactBase64(raw);
+  if (body.length < MIN_BASE64_CHARS) return null;
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(body)) return null;
+  return `data:${mimeFromBase64(body)};base64,${body}`;
+}
+
+function basenameOf(path) {
+  const raw = asNonEmptyString(path);
+  if (!raw) return "";
+  const parts = raw.replace(/\\/g, "/").split("/");
+  return parts[parts.length - 1] || "";
+}
+
+function captionOf(record) {
+  const named = asNonEmptyString(record.filename) || asNonEmptyString(record.caption);
+  if (named) return named;
+  return basenameOf(record.savedPath) || basenameOf(record.saved_path);
+}
+
+function generatedField(record) {
+  return record.generatedImage;
+}
+
+function resultBytes(record) {
+  const direct = generatedImageDataUrl(record.result);
+  if (direct) return direct;
+  const generated = generatedField(record);
+  const fromString = generatedImageDataUrl(typeof generated === "string" ? generated : null);
+  if (fromString) return fromString;
+  const nested = asRecord(generated);
+  if (nested) {
+    const fromNested = generatedImageDataUrl(nested.result);
+    if (fromNested) return fromNested;
+  }
+  return generatedImageDataUrl(record.b64_json);
+}
+
+function mediaItemFrom(record) {
+  if (!record) return null;
+  if (!statusAllowsPaint(record.status)) return null;
+  const dataUrl = resultBytes(record);
+  if (!dataUrl) return null;
+  const typed = isImageItemType(record.type) || isImageItemType(record.kind);
+  const generated = generatedField(record);
+  const wrapped = asRecord(generated);
+  const hasGeneratedField = generated != null;
+  if (!typed && !wrapped && !hasGeneratedField && !isImageItemType(record.name)) return null;
+  const filename = captionOf(record) || (wrapped ? captionOf(wrapped) : "") || "generated.png";
+  return {
+    kind: "image",
+    dataUrl,
+    filename,
+    caption: filename,
+  };
+}
+
+function isImagePart(part) {
+  return isGeneratedImagePayload(part) || mediaItemFrom(asRecord(part)) != null;
+}
+
+function walk(value, out, depth, seen) {
+  if (depth > WALK_DEPTH || value == null) return;
+  if (typeof value !== "object") return;
+  if (seen.has(value)) return;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const entry of value) walk(entry, out, depth + 1, seen);
+    return;
+  }
+
+  const item = mediaItemFrom(value);
+  if (item) out.push(item);
+
+  const nested = asRecord(value.generatedImage);
+  if (nested) {
+    const wrapped = mediaItemFrom({ ...nested, type: nested.type || "generatedImage" });
+    if (wrapped) out.push(wrapped);
+  }
+
+  const innerItem = asRecord(value.item);
+  if (innerItem) walk(innerItem, out, depth + 1, seen);
+  const detail = asRecord(value.detail);
+  if (detail) walk(detail, out, depth + 1, seen);
+
+  if (Array.isArray(value.content)) walk(value.content, out, depth + 1, seen);
+  if (Array.isArray(value.images)) walk(value.images, out, depth + 1, seen);
+  const text = value.text;
+  if (text && typeof text === "object") walk(text, out, depth + 1, seen);
+}
+
+function dedupe(items) {
+  const seen = new Set();
+  const out = [];
+  for (const item of items) {
+    const key = item.dataUrl;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+/** True when `value` itself is a Codex generated-image result, not prose wrapping one. */
+export function isGeneratedImagePayload(value) {
+  const rec = asRecord(value);
+  if (!rec) return false;
+  if (!isImageItemType(rec.type) && !isImageItemType(rec.kind)) return false;
+  return mediaItemFrom(rec) != null;
+}
+
+/**
+ * Show-media items for a Codex generated-image result.
+ * Empty when the payload has no completed image bytes — never invents a card.
+ */
+export function generatedImageMediaItems(payload) {
+  const out = [];
+  walk(payload, out, 0, new WeakSet());
+  return dedupe(out);
+}
+
+function textPartsOf(content) {
+  if (!Array.isArray(content)) return "";
+  const parts = [];
+  for (const part of content) {
+    if (typeof part === "string") {
+      if (part) parts.push(part);
+      continue;
+    }
+    const rec = asRecord(part);
+    if (!rec || isImagePart(rec)) continue;
+    const text = asNonEmptyString(rec.text);
+    if (text) parts.push(text);
+  }
+  return parts.join("\n");
+}
+
+function dumpsImageBytes(text, items) {
+  for (const item of items) {
+    const comma = item.dataUrl.indexOf(",");
+    const body = comma >= 0 ? item.dataUrl.slice(comma + 1) : "";
+    if (body && text.includes(body.slice(0, 24))) return true;
+  }
+  return false;
+}
+
+/**
+ * Visible prose that remains after the image card is painted.
+ * Image-only payloads return "" so the chat does not dump base64/JSON.
+ */
+export function generatedImageRemainderText(payload, items) {
+  const media = Array.isArray(items) ? items : generatedImageMediaItems(payload);
+  if (!media.length) {
+    if (typeof payload === "string") return payload;
+    return "";
+  }
+  if (isGeneratedImagePayload(payload)) return "";
+  const rec = asRecord(payload);
+  if (!rec) return "";
+  if (typeof rec.text === "string") {
+    return dumpsImageBytes(rec.text, media) ? "" : rec.text;
+  }
+  if (rec.text && typeof rec.text === "object") {
+    return generatedImageRemainderText(rec.text, media);
+  }
+  if (Array.isArray(rec.content)) return textPartsOf(rec.content);
+  return "";
+}
+
+/**
+ * Convert a generated-image payload into a show-media paint.
+ * `showMedia` is the shipped chat painter (composeShowMediaReply / onShowMedia).
+ * Missing attachments fail closed: painted is 0 when there are no items or no painter.
+ */
+export async function presentGeneratedImage(payload, showMedia) {
+  const items = generatedImageMediaItems(payload);
+  if (!items.length) return { painted: 0, items };
+  if (typeof showMedia !== "function") return { painted: 0, items };
+  const reply = await showMedia(items);
+  const painted = typeof reply?.painted === "number" ? reply.painted : 0;
+  return { painted, items, reply };
+}


### PR DESCRIPTION
Fixes #1994.

## What happened

A Codex sidebar-panel backend successfully generated an image (generatedImage result, file on disk) but the panel chat never showed an attachment. The message handoff kept the text half of that payload and dropped the bytes, so the tool result claimed the image was already displayed while the sidebar stayed empty. Calling show-media with the PNG path painted it, which is the missing renderer path.

## What this does

1. Convert completed Codex generatedImage / imageGeneration results (base64 or data URL) into the existing show-media item shape.
2. Paint those items through the shipped chat media renderer before the say text bubble.
3. Keep leftover prose; skip the text bubble for image-only frames so the chat does not dump base64/JSON.
4. Fail closed: in-progress or result-less payloads produce no card.

## Tests

```
node --test browser_tests/unit/generated-image-chat.test.mjs
```

10/10 pass. A missing result paints zero cards; a completed result is handed to the shipped painter and appears as a chat attachment. The message-handler slice is executed from web/js/comfyui-mcp-panel.js, not a replica.
