### PR TITLE
fix(1997): write StringMultilineTagEditor text through the live DOM editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget writes DOM-backed multiline editors (StringMultilineTagEditor `text`) through the live input/contenteditable that getValue reads, so a no-op setValue after configure no longer refuses the update (#1997)
+
 ## [0.15.127] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/dom-backed-text-widget.test.mjs
+++ b/browser_tests/unit/dom-backed-text-widget.test.mjs
@@ -1,0 +1,278 @@
+/**
+ * #1997 — panel_set_widget on a live StringMultilineTagEditor `text` widget
+ * assigned `.value` and then observed a revert, because the pack's
+ * `options.setValue` is a no-op after onConfigure and `getValue` reads the
+ * contenteditable. The write must reach that live editor (and fire `input`,
+ * which is how the pack copies the text into state / localStorage).
+ *
+ * These drive applyWidgetWrite(), the SAME function graph_set_widget uses.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyWidgetWrite, WidgetWriteError } from "../../web/js/lib/widget-write.js";
+
+const HOOKS = {};
+
+function makeContentEditable(initial) {
+  return {
+    tagName: "DIV",
+    contentEditable: "true",
+    isContentEditable: true,
+    className: "comfy-multiline-input",
+    textContent: initial,
+    dispatched: [],
+    dispatchEvent(ev) {
+      this.dispatched.push(ev?.type ?? ev);
+      return true;
+    },
+  };
+}
+
+/** TTS-Audio-Suite StringMultilineTagEditor after onConfigure has run. */
+function makeTagEditorWidget({ initial = "old script", setValueNoop = true } = {}) {
+  const editor = makeContentEditable(initial);
+  const options = {
+    getValue() {
+      return editor.textContent;
+    },
+    setValue(v) {
+      if (setValueNoop) return;
+      editor.textContent = String(v);
+    },
+  };
+  const widget = {
+    name: "text",
+    type: "customtext",
+    inputEl: editor,
+    element: {
+      querySelector(sel) {
+        return /comfy-multiline-input|contenteditable/.test(String(sel)) ? editor : null;
+      },
+    },
+    options,
+    get value() {
+      return options.getValue();
+    },
+    set value(v) {
+      options.setValue(v);
+    },
+  };
+  return { widget, editor };
+}
+
+test("#1997: StringMultilineTagEditor text sticks after setValue becomes a no-op", () => {
+  const { widget, editor } = makeTagEditorWidget({ initial: "old script" });
+  const node = { id: 143, type: "StringMultilineTagEditor", widgets: [widget] };
+
+  const set = applyWidgetWrite(node, "text", "[de:Alice] Hallo", HOOKS);
+
+  assert.equal(set.value, "[de:Alice] Hallo");
+  assert.equal(editor.textContent, "[de:Alice] Hallo");
+  assert.equal(widget.value, "[de:Alice] Hallo");
+  assert.ok(editor.dispatched.includes("input"), "the pack's input listener must run so state/localStorage update");
+});
+
+test("#1997: clearing StringMultilineTagEditor text to '' writes the live editor", () => {
+  const { widget, editor } = makeTagEditorWidget({ initial: "old script" });
+  const node = { id: 143, type: "StringMultilineTagEditor", widgets: [widget] };
+
+  const set = applyWidgetWrite(node, "text", "", HOOKS);
+
+  assert.equal(set.value, "");
+  assert.equal(editor.textContent, "");
+  assert.equal(widget.value, "");
+});
+
+test("#1997: a textarea-backed customtext widget updates when setValue no-ops", () => {
+  const textarea = {
+    tagName: "TEXTAREA",
+    value: "old",
+    dispatched: [],
+    dispatchEvent(ev) {
+      this.dispatched.push(ev?.type ?? ev);
+      return true;
+    },
+  };
+  const options = {
+    getValue() {
+      return textarea.value;
+    },
+    setValue() {},
+  };
+  const widget = {
+    name: "text",
+    type: "customtext",
+    inputEl: textarea,
+    options,
+    get value() {
+      return options.getValue();
+    },
+    set value(v) {
+      options.setValue(v);
+    },
+  };
+  const node = { id: 7, type: "CustomMultiline", widgets: [widget] };
+
+  const set = applyWidgetWrite(node, "text", "new copy", HOOKS);
+
+  assert.equal(set.value, "new copy");
+  assert.equal(textarea.value, "new copy");
+  assert.ok(textarea.dispatched.includes("input"));
+});
+
+test("#1997: a nested contenteditable under widget.element is found when inputEl is absent", () => {
+  const editor = makeContentEditable("old");
+  const options = {
+    getValue() {
+      return editor.textContent;
+    },
+    setValue() {},
+  };
+  const widget = {
+    name: "text",
+    type: "customtext",
+    element: {
+      querySelector(sel) {
+        return String(sel).includes("contenteditable") ? editor : null;
+      },
+    },
+    options,
+    get value() {
+      return options.getValue();
+    },
+    set value(v) {
+      options.setValue(v);
+    },
+  };
+  const node = { id: 8, type: "StringMultilineTagEditor", widgets: [widget] };
+
+  const set = applyWidgetWrite(node, "text", "from element", HOOKS);
+  assert.equal(set.value, "from element");
+  assert.equal(editor.textContent, "from element");
+});
+
+test("#1997: a nested textarea under widget.element is found when inputEl is absent", () => {
+  const textarea = { tagName: "TEXTAREA", value: "old", dispatchEvent() { return true; } };
+  const options = {
+    getValue() {
+      return textarea.value;
+    },
+    setValue() {},
+  };
+  const widget = {
+    name: "text",
+    type: "customtext",
+    element: {
+      querySelector(sel) {
+        return String(sel).includes("textarea") ? textarea : null;
+      },
+    },
+    options,
+    get value() {
+      return options.getValue();
+    },
+    set value(v) {
+      options.setValue(v);
+    },
+  };
+  const node = { id: 8, type: "NestedTextEditor", widgets: [widget] };
+
+  const set = applyWidgetWrite(node, "text", "from element", HOOKS);
+  assert.equal(set.value, "from element");
+  assert.equal(textarea.value, "from element");
+});
+
+test("#1997: a DOM widget whose setValue already sticks is not refused", () => {
+  const textarea = { tagName: "TEXTAREA", value: "old", dispatchEvent() { return true; } };
+  let setValueCalls = 0;
+  const options = {
+    getValue() {
+      return textarea.value;
+    },
+    setValue(v) {
+      setValueCalls += 1;
+      textarea.value = String(v);
+    },
+  };
+  const widget = {
+    name: "text",
+    type: "customtext",
+    inputEl: textarea,
+    options,
+    get value() {
+      return options.getValue();
+    },
+    set value(v) {
+      options.setValue(v);
+    },
+  };
+  const node = { id: 9, type: "HealthyDomText", widgets: [widget] };
+
+  const set = applyWidgetWrite(node, "text", "already works", HOOKS);
+  assert.equal(set.value, "already works");
+  assert.equal(textarea.value, "already works");
+  assert.ok(setValueCalls >= 1);
+});
+
+test("#1997: a failed write rolls the contenteditable back to the previous text", () => {
+  const { widget, editor } = makeTagEditorWidget({ initial: "old script" });
+  widget.options.property = "bound";
+  const node = {
+    id: 143,
+    type: "StringMultilineTagEditor",
+    widgets: [widget],
+    properties: { bound: "old script" },
+    setProperty() {
+      /* leave properties.bound unchanged so verification fails closed */
+    },
+  };
+
+  assert.throws(
+    () => applyWidgetWrite(node, "text", "new script", HOOKS),
+    (err) => err instanceof WidgetWriteError && /bound/.test(err.message),
+  );
+  assert.equal(editor.textContent, "old script", "rollback must restore the live editor, not only .value");
+  assert.equal(widget.value, "old script");
+});
+
+test("#1997: a non-text-bearing DOM widget is still a diagnosis, not a guessed write", () => {
+  const widget = {
+    name: "pix_prompt_ui",
+    element: {},
+    options: {
+      getValue: () => null,
+      setValue() {},
+    },
+    get value() {
+      return this.options.getValue();
+    },
+    set value(v) {
+      this.options.setValue(v);
+    },
+  };
+  const node = {
+    id: 44,
+    type: "PixaromaPrompt",
+    widgets: [widget],
+    properties: { promptState: { text: "" }, mode: "a" },
+  };
+
+  assert.throws(
+    () => applyWidgetWrite(node, "pix_prompt_ui", "hello", HOOKS),
+    (err) =>
+      err instanceof WidgetWriteError &&
+      /did not retain/.test(err.message) &&
+      /DOM-backed display widget/.test(err.message) &&
+      /panel_set_property/.test(err.message),
+  );
+  assert.equal(widget.value, null);
+});
+
+test("#1997: a plain string widget without a DOM editor is unchanged", () => {
+  const widget = { name: "text", type: "customtext", value: "keep me" };
+  const node = { id: 1, type: "CLIPTextEncode", widgets: [widget] };
+  const set = applyWidgetWrite(node, "text", "plain write", HOOKS);
+  assert.equal(set.value, "plain write");
+  assert.equal(widget.value, "plain write");
+});

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1400,20 +1400,140 @@ function liveHostPromotedWidgets(subgraphNode, hostInput, innerWidget) {
   return rematerializeHostPromotedWidgets(subgraphNode, hostInput, innerWidget);
 }
 
+/**
+ * #1997 — the live text control a DOM-backed STRING widget actually reads.
+ *
+ * ComfyUI `addDOMWidget` wires `get value` / `set value` through `options.getValue`
+ * / `options.setValue`. Packs such as TTS-Audio-Suite's StringMultilineTagEditor
+ * implement `getValue` as "read the contenteditable" and make `setValue` a no-op
+ * once `onConfigure` has loaded the workflow — so `widget.value = x` appears to
+ * assign and then reverts. The control itself is `widget.inputEl` (or a textarea /
+ * contenteditable under `widget.element`). Writing that element is what an
+ * on-canvas edit does; `getValue` then returns the new string.
+ *
+ * Detection is structural, not by node type: a live textarea/input/contenteditable,
+ * never a guess at `node.properties`. Widgets whose getValue is a no-op (Pixaroma
+ * `pix_prompt_ui`) have no such control and stay on the #698 diagnosis path.
+ */
+function liveTextEditorElement(widget) {
+  if (!widget || typeof widget !== "object") return null;
+  const seen = [];
+  const push = (el) => {
+    if (el && typeof el === "object" && !seen.includes(el)) seen.push(el);
+  };
+  try {
+    push(widget.inputEl);
+  } catch {
+    /* unreadable inputEl is simply absent */
+  }
+  try {
+    push(widget.element);
+  } catch {
+    /* unreadable element is simply absent */
+  }
+  for (const el of seen) {
+    if (isLiveTextEditor(el)) return el;
+    let inner = null;
+    try {
+      if (typeof el.querySelector === "function") {
+        inner = el.querySelector(
+          "textarea, input[type='text'], input:not([type]), [contenteditable='true'], [contenteditable='']",
+        );
+      }
+    } catch {
+      inner = null;
+    }
+    if (inner && isLiveTextEditor(inner)) return inner;
+  }
+  return null;
+}
+
+function isLiveTextEditor(el) {
+  if (!el || typeof el !== "object") return false;
+  const tag = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+  if (tag === "TEXTAREA") return true;
+  if (tag === "INPUT") {
+    const type = String(el.type || "text").toLowerCase();
+    return type === "text" || type === "search" || type === "url" || type === "email" || type === "password" || type === "";
+  }
+  if (el.isContentEditable === true || el.contentEditable === true || el.contentEditable === "true" || el.contentEditable === "") {
+    return true;
+  }
+  return typeof el.className === "string" && /\bcomfy-multiline-input\b/.test(el.className);
+}
+
+function dispatchDomEvent(el, type) {
+  try {
+    if (typeof el.dispatchEvent !== "function" || typeof Event !== "function") return;
+    el.dispatchEvent(new Event(type, { bubbles: true }));
+  } catch {
+    /* best-effort; verification still decides whether the value stuck */
+  }
+}
+
+function writeLiveTextEditor(el, text) {
+  const tag = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+  const editable =
+    el.isContentEditable === true ||
+    el.contentEditable === true ||
+    el.contentEditable === "true" ||
+    el.contentEditable === "" ||
+    (typeof el.className === "string" && /\bcomfy-multiline-input\b/.test(el.className));
+  if (tag === "TEXTAREA" || tag === "INPUT") {
+    el.value = text;
+  } else if (editable) {
+    el.textContent = text;
+  } else {
+    return false;
+  }
+  // StringMultilineTagEditor's input listener copies getPlainText() into state
+  // and localStorage; without this event the canvas shows the new text and a
+  // reload restores the old one.
+  dispatchDomEvent(el, "input");
+  dispatchDomEvent(el, "change");
+  return true;
+}
+
+function widgetHoldsValue(widget, coerced) {
+  try {
+    return Object.is(widget.value, coerced);
+  } catch {
+    return false;
+  }
+}
+
+/** When a string write did not stick on `.value`, copy it into the live editor. */
+function syncDomBackedTextIfNeeded(widget, coerced) {
+  if (typeof coerced !== "string") return;
+  if (widgetHoldsValue(widget, coerced)) return;
+  const el = liveTextEditorElement(widget);
+  if (!el) return;
+  writeLiveTextEditor(el, coerced);
+}
+
 /** Assign a widget value and drive options.setValue when present (store-backed rails). */
 function assignWidgetValue(widget, coerced) {
   widget.value = coerced;
-  let setValue;
   try {
-    setValue = widget.options?.setValue;
-  } catch {
-    setValue = null;
-  }
-  if (typeof setValue !== "function") return;
-  try {
-    setValue.call(widget, coerced);
+    const setValue = widget.options?.setValue;
+    if (typeof setValue === "function") setValue.call(widget, coerced);
   } catch {
     /* verification below still decides whether the value stuck */
+  }
+  try {
+    syncDomBackedTextIfNeeded(widget, coerced);
+  } catch {
+    /* verification below still decides whether the value stuck */
+  }
+}
+
+/** Restore a captured prior value, including a DOM-backed editor this write updated. */
+function restoreWidgetValue(widget, previous) {
+  widget.value = previous;
+  try {
+    syncDomBackedTextIfNeeded(widget, previous);
+  } catch {
+    /* restore best-effort; read-back below is authoritative */
   }
 }
 
@@ -2860,14 +2980,14 @@ export function applyWidgetWrite(
       // The read-back below still compares it against the captured clone either way.
       if (!instanceScoped || definitionMoved) {
         try {
-          w.value = previous;
+          restoreWidgetValue(w, previous);
         } catch {
           /* restore best-effort; read-back below is authoritative */
         }
       }
       if (parentWidget) {
         try {
-          parentWidget.value = previousParent;
+          restoreWidgetValue(parentWidget, previousParent);
         } catch {
           /* restore best-effort; read-back below is authoritative */
         }
@@ -2876,7 +2996,7 @@ export function applyWidgetWrite(
       // the just-written value after a failed write.
       for (let i = 0; i < displayWidgets.length; i++) {
         try {
-          displayWidgets[i].value = previousDisplays[i];
+          restoreWidgetValue(displayWidgets[i], previousDisplays[i]);
         } catch {
           /* restore best-effort; read-back below is authoritative */
         }


### PR DESCRIPTION
## Summary

`panel_set_widget` could not update the `text` widget on a live `StringMultilineTagEditor` (TTS-Audio-Suite). The pack's `options.setValue` is a no-op after `onConfigure`, and `getValue` reads the contenteditable, so assigning `widget.value` looked applied and then reverted with the #698 DOM-backed diagnosis — and no way to write the real editor.

When a string write does not stick on `.value`, the write now copies it into the live textarea / input / contenteditable (`widget.inputEl`, else a descendant of `widget.element`) and dispatches `input` so the pack copies the text into editor state and localStorage. Rollback restores the same control. Non-text DOM widgets (PixaromaPrompt `pix_prompt_ui`) still fail with the #698 diagnosis; they are not guessed into `node.properties`.

Fixes #1997

## Test plan

- [x] `node --test browser_tests/unit/dom-backed-text-widget.test.mjs`
- [x] `npm run test:unit` (7488 pass, 0 fail, 1 todo)
