### PR TITLE
fix(2001): ack inner-subgraph widget writes even if callback/restore hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget acknowledges an inner-subgraph widget write once readback matches, instead of waiting out the 90s relay on a hanging widget callback or parent-rail restore (#2001)
+
 ## [0.15.143] - 2026-08-30
 
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
 - panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
-- panel_set_widget acknowledges an inner-subgraph widget write once readback matches, instead of waiting out the 90s relay on a hanging widget callback or parent-rail restore (#2001)
 
 
 ## [0.15.142] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
 - panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
+- panel_set_widget acknowledges an inner-subgraph widget write once readback matches, instead of waiting out the 90s relay on a hanging widget callback or parent-rail restore (#2001)
 
 
 ## [0.15.142] - 2026-08-30

--- a/browser_tests/unit/set-widget-subgraph-timeout.test.mjs
+++ b/browser_tests/unit/set-widget-subgraph-timeout.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * #2001 — `panel_set_widget` timed out at 90s after an inner-subgraph scalar
+ * write had already stuck. The assignment/readback is the receipt; a widget
+ * callback thenable, a parent-rail restore callback, or a canvas rAF that
+ * never fires must not own the command reply.
+ *
+ * These drive applyWidgetWrite / runSetWidget / withPreservedPromotedInstanceWidgets
+ * — the SAME units the dispatcher uses — so a later `await callback()` or an
+ * unbounded rAF flush fails a test instead of the relay.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { applyWidgetWrite } from "../../web/js/lib/widget-write.js";
+import {
+  runSetWidget,
+  awaitFrontendWidgetFlush,
+  FRONTEND_WIDGET_FLUSH_MS,
+} from "../../web/js/lib/set-widget.js";
+import {
+  collectSubgraphInstanceNodes,
+  restorePromotedInstanceWidgets,
+  snapshotPromotedInstanceWidgets,
+  withPreservedPromotedInstanceWidgets,
+} from "../../web/js/lib/subgraph-instance-widgets.js";
+import { CONTROL_AFTER_GENERATE_MODES } from "../../web/js/lib/control-after-generate.js";
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+const SET_WIDGET_SRC = readFileSync(new URL("../../web/js/lib/set-widget.js", import.meta.url), "utf8");
+
+const NEVER = new Promise(() => {});
+
+function mkCtor() {
+  const c = function NodeCtor() {};
+  c.nodeData = { input: { required: {} } };
+  return c;
+}
+
+function innerKSamplerAdvanced(controlValue = "fixed") {
+  const ctor = mkCtor();
+  return {
+    id: 6,
+    type: "KSamplerAdvanced",
+    constructor: ctor,
+    widgets: [
+      { name: "noise_seed", type: "INT", value: 0 },
+      {
+        name: "control_after_generate",
+        type: "combo",
+        value: controlValue,
+        options: {
+          values: [...CONTROL_AFTER_GENERATE_MODES],
+          serialize: false,
+          canvasOnly: true,
+        },
+      },
+    ],
+  };
+}
+
+function wired(extra = {}) {
+  const r = { KSamplerAdvanced: mkCtor() };
+  return {
+    registry: r,
+    getRegistry: () => r,
+    getFreshObjectInfo: async () => ({ KSamplerAdvanced: {} }),
+    beforeChange() {},
+    afterChange() {},
+    setDirty() {},
+    ...extra,
+  };
+}
+
+function neverFiringFlush() {
+  return awaitFrontendWidgetFlush({
+    setTimer: (fn) => {
+      queueMicrotask(fn);
+      return 1;
+    },
+    clearTimer() {},
+  });
+}
+
+test("#2001 FRONTEND_WIDGET_FLUSH_MS is a short bound, not the 90s relay", () => {
+  assert.equal(FRONTEND_WIDGET_FLUSH_MS, 250);
+  assert.match(SET_WIDGET_SRC, /withTimeout\(flush, FRONTEND_WIDGET_FLUSH_MS/);
+});
+
+test("#2001 awaitFrontendWidgetFlush resolves when rAF never fires", async () => {
+  const previousRaf = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = () => 1;
+  try {
+    await awaitFrontendWidgetFlush({
+      setTimer: (fn) => {
+        queueMicrotask(fn);
+        return 1;
+      },
+      clearTimer() {},
+    });
+  } finally {
+    if (previousRaf === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = previousRaf;
+  }
+});
+
+test("#2001 an inner control_after_generate write still replies when rAF never fires", async () => {
+  const previousRaf = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = () => 1;
+  try {
+    const node = innerKSamplerAdvanced("fixed");
+    const res = await runSetWidget(node, "control_after_generate", "randomize", {
+      ...wired(),
+      awaitFrontendWidgetFlush: neverFiringFlush,
+    });
+    assert.equal(res.set.value, "randomize");
+    assert.equal(res.set.previous, "fixed");
+    assert.equal(node.widgets[1].value, "randomize");
+  } finally {
+    if (previousRaf === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = previousRaf;
+  }
+});
+
+test("#2001 applyWidgetWrite does not wait on a hanging widget-callback thenable", () => {
+  const node = innerKSamplerAdvanced("fixed");
+  node.widgets[1].callback = () => NEVER;
+  const set = applyWidgetWrite(node, "control_after_generate", "randomize", {});
+  assert.equal(set.value, "randomize");
+  assert.equal(node.widgets[1].value, "randomize");
+});
+
+test("#2001 applyWidgetWrite does not wait on a hanging options.setValue thenable", () => {
+  const node = innerKSamplerAdvanced("fixed");
+  node.widgets[1].options.setValue = () => NEVER;
+  const set = applyWidgetWrite(node, "control_after_generate", "randomize", {});
+  assert.equal(set.value, "randomize");
+  assert.equal(node.widgets[1].value, "randomize");
+});
+
+test("#2001 restore does not wait on a hanging parent-rail callback thenable", () => {
+  const subgraph = { id: "sg-uuid", _nodes: [] };
+  const store = { value: "INSTANCE-A" };
+  const widgetId = "g:82:text";
+  const rail = {
+    name: "text",
+    widgetId,
+    get value() {
+      return store.value;
+    },
+    set value(next) {
+      store.value = next;
+    },
+    callback() {
+      return NEVER;
+    },
+  };
+  const node = {
+    id: 82,
+    type: subgraph.id,
+    subgraph,
+    inputs: [{ name: "text", widgetId }],
+    widgets: [rail],
+  };
+  const root = { _nodes: [node] };
+  const snap = snapshotPromotedInstanceWidgets(root, subgraph);
+  store.value = "";
+  const res = restorePromotedInstanceWidgets(root, snap);
+  assert.equal(res.restored, 1);
+  assert.equal(store.value, "INSTANCE-A");
+});
+
+test("#2001 withPreserved still returns a landed inner mutation when restore throws", async () => {
+  const subgraph = { id: "sg-uuid", _nodes: [] };
+  const rail = {
+    name: "text",
+    widgetId: "g:82:text",
+    value: "keep-me",
+  };
+  let restoring = false;
+  const wrapper = {
+    id: 82,
+    type: subgraph.id,
+    subgraph,
+    get inputs() {
+      if (restoring) throw new Error("restore exploded");
+      return [{ name: "text", widgetId: "g:82:text" }];
+    },
+    widgets: [rail],
+  };
+  const root = { _nodes: [wrapper] };
+  const out = await withPreservedPromotedInstanceWidgets(root, subgraph, () => {
+    restoring = true;
+    rail.value = "";
+    return { set: { node_id: 6, widget: "control_after_generate", value: "randomize" } };
+  });
+  assert.equal(out.set.value, "randomize");
+});
+
+test("#2001 withPreserved returns the inner mutation result even when restore callbacks hang", async () => {
+  const subgraph = { id: "sg-uuid", _nodes: [{ id: 6, type: "KSamplerAdvanced" }] };
+  const store = { value: "keep-me" };
+  const widgetId = "g:82:text";
+  const rail = {
+    name: "text",
+    widgetId,
+    get value() {
+      return store.value;
+    },
+    set value(next) {
+      store.value = next;
+    },
+    callback() {
+      return NEVER;
+    },
+  };
+  const wrapper = {
+    id: 82,
+    type: subgraph.id,
+    subgraph,
+    inputs: [{ name: "text", widgetId }],
+    widgets: [rail],
+  };
+  const root = { _nodes: [wrapper] };
+  const out = await withPreservedPromotedInstanceWidgets(root, subgraph, () => {
+    store.value = "";
+    return { set: { node_id: 6, widget: "control_after_generate", value: "randomize" } };
+  });
+  assert.equal(out.set.value, "randomize");
+  assert.equal(store.value, "keep-me", "the rail restore still landed");
+});
+
+test("#2001 collectSubgraphInstanceNodes stops when subgraph identity is a new object each read", () => {
+  let reads = 0;
+  const node = {
+    id: 1,
+    type: "sg-uuid",
+    get subgraph() {
+      reads += 1;
+      return { id: "sg-uuid", _nodes: [] };
+    },
+  };
+  const found = collectSubgraphInstanceNodes({ _nodes: [node] }, { id: "sg-uuid" });
+  assert.ok(found.some((n) => n.id === 1));
+  assert.ok(reads <= 10000 + 2, `walk must be capped, got ${reads} subgraph reads`);
+});
+
+test("#2001 inner subgraph mutations still run inside the preserve wrapper", () => {
+  assert.match(PANEL_SRC, /withPreservedPromotedInstanceWidgets/);
+  assert.match(
+    PANEL_SRC,
+    /visibleMutationTarget\.graph !== visibleMutationTarget\.rootGraph/,
+  );
+});

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -117,11 +117,12 @@ export const COMBO_REFRESH_NEVER_RAN = Symbol("combo-refresh-never-ran");
  * that itself queues work is visible. No rAF in Node tests → two microtasks,
  * so existing runSetWidget tests do not hang or grow a timer.
  *
- * #1995 — the wait is BOUNDED. After reconnect a backgrounded tab never fires
- * rAF, so an unbounded frame wait held the reply until the relay timed out
- * while the callback had already applied the value. The bound is long enough
- * for a visible frame and short enough that an applied write still gets a
- * receipt. Injectable timers so tests can fire the bound without sleeping.
+ * #1995/#2001 — the wait is BOUNDED. After reconnect, or after an inner-subgraph
+ * widget write, a backgrounded tab / stopped canvas loop never fires rAF, so an
+ * unbounded frame wait held the reply until the relay timed out while the
+ * assignment had already stuck. The bound is long enough for a visible frame
+ * and short enough that an applied write still gets a receipt. Injectable
+ * timers so tests can fire the bound without sleeping.
  */
 export const FRONTEND_WIDGET_FLUSH_MS = 250;
 

--- a/web/js/lib/subgraph-instance-widgets.js
+++ b/web/js/lib/subgraph-instance-widgets.js
@@ -17,6 +17,15 @@
 
 import { promotedValueScope } from "./widget-write.js";
 
+function detachThenable(value) {
+  if (value == null || typeof value.then !== "function") return;
+  try {
+    value.then(undefined, () => {});
+  } catch {
+    /* a throwing then() is not a restore verdict */
+  }
+}
+
 function cloneValue(value) {
   if (value == null || typeof value !== "object") return value;
   try {
@@ -53,13 +62,20 @@ function subgraphIdentity(subgraph) {
  * AND the type UUID (`SubgraphNode.type === subgraph.id`); match either so a
  * clone that did not keep object identity still restores.
  */
+/** Hard cap on graphs visited while collecting instances. A `node.subgraph`
+ *  getter that yields a new object each time would otherwise walk forever, and
+ *  that walk sits on the post-mutation restore path (#2001). */
+const MAX_SUBGRAPH_WALKS = 10000;
+
 export function collectSubgraphInstanceNodes(rootGraph, subgraph) {
   const out = [];
   if (!rootGraph || !subgraph) return out;
   const wantId = subgraphIdentity(subgraph);
   const stack = [rootGraph];
   const seen = new Set();
+  let walks = 0;
   while (stack.length) {
+    if (++walks > MAX_SUBGRAPH_WALKS) break;
     const graph = stack.pop();
     if (!graph || seen.has(graph)) continue;
     seen.add(graph);
@@ -196,7 +212,11 @@ export function restorePromotedInstanceWidgets(rootGraph, snapshot) {
     }
     if (typeof found.rail.callback === "function") {
       try {
-        found.rail.callback(next);
+        // #2001 — the setter is the store. A callback that returns a thenable
+        // (PromotedWidgetView forwarding into openSubgraph / Vue nextTick) must
+        // not own the inner-mutation reply. Detach; a throw still must not undo
+        // the landed restore.
+        detachThenable(found.rail.callback(next));
       } catch {
         /* setter is the store; a callback throw must not undo a landed restore */
       }
@@ -330,6 +350,10 @@ export async function withPreservedPromotedInstanceWidgets(rootGraph, subgraph, 
     } catch {
       /* a hostile thenable must not skip restore */
     }
-    restorePromotedInstanceWidgets(rootGraph, snapshot);
+    try {
+      restorePromotedInstanceWidgets(rootGraph, snapshot);
+    } catch {
+      /* #2001 — a restore throw must not turn a landed inner mutation into a missing reply */
+    }
   }
 }

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1867,6 +1867,15 @@ function assignLiveCustomText(widget, coerced) {
 }
 
 /** Assign a widget value and drive options.setValue when present (store-backed rails). */
+function detachThenable(value) {
+  if (value == null || typeof value.then !== "function") return;
+  try {
+    value.then(undefined, () => {});
+  } catch {
+    /* a throwing then() is not a write verdict */
+  }
+}
+
 function assignWidgetValue(widget, coerced) {
   if (typeof coerced === "string" && isLiveCustomTextWidget(widget)) {
     assignLiveCustomText(widget, coerced);
@@ -1875,7 +1884,7 @@ function assignWidgetValue(widget, coerced) {
   widget.value = coerced;
   try {
     const setValue = widget.options?.setValue;
-    if (typeof setValue === "function") setValue.call(widget, coerced);
+    if (typeof setValue === "function") detachThenable(setValue.call(widget, coerced));
   } catch {
     /* verification below still decides whether the value stuck */
   }
@@ -2943,11 +2952,14 @@ export function applyWidgetWrite(
       if (widgetCallback !== null && widgetCallback !== undefined) {
         const callbackArgs = [coerced, canvas, valueNode, valueNode.pos, undefined];
         threwFromCallback = true;
-        const callbackResult = reflectApply(widgetCallback, valueWidget, callbackArgs);
+        const callbackRet = reflectApply(widgetCallback, valueWidget, callbackArgs);
         threwFromCallback = false; // reached only when it RETURNED — a throw leaves it set
-        // A thenable is an unacked frontend callback. Never wait for it: a
-        // customtext Promise that never settles is the #2020 hang.
-        void callbackResult;
+        // #2001/#2020 — a callback that RETURNS a thenable (subgraph navigation,
+        // Vue nextTick, customtext, an openSubgraph receipt) has already been
+        // invoked. Awaiting it would own the command reply for as long as that
+        // work stays pending. Detach: a later rejection must not become an
+        // unhandled-rejection, and the assignment above is the receipt.
+        detachThenable(callbackRet);
       }
     }
     // #1533 — AFTER the callback, still inside this envelope so afterChange


### PR DESCRIPTION
## Summary
`panel_set_widget` applied a scalar on an inner KSamplerAdvanced (`control_after_generate`) then waited out the 90s relay: readback already showed `randomize`, but no reply left the tab.

The assignment/readback is the receipt. After that:

- do not await a widget callback or `options.setValue` thenable (subgraph navigation / Vue nextTick)
- do not await a parent-rail restore callback on the inner-mutation preserve path
- cap the subgraph-instance walk so a new-object `node.subgraph` getter cannot loop forever
- swallow a restore throw so it cannot replace a landed inner mutation with a missing reply

#1995 already bounds the post-write rAF flush; this keeps that bound and covers the inner-subgraph preserve path the reporter hit.

## Test plan
- `node --test browser_tests/unit/set-widget-subgraph-timeout.test.mjs`
- `node --test browser_tests/unit/subgraph-instance-widgets.test.mjs browser_tests/unit/widget-write.test.mjs browser_tests/unit/delivery-ack.test.mjs browser_tests/unit/primitive-widget-retain.test.mjs`

Fixes #2001