### PR TITLE
fix(1999): restore Desktop ComfyUI after stop, or refuse before Manager reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_strip_workflow no longer fails when a newer MCP requires the panel's node schema: graph_get_object_info is a canvas-independent read (not a mutation), and graph_serialize keeps extra schema fields while attaching name-keyed widget values so conversion does not depend on positional schema agreement (#1996)
 - scoped panel_run keeps the run-to-node target when a queuePrompt wrapper drops the third argument, instead of relying only on request-body repair (#1998)
+- panel_restart_comfyui uses ComfyUI Desktop's restartCore/restartApp to restore the backend after stop, and refuses a Manager reboot when no Desktop relaunch path is available, so a Desktop instance is not left stopped (#1999)
 
 ## [0.15.140] - 2026-08-30
 

--- a/browser_tests/unit/desktop-restart-restore.test.mjs
+++ b/browser_tests/unit/desktop-restart-restore.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * #1999 — panel_restart_comfyui must not stop Desktop ComfyUI unless a
+ * Desktop relaunch path will restore it.
+ *
+ * THE REPORT. Manager reboot was dispatched into a ComfyUI Desktop instance,
+ * the server went down, and nothing brought it back. The follow-up lifecycle
+ * tool then refused because it could not prove Desktop still supervised the
+ * port. Newly installed custom nodes stayed unloaded.
+ *
+ * These drive the shipped helper. A Manager POST on a Desktop shell with no
+ * restore function, or skipping the proven restore when it exists, fails them.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  decideDesktopRestartRestore,
+  resolveDesktopRestore,
+} from "../../web/js/lib/desktop-restart-restore.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function rebootExecutorSource() {
+  const at = SRC.indexOf("  async comfy_reboot({ force } = {}) {");
+  assert.ok(at > 0, "comfy_reboot must exist");
+  return SRC.slice(at, SRC.indexOf("  async free_vram()", at));
+}
+
+test("#1999: a browser tab is not Desktop — Manager reboot stays the path", () => {
+  const decision = decideDesktopRestartRestore({
+    desktopShell: false,
+    restore: { name: "restartCore", restore: () => {} },
+  });
+  assert.equal(decision.kind, "manager_reboot");
+  assert.equal(decision.via, null);
+});
+
+test("#1999: Desktop with restartCore restores through Desktop, not Manager", () => {
+  const decision = decideDesktopRestartRestore({
+    desktopShell: true,
+    restore: { name: "restartCore", restore: () => {} },
+  });
+  assert.equal(decision.kind, "desktop_restore");
+  assert.equal(decision.via, "restartCore");
+  assert.match(decision.note, /restartCore/);
+  assert.match(decision.note, /restores the backend after stop/);
+});
+
+test("#1999: restartApp / relaunchApp are also proven restore paths", () => {
+  for (const name of ["restartApp", "relaunchApp"]) {
+    const decision = decideDesktopRestartRestore({
+      desktopShell: true,
+      restore: { name, restore: () => {} },
+    });
+    assert.equal(decision.kind, "desktop_restore", name);
+    assert.equal(decision.via, name);
+  }
+});
+
+test("#1999: Desktop without a restore function refuses before the stop", () => {
+  const decision = decideDesktopRestartRestore({ desktopShell: true, restore: null });
+  assert.equal(decision.kind, "refuse");
+  assert.equal(decision.via, null);
+  assert.match(decision.note, /Refusing to restart/);
+  assert.match(decision.note, /Desktop/);
+  assert.match(decision.note, /STOP the backend/);
+  assert.match(decision.note, /ComfyUI Desktop app/);
+});
+
+test("#1999: a named restore without a function is not a path", () => {
+  const decision = decideDesktopRestartRestore({
+    desktopShell: true,
+    restore: { name: "restartCore", restore: "not-a-function" },
+  });
+  assert.equal(decision.kind, "refuse");
+});
+
+test("#1999: resolveDesktopRestore prefers restartCore over a whole-app relaunch", () => {
+  const calls = [];
+  const bridge = {
+    restartApp() {
+      calls.push("restartApp");
+    },
+    restartCore() {
+      calls.push("restartCore");
+    },
+    relaunchApp() {
+      calls.push("relaunchApp");
+    },
+  };
+  const resolved = resolveDesktopRestore(bridge);
+  assert.equal(resolved.name, "restartCore");
+  resolved.restore();
+  assert.deepEqual(calls, ["restartCore"]);
+});
+
+test("#1999: resolveDesktopRestore accepts restartApp when restartCore is absent", () => {
+  const resolved = resolveDesktopRestore({
+    restartApp() {
+      return "app";
+    },
+  });
+  assert.equal(resolved.name, "restartApp");
+  assert.equal(resolved.restore(), "app");
+});
+
+test("#1999: garbage is omitted, never guessed", () => {
+  for (const value of [null, undefined, "", 1, [], { restartCore: "no" }, { relaunchApp: {} }]) {
+    assert.equal(resolveDesktopRestore(value), null, String(value));
+  }
+});
+
+test("#1999: comfy_reboot consults the helper before any Manager POST", () => {
+  const reboot = rebootExecutorSource();
+  const helperAt = reboot.indexOf("decideDesktopRestartRestore(");
+  const fetchAt = reboot.indexOf("api.fetchApi(route, { method })");
+  assert.ok(helperAt > 0, "comfy_reboot must call decideDesktopRestartRestore");
+  assert.ok(fetchAt > helperAt, "the Desktop decision must precede the Manager reboot POST");
+  assert.match(reboot, /kind === ["']refuse["']/);
+  assert.match(reboot, /kind === ["']desktop_restore["']/);
+});
+
+test("#1999: a Desktop restore never falls through to Manager reboot", () => {
+  const reboot = rebootExecutorSource();
+  const restoreAt = reboot.indexOf('kind === "desktop_restore"');
+  const fetchAt = reboot.indexOf("api.fetchApi(route, { method })");
+  assert.ok(restoreAt > 0);
+  const restoreReturn = reboot.lastIndexOf("return {", fetchAt);
+  assert.ok(restoreReturn > restoreAt, "desktop_restore must return before the Manager POST");
+  const restoreBlock = reboot.slice(restoreAt, fetchAt);
+  assert.match(restoreBlock, /via: desktopRestore\.name/);
+  assert.match(restoreBlock, /desktopRestore\.restore\(\)/);
+  assert.doesNotMatch(restoreBlock, /api\.fetchApi/);
+});
+
+test("#1999: a Desktop refuse names the server and does not POST Manager", () => {
+  const reboot = rebootExecutorSource();
+  const refuseAt = reboot.indexOf('kind === "refuse"');
+  const fetchAt = reboot.indexOf("api.fetchApi(route, { method })");
+  assert.ok(refuseAt > 0 && refuseAt < fetchAt);
+  const branch = reboot.slice(reboot.lastIndexOf("return {", refuseAt + 80), fetchAt);
+  assert.match(branch, /refused: true/);
+  assert.match(branch, /rebootTargetFields\(\)/);
+  assert.match(branch, /rebooting: false/);
+});
+
+test("#1999: a restore that fails while the backend is still up refuses, not a silent stop", () => {
+  const reboot = rebootExecutorSource();
+  assert.match(reboot, /comfyBackendIsDown\(\)/);
+  assert.match(reboot, /failed before the backend went down/);
+  assert.match(reboot, /ComfyUI was NOT restarted/);
+});
+
+test("#1999: the panel imports and calls the shipped helper", () => {
+  assert.match(SRC, /from "\.\/lib\/desktop-restart-restore\.js"/);
+  assert.ok(SRC.includes("decideDesktopRestartRestore("));
+  assert.ok(SRC.includes("resolveDesktopRestore("));
+  assert.ok(SRC.includes("window.__comfyDesktop2"));
+});

--- a/browser_tests/unit/reboot-target-identity.test.mjs
+++ b/browser_tests/unit/reboot-target-identity.test.mjs
@@ -58,12 +58,13 @@ test("it is a plain function, not a method on the executors table", () => {
 
 // ── every branch, including the ones that failed ───────────────────────────
 
-test("all seven reply branches name the target", () => {
+test("all reply branches name the target", () => {
   // The failures matter most: "which server refused?" is the whole question when
   // the panel and the headless tool disagree about what they are pointing at.
   // #1913 adds the bound-identity refusal as a seventh named branch.
+  // #1999 adds the Desktop restore / refuse / restore-failed-upright branches.
   const spread = (reboot.match(/\.\.\.rebootTargetFields\(\)/g) || []).length;
-  assert.equal(spread, 7, `expected 7 branches to carry the target, found ${spread}`);
+  assert.equal(spread, 10, `expected 10 branches to carry the target, found ${spread}`);
 });
 
 test("the successful reboot says which server is going down", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -644,6 +644,7 @@ import {
   POINTER_WATCH_UNAVAILABLE_NOTICE,
 } from "./lib/live-canvas-capture-gate.js";
 import { decideBoundRestart, normalizeBoundOrigin } from "./lib/bound-restart-witness.js";
+import { decideDesktopRestartRestore, resolveDesktopRestore } from "./lib/desktop-restart-restore.js";
 import { settleOpenedWorkflowTarget } from "./lib/settle-open-target.js";
 import { settleOwnedOpenedWorkflowActive } from "./lib/settle-open-active.js";
 import { settleOpenedWorkflowReadable } from "./lib/settle-open-readable.js";
@@ -27051,6 +27052,54 @@ const GRAPH_TOOL_EXECUTORS = {
         // Queue probe failed (ComfyUI unreachable / no /queue) — fall through and
         // reboot; don't block a needed restart on a flaky probe.
       }
+    }
+    // #1999 — Desktop Manager reboot can stop the Python backend without
+    // Desktop bringing it back. A proven Electron restore (restartCore
+    // stops AND starts; restartApp / relaunchApp relaunch the app) is
+    // the recoverable path. Without one, refuse while the server is still
+    // up — a Manager POST here is a stop that nothing in this tab undoes.
+    const desktopBridge =
+      (typeof window !== "undefined" &&
+        (window.electronAPI ?? window.comfyAPI?.electron ?? window.api ?? window.__comfyDesktop2)) ||
+      null;
+    const desktopRestore = resolveDesktopRestore(desktopBridge);
+    const desktopDecision = decideDesktopRestartRestore({
+      desktopShell: isEmbeddedDesktopShell({
+        electronBridge: desktopBridge,
+        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "",
+      }),
+      restore: desktopRestore,
+    });
+    if (desktopDecision.kind === "refuse") {
+      return {
+        rebooting: false,
+        refused: true,
+        ...rebootTargetFields(),
+        error: desktopDecision.note,
+      };
+    }
+    if (desktopDecision.kind === "desktop_restore" && desktopRestore) {
+      try {
+        await desktopRestore.restore();
+      } catch (err) {
+        if (!comfyBackendIsDown()) {
+          return {
+            rebooting: false,
+            refused: true,
+            ...rebootTargetFields(),
+            error:
+              `ComfyUI Desktop ${desktopRestore.name} failed before the backend went down` +
+              (err && err.message ? `: ${err.message}` : "") +
+              ". ComfyUI was NOT restarted.",
+          };
+        }
+      }
+      return {
+        rebooting: true,
+        via: desktopRestore.name,
+        ...rebootTargetFields(),
+        note: desktopDecision.note,
+      };
     }
     // Fire the reboot. IMPORTANT: a "successful" reboot usually looks like a
     // FAILED fetch. The bundled Desktop Manager handler calls exit(0) the instant

--- a/web/js/lib/desktop-restart-restore.js
+++ b/web/js/lib/desktop-restart-restore.js
@@ -1,0 +1,82 @@
+/**
+ * #1999 — Desktop Manager reboot can STOP the Python backend without
+ * anything bringing it back.
+ *
+ * THE REPORT. `panel_restart_comfyui` POSTed ComfyUI-Manager reboot into a
+ * ComfyUI Desktop instance, observed the server go down, then waited out the
+ * readiness budget with `server_ready:false`. The follow-up lifecycle tool
+ * refused because it could not prove a Desktop app still supervised the port.
+ * Newly installed custom nodes stayed unloaded and the user was blocked.
+ *
+ * A Manager reboot is identity-free in mechanism (POST, that server exits).
+ * On Desktop the supervisor that is supposed to spawn the next backend is
+ * the Electron app — and it does not always. A URL is not a relaunch path.
+ *
+ * WHAT THIS MODULE DECIDES. Before that POST:
+ *
+ *   * a Desktop shell with a proven restore function (`restartCore` kills
+ *     and starts the backend; `restartApp` / `relaunchApp` relaunch the
+ *     app) → use that function, never Manager;
+ *   * a Desktop shell without that function → refuse, while the server is
+ *     still up;
+ *   * not a Desktop shell → Manager reboot, unchanged.
+ *
+ * The restore function is the recoverable supervisor/launch route. Calling
+ * it is the bounded recovery. Guessing that Desktop will notice an
+ * `exit(0)` is what left the reporter's server dead.
+ */
+
+/** Desktop APIs that stop AND start. Order is preference, not fallback after a stop. */
+const DESKTOP_RESTORE_FNS = ["restartCore", "restartApp", "relaunchApp"];
+
+/**
+ * @param {unknown} bridge
+ * @returns {{ name: string, restore: () => unknown } | null}
+ */
+export function resolveDesktopRestore(bridge) {
+  if (!bridge || typeof bridge !== "object") return null;
+  const obj = /** @type {Record<string, unknown>} */ (bridge);
+  for (const name of DESKTOP_RESTORE_FNS) {
+    const fn = obj[name];
+    if (typeof fn === "function") {
+      return { name, restore: () => fn.call(obj) };
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {{
+ *   desktopShell?: boolean,
+ *   restore?: { name?: unknown, restore?: unknown } | null,
+ * }} [input]
+ * @returns {{
+ *   kind: "manager_reboot" | "desktop_restore" | "refuse",
+ *   via: string | null,
+ *   note: string,
+ * }}
+ */
+export function decideDesktopRestartRestore({ desktopShell = false, restore = null } = {}) {
+  if (desktopShell !== true) {
+    return { kind: "manager_reboot", via: null, note: "" };
+  }
+  const name = typeof restore?.name === "string" ? restore.name : "";
+  const restoreFn = restore?.restore;
+  if (name && typeof restoreFn === "function") {
+    return {
+      kind: "desktop_restore",
+      via: name,
+      note:
+        `Restarting via ComfyUI Desktop ${name} so the Desktop app restores the backend after stop.`,
+    };
+  }
+  return {
+    kind: "refuse",
+    via: null,
+    note:
+      "Refusing to restart: this is a ComfyUI Desktop instance, and no Desktop relaunch " +
+      "path (restartCore / restartApp / relaunchApp) is available. A Manager reboot would " +
+      "STOP the backend and nothing in this tab can bring it back. Restart it from the " +
+      "ComfyUI Desktop app.",
+  };
+}


### PR DESCRIPTION
## Problem

`panel_restart_comfyui` dispatched a ComfyUI-Manager reboot into a Desktop instance, observed the server go down, then waited out the readiness budget with `server_ready:false` / `panel_tab_reconnected:false`. The follow-up lifecycle tool refused because it could not prove a Desktop app still supervised the port. Newly installed custom nodes stayed unloaded and the user was blocked.

A Manager reboot is `exit(0)` on the Python backend. Desktop is supposed to spawn the next one, and it does not always. The stop had already happened.

## Fix

Before that POST, `comfy_reboot` now consults a proven Desktop relaunch path:

- **Desktop shell + `restartCore` / `restartApp` / `relaunchApp`:** use that Electron API. Those stop *and* start, so Desktop restores the backend after stop.
- **Desktop shell without that path:** refuse while the server is still up. A Manager reboot here is a stop this tab cannot undo.
- **Not Desktop:** Manager reboot, unchanged.

## Tests

`browser_tests/unit/desktop-restart-restore.test.mjs` plus the reboot-target identity branch count.

Fixes #1999
