### PR TITLE
fix(2002): do not persist object/null proxyWidgets from legacy promote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
 - panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
+- panel_promote_widget refuses canvas-only callback widgets (control_after_generate) and writes only [nodeId, widgetName] string pairs through the legacy promotion store, so saved workflows stay loadable (#2002)
 
 
 ## [0.15.142] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_set_widget acknowledges an inner-subgraph widget write once readback matches, instead of waiting out the 90s relay on a hanging widget callback or parent-rail restore (#2001)
+- panel_promote_widget refuses canvas-only callback widgets (control_after_generate) and writes only [nodeId, widgetName] string pairs through the legacy promotion store, so saved workflows stay loadable (#2002)
 
 ## [0.15.143] - 2026-08-30
 
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
 - panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
-- panel_promote_widget refuses canvas-only callback widgets (control_after_generate) and writes only [nodeId, widgetName] string pairs through the legacy promotion store, so saved workflows stay loadable (#2002)
 
 
 ## [0.15.142] - 2026-08-30

--- a/browser_tests/unit/promote-widget-preview-store.test.mjs
+++ b/browser_tests/unit/promote-widget-preview-store.test.mjs
@@ -114,6 +114,7 @@ function makeHarness({
       : { name: widget.name, type: widget.type ?? "*", label: widget.label, widget: { name: widget.name } },
   linkConnects = true,
   atRoot = false,
+  parentProperties,
 } = {}) {
   const parentInputs = [];
   const subgraph = {
@@ -142,6 +143,7 @@ function makeHarness({
     subgraph,
     inputs: parentInputs,
     rootGraph: { id: "root-uuid" },
+    properties: parentProperties ?? {},
     computeSize() {},
     setDirtyCanvas() {},
     invalidatePromotedViews() {},
@@ -302,7 +304,7 @@ test("#1271 a preview widget without previewExposure still reports the real link
 
 test("#1271 a failed link-only promote still uses the legacy store when it exists", () => {
   const legacy = makeLegacyPromotionStore();
-  const { fn } = makeHarness({
+  const { fn, parent } = makeHarness({
     stores: { promotion: legacy },
     innerWidgets: [{ name: "cfg", type: "number" }],
     slotFor: () => null,
@@ -315,7 +317,12 @@ test("#1271 a failed link-only promote still uses the legacy store when it exist
   assert.equal(legacy.calls[0][0], "promote");
   assert.equal(legacy.calls[0][1], "root-uuid");
   assert.equal(legacy.calls[0][2], 10);
-  assert.deepEqual(legacy.calls[0][3], { sourceNodeId: "3", sourceWidgetName: "cfg" });
+  // 1.41 usePromotionStore.promote(graphId, subgraphNodeId, interiorNodeId, widgetName)
+  // — four strings. The previous 3-arg source object became [object, null] in
+  // properties.proxyWidgets and the saved workflow would not load (#2002).
+  assert.equal(legacy.calls[0][3], "3");
+  assert.equal(legacy.calls[0][4], "cfg");
+  assert.deepEqual(parent.properties.proxyWidgets, [["3", "cfg"]]);
 });
 
 test("#1271 a type-preview widget (no $$ prefix) still uses previewExposure", () => {
@@ -465,4 +472,165 @@ test("#2321 nested subgraph: promote from innermost graph (root → 142 → 133 
   assert.equal(result.promoted, "steps", "promotion should succeed");
   assert.equal(result.from_node, innerNode.id, "source node should be inner");
   assert.deepEqual(result.on_subgraph_nodes, [133], "must find node 133 as the parent");
+});
+
+const CONTROL_AFTER_GENERATE = {
+  name: "control_after_generate",
+  type: "combo",
+  value: "randomize",
+  options: {
+    values: ["fixed", "increment", "decrement", "randomize"],
+    serialize: false,
+    canvasOnly: true,
+  },
+};
+
+function assertLoadableProxyWidgets(proxyWidgets) {
+  assert.ok(Array.isArray(proxyWidgets), "proxyWidgets must be an array");
+  const roundTrip = JSON.parse(JSON.stringify(proxyWidgets));
+  for (const [i, entry] of roundTrip.entries()) {
+    assert.ok(Array.isArray(entry), `proxyWidgets[${i}] must be a pair`);
+    assert.equal(typeof entry[0], "string", `proxyWidgets[${i}][0] must be a string (got ${typeof entry[0]})`);
+    assert.ok(entry[0].length > 0, `proxyWidgets[${i}][0] must be non-empty`);
+    assert.equal(typeof entry[1], "string", `proxyWidgets[${i}][1] must be a string (got ${typeof entry[1]})`);
+    assert.ok(entry[1].length > 0, `proxyWidgets[${i}][1] must be non-empty`);
+  }
+}
+
+/** Mirrors ComfyUI 1.41 usePromotionStore + SubgraphNode.serialize: the store
+ *  holds {interiorNodeId, widgetName}, serialize copies [interiorNodeId, widgetName]
+ *  onto properties.proxyWidgets. Passing a source object as interiorNodeId is
+ *  exactly the [object, null] load failure. */
+function makeFrontendPromotionStore() {
+  const byHost = new Map();
+  const keyOf = (graphId, nodeId) => `${graphId}|${nodeId}`;
+  const store = {
+    calls: [],
+    getPromotions(graphId, nodeId) {
+      return [...(byHost.get(keyOf(graphId, nodeId)) ?? [])];
+    },
+    setPromotions(graphId, nodeId, entries) {
+      byHost.set(keyOf(graphId, nodeId), [...entries]);
+    },
+    promote(graphId, subgraphNodeId, interiorNodeId, widgetName) {
+      store.calls.push(["promote", graphId, subgraphNodeId, interiorNodeId, widgetName]);
+      const entries = store.getPromotions(graphId, subgraphNodeId);
+      entries.push({ interiorNodeId, widgetName });
+      store.setPromotions(graphId, subgraphNodeId, entries);
+    },
+    demote(graphId, subgraphNodeId, interiorNodeId, widgetName) {
+      store.calls.push(["demote", graphId, subgraphNodeId, interiorNodeId, widgetName]);
+      store.setPromotions(
+        graphId,
+        subgraphNodeId,
+        store.getPromotions(graphId, subgraphNodeId).filter(
+          (e) => !(e.interiorNodeId === interiorNodeId && e.widgetName === widgetName),
+        ),
+      );
+    },
+    serialize(parent, graphId) {
+      parent.properties ??= {};
+      parent.properties.proxyWidgets = store.getPromotions(graphId, parent.id).map((e) => [
+        e.interiorNodeId,
+        e.widgetName ?? null,
+      ]);
+    },
+  };
+  return store;
+}
+
+test("#2002 a canvas-only callback widget is refused and never writes proxyWidgets", () => {
+  const legacy = makeLegacyPromotionStore();
+  const { fn, parent } = makeHarness({
+    stores: { promotion: legacy },
+    innerWidgets: [
+      { name: "noise_seed", type: "INT", value: 1 },
+      CONTROL_AFTER_GENERATE,
+    ],
+    slotFor: () => null,
+  });
+
+  assert.throws(
+    () => fn({ node_id: 3, widget: "control_after_generate" }),
+    (err) => {
+      assert.match(err.message, /not backed by a connectable input slot/);
+      assert.match(err.message, /canvas-only callback widget/);
+      assert.match(err.message, /unloadable properties\.proxyWidgets/);
+      return true;
+    },
+  );
+  assert.equal(legacy.calls.length, 0, "must not call the promotion store");
+  assert.deepEqual(parent.properties.proxyWidgets, undefined);
+});
+
+test("#2002 legacy-store serialize writes [string, string] pairs, never [object, null]", () => {
+  const store = makeFrontendPromotionStore();
+  const { fn, parent } = makeHarness({
+    stores: { promotion: store },
+    innerWidgets: [{ name: "cfg", type: "number" }],
+    slotFor: () => null,
+  });
+
+  const result = fn({ node_id: 3, widget: "cfg" });
+  store.serialize(parent, "root-uuid");
+
+  assert.equal(result.strategy, "legacy-store");
+  assertLoadableProxyWidgets(parent.properties.proxyWidgets);
+  assert.deepEqual(parent.properties.proxyWidgets, [["3", "cfg"]]);
+  assert.equal(store.calls[0][3], "3");
+  assert.equal(store.calls[0][4], "cfg");
+  assert.notEqual(typeof store.calls[0][3], "object");
+});
+
+test("#2002 demote strips a pre-existing object/null proxyWidgets entry so the graph can load", () => {
+  const store = makeFrontendPromotionStore();
+  const corrupt = { sourceNodeId: "3", sourceWidgetName: "control_after_generate" };
+  store.setPromotions("root-uuid", 10, [
+    { interiorNodeId: corrupt, widgetName: undefined },
+    { interiorNodeId: "3", widgetName: "steps" },
+  ]);
+  const { fn, parent } = makeHarness({
+    stores: { promotion: store },
+    innerWidgets: [CONTROL_AFTER_GENERATE],
+    slotFor: () => null,
+    parentProperties: {
+      proxyWidgets: [
+        [corrupt, null],
+        ["3", "steps"],
+      ],
+    },
+  });
+
+  const result = fn({ node_id: 3, widget: "control_after_generate", demote: true });
+  store.serialize(parent, "root-uuid");
+
+  assert.equal(result.strategy, "legacy-store");
+  assert.equal(result.demoted, "control_after_generate");
+  assertLoadableProxyWidgets(parent.properties.proxyWidgets);
+  assert.deepEqual(parent.properties.proxyWidgets, [["3", "steps"]]);
+});
+
+test("#2002 a later valid legacy promotion keeps existing string pairs and drops garbage", () => {
+  const store = makeFrontendPromotionStore();
+  store.setPromotions("root-uuid", 10, [
+    { interiorNodeId: { sourceNodeId: "3", sourceWidgetName: "cfg" }, widgetName: undefined },
+    { interiorNodeId: "3", widgetName: "steps" },
+  ]);
+  const { fn, parent } = makeHarness({
+    stores: { promotion: store },
+    innerWidgets: [{ name: "cfg", type: "number" }],
+    slotFor: () => null,
+    parentProperties: {
+      proxyWidgets: [[{ sourceNodeId: "3", sourceWidgetName: "cfg" }, null], ["3", "steps"]],
+    },
+  });
+
+  fn({ node_id: 3, widget: "cfg" });
+  store.serialize(parent, "root-uuid");
+
+  assertLoadableProxyWidgets(parent.properties.proxyWidgets);
+  assert.deepEqual(parent.properties.proxyWidgets, [
+    ["3", "steps"],
+    ["3", "cfg"],
+  ]);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9925,13 +9925,92 @@ function getPiniaStore(id) {
  *  promote/demote/isPromoted) — the state that exposes an inner subgraph widget
  *  on the parent SubgraphNode. Frontend >= 1.48 removed this store: value
  *  widgets promote via linked subgraph inputs, and preview widgets use
- *  `previewExposure` instead. */
+ *  `previewExposure` instead.
+ *
+ *  1.41 `promote`/`demote` take four strings
+ *  `(graphId, subgraphNodeId, interiorNodeId, widgetName)`. Passing a source
+ *  object as the third argument wrote `properties.proxyWidgets[n] = [object, null]`,
+ *  which the load validator rejects (#2002). */
 function getPromotionStore() {
   const store = getPiniaStore("promotion");
   if (!store || typeof store.promote !== "function") {
     throw new Error("widget-promotion unavailable on this ComfyUI frontend (no 'promotion' store)");
   }
   return store;
+}
+
+/** Canvas-only callback widgets (`control_after_generate` and similar): both
+ *  `serialize:false` and `canvasOnly:true`. They have no connectable input slot,
+ *  so the link-only path cannot promote them, and the legacy store used to persist
+ *  an unloadable `proxyWidgets` entry for them (#2002). */
+function isCanvasOnlyCallbackWidget(widget) {
+  if (!widget) return false;
+  const opts = widget.options ?? {};
+  const serializeFalse = widget.serialize === false || opts.serialize === false;
+  const canvasOnly = widget.canvasOnly === true || opts.canvasOnly === true;
+  return serializeFalse && canvasOnly;
+}
+
+/** Frontend load schema for `properties.proxyWidgets`: `[string, string][]`. */
+function isValidProxyWidgetPair(entry) {
+  return (
+    Array.isArray(entry) &&
+    entry.length >= 2 &&
+    typeof entry[0] === "string" &&
+    entry[0].length > 0 &&
+    typeof entry[1] === "string" &&
+    entry[1].length > 0
+  );
+}
+
+/** Drive the 1.41 promotion store with string ids, then rebuild both the store
+ *  and `properties.proxyWidgets` from the union of valid name pairs so serialize
+ *  cannot persist the object/null shape the old 3-arg call wrote (#2002). */
+function applyLegacyPromotionStore(store, action, parent, rootGraph, source) {
+  const rootGraphId = parent.rootGraph?.id ?? rootGraph?.id;
+  const interiorNodeId = String(source.sourceNodeId ?? "");
+  const widgetName = String(source.sourceWidgetName ?? "");
+  if (!interiorNodeId || !widgetName) {
+    throw new Error("legacy promotion requires a string node id and widget name");
+  }
+  store[action](rootGraphId, parent.id, interiorNodeId, widgetName);
+
+  const seen = new Set();
+  const pairs = [];
+  const addPair = (id, name) => {
+    if (typeof id !== "string" || !id || typeof name !== "string" || !name) return;
+    const key = `${id}\0${name}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    pairs.push([id, name]);
+  };
+  const raw = Array.isArray(parent.properties?.proxyWidgets) ? parent.properties.proxyWidgets : [];
+  for (const entry of raw) {
+    if (isValidProxyWidgetPair(entry)) addPair(entry[0], entry[1]);
+  }
+  if (typeof store.getPromotions === "function") {
+    for (const entry of store.getPromotions(rootGraphId, parent.id) ?? []) {
+      addPair(entry?.interiorNodeId, entry?.widgetName);
+    }
+  }
+  const wantedKey = `${interiorNodeId}\0${widgetName}`;
+  let next;
+  if (action === "demote") {
+    next = pairs.filter(([id, name]) => `${id}\0${name}` !== wantedKey);
+  } else {
+    addPair(interiorNodeId, widgetName);
+    next = pairs;
+  }
+
+  const props = parent.properties ?? (parent.properties = {});
+  props.proxyWidgets = next;
+  if (typeof store.setPromotions === "function") {
+    store.setPromotions(
+      rootGraphId,
+      parent.id,
+      next.map(([id, name]) => ({ interiorNodeId: id, widgetName: name })),
+    );
+  }
 }
 
 /** Reach ComfyUI's PREVIEW-widget exposure store (id "previewExposure"; methods
@@ -26440,6 +26519,18 @@ const GRAPH_TOOL_EXECUTORS = {
           // Don't mask why the primary path failed — that message is the useful
           // one. The legacy store is gone on frontend >= 1.48; if it is also
           // missing here, surface BOTH errors rather than only "no promotion store".
+          // Canvas-only callback widgets (control_after_generate) have no slot
+          // and must not fall through: the 3-arg object call used to append
+          // [object, null] to properties.proxyWidgets and the saved workflow
+          // would not load (#2002).
+          if (!demote && isCanvasOnlyCallbackWidget(w)) {
+            throw new Error(
+              `${linkErr?.message ?? linkErr}. Widget "${w.name}" is a canvas-only callback ` +
+                `widget and cannot be promoted — the legacy store would write unloadable ` +
+                `properties.proxyWidgets. Set it on the inner node, or promote a connectable ` +
+                `value widget instead.`,
+            );
+          }
           strategy = "legacy-store";
           let store;
           try {
@@ -26448,8 +26539,7 @@ const GRAPH_TOOL_EXECUTORS = {
             throw new Error(`${linkErr?.message ?? linkErr} (and ${storeErr.message})`);
           }
           for (const p of parents) {
-            const rootGraphId = p.rootGraph?.id ?? rootGraph?.id;
-            store[action](rootGraphId, p.id, source);
+            applyLegacyPromotionStore(store, action, p, rootGraph, source);
           }
         }
       }


### PR DESCRIPTION
## Summary

`panel_promote_widget` on frontend 1.41 used the `legacy-store` path and called `usePromotionStore.promote` with a source object. The store's real signature is four strings `(graphId, subgraphNodeId, interiorNodeId, widgetName)`. Serialize then wrote `properties.proxyWidgets[n] = [object, null]`, which the load validator rejects (`Expected string, received object at "[8][0]"`). Reopening the workflow failed part-way.

## Fix

- Refuse canvas-only callback widgets (`control_after_generate`) on promote — they have no connectable slot and must not fall through to the store.
- Call the 1.41 store with string node id and widget name.
- Rebuild `properties.proxyWidgets` (and the store, when `setPromotions` exists) as valid `[nodeId, widgetName]` pairs only. Demote still strips a leftover object/null entry so an already-corrupted graph can be saved loadable.

## Tests

`browser_tests/unit/promote-widget-preview-store.test.mjs` — refuse `control_after_generate`, serialize only string pairs, demote repairs object/null, later valid promotions keep existing pairs.

Fixes #2002