### PR TITLE
fix(2000): stop chat autoscroll from blocking upward scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- chat autoscroll no longer yanks the transcript back to the bottom while the user is scrolling up: an upward gesture unsticks immediately, including inside the 48px slack, and the stabilizer waits until they return to the bottom or jump to latest (#2000)
+
+
 ## [0.15.141] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/chat-render-containment.test.mjs
+++ b/browser_tests/unit/chat-render-containment.test.mjs
@@ -30,19 +30,25 @@ test("#1801 contains every direct chat message without changing the feed surface
   );
   assert.match(
     source,
-    /import \{ createChatScrollIntentTracker, updateChatStickiness \} from "\.\/lib\/chat-scroll-intent\.js";/,
+    /import \{\s*createChatScrollIntentTracker,\s*isLeavingBottomScrollIntent,\s*updateChatStickiness,\s*\} from "\.\/lib\/chat-scroll-intent\.js";/,
   );
 
   const scrollIntentStart = source.indexOf("const scrollIntent = createChatScrollIntentTracker();");
   assert.ok(scrollIntentStart >= 0, "the production scroll listener must track user intent");
   const scrollListenerEnd = source.indexOf("  const chatScrollStabilizer =", scrollIntentStart);
   const scrollListener = source.slice(scrollIntentStart, scrollListenerEnd);
-  assert.match(scrollListener, /scrollIntent\.consume\(\)/);
+  assert.match(scrollListener, /scrollIntent\.consumeIntent\(\)/);
   assert.match(scrollListener, /scrollIntent\.endProgrammaticScroll\(\)/);
+  assert.match(scrollListener, /isLeavingBottomScrollIntent\(/);
   assert.match(scrollListener, /updateChatStickiness\(/);
   assert.doesNotMatch(scrollListener, /stickToBottom\s*=\s*atBottom\(\)/);
   assert.match(source, /scrollIntent\.noteProgrammaticScroll\(\{ behavior: "smooth" \}\);\s*log\.scrollTo\(/);
   assert.match(source, /beforeScroll: \(\) => scrollIntent\.noteProgrammaticScroll\(\)/);
+  assert.match(
+    source,
+    /shouldStick: \(\) => stickToBottom && !scrollIntent\.hasPending\(\)/,
+    "the stabilizer must not yank while an upward gesture is still pending",
+  );
 
   const ruleStart = source.indexOf(".cmcp-log > :not(.cmcp-empty) {");
   assert.ok(ruleStart >= 0, "the production chat feed must contain its message rule");

--- a/browser_tests/unit/chat-scroll-intent.test.mjs
+++ b/browser_tests/unit/chat-scroll-intent.test.mjs
@@ -5,9 +5,11 @@ import { fileURLToPath } from "node:url";
 
 import {
   createChatScrollIntentTracker,
+  isLeavingBottomScrollIntent,
   isUserScrollIntent,
   updateChatStickiness,
 } from "../../web/js/lib/chat-scroll-intent.js";
+import { createChatScrollStabilizer } from "../../web/js/lib/chat-scroll-stabilizer.js";
 import { revealInteractiveCard } from "../../web/js/lib/interactive-card-reveal.js";
 
 const panelSource = readFileSync(
@@ -86,9 +88,17 @@ function buildProductionScrollSurface(options) {
     "atBottom",
     "createChatScrollIntentTracker",
     "updateChatStickiness",
+    "isLeavingBottomScrollIntent",
     `let stickToBottom = true;\n${productionListener}\nreturn {\n  log,\n  newMsgBtn,\n  scrollIntent,\n  disposeChatScrollListeners,\n  get stickToBottom() { return stickToBottom; },\n};`,
   );
-  return build(log, newMsgBtn, atBottom, createChatScrollIntentTracker, updateChatStickiness);
+  return build(
+    log,
+    newMsgBtn,
+    atBottom,
+    createChatScrollIntentTracker,
+    updateChatStickiness,
+    isLeavingBottomScrollIntent,
+  );
 }
 
 function productionRevealScrollNowSource(painterName) {
@@ -235,6 +245,35 @@ test("non-bottom browser scrolls preserve stickiness, while user scrolls unstick
     true,
     "reaching the bottom always re-sticks",
   );
+  assert.equal(
+    updateChatStickiness(true, { atBottom: true, userScrollIntent: true, leavingBottom: true }),
+    false,
+    "an upward gesture inside the slack zone must unstick",
+  );
+  assert.equal(
+    updateChatStickiness(false, { atBottom: true, userScrollIntent: true, leavingBottom: false }),
+    true,
+    "a downward user scroll that lands on the bottom re-sticks",
+  );
+  assert.equal(
+    updateChatStickiness(true, { atBottom: true, userScrollIntent: true, leavingBottom: false }),
+    true,
+    "a non-leaving user gesture at the bottom stays stuck",
+  );
+});
+
+test("wheel-up and page-up are leaving-bottom intent; wheel-down and pointerdown are not", () => {
+  assert.equal(isLeavingBottomScrollIntent({ type: "wheel", deltaY: -40 }), true);
+  assert.equal(isLeavingBottomScrollIntent({ type: "wheel", deltaY: 40 }), false);
+  assert.equal(isLeavingBottomScrollIntent({ type: "wheel", deltaY: -40, ctrlKey: true }), false);
+  assert.equal(isLeavingBottomScrollIntent({ type: "keydown", key: "ArrowUp" }), true);
+  assert.equal(isLeavingBottomScrollIntent({ type: "keydown", key: "PageUp" }), true);
+  assert.equal(isLeavingBottomScrollIntent({ type: "keydown", key: "Home" }), true);
+  assert.equal(isLeavingBottomScrollIntent({ type: "keydown", key: "ArrowDown" }), false);
+  assert.equal(isLeavingBottomScrollIntent({ type: "keydown", key: "End" }), false);
+  assert.equal(isLeavingBottomScrollIntent({ type: "pointerdown" }), false);
+  assert.equal(isLeavingBottomScrollIntent({ type: "touchmove", deltaY: -12 }), true);
+  assert.equal(isLeavingBottomScrollIntent({ type: "touchmove", deltaY: 12 }), false);
 });
 
 test("production DOM wiring expires input that never scrolls before a later browser scroll", async () => {
@@ -354,6 +393,91 @@ test("keydown in form fields (nested editable elements) counts as scroll intent"
     surface.stickToBottom,
     false,
     "a keydown event on a nested form field must count as scroll intent"
+  );
+
+  surface.disposeChatScrollListeners();
+  surface.scrollIntent.dispose();
+});
+
+test("#2000 wheel-up unsticks immediately, even while still inside the bottom slack", () => {
+  const surface = buildProductionScrollSurface();
+  // True bottom: scrollHeight 1000, clientHeight 100 → scrollTop 900.
+  // Slack is 48px, so 870 is still "at bottom" for atBottom().
+  surface.log._scrollTop = 900;
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, true, "resting at the true bottom stays stuck");
+
+  emit(surface.log, "wheel", { deltaY: -30 });
+  assert.equal(
+    surface.stickToBottom,
+    false,
+    "the upward wheel must unstick before the scroll event lands",
+  );
+  assert.equal(surface.scrollIntent.hasPending(), true);
+
+  surface.log._scrollTop = 870;
+  emit(surface.log, "scroll");
+  assert.equal(
+    surface.stickToBottom,
+    false,
+    "a 30px wheel-up inside the 48px slack must not re-stick",
+  );
+
+  surface.disposeChatScrollListeners();
+  surface.scrollIntent.dispose();
+});
+
+test("#2000 pending upward intent blocks the stabilizer from yanking back to the pin", () => {
+  const surface = buildProductionScrollSurface();
+  surface.log._scrollTop = 900;
+  const frames = [];
+  const stabilizer = createChatScrollStabilizer({
+    log: surface.log,
+    shouldStick: () => surface.stickToBottom && !surface.scrollIntent.hasPending(),
+    beforeScroll: () => surface.scrollIntent.noteProgrammaticScroll(),
+    requestFrame: (fn) => frames.push(fn),
+    ResizeObserverCtor: null,
+    MutationObserverCtor: null,
+  });
+
+  emit(surface.log, "wheel", { deltaY: -80 });
+  assert.equal(surface.stickToBottom, false);
+  surface.log._scrollTop = 860;
+  stabilizer.schedule();
+  assert.equal(frames.length, 0, "schedule must be a no-op while the user is leaving the bottom");
+
+  if (frames.length) frames.shift()();
+  assert.equal(surface.log.scrollTop, 860, "the stabilizer must not overwrite the upward wheel");
+
+  stabilizer.dispose();
+  surface.disposeChatScrollListeners();
+  surface.scrollIntent.dispose();
+});
+
+test("#2000 downward scroll to the latest message re-sticks; anchoring without intent does not unstick", () => {
+  const surface = buildProductionScrollSurface();
+  surface.log._scrollTop = 900;
+  emit(surface.log, "scroll");
+
+  emit(surface.log, "wheel", { deltaY: 80 });
+  assert.equal(surface.stickToBottom, true, "a downward wheel at the pin must not unstick");
+
+  emit(surface.log, "wheel", { deltaY: -80 });
+  surface.log._scrollTop = 820;
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, false, "the reader has left the pin");
+
+  emit(surface.log, "wheel", { deltaY: 80 });
+  surface.log._scrollTop = 900;
+  emit(surface.log, "scroll");
+  assert.equal(surface.stickToBottom, true, "returning to the bottom re-sticks");
+
+  surface.log._scrollTop = 850;
+  emit(surface.log, "scroll");
+  assert.equal(
+    surface.stickToBottom,
+    true,
+    "a content-visibility anchoring scroll without user intent must keep autoscroll",
   );
 
   surface.disposeChatScrollListeners();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -91,7 +91,11 @@ import {
 // it is how this repo keeps producing near-duplicate bugs, per that file's own header.
 import { withTimeout } from "./lib/bounded-step.js";
 import { createChatScrollStabilizer } from "./lib/chat-scroll-stabilizer.js";
-import { createChatScrollIntentTracker, updateChatStickiness } from "./lib/chat-scroll-intent.js";
+import {
+  createChatScrollIntentTracker,
+  isLeavingBottomScrollIntent,
+  updateChatStickiness,
+} from "./lib/chat-scroll-intent.js";
 import { createRunReceiptOutbox } from "./lib/run-receipt-outbox.js";
 import {
   mergeRunCompletionMetadata,
@@ -33116,6 +33120,7 @@ function buildPanel() {
   const onNewMessagesClick = () => {
     stickToBottom = true;
     newMsgBtn.hidden = true;
+    scrollIntent.clearUserIntent();
     scrollIntent.noteProgrammaticScroll({ behavior: "smooth" });
     log.scrollTo({ top: log.scrollHeight, behavior: "smooth" });
     chatScrollStabilizer.schedule();
@@ -33126,9 +33131,16 @@ function buildPanel() {
   // real height; scroll anchoring then emits a browser scroll event with no user intent.
   // Such an event must not latch stickToBottom off while the transcript settles.
   const scrollIntent = createChatScrollIntentTracker();
+  let lastChatScrollTop = log.scrollTop;
   const chatScrollIntentListenerOptions = { passive: true };
   const onChatScrollIntent = (event) => {
     scrollIntent.note(event);
+    // Unstick on the gesture itself. Waiting for the matching scroll event lets
+    // the stabilizer's already-queued rAF overwrite the first wheel ticks while
+    // stickToBottom is still true, so a long streaming turn never leaves the pin.
+    if (isLeavingBottomScrollIntent(event) || scrollIntent.hasLeavingBottom()) {
+      stickToBottom = false;
+    }
   };
   const onChatScrollEnd = (event) => {
     if (event.target !== event.currentTarget) return;
@@ -33137,9 +33149,13 @@ function buildPanel() {
   const onChatLogScroll = (event) => {
     if (event.target !== event.currentTarget) return;
     const isAtBottom = atBottom();
+    const scrolledUp = log.scrollTop < lastChatScrollTop;
+    lastChatScrollTop = log.scrollTop;
+    const { userScrollIntent, leavingBottom } = scrollIntent.consumeIntent();
     stickToBottom = updateChatStickiness(stickToBottom, {
       atBottom: isAtBottom,
-      userScrollIntent: scrollIntent.consume(),
+      userScrollIntent,
+      leavingBottom: leavingBottom || (userScrollIntent && scrolledUp),
     });
     if (isAtBottom) newMsgBtn.hidden = true;
   };
@@ -33157,7 +33173,7 @@ function buildPanel() {
   log.addEventListener("scroll", onChatLogScroll);
   const chatScrollStabilizer = createChatScrollStabilizer({
     log,
-    shouldStick: () => stickToBottom,
+    shouldStick: () => stickToBottom && !scrollIntent.hasPending(),
     beforeScroll: () => scrollIntent.noteProgrammaticScroll(),
   });
   body.appendChild(newMsgBtn);
@@ -36891,6 +36907,7 @@ function buildPanel() {
       forceStick: () => {
         stickToBottom = true;
         newMsgBtn.hidden = true;
+        scrollIntent.clearUserIntent();
       },
       scrollNow: () => {
         scrollIntent.noteProgrammaticScroll();
@@ -37204,6 +37221,7 @@ function buildPanel() {
       forceStick: () => {
         stickToBottom = true;
         newMsgBtn.hidden = true;
+        scrollIntent.clearUserIntent();
       },
       scrollNow: () => {
         scrollIntent.noteProgrammaticScroll();
@@ -37250,6 +37268,7 @@ function buildPanel() {
   function appendUser(text, opts = {}) {
     stickToBottom = true; // your own message → always jump to the latest
     newMsgBtn.hidden = true;
+    scrollIntent.clearUserIntent();
     // Capture the rewind anchor NOW (the latest turn's UUID) so a later rewind to
     // this message forks the conversation right before it — stored directly (not as
     // an index, which a bounded-ring shift() would invalidate).

--- a/web/js/lib/chat-scroll-intent.js
+++ b/web/js/lib/chat-scroll-intent.js
@@ -9,6 +9,8 @@ const VERTICAL_SCROLL_KEYS = new Set([
   "Spacebar",
 ]);
 
+const LEAVING_BOTTOM_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
+
 // Chromium dispatches a user wheel event before its scroll event, but the scroll
 // can land on the next rendering opportunity. Keep the association long enough
 // for that browser ordering without allowing an input that did not scroll to
@@ -22,9 +24,22 @@ export function isUserScrollIntent(event) {
   return event.type === "keydown" && VERTICAL_SCROLL_KEYS.has(event.key);
 }
 
+// True when the gesture is trying to reveal earlier transcript (decrease scrollTop).
+// Distinct from isUserScrollIntent: a downward wheel to the latest message must
+// still re-stick, and a pointerdown on a card is not itself a leave-bottom.
+export function isLeavingBottomScrollIntent(event) {
+  if (!event) return false;
+  if (event.ctrlKey) return false;
+  if (event.type === "wheel") return Number(event.deltaY) < 0;
+  if (event.type === "touchmove" && typeof event.deltaY === "number") return event.deltaY < 0;
+  return event.type === "keydown" && LEAVING_BOTTOM_KEYS.has(event.key);
+}
+
 export function createChatScrollIntentTracker() {
   let pending = false;
+  let pendingLeave = false;
   let pendingTimer = null;
+  let lastTouchY = null;
   let programmatic = [];
   let disposed = false;
 
@@ -44,20 +59,33 @@ export function createChatScrollIntentTracker() {
 
   const clearPending = () => {
     pending = false;
+    pendingLeave = false;
     clearPendingTimer();
   };
 
   return {
     note(event) {
       if (disposed) return;
+      let touchLeaving = false;
+      if (event?.type === "touchmove") {
+        const y = event.touches?.[0]?.clientY;
+        if (typeof y === "number") {
+          touchLeaving = lastTouchY != null && y > lastTouchY;
+          lastTouchY = y;
+        }
+      } else {
+        lastTouchY = null;
+      }
       if (!isUserScrollIntent(event)) return;
       // A new user event owns the next scroll transaction, even if it interrupts
       // an in-flight smooth programmatic scroll.
       clearProgrammatic();
       pending = true;
+      pendingLeave = isLeavingBottomScrollIntent(event) || touchLeaving;
       clearPendingTimer();
       pendingTimer = setTimeout(() => {
         pending = false;
+        pendingLeave = false;
         pendingTimer = null;
       }, USER_SCROLL_INTENT_EXPIRY_MS);
     },
@@ -83,33 +111,52 @@ export function createChatScrollIntentTracker() {
       }
       programmatic = programmatic.filter(({ smooth }) => !smooth);
     },
-    consume() {
-      if (disposed) return false;
+    consumeIntent() {
+      if (disposed) return { userScrollIntent: false, leavingBottom: false };
       if (programmatic.some(({ smooth }) => smooth)) {
         // An app-owned scroll must not spend a genuine user marker. Auto scrolls
         // have one event; smooth scrolls remain guarded until scrollend (or the
         // bounded fallback above).
-        return false;
+        return { userScrollIntent: false, leavingBottom: false };
       }
       const autoIndex = programmatic.findIndex(({ smooth }) => !smooth);
       if (autoIndex !== -1) {
         const [scroll] = programmatic.splice(autoIndex, 1);
         if (scroll.timer !== null) clearTimeout(scroll.timer);
-        return false;
+        return { userScrollIntent: false, leavingBottom: false };
       }
-      const wasPending = pending;
+      const intent = { userScrollIntent: pending, leavingBottom: pendingLeave };
       clearPending();
-      return wasPending;
+      return intent;
+    },
+    consume() {
+      return this.consumeIntent().userScrollIntent;
+    },
+    hasPending() {
+      return !disposed && pending;
+    },
+    hasLeavingBottom() {
+      return !disposed && pendingLeave;
+    },
+    clearUserIntent() {
+      if (disposed) return;
+      lastTouchY = null;
+      clearPending();
     },
     dispose() {
       disposed = true;
+      lastTouchY = null;
       clearPending();
       clearProgrammatic();
     },
   };
 }
 
-export function updateChatStickiness(stickToBottom, { atBottom, userScrollIntent }) {
+export function updateChatStickiness(stickToBottom, { atBottom, userScrollIntent, leavingBottom = false }) {
+  // An upward user gesture must unstick even while still inside BOTTOM_SLACK_PX.
+  // Re-sticking there lets streaming/stabilizer writes overwrite each wheel tick
+  // and the transcript never leaves the pin.
+  if (userScrollIntent && leavingBottom) return false;
   if (atBottom) return true;
   return userScrollIntent ? false : stickToBottom;
 }


### PR DESCRIPTION
## Summary

Fixes #2000. During a long streaming turn, wheel/touch/keyboard scrolling up was overwritten by chat autoscroll. `updateChatStickiness` re-stuck as soon as `scrollTop` was still inside the 48px slack, and the stabilizer's already-queued frame wrote `scrollTop = scrollHeight` before the user's first ticks could accumulate.

## Solution

- Treat an upward gesture (wheel `deltaY < 0`, PageUp/ArrowUp/Home, upward touch) as leave-bottom intent and unstick **on the gesture**, not after the matching scroll event.
- Keep that unstick even while still inside `BOTTOM_SLACK_PX`, so small wheel notches are not yanked back to the pin.
- Pause the scroll stabilizer while user intent is pending (`shouldStick` requires `!scrollIntent.hasPending()`).
- Re-stick only when the user returns to the bottom or uses jump-to-latest / own-message / interactive-card force-stick.

Content-visibility anchoring without user intent still does not unstick (#1841).

## Tests

- `browser_tests/unit/chat-scroll-intent.test.mjs`: wheel-up unsticks immediately inside slack; pending intent blocks the stabilizer; downward scroll to the latest message re-sticks; anchoring without intent keeps autoscroll.
- Production contract in `chat-render-containment.test.mjs` for `consumeIntent`, `isLeavingBottomScrollIntent`, and `shouldStick`.

## Verification

- `node --test browser_tests/unit/chat-scroll-intent.test.mjs browser_tests/unit/chat-render-containment.test.mjs browser_tests/unit/chat-scroll-stabilizer.test.mjs browser_tests/unit/interactive-card-reveal.test.mjs` — pass
- `npm run test:unit` — 7492 pass, 0 fail, 1 todo

Fixes #2000