### PR TITLE
fix(1998): keep partial exec target through queuePrompt wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_strip_workflow no longer fails when a newer MCP requires the panel's node schema: graph_get_object_info is a canvas-independent read (not a mutation), and graph_serialize keeps extra schema fields while attaching name-keyed widget values so conversion does not depend on positional schema agreement (#1996)
+- scoped panel_run keeps the run-to-node target when a queuePrompt wrapper drops the third argument, instead of relying only on request-body repair (#1998)
 
 ## [0.15.140] - 2026-08-30
 

--- a/browser_tests/unit/method-capture-intrinsic.test.mjs
+++ b/browser_tests/unit/method-capture-intrinsic.test.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath } from "node:url";
 
 const FILES = [
   "configure-app-mode.js",
+  "queue-prompt-scope-adapter.js",
   "run-prompt-snapshot.js",
   "run-scope-guard.js",
   "widget-null-safety.js",

--- a/browser_tests/unit/queue-prompt-scope-adapter.test.mjs
+++ b/browser_tests/unit/queue-prompt-scope-adapter.test.mjs
@@ -1,0 +1,152 @@
+// #1998 — 1.41.21-shaped queuePrompt wrappers drop the third argument.
+// Native ComfyApp stores queueNodeIds on the queue item and later passes
+// { partialExecutionTargets } to api.queuePrompt. The adapter restores that
+// target through the live wrappers for this run's mark, and request-body
+// repair remains the last fallback when a wrapper never calls through.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  installQueuePromptScopeAdapter,
+  mergeQueuePromptScopeOptions,
+} from "../../web/js/lib/queue-prompt-scope-adapter.js";
+
+const MARK = 2 ** 30 - 2;
+const TARGETS = ["259"];
+
+test("#1998 mergeQueuePromptScopeOptions writes partialExecutionTargets without stripping other keys", () => {
+  assert.deepEqual(mergeQueuePromptScopeOptions(undefined, TARGETS), {
+    partialExecutionTargets: TARGETS,
+  });
+  assert.deepEqual(mergeQueuePromptScopeOptions({ previewMethod: "taesd" }, TARGETS), {
+    previewMethod: "taesd",
+    partialExecutionTargets: TARGETS,
+  });
+  const already = { partialExecutionTargets: ["14"] };
+  assert.equal(mergeQueuePromptScopeOptions(already, TARGETS).partialExecutionTargets, already.partialExecutionTargets);
+  assert.deepEqual(mergeQueuePromptScopeOptions(["259"], TARGETS), {
+    partialExecutionTargets: TARGETS,
+  });
+});
+
+test("#1998 adapter is a no-op without targets and never throws on hostile input", () => {
+  const restoreEmpty = installQueuePromptScopeAdapter({});
+  assert.equal(typeof restoreEmpty, "function");
+  restoreEmpty();
+  restoreEmpty();
+
+  const hostile = {};
+  Object.defineProperty(hostile, "queuePrompt", {
+    get() {
+      throw new Error("boom");
+    },
+  });
+  Object.defineProperty(hostile, "queueItems", {
+    get() {
+      throw new Error("boom");
+    },
+  });
+  const restore = installQueuePromptScopeAdapter({
+    app: hostile,
+    api: hostile,
+    targets: TARGETS,
+    queueMark: MARK,
+  });
+  restore();
+});
+
+test("#1998 queueItems pop restores queueNodeIds for this run's mark only", () => {
+  const ours = { number: MARK, batchCount: 1 };
+  const foreign = { number: 0, batchCount: 1 };
+  const kept = { number: MARK, batchCount: 1, queueNodeIds: ["14"] };
+  const app = {
+    queueItems: [kept, foreign, ours],
+    queuePrompt: async () => {},
+  };
+  const restore = installQueuePromptScopeAdapter({
+    app,
+    targets: TARGETS,
+    queueMark: MARK,
+  });
+  try {
+    assert.deepEqual(app.queueItems.pop().queueNodeIds, TARGETS);
+    assert.equal(app.queueItems.pop().queueNodeIds, undefined);
+    assert.deepEqual(app.queueItems.pop().queueNodeIds, ["14"]);
+  } finally {
+    restore();
+  }
+  app.queueItems.push({ number: MARK, batchCount: 1 });
+  assert.equal(app.queueItems.pop().queueNodeIds, undefined, "restore must uninstall the pop hook");
+});
+
+test("#1998 api.queuePrompt wrap injects partialExecutionTargets for this run's mark", async () => {
+  const seen = [];
+  const api = {
+    async queuePrompt(number, prompt, options) {
+      seen.push({ number, prompt, options });
+      return true;
+    },
+  };
+  const restore = installQueuePromptScopeAdapter({
+    api,
+    targets: TARGETS,
+    queueMark: MARK,
+  });
+  try {
+    await api.queuePrompt(MARK, { output: {} });
+    await api.queuePrompt(0, { output: {} });
+    await api.queuePrompt(MARK, { output: {} }, { previewMethod: "taesd" });
+  } finally {
+    restore();
+  }
+  assert.deepEqual(seen[0].options.partialExecutionTargets, TARGETS);
+  assert.equal(seen[1].options, undefined);
+  assert.deepEqual(seen[2].options, {
+    previewMethod: "taesd",
+    partialExecutionTargets: TARGETS,
+  });
+});
+
+test("#1998 two-arg app wrapper still stores queueNodeIds on the 1.41.21 queue item", async () => {
+  class NativeApp {
+    constructor() {
+      this.queueItems = [];
+      this.last = null;
+    }
+    async queuePrompt(number, batchCount = 1, queueNodeIds) {
+      this.queueItems.push({ number, batchCount, queueNodeIds });
+      this.last = this.queueItems.pop();
+      return true;
+    }
+  }
+  const app = new NativeApp();
+  const native = NativeApp.prototype.queuePrompt;
+  app.queuePrompt = async function (number, batch) {
+    return native.apply(app, [number, batch]);
+  };
+
+  const restore = installQueuePromptScopeAdapter({
+    app,
+    targets: TARGETS,
+    queueMark: MARK,
+  });
+  try {
+    await app.queuePrompt(MARK, 1, TARGETS);
+  } finally {
+    restore();
+  }
+  assert.deepEqual(app.last.queueNodeIds, TARGETS);
+});
+
+test("#1998 dispatchScopedRun actually installs the adapter", () => {
+  const source = readFileSync(
+    fileURLToPath(new URL("../../web/js/lib/run-scope-guard.js", import.meta.url)),
+    "utf8",
+  );
+  assert.match(source, /installQueuePromptScopeAdapter/);
+  assert.match(source, /restoreQueuePromptAdapter\(\)/);
+  assert.match(source, /adapterMarks\.mark = mark/);
+});

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -332,6 +332,85 @@ function makeFrontend1496({ dropAppArgs = false, dropApiArgs = false, apiTarget,
   return { app, api };
 }
 
+// 1.41.21 topology: native app.queuePrompt pushes {number, batchCount, queueNodeIds}
+// then later calls api.queuePrompt(number, prompt, { partialExecutionTargets }).
+// Two-arg own-property wrappers capture the original function and omit the third
+// argument — the field report on frontend 1.41.21.
+function makeFrontend14121({ dropAppArgs = false, dropApiArgs = false, apiTarget, output = OUR_OUTPUT } = {}) {
+  class NativeApi {
+    async queuePrompt(number, data, options) {
+      const targets = options?.partialExecutionTargets;
+      const body = frontendBody({
+        output: data?.output ?? output,
+        number,
+        targets: Array.isArray(targets) && targets.length ? targets : null,
+      });
+      api.posted.push(body);
+      await api.fetchApi("/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return { prompt_id: "x" };
+    }
+  }
+
+  const api = new NativeApi();
+  api.fetchApi = apiTarget.fetchApi;
+  api.posted = [];
+  const nativeApiQueuePrompt = NativeApi.prototype.queuePrompt;
+  if (dropApiArgs) {
+    api.queuePrompt = async function (number, prompt) {
+      return nativeApiQueuePrompt.apply(api, [number, prompt]);
+    };
+  } else {
+    api.queuePrompt = async function (...args) {
+      return nativeApiQueuePrompt.apply(api, args);
+    };
+  }
+
+  class NativeApp {
+    constructor() {
+      this.api = api;
+      this.queueItems = [];
+      this.processingQueue = false;
+      this.graphToPrompt = async () => ({ output, workflow: {} });
+    }
+
+    async queuePrompt(number, batchCount = 1, queueNodeIds) {
+      this.queueItems.push({ number, batchCount, queueNodeIds });
+      if (this.processingQueue) return false;
+      this.processingQueue = true;
+      try {
+        while (this.queueItems.length) {
+          const item = this.queueItems.pop();
+          const p = await this.graphToPrompt();
+          const options = item.queueNodeIds?.length
+            ? { partialExecutionTargets: item.queueNodeIds }
+            : undefined;
+          await this.api.queuePrompt(item.number, p, options);
+        }
+      } finally {
+        this.processingQueue = false;
+      }
+      return true;
+    }
+  }
+
+  const app = new NativeApp();
+  const nativeAppQueuePrompt = NativeApp.prototype.queuePrompt;
+  if (dropAppArgs) {
+    app.queuePrompt = async function (number, batch) {
+      return nativeAppQueuePrompt.apply(app, [number, batch]);
+    };
+  } else {
+    app.queuePrompt = async function (...args) {
+      return nativeAppQueuePrompt.apply(app, args);
+    };
+  }
+  return { app, api };
+}
+
 // ---------------------------------------------------------------------------
 // Pure helpers
 // ---------------------------------------------------------------------------
@@ -4370,6 +4449,60 @@ test("#1782 exact-target fallback: a store-layer options object in the body is r
     assert.equal(res.status, 200, "exact ids in the store-layer shape are not a refusal");
     assert.equal(guard.state.repaired, 1);
     assert.equal(guard.state.dropped, null);
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#1998 1.41.21 two-arg app wrapper still delivers the target through queuePrompt", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const { app, api } = makeFrontend14121({
+      dropAppArgs: true,
+      apiTarget: { fetchApi: server },
+    });
+    const result = await dispatchScopedRun({
+      app,
+      apiTarget: api,
+      execIds: ["14"],
+      batch: 1,
+      toNodeId: 14,
+    });
+
+    assert.equal(Object.prototype.hasOwnProperty.call(app, "queuePrompt"), true);
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.scopeAppliedBy, "frontend", "queue item restore reaches api.queuePrompt before body repair");
+    assert.equal(result.repaired, 0);
+    assert.equal(server.calls.length, 1);
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#1998 captured two-arg api wrapper still falls through to request-body repair", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const { app, api } = makeFrontend14121({
+      dropAppArgs: true,
+      dropApiArgs: true,
+      apiTarget: { fetchApi: server },
+    });
+    const result = await dispatchScopedRun({
+      app,
+      apiTarget: api,
+      execIds: ["14"],
+      batch: 1,
+      toNodeId: 14,
+    });
+
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.scopeAppliedBy, "request_body_repair");
+    assert.equal(result.repaired, 1);
+    assert.equal(server.calls.length, 1);
     assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
   } finally {
     stop();

--- a/web/js/lib/queue-prompt-scope-adapter.js
+++ b/web/js/lib/queue-prompt-scope-adapter.js
@@ -1,0 +1,238 @@
+/**
+ * #1998 — restore a dropped partial-execution target on the 1.41.21 queuePrompt
+ * path without bypassing live wrappers.
+ *
+ * Native ComfyApp.queuePrompt is `(number, batchCount, queueNodeIds)` and later
+ * calls `api.queuePrompt(number, prompt, { partialExecutionTargets })`. Custom
+ * nodes often replace either method with a two-argument wrapper, so the target
+ * never reaches that call. ComfyUI itself documents the same hijack for extra
+ * `api.queuePrompt` parameters (auth lives on a field, not an argument).
+ *
+ * This adapter does not replace those wrappers. For the duration of one scoped
+ * dispatch it:
+ *   1. forwards the third argument through the live `app.queuePrompt` /
+ *      `api.queuePrompt` functions via apply;
+ *   2. writes the resolved target onto a queue item that still lacks
+ *      `queueNodeIds` when native 1.41.21 pops it after a two-arg app wrapper
+ *      returned;
+ *   3. injects `partialExecutionTargets` when `api.queuePrompt` is invoked
+ *      with this run's queue mark and no usable options object.
+ *
+ * Request-body repair stays the last fallback for a wrapper that captured the
+ * native function and never calls through with the third argument.
+ */
+
+const rawApply = Reflect.apply;
+const hasOwn = Object.prototype.hasOwnProperty;
+const getPrototypeOf = Object.getPrototypeOf;
+const QUEUE_ITEMS_ADAPTER = Symbol("cmcp-queue-prompt-scope-adapter");
+
+function readProp(obj, name) {
+  try {
+    return obj ? obj[name] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isUsableProto(proto) {
+  return !!proto && proto !== Object.prototype && proto !== Function.prototype && proto !== Array.prototype;
+}
+
+function markOf(opts) {
+  try {
+    const n = Number(opts?.queueMarkRef?.mark ?? opts?.queueMark);
+    return Number.isFinite(n) ? n : NaN;
+  } catch {
+    return NaN;
+  }
+}
+
+function sameMark(number, opts) {
+  const expected = markOf(opts);
+  if (!Number.isFinite(expected)) return false;
+  const got = Number(number);
+  return Number.isFinite(got) && got === expected;
+}
+
+function usableTargets(targets) {
+  return Array.isArray(targets) && targets.length ? targets : null;
+}
+
+/**
+ * Build the api.queuePrompt options object for this run. Unknown keys are
+ * copied when `options` is already a plain object, so a wrapper that also
+ * carries previewMethod / intent is not stripped.
+ *
+ * @param {unknown} options
+ * @param {string[]} targets
+ */
+export function mergeQueuePromptScopeOptions(options, targets) {
+  const execIds = usableTargets(targets);
+  const base = {};
+  if (options && typeof options === "object" && !Array.isArray(options)) {
+    try {
+      for (const key of Object.keys(options)) {
+        base[key] = options[key];
+      }
+    } catch {
+      // Hostile keys still get the execution target below.
+    }
+  }
+  if (execIds && (!Array.isArray(base.partialExecutionTargets) || !base.partialExecutionTargets.length)) {
+    base.partialExecutionTargets = execIds;
+  }
+  return base;
+}
+
+function restoreQueueNodeIds(item, targets, opts) {
+  const execIds = usableTargets(targets);
+  if (!execIds || !item || typeof item !== "object") return;
+  try {
+    if (!sameMark(item.number, opts)) return;
+    const existing = item.queueNodeIds;
+    if (Array.isArray(existing) && existing.length) return;
+    item.queueNodeIds = execIds;
+  } catch {
+    // A throwing item must not break the real push.
+  }
+}
+
+function wrapOwnOrProto(obj, name, adapt) {
+  if (!obj) return null;
+  let current;
+  try {
+    current = obj[name];
+  } catch {
+    return null;
+  }
+  if (typeof current !== "function") return null;
+  let hadOwn;
+  try {
+    hadOwn = hasOwn.call(obj, name);
+  } catch {
+    return null;
+  }
+  const adapted = function adaptedQueuePrompt(...args) {
+    return adapt(current, this, args);
+  };
+  try {
+    obj[name] = adapted;
+  } catch {
+    return null;
+  }
+  return () => {
+    try {
+      if (hadOwn) obj[name] = current;
+      else delete obj[name];
+    } catch {
+      // Restore is best-effort; the scoped run is already finished.
+    }
+  };
+}
+
+function wrapQueueItemsPop(app, targets, opts, restores, seen) {
+  let items;
+  try {
+    items = app?.queueItems;
+  } catch {
+    return;
+  }
+  if (!Array.isArray(items) || seen.has(items)) return;
+  if (readProp(items, QUEUE_ITEMS_ADAPTER)) {
+    seen.add(items);
+    return;
+  }
+  // Native 1.41.21 reads queueNodeIds from the popped item. Wrapping pop — not
+  // push — keeps a deferred item untouched until the processor actually runs it.
+  const restore = wrapOwnOrProto(items, "pop", (original, thisArg, args) => {
+    const item = rawApply(original, thisArg ?? items, args);
+    restoreQueueNodeIds(item, targets, opts);
+    return item;
+  });
+  if (!restore) return;
+  seen.add(items);
+  try {
+    Object.defineProperty(items, QUEUE_ITEMS_ADAPTER, {
+      value: true,
+      configurable: true,
+      enumerable: false,
+      writable: false,
+    });
+  } catch {
+    // Symbol tag is a de-dupe aid, not required for correctness.
+  }
+  restores.push(() => {
+    try {
+      delete items[QUEUE_ITEMS_ADAPTER];
+    } catch {
+      /* ignore */
+    }
+    restore();
+  });
+}
+
+function wrapQueuePrompt(obj, targets, opts, restores, seen, itemSeen, kind) {
+  if (!obj || typeof obj !== "object" || seen.has(obj)) return;
+  seen.add(obj);
+  const restore = wrapOwnOrProto(obj, "queuePrompt", (original, thisArg, args) => {
+    const recv = thisArg ?? obj;
+    if (kind === "app") {
+      wrapQueueItemsPop(recv, targets, opts, restores, itemSeen);
+      if (sameMark(args[0], opts) && args[2] == null) {
+        return rawApply(original, recv, [args[0], args[1], targets, ...args.slice(3)]);
+      }
+      return rawApply(original, recv, args);
+    }
+    if (sameMark(args[0], opts)) {
+      const merged = mergeQueuePromptScopeOptions(args[2], targets);
+      return rawApply(original, recv, [args[0], args[1], merged, ...args.slice(3)]);
+    }
+    return rawApply(original, recv, args);
+  });
+  if (restore) restores.push(restore);
+  try {
+    const proto = getPrototypeOf(obj);
+    if (isUsableProto(proto)) wrapQueuePrompt(proto, targets, opts, restores, seen, itemSeen, kind);
+  } catch {
+    // Prototype walk is optional.
+  }
+}
+
+/**
+ * Install the scoped-run adapter. Returns a restore function that is safe to
+ * call more than once and must run even when queuePrompt throws.
+ *
+ * @param {{app?: object, api?: object, extraApis?: unknown[], targets?: string[], queueMark?: number, queueMarkRef?: {mark: number}}} opts
+ * @returns {() => void}
+ */
+export function installQueuePromptScopeAdapter(opts = {}) {
+  const targets = usableTargets(opts.targets);
+  const restores = [];
+  let restored = false;
+  const restore = () => {
+    if (restored) return;
+    restored = true;
+    for (let i = restores.length - 1; i >= 0; i--) {
+      try {
+        restores[i]();
+      } catch {
+        // Each restore is independent so one hostile setter cannot skip the rest.
+      }
+    }
+  };
+  if (!targets) return restore;
+
+  const seenApp = new Set();
+  const seenApi = new Set();
+  const seenItems = new Set();
+  wrapQueuePrompt(opts.app, targets, opts, restores, seenApp, seenItems, "app");
+  wrapQueueItemsPop(opts.app, targets, opts, restores, seenItems);
+  wrapQueuePrompt(opts.api, targets, opts, restores, seenApi, seenItems, "api");
+  wrapQueuePrompt(readProp(opts.app, "api"), targets, opts, restores, seenApi, seenItems, "api");
+  const extra = Array.isArray(opts.extraApis) ? opts.extraApis : [];
+  for (const api of extra) {
+    if (api && api !== opts.api) wrapQueuePrompt(api, targets, opts, restores, seenApi, seenItems, "api");
+  }
+  return restore;
+}

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -33,6 +33,7 @@ import { controlAfterGenerateEntries } from "./control-after-generate.js";
 // own header), so there is not one.
 import { withTimeout } from "./bounded-step.js";
 import { scrubSecretShapedText } from "./http-failure.js";
+import { installQueuePromptScopeAdapter } from "./queue-prompt-scope-adapter.js";
 
 // #1854 — the intrinsic captured ONCE at module load. Invoking through a
 // per-call property lookup on the function object would read an overrideable
@@ -2333,6 +2334,17 @@ export async function dispatchScopedRun({
   }
   let dropped = null;
   let restampUsed = false;
+  // #1998 — restore a dropped third argument through live 1.41.21-shaped
+  // queuePrompt wrappers for this run's mark only. Request-body repair stays
+  // the last attempt when a wrapper never calls through.
+  const adapterMarks = { mark };
+  const restoreQueuePromptAdapter = installQueuePromptScopeAdapter({
+    app,
+    api: apiTarget,
+    targets: execIds,
+    queueMarkRef: adapterMarks,
+  });
+  try {
   for (;;) {
     let restampAgain = false;
     dropped = null;
@@ -2614,6 +2626,7 @@ export async function dispatchScopedRun({
           volatileInputs = live.volatileInputs;
           volatileList = volatileInputs ? [...volatileInputs].sort() : [];
           mark = newScopedQueueMark();
+          adapterMarks.mark = mark;
           break;
         }
       }
@@ -2649,5 +2662,8 @@ export async function dispatchScopedRun({
     }
     if (restampAgain) continue;
     return { outcome: "refused", queueMark: mark, verified: 0, volatileInputs: volatileList, error: dropped };
+  }
+  } finally {
+    restoreQueuePromptAdapter();
   }
 }


### PR DESCRIPTION
## Summary

`panel_run` with `to_node_id` recovered via `scope_applied_by=request_body_repair` on ComfyUI frontend 1.41.21 because own-property `app.queuePrompt` / `api.queuePrompt` wrappers dropped the third partial-execution argument. Native 1.41.21 still supports positional `queueNodeIds` and translates it to `api.queuePrompt(..., { partialExecutionTargets })`; the wrappers never forwarded that argument.

This adds a scoped-run adapter that restores the target **through** those live wrappers for this run's queue mark:

- missing third `app.queuePrompt` argument is filled with the resolved execution ids
- a popped `queueItems` entry that still lacks `queueNodeIds` gets the same ids (the 1.41.21 processor reads that field)
- `api.queuePrompt` calls for this mark get `partialExecutionTargets` when options were dropped

Request-body repair stays the last fallback when a wrapper captured the native function and never calls through. Wrappers are not bypassed, so rgthree-style prompt rewrites still run.

Fixes #1998

## Tests

```
node --test browser_tests/unit/queue-prompt-scope-adapter.test.mjs browser_tests/unit/run-scope-guard.test.mjs browser_tests/unit/method-capture-intrinsic.test.mjs browser_tests/unit/run-command-budget.test.mjs
```

167 + related tests passed. Full `browser_tests/unit/*.test.mjs`: 7489 pass, 1 todo.
