### PR TITLE
fix(#2004): explicit copy_nodes node_ids replace a stale additive selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
+- panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
 
 ## [0.15.142] - 2026-08-30
 

--- a/browser_tests/unit/copy-paste-layout.test.mjs
+++ b/browser_tests/unit/copy-paste-layout.test.mjs
@@ -713,3 +713,30 @@ test("shipped copy still fails loud on a missing node_id", () => {
   const { copy } = shippedCopyPaste(src.graph, src.canvas, src.LG);
   assert.throws(() => copy({ node_ids: [src.graph._nodes[0].id, 99999] }), /not found/);
 });
+
+test("#2004 explicit node_ids copy does not keep a stale additive selection", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  const src = makeBranchedGraph();
+  // Frontend 1.41-style: selectItems ADDS to the current Set instead of replacing it.
+  src.canvas.selectItems = function (items) {
+    for (const it of items ?? []) this.selectedItems.add(it);
+  };
+  const stale = src.branches[0];
+  src.canvas.selectedItems = new Set([stale.lora, stale.sampler, stale.group]);
+  src.canvas.selected_nodes = {
+    [stale.lora.id]: stale.lora,
+    [stale.sampler.id]: stale.sampler,
+  };
+
+  const { copy } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+  const target = src.branches[4].sampler;
+  const copied = copy({ node_ids: [target.id] });
+  assert.equal(copied.copied, 1, "only the requested node is copied");
+  assert.equal(copied.copied_groups, 0, "stale fully-selected group is not copied");
+
+  const payload = JSON.parse(getInMemoryClipboard());
+  assert.equal(payload.nodes.length, 1, "clipboard contains only the requested node");
+  assert.equal(payload.nodes[0].id, target.id);
+  assert.equal(payload.groups.length, 0, "clipboard itself has no leftover group");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -24723,6 +24723,12 @@ const GRAPH_TOOL_EXECUTORS = {
         throw new Error(`node_ids not found in the current graph: ${missing.join(", ")}`);
       }
       const ns = resolved.map((r) => r.node);
+      // #2004: some frontends' selectItems is additive, so leftover nodes/groups
+      // would otherwise stay selected and be serialized with the explicit ids.
+      canvas.selectedItems?.clear?.();
+      if (canvas.selected_nodes && typeof canvas.selected_nodes === "object") {
+        for (const id of Object.keys(canvas.selected_nodes)) delete canvas.selected_nodes[id];
+      }
       if (typeof canvas.selectItems === "function") canvas.selectItems(ns);
       else if (typeof canvas.selectNodes === "function") canvas.selectNodes(ns);
     }


### PR DESCRIPTION
`panel_copy_nodes({node_ids:[...]})` called `canvas.selectItems(ns)` without clearing first. On ComfyUI frontend 1.41, `selectItems` is additive, so a leftover group (for example a selected ControlNet group) stayed selected and was serialized into the clipboard. Paste then created the stale group plus its nodes instead of only the requested id.

Clear `selectedItems` and `selected_nodes` before selecting the explicit set. A regression test drives an additive `selectItems` with a stale node/group selection and asserts the clipboard contains only the requested node.

Fixes #2004