### PR TITLE
fix(1996): keep panel_strip_workflow working when MCP graph schema is newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_strip_workflow no longer fails when a newer MCP requires the panel's node schema: graph_get_object_info is a canvas-independent read (not a mutation), and graph_serialize keeps extra schema fields while attaching name-keyed widget values so conversion does not depend on positional schema agreement (#1996)
+
 ## [0.15.140] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/read-only-graph-commands.test.mjs
+++ b/browser_tests/unit/read-only-graph-commands.test.mjs
@@ -52,6 +52,8 @@ test("every command already treated as a read still is", () => {
     "graph_get_subgraph",
     "graph_list_subgraphs",
     "graph_screenshot",
+    "graph_get_errors",
+    "graph_get_object_info",
   ]) {
     assert.equal(graphCommandMayMutateWorkflow(cmd), false, cmd);
   }
@@ -89,13 +91,23 @@ test("an UNKNOWN command is a mutation — the list fails closed", () => {
   assert.equal(graphCommandMayMutateWorkflow(undefined), true);
 });
 
-test("the two other unlisted reads are deliberately still refused", () => {
-  // Recorded rather than assumed. `graph_get_object_info` and
-  // `graph_prompt_director_audit` also look like reads, but "looks like" is not
-  // the standard for lowering a guard's bar, so they stay out until someone
-  // establishes it. If a later change admits one, this test fails and asks for
-  // the evidence to be written down with it.
-  assert.equal(graphCommandMayMutateWorkflow("graph_get_object_info"), true);
+test("#1996 graph_get_object_info is a READ — strip must not hit the dirty-mutation fence", () => {
+  // Established the same way #1478 was: the executor fetches /object_info and
+  // writes no graph state. Newer MCP requires this command for
+  // panel_strip_workflow; leaving it classified as a mutation refused the
+  // schema read on a dirty tab.
+  assert.equal(graphCommandMayMutateWorkflow("graph_get_object_info"), false);
+  assert.deepEqual(
+    graphCommandBindingBar("graph_get_object_info"),
+    graphCommandBindingBar("graph_serialize"),
+  );
+});
+
+test("the remaining unlisted read is deliberately still refused", () => {
+  // Recorded rather than assumed. `graph_prompt_director_audit` also looks like
+  // a read, but "looks like" is not the standard for lowering a guard's bar, so
+  // it stays out until someone establishes it. If a later change admits it,
+  // this test fails and asks for the evidence to be written down with it.
   assert.equal(graphCommandMayMutateWorkflow("graph_prompt_director_audit"), true);
 });
 

--- a/browser_tests/unit/strip-schema-skew.test.mjs
+++ b/browser_tests/unit/strip-schema-skew.test.mjs
@@ -1,0 +1,207 @@
+/**
+ * #1996 — panel_strip_workflow fails when MCP is newer than panel graph schema
+ * support.
+ *
+ * Newer MCP (0.52.146+) converts the live canvas with `graph_serialize` then
+ * `graph_get_object_info`. Two production holes:
+ *
+ *   1. `graph_get_object_info` was classified as a MUTATION and was not
+ *      canvas-independent, so a dirty/unbound tab or a uuid-fence miss refused
+ *      the schema read. Strip then failed with "too old for graph_get_object_info"
+ *      (or a dirty-mutation refusal) even though the command exists.
+ *   2. `graph_serialize` returned LiteGraph's positional `widgets_values` only.
+ *      A newer graph schema (extra keys, version > 0.4, V3 nested widgets) must
+ *      survive the capture, and name-keyed `capturedWidgetValues` must ride along
+ *      so MCP can convert without agreeing on positional widget order.
+ *
+ * These tests drive the REAL helpers and pin the PANEL wiring, not a replica.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  attachCapturedWidgetValues,
+  capturedWidgetValuesForNode,
+  collectLiveNodes,
+  serializeLiveGraph,
+} from "../../web/js/lib/graph-serialize-capture.js";
+import { commandIsCanvasIndependent, activeWorkflowFenceApplies } from "../../web/js/lib/workflow-chat-identity.js";
+import { graphCommandMayMutateWorkflow, graphCommandBindingBar } from "../../web/js/lib/graph-binding.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const PANEL = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+
+function newerSchemaWorkflow(over = {}) {
+  return {
+    last_node_id: 1,
+    last_link_id: 1,
+    version: 1.2,
+    extra: { frontendVersion: "1.49.9", future_mcp_schema: { nested: true } },
+    nodes: [
+      {
+        id: 1,
+        type: "KSampler",
+        widgets_values: [7, "fixed"],
+        future_v3_slot: { kind: "COMFY_DYNAMICCOMBO_V3" },
+      },
+    ],
+    links: [{ id: 1, origin_id: 2, origin_slot: 0, target_id: 1, target_slot: 0, type: "MODEL" }],
+    ...over,
+  };
+}
+
+function liveSampler(over = {}) {
+  return {
+    id: 1,
+    type: "KSampler",
+    widgets: [
+      { name: "seed", value: 7 },
+      { name: "control_after_generate", value: "fixed" },
+    ],
+    ...over,
+  };
+}
+
+test("#1996 graph_get_object_info is canvas-independent — strip cannot be uuid-fenced off the schema", () => {
+  assert.equal(commandIsCanvasIndependent("graph_get_object_info"), true);
+  assert.equal(activeWorkflowFenceApplies({ cmd: "graph_get_object_info" }), false);
+  // A canvas capture still answers for the active workflow.
+  assert.equal(commandIsCanvasIndependent("graph_serialize"), false);
+  assert.equal(activeWorkflowFenceApplies({ cmd: "graph_serialize" }), true);
+});
+
+test("#1996 graph_get_object_info is a read, same bar as the capture it pairs with", () => {
+  assert.equal(graphCommandMayMutateWorkflow("graph_get_object_info"), false);
+  assert.deepEqual(
+    graphCommandBindingBar("graph_get_object_info"),
+    graphCommandBindingBar("graph_serialize"),
+  );
+});
+
+test("#1996 the executor reads /object_info, not the canvas", () => {
+  const start = PANEL.indexOf("async graph_get_object_info({ if_none_match } = {}) {");
+  assert.ok(start >= 0, "graph_get_object_info must exist");
+  const next = PANEL.indexOf("\n  graph_get_virtual_types()", start);
+  const body = PANEL.slice(start, next > start ? next : start + 4000);
+  assert.match(body, /fetchWholeObjectInfo/);
+  assert.doesNotMatch(body, /getGraphCtx/);
+});
+
+test("#1996 graph_serialize uses serializeLiveGraph so extra schema fields and named widgets survive", () => {
+  const start = PANEL.indexOf("graph_serialize() {");
+  assert.ok(start >= 0, "graph_serialize must exist");
+  const body = PANEL.slice(start, PANEL.indexOf("\n  graph_configure_app_mode", start));
+  assert.match(body, /serializeLiveGraph\(rootGraph/);
+  assert.doesNotMatch(
+    body,
+    /const workflow = rootGraph\.serialize\(\)/,
+    "the production strip capture must not return a bare serialize() — that drops the name map and does not retry a V3 throw",
+  );
+  assert.match(body, /reconcileGraphDynamicWidgets/);
+});
+
+test("#1996 capturedWidgetValues is a name-keyed map of the LIVE widgets", () => {
+  const captured = capturedWidgetValuesForNode(liveSampler());
+  assert.deepEqual(captured, { seed: 7, control_after_generate: "fixed" });
+  assert.equal(capturedWidgetValuesForNode({ id: 1, widgets: [] }), null);
+  assert.equal(capturedWidgetValuesForNode({ id: 1 }), null);
+});
+
+test("#1996 attachCapturedWidgetValues keeps a newer schema's extra fields and version", () => {
+  const workflow = newerSchemaWorkflow();
+  attachCapturedWidgetValues(workflow, [liveSampler()]);
+  assert.equal(workflow.version, 1.2);
+  assert.deepEqual(workflow.extra, { frontendVersion: "1.49.9", future_mcp_schema: { nested: true } });
+  assert.deepEqual(workflow.links[0], {
+    id: 1,
+    origin_id: 2,
+    origin_slot: 0,
+    target_id: 1,
+    target_slot: 0,
+    type: "MODEL",
+  });
+  assert.deepEqual(workflow.nodes[0].future_v3_slot, { kind: "COMFY_DYNAMICCOMBO_V3" });
+  assert.deepEqual(workflow.nodes[0].widgets_values, [7, "fixed"]);
+  assert.deepEqual(workflow.nodes[0].capturedWidgetValues, {
+    seed: 7,
+    control_after_generate: "fixed",
+  });
+});
+
+test("#1996 attachCapturedWidgetValues stamps subgraph definition nodes without cloning them away", () => {
+  const inner = { id: 9, type: "CLIPTextEncode", widgets_values: ["hello"] };
+  const workflow = newerSchemaWorkflow({
+    definitions: { subgraphs: [{ id: "sg", nodes: [inner], links: [] }] },
+  });
+  attachCapturedWidgetValues(workflow, [
+    liveSampler(),
+    { id: 9, widgets: [{ name: "text", value: "hello" }] },
+  ]);
+  assert.equal(workflow.definitions.subgraphs[0].nodes[0], inner);
+  assert.deepEqual(inner.capturedWidgetValues, { text: "hello" });
+});
+
+test("#1996 collectLiveNodes walks nested subgraph instances", () => {
+  const inner = { id: 4, type: "SaveVideo" };
+  const host = { id: 3, type: "SubgraphNode", subgraph: { _nodes: [inner] } };
+  const collected = collectLiveNodes({ _nodes: [liveSampler(), host] });
+  assert.equal(collected.length, 3);
+  assert.equal(collected[2], inner);
+});
+
+test("#1996 serializeLiveGraph attaches named widgets and preserves extra schema keys", () => {
+  const live = liveSampler();
+  const raw = newerSchemaWorkflow();
+  const root = {
+    _nodes: [live],
+    serialize() {
+      return raw;
+    },
+  };
+  const out = serializeLiveGraph(root);
+  assert.equal(out, raw, "must mutate the serialize() object in place, not clone extra fields away");
+  assert.equal(out.version, 1.2);
+  assert.equal(out.extra.future_mcp_schema.nested, true);
+  assert.deepEqual(out.nodes[0].capturedWidgetValues, {
+    seed: 7,
+    control_after_generate: "fixed",
+  });
+});
+
+test("#1996 serializeLiveGraph retries once after reconcile when serialize throws", () => {
+  const live = liveSampler();
+  let calls = 0;
+  let reconciled = 0;
+  const root = {
+    _nodes: [live],
+    serialize() {
+      calls += 1;
+      if (calls === 1) throw new Error("Dynamic widget doesn't exist on node");
+      return newerSchemaWorkflow();
+    },
+  };
+  const out = serializeLiveGraph(root, {
+    reconcile() {
+      reconciled += 1;
+    },
+  });
+  assert.equal(calls, 2);
+  assert.ok(reconciled >= 2, "reconcile runs before the first serialize and again on retry");
+  assert.deepEqual(out.nodes[0].capturedWidgetValues.seed, 7);
+});
+
+test("#1996 a serialize throw that survives reconcile is rethrown, not swallowed", () => {
+  const root = {
+    _nodes: [liveSampler()],
+    serialize() {
+      throw new Error("Dynamic widget doesn't exist on node");
+    },
+  };
+  assert.throws(
+    () => serializeLiveGraph(root, { reconcile() {} }),
+    /Dynamic widget doesn't exist on node/,
+  );
+});

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -138,7 +138,7 @@ test('#932 an UNRESOLVABLE active uuid still lets the probe through', () => {
 test('#932 the shared predicate covers BOTH guards, and is strictly wider', () => {
   // Everything canvas-independent stays targetless…
   for (const cmd of ['nodes_search', 'nodes_list', 'nodes_install', 'nodes_queue_status',
-                     'graph_update_node', 'comfy_reboot', 'free_vram']) {
+                     'graph_update_node', 'graph_get_object_info', 'comfy_reboot', 'free_vram']) {
     assert.equal(commandIsCanvasTargetless(cmd), true, `${cmd} targets no canvas`)
   }
   // …plus exactly one more.
@@ -186,6 +186,7 @@ test('#602 fence does NOT apply to canvas-independent Manager/server commands', 
     'nodes_install',
     'nodes_queue_status',
     'graph_update_node', // a Manager PACK update misnamed with a graph_ prefix
+    'graph_get_object_info', // #1996 — node schema, not a canvas
     'comfy_reboot',
     'free_vram',
   ]) {
@@ -738,7 +739,8 @@ test('#607 non-canvas commands are exempt from the workflow-instance fence', () 
     'nodes_install',
     'nodes_queue_status',
     // graph_update_node: a Manager PACK update misnamed with a graph_ prefix (#624).
-    'graph_update_node'
+    'graph_update_node',
+    'graph_get_object_info',
   ]) {
     assert.equal(activeWorkflowFenceApplies({ cmd }), false, `${cmd} must not be fenced`)
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -430,6 +430,7 @@ import {
   reconcileGraphDynamicWidgets,
   installGraphToPromptDynamicReconcile,
 } from "./lib/dynamic-widget-reconcile.js";
+import { serializeLiveGraph } from "./lib/graph-serialize-capture.js";
 import {
   createDeferredWidgetEditQueue,
   deferredWidgetQueueCounts,
@@ -13949,10 +13950,13 @@ const GRAPH_TOOL_EXECUTORS = {
   // on save). Not two blocks (summary then graph): this command is the capture
   // panel_strip_workflow converts; that tool's own structuredContent.graph is
   // the combined summary+graph form, not a second block from here. Read-only;
-  // subgraph defs ride along in workflow.definitions.
+  // subgraph defs ride along in workflow.definitions. #1996 extra schema fields
+  // stay; capturedWidgetValues rides along for positional-schema skew.
   graph_serialize() {
     const { rootGraph } = getGraphCtx();
-    const workflow = rootGraph.serialize();
+    const workflow = serializeLiveGraph(rootGraph, {
+      reconcile: (graph) => reconcileGraphDynamicWidgets(graph),
+    });
     return { workflow, node_count: workflow?.nodes?.length ?? 0 };
   },
 

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -2664,12 +2664,14 @@ const READ_ONLY_GRAPH_COMMANDS = new Set([
   // corrupts a graph, and that asymmetry is the whole reason reads have a lower
   // bar at all. So this grows one verified command at a time, never by pattern.
   //
-  // `graph_get_object_info` and `graph_prompt_director_audit` are also absent and
-  // also look like reads, but "looks like" is not the standard for weakening a
-  // guard — they stay out until someone establishes it the way this one was
-  // (the orchestrator's own tool description says "Read-only", and its executor
-  // touches no graph state).
+  // #1996 — `graph_get_object_info` reads THIS tab's /object_info and writes no
+  // graph state. Newer MCP requires it for panel_strip_workflow; classifying it
+  // as a mutation refused the schema read on a dirty or unbound tab and failed
+  // strip. It is also canvas-independent (workflow-chat-identity.js): the reply
+  // describes node types, not the active workflow. `graph_prompt_director_audit`
+  // stays out until established the same way.
   "graph_get_errors",
+  "graph_get_object_info",
 ]);
 
 export function graphCommandMayMutateWorkflow(command) {

--- a/web/js/lib/graph-serialize-capture.js
+++ b/web/js/lib/graph-serialize-capture.js
@@ -1,0 +1,116 @@
+/**
+ * #1996 — live-canvas capture for panel_strip_workflow.
+ *
+ * Newer MCP converts this capture against the panel's own node schema
+ * (`graph_get_object_info`). The serialized `widgets_values` array is
+ * positional in the FRONTEND's order, which that schema does not always
+ * reproduce (V3 DynamicCombo nested leaves, JS-added widgets). MCP prefers
+ * a name-keyed `capturedWidgetValues` map when present. Attach it here so
+ * strip does not depend on schema-version agreement for widget routing.
+ *
+ * Unknown extra fields on the serialized graph (a newer LiteGraph / MCP
+ * schema) are left in place. This helper only ADDS the name map.
+ */
+
+function asNodeList(graph) {
+  if (!graph || typeof graph !== "object") return [];
+  if (Array.isArray(graph._nodes)) return graph._nodes;
+  if (Array.isArray(graph.nodes)) return graph.nodes;
+  return [];
+}
+
+/** Live nodes on this graph and any nested subgraph instances. */
+export function collectLiveNodes(graph, out = []) {
+  for (const node of asNodeList(graph)) {
+    if (!node) continue;
+    out.push(node);
+    if (node.subgraph) collectLiveNodes(node.subgraph, out);
+  }
+  return out;
+}
+
+/**
+ * Name→value map for one live node's widgets, or null when none are named.
+ * Values are the live widget values, not the positional serialize() row.
+ */
+export function capturedWidgetValuesForNode(liveNode) {
+  const widgets = liveNode?.widgets;
+  if (!Array.isArray(widgets) || widgets.length === 0) return null;
+  const captured = {};
+  let any = false;
+  for (const widget of widgets) {
+    if (!widget || typeof widget.name !== "string") continue;
+    captured[widget.name] = widget.value;
+    any = true;
+  }
+  return any ? captured : null;
+}
+
+/**
+ * Stamp `capturedWidgetValues` onto serialized nodes that have a matching live
+ * node. Does not clone, strip, or rewrite any other field — a newer schema's
+ * extra keys and version stamp stay as serialize() emitted them.
+ */
+export function attachCapturedWidgetValues(workflow, liveNodes) {
+  if (!workflow || typeof workflow !== "object") return workflow;
+  const nodes = workflow.nodes;
+  if (!Array.isArray(nodes)) return workflow;
+  const liveById = new Map();
+  for (const live of liveNodes ?? []) {
+    if (live && live.id != null) liveById.set(live.id, live);
+  }
+  for (const node of nodes) {
+    if (!node || typeof node !== "object" || node.id == null) continue;
+    const captured = capturedWidgetValuesForNode(liveById.get(node.id));
+    if (captured) node.capturedWidgetValues = captured;
+  }
+  const subgraphs = workflow.definitions?.subgraphs;
+  if (Array.isArray(subgraphs)) {
+    for (const def of subgraphs) attachCapturedWidgetValues(def, liveNodes);
+  }
+  return workflow;
+}
+
+function runSerialize(rootGraph) {
+  if (typeof rootGraph?.serialize !== "function") {
+    throw new Error("The live canvas has no serialize()");
+  }
+  return rootGraph.serialize();
+}
+
+/**
+ * Serialize the live root, retrying once after an optional reconcile if the
+ * first serialize throws (V3 DynamicCombo leftovers). Then attach name-keyed
+ * widget values for the converter.
+ *
+ * @param {object} rootGraph
+ * @param {{ reconcile?: ((graph: object) => void) | null }} [opts]
+ */
+export function serializeLiveGraph(rootGraph, { reconcile = null } = {}) {
+  if (typeof reconcile === "function") {
+    try {
+      reconcile(rootGraph);
+    } catch {
+      // Best-effort: a hostile node must not block the capture.
+    }
+  }
+  let workflow;
+  try {
+    workflow = runSerialize(rootGraph);
+  } catch (first) {
+    if (typeof reconcile === "function") {
+      try {
+        reconcile(rootGraph);
+      } catch {
+        /* retry with whatever we could clean */
+      }
+    }
+    try {
+      workflow = runSerialize(rootGraph);
+    } catch (retry) {
+      throw retry ?? first;
+    }
+  }
+  attachCapturedWidgetValues(workflow, collectLiveNodes(rootGraph));
+  return workflow;
+}

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -388,7 +388,9 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
  *  touches no graph. graph_get_virtual_types (comfyui-mcp#1400) reads the GLOBAL
  *  LiteGraph class registry, never a canvas, and its reply describes no workflow —
  *  and it is pulled by the orchestrator at hello, where no workflow stamp exists
- *  to agree with. */
+ *  to agree with. graph_get_object_info (#1996) reads THIS tab's /object_info
+ *  (the node schema), never a canvas; panel_strip_workflow needs it even when
+ *  the canvas binding is unproven, because the schema is per-ComfyUI. */
 const CANVAS_INDEPENDENT_COMMANDS = new Set([
   'nodes_search',
   'nodes_list',
@@ -396,6 +398,7 @@ const CANVAS_INDEPENDENT_COMMANDS = new Set([
   'nodes_queue_status',
   'graph_update_node',
   'graph_get_virtual_types',
+  'graph_get_object_info',
   'fetch_image',
   'fetch_comfyui_read',
   'comfy_reboot',


### PR DESCRIPTION
Fixes #1996.

## What happened

`panel_strip_workflow({})` failed when a newer MCP required the panel node schema (`graph_get_object_info`) that an older panel did not expose, or that this panel still fenced as a mutation. Strip then could not classify an otherwise valid live canvas.

## What this does

1. Treat `graph_get_object_info` as a **canvas-independent read**. It fetches this tab's `/object_info` and writes no graph state, so a dirty, unbound, or uuid-mismatched tab must not refuse the schema read that strip needs.
2. Capture through `serializeLiveGraph`: extra/unknown LiteGraph/MCP schema fields stay as `serialize()` emitted them; name-keyed `capturedWidgetValues` ride along so MCP can convert without agreeing on positional widget order. A V3 DynamicCombo serialize throw retries once after reconcile.

## Tests

```
node --test browser_tests/unit/strip-schema-skew.test.mjs browser_tests/unit/read-only-graph-commands.test.mjs browser_tests/unit/workflow-chat-identity.test.mjs
npm run test:unit
```

7491 passed, 0 failed, 1 existing todo.

Do not merge or bump versions.
