### PR TITLE
fix(#1995): queued runs keep their receipt; applied widget writes do not hang on rAF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- after reconnect, a queued run is never reported as user-rejected (#1995)
 - panel_set_widget writes DOM-backed multiline editors (StringMultilineTagEditor `text`) through the live input/contenteditable that getValue reads, so a no-op setValue after configure no longer refuses the update (#1997)
 
 ## [0.15.127] - 2026-08-30

--- a/browser_tests/unit/delivery-ack.test.mjs
+++ b/browser_tests/unit/delivery-ack.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * #1995 — a queued run must not be reported as user-rejected, and an applied
+ * widget write must not be reported as a hard timeout with no receipt.
+ *
+ * These drive the SHIPPED ack helpers (web/js/lib/delivery-ack.js) plus the
+ * run/widget result wiring, so deleting either — the rewrite that forbids a
+ * false rejected/timeout, or the call sites that actually use it — fails here.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { honestRunAck, honestWidgetAck } from "../../web/js/lib/delivery-ack.js";
+import {
+  awaitFrontendWidgetFlush,
+  FRONTEND_WIDGET_FLUSH_MS,
+} from "../../web/js/lib/set-widget.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+const SET_WIDGET_SRC = readFileSync(join(HERE, "../../web/js/lib/set-widget.js"), "utf8");
+
+const QUEUED_PROMPT_ID = "a0afaf59-18bf-4246-b445-beff69a20d12";
+const USER_REJECTED =
+  "The user doesn't want to proceed with this tool use. The tool use was rejected";
+
+test("#1995 a minted prompt id is never reported as user-rejected", () => {
+  const out = honestRunAck({
+    queued: false,
+    prompt_id: QUEUED_PROMPT_ID,
+    error: USER_REJECTED,
+  });
+  assert.equal(out.queued, true, "a queued prompt is queued, not refused");
+  assert.equal(out.prompt_id, QUEUED_PROMPT_ID);
+  assert.equal(out.error, undefined, "user-rejected language is stripped once a receipt exists");
+  assert.doesNotMatch(JSON.stringify(out), /rejected|doesn't want/i);
+});
+
+test("#1995 a lost run ack without a receipt is unknown, not user-rejected", () => {
+  const out = honestRunAck({
+    queued: false,
+    error: USER_REJECTED,
+  });
+  assert.equal(out.queued_unknown, true);
+  assert.notEqual(out.queued, false, "no receipt means unknown, not a definite refusal");
+  assert.doesNotMatch(String(out.error), /rejected|doesn't want/i);
+  assert.match(String(out.retry_guidance), /queue/i);
+});
+
+test("#1995 a genuine refusal without a prompt id stays a refusal", () => {
+  const out = honestRunAck({
+    queued: false,
+    error: "node 12 is not an output node",
+  });
+  assert.equal(out.queued, false);
+  assert.match(out.error, /not an output node/);
+});
+
+test("#1995 a clean queued accept is unchanged", () => {
+  const accept = { queued: true, prompt_id: QUEUED_PROMPT_ID, batch_count: 1 };
+  assert.equal(honestRunAck(accept), accept);
+});
+
+test("#1995 a mixed top-level refusal that already carries the id is unchanged", () => {
+  const mixed = {
+    queued: false,
+    prompt_id: QUEUED_PROMPT_ID,
+    error: "prompt outputs failed validation",
+    error_type: "prompt_outputs_failed_validation",
+  };
+  assert.equal(honestRunAck(mixed), mixed);
+});
+
+test("#1995 an applied widget write is never a hard timeout with no receipt", () => {
+  const set = { node_id: 181, widget: "duration", value: 6 };
+  const out = honestWidgetAck({ set }, { timeout: true });
+  assert.equal(out.applied, true);
+  assert.equal(out.set.value, 6);
+  assert.equal(out.set.node_id, 181);
+  assert.equal(out.error, undefined, "an applied write is a receipt, not a timeout error");
+  assert.match(String(out.ack_note), /applied/i);
+});
+
+test("#1995 an ordinary applied write keeps its receipt", () => {
+  const set = { node_id: 132, widget: "cfg", value: 1.2 };
+  const out = honestWidgetAck({ set, warning: "advisory" });
+  assert.equal(out.applied, true);
+  assert.equal(out.set.value, 1.2);
+  assert.equal(out.warning, "advisory");
+  assert.equal(out.error, undefined);
+});
+
+test("#1995 a widget timeout with no write receipt stays unknown, not applied", () => {
+  const out = honestWidgetAck({}, { timeout: true });
+  assert.equal(out.applied, false);
+  assert.match(String(out.error), /receipt/i);
+  assert.doesNotMatch(String(out.error), /rejected/i);
+});
+
+test("#1995 a frontend flush whose animation frame never fires still settles", async () => {
+  const previousRaf = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = () => 1;
+  const timers = [];
+  try {
+    const flushed = awaitFrontendWidgetFlush({
+      setTimer: (fn) => {
+        timers.push(fn);
+        return timers.length;
+      },
+      clearTimer: () => {},
+    });
+    assert.equal(timers.length, 1, "the bound must arm instead of waiting forever on rAF");
+    timers[0]();
+    await flushed;
+  } finally {
+    if (previousRaf === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = previousRaf;
+  }
+});
+
+test("#1995 the flush bound is short of the 30s relay window", () => {
+  assert.equal(FRONTEND_WIDGET_FLUSH_MS, 250);
+  assert.ok(FRONTEND_WIDGET_FLUSH_MS < 30000);
+});
+
+test("#1995 wiring: graph_run returns through honestRunAck", () => {
+  assert.match(PANEL_SRC, /if \(rejection\) return honestRunAck\(rejection\);/);
+  assert.match(PANEL_SRC, /return honestRunAck\(accept\);/);
+  assert.match(PANEL_SRC, /import \{ honestRunAck \} from "\.\/lib\/delivery-ack\.js";/);
+});
+
+test("#1995 wiring: the widget write path acks through honestWidgetAck after a bounded flush", () => {
+  assert.match(SET_WIDGET_SRC, /withTimeout\(flush, FRONTEND_WIDGET_FLUSH_MS/);
+  assert.match(SET_WIDGET_SRC, /return withWarning\(honestWidgetAck\(\{ set, \.\.\.extraResult \}\)\);/);
+  assert.match(SET_WIDGET_SRC, /from "\.\/delivery-ack\.js";/);
+});

--- a/browser_tests/unit/delivery-ack.test.mjs
+++ b/browser_tests/unit/delivery-ack.test.mjs
@@ -49,6 +49,30 @@ test("#1995 a lost run ack without a receipt is unknown, not user-rejected", () 
   assert.match(String(out.retry_guidance), /queue/i);
 });
 
+test("#1995 a rewritten run ack keeps queue-time disclosures", () => {
+  const feeds = [{ node_id: 12, widget: "text", origin_type: "PrimitiveNode" }];
+  const withId = honestRunAck({
+    queued: false,
+    prompt_id: QUEUED_PROMPT_ID,
+    error: USER_REJECTED,
+    virtual_source_feeds: feeds,
+    virtual_source_note: "the stored inner value executes",
+  });
+  assert.equal(withId.queued, true);
+  assert.deepEqual(withId.virtual_source_feeds, feeds);
+  assert.match(withId.virtual_source_note, /stored inner value/);
+
+  const lost = honestRunAck({
+    queued: false,
+    error: USER_REJECTED,
+    virtual_source_feeds: feeds,
+    virtual_source_note: "the stored inner value executes",
+  });
+  assert.equal(lost.queued_unknown, true);
+  assert.deepEqual(lost.virtual_source_feeds, feeds, "a lost ack must not drop the queue-time scan");
+  assert.match(lost.virtual_source_note, /stored inner value/);
+});
+
 test("#1995 a genuine refusal without a prompt id stays a refusal", () => {
   const out = honestRunAck({
     queued: false,

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -53,6 +53,7 @@ import {
   describeUnrunnable,
 } from "../../web/js/lib/missing-node-preflight.js";
 import { buildQueueAcceptResult, summarizePromptRejection } from "../../web/js/lib/queue-rejection.js";
+import { honestRunAck } from "../../web/js/lib/delivery-ack.js";
 import { installGraphToPromptNullSafety } from "../../web/js/lib/widget-null-safety.js";
 import { installGraphToPromptDynamicReconcile } from "../../web/js/lib/dynamic-widget-reconcile.js";
 import {
@@ -723,6 +724,7 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
     rgthreeFixedSeedNote,
     summarizePromptRejection,
     buildQueueAcceptResult,
+    honestRunAck,
     collectVirtualSourceFeeds,
     virtualSourceNote,
     collectDisabledAncestorOutputs,

--- a/browser_tests/unit/virtual-source-promotion.test.mjs
+++ b/browser_tests/unit/virtual-source-promotion.test.mjs
@@ -263,7 +263,7 @@ test("#1181 graph_run discloses a virtual-fed subgraph input at QUEUE time, scop
   // how the run is scoped. Pin that the scan comes AFTER that block closes.
   const exempt = src.indexOf("if (!partialTargets) {");
   const scan = src.indexOf("collectVirtualSourceFeeds(rootGraph)");
-  const blockEnd = src.indexOf("return accept;", exempt);
+  const blockEnd = src.indexOf("return honestRunAck(accept);", exempt);
   assert.ok(exempt > 0 && scan > blockEnd - 4000 && scan < blockEnd, "scan runs outside the scoped-run exemption");
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -845,6 +845,7 @@ import {
   contentProofExclusiveAmongOpen,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
+import { honestRunAck } from "./lib/delivery-ack.js";
 import {
   createRunFetchInterceptor,
   dispatchScopedRun,
@@ -19979,7 +19980,9 @@ const GRAPH_TOOL_EXECUTORS = {
       // dropped outputs, not a refusal of the whole prompt.
       acceptedPromptIds: queuedPromptIds,
     });
-    if (rejection) return rejection;
+    // #1995 — a minted prompt id is a queue receipt. Never rewrite that as a
+    // user-rejected tool result; a lost ack without an id is unknown, not refused.
+    if (rejection) return honestRunAck(rejection);
     // Surface the queued prompt_id(s) so the agent can correlate/track the run —
     // #370 reconciliation and mcp#531 (panel_run must return the prompt_id even
     // when a render is already running) both depend on this being reported.
@@ -20219,7 +20222,7 @@ const GRAPH_TOOL_EXECUTORS = {
     } catch {
       /* a diagnostic must never take down the run it describes */
     }
-    return accept;
+    return honestRunAck(accept);
   },
 
   // WHY IS THAT NODE RED? — the single error surface. LiteGraph only sets a

--- a/web/js/lib/delivery-ack.js
+++ b/web/js/lib/delivery-ack.js
@@ -1,0 +1,110 @@
+/**
+ * #1995 — delivery acknowledgements must match what actually happened.
+ *
+ * Two reconnect failures share one mapping bug:
+ *   - a run ComfyUI queued is reported as a user-rejected tool result, so the
+ *     caller believes nothing is on the GPU while a prompt_id is already live;
+ *   - a widget write that already applied is reported as a hard timeout with no
+ *     receipt, so the caller re-reads to avoid a double write.
+ *
+ * A minted prompt id is a receipt the backend issues only after queueing. A
+ * `set` object with a value is a receipt the write path issues only after the
+ * callback returned. Neither may be rewritten as "rejected" or as a timeout
+ * that names no receipt.
+ *
+ * Dependency-free. Unit-testable with plain values.
+ */
+
+const USER_REJECTED_RE =
+  /user doesn't want to proceed|tool use was rejected|user rejected/i;
+
+function looksLikeUserRejected(text) {
+  return typeof text === "string" && USER_REJECTED_RE.test(text);
+}
+
+function normalizeIds(ids) {
+  const out = [];
+  const raw = Array.isArray(ids) ? ids : ids == null ? [] : [ids];
+  for (const value of raw) {
+    if (value == null) continue;
+    const id = String(value).trim();
+    if (id !== "" && !out.includes(id)) out.push(id);
+  }
+  return out;
+}
+
+function idsFrom(result) {
+  if (!result || typeof result !== "object") return [];
+  if (Array.isArray(result.prompt_ids) && result.prompt_ids.length) {
+    return normalizeIds(result.prompt_ids);
+  }
+  return normalizeIds(result.prompt_id);
+}
+
+/**
+ * Rewrite a run result so a queued prompt is never a user-rejected outcome.
+ *
+ * @param {object|null|undefined} result
+ * @returns {object|null|undefined}
+ */
+export function honestRunAck(result) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return result;
+  const ids = idsFrom(result);
+  const rejectedLanguage = looksLikeUserRejected(result.error);
+
+  if (ids.length && rejectedLanguage) {
+    const out = { ...result, queued: true, prompt_id: ids[0] };
+    delete out.error;
+    delete out.error_type;
+    delete out.queued_unknown;
+    if (ids.length > 1) out.prompt_ids = ids;
+    return out;
+  }
+
+  if (!ids.length && rejectedLanguage) {
+    return {
+      queued_unknown: true,
+      error:
+        "The queue acknowledgement was lost or incomplete, so the panel cannot confirm or correlate this run.",
+      retry_guidance:
+        "The run may have been accepted. Check the ComfyUI queue or history before retrying; a blind retry can duplicate the render.",
+    };
+  }
+
+  return result;
+}
+
+/**
+ * Rewrite a widget-write result so an applied mutation is never a hard timeout
+ * with no receipt.
+ *
+ * @param {object|null|undefined} result
+ * @param {{ timeout?: boolean }} [opts]
+ * @returns {object|null|undefined}
+ */
+export function honestWidgetAck(result, { timeout = false } = {}) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return result;
+  const set = result.set;
+  const applied = !!(set && typeof set === "object" && Object.prototype.hasOwnProperty.call(set, "value"));
+
+  if (applied) {
+    const out = { ...result, applied: true };
+    if (timeout) {
+      out.ack_note =
+        "The write applied; a later canvas flush did not settle in time, so this receipt is the widget value itself.";
+    }
+    delete out.error;
+    return out;
+  }
+
+  if (timeout) {
+    return {
+      ...result,
+      applied: false,
+      error:
+        "The widget write did not produce a receipt before the wait ended. Check the canvas before retrying; a blind retry can apply the value twice.",
+    };
+  }
+
+  return result;
+}

--- a/web/js/lib/delivery-ack.js
+++ b/web/js/lib/delivery-ack.js
@@ -62,13 +62,16 @@ export function honestRunAck(result) {
   }
 
   if (!ids.length && rejectedLanguage) {
-    return {
-      queued_unknown: true,
-      error:
-        "The queue acknowledgement was lost or incomplete, so the panel cannot confirm or correlate this run.",
-      retry_guidance:
-        "The run may have been accepted. Check the ComfyUI queue or history before retrying; a blind retry can duplicate the render.",
-    };
+    const out = { ...result };
+    delete out.queued;
+    delete out.error;
+    delete out.error_type;
+    out.queued_unknown = true;
+    out.error =
+      "The queue acknowledgement was lost or incomplete, so the panel cannot confirm or correlate this run.";
+    out.retry_guidance =
+      "The run may have been accepted. Check the ComfyUI queue or history before retrying; a blind retry can duplicate the render.";
+    return out;
   }
 
   return result;

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -56,6 +56,8 @@ import {
   serverDeclaresEmptyComboOptions,
   serverDeclaresRemoteComboOptions,
 } from "./input-asset.js";
+import { withTimeout } from "./bounded-step.js";
+import { honestWidgetAck } from "./delivery-ack.js";
 
 /**
  * Fire an undo-history hook that can never escape.
@@ -114,9 +116,17 @@ export const COMBO_REFRESH_NEVER_RAN = Symbol("combo-refresh-never-ran");
  * one animation frame when the host has rAF, then another microtask so a mount
  * that itself queues work is visible. No rAF in Node tests → two microtasks,
  * so existing runSetWidget tests do not hang or grow a timer.
+ *
+ * #1995 — the wait is BOUNDED. After reconnect a backgrounded tab never fires
+ * rAF, so an unbounded frame wait held the reply until the relay timed out
+ * while the callback had already applied the value. The bound is long enough
+ * for a visible frame and short enough that an applied write still gets a
+ * receipt. Injectable timers so tests can fire the bound without sleeping.
  */
-export function awaitFrontendWidgetFlush() {
-  return new Promise((resolve) => {
+export const FRONTEND_WIDGET_FLUSH_MS = 250;
+
+export function awaitFrontendWidgetFlush(timers) {
+  const flush = new Promise((resolve) => {
     queueMicrotask(() => {
       if (typeof requestAnimationFrame === "function") {
         requestAnimationFrame(() => queueMicrotask(resolve));
@@ -125,6 +135,7 @@ export function awaitFrontendWidgetFlush() {
       }
     });
   });
+  return withTimeout(flush, FRONTEND_WIDGET_FLUSH_MS, () => undefined, timers);
 }
 
 function widgetValuesMatch(expected, actual) {
@@ -1033,7 +1044,7 @@ export async function runSetWidget(
 
   async function succeedWrite(extra = {}, extraResult = {}) {
     const set = await retainVerifiedWrite(write(extra), () => write(extra));
-    return withWarning({ set, ...extraResult });
+    return withWarning(honestWidgetAck({ set, ...extraResult }));
   }
 
   // #558: the value widget being written may be governed by a non-`fixed`
@@ -1570,7 +1581,7 @@ export async function runSetWidget(
           }
           throw unreadableErr;
         }
-        return withWarning({
+        return withWarning(honestWidgetAck({
           set,
           ...(typeof refreshCombos === "function" ? { refreshed: true } : {}),
           // A stateful callback that finally answered `[]` landed on #507's acceptance instead,
@@ -1610,7 +1621,7 @@ export async function runSetWidget(
                   `itself — may show it as out-of-range.`,
               }
             : {}),
-        });
+        }));
       }
       // The shape test said the server does NOT declare this input's list empty — but when the
       // only schema available is #1223's snapshot, that "no" is not the server publishing a


### PR DESCRIPTION
After reconnect, two related delivery acks lied about work that had already happened.

A queued run could come back as a user-rejected tool result even though ComfyUI had minted a prompt id and later completed (or failed) that same prompt. A widget write could hit the 30s relay timeout with no receipt while the callback had already applied the value — typically because the post-write flush waited on an animation frame that a backgrounded tab never fires.

This keeps the ack matched to the receipt:

- If a prompt id exists, the run result is queued. User-rejected language is stripped. A lost ack with no id is `queued_unknown`, not a refusal.
- An applied widget write returns the `set` receipt. The frontend flush is bounded at 250ms so a missing canvas frame cannot hold the reply past the relay window.

Fixes #1995
