### PR TITLE
fix(#2005): accept legacy proxyWidgets object/null metadata on save_subgraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
 - panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
+- panel_save_subgraph rewrites legacy proxyWidgets object/null metadata to the string-tuple schema before publishing, and refuses with the affected inner node/widget and a demote repair when that mapping cannot be proved lossless (#2005)
 
 
 ## [0.15.142] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_set_widget acknowledges an inner-subgraph widget write once readback matches, instead of waiting out the 90s relay on a hanging widget callback or parent-rail restore (#2001)
 - panel_promote_widget refuses canvas-only callback widgets (control_after_generate) and writes only [nodeId, widgetName] string pairs through the legacy promotion store, so saved workflows stay loadable (#2002)
+- panel_save_subgraph rewrites legacy proxyWidgets object/null metadata to the string-tuple schema before publishing, and refuses with the affected inner node/widget and a demote repair when that mapping cannot be proved lossless (#2005)
 
 
 ## [0.15.143] - 2026-08-30
@@ -22,7 +23,6 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
 - panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
-- panel_save_subgraph rewrites legacy proxyWidgets object/null metadata to the string-tuple schema before publishing, and refuses with the affected inner node/widget and a demote repair when that mapping cannot be proved lossless (#2005)
 
 
 ## [0.15.142] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_set_widget on a subgraph's promoted widget writes the enclosing container rail even when the call lands on the inner link-driven terminal, instead of reporting applied while the parent value stays stale (#2109)
 - live graph reads recover after a manual canvas edit: a hung panel_graph_outline no longer pins retries, tracker snapshot flush stays mutation-only, and image/canvas widget values are clipped without a full stringify that could miss the 20s RPC window (#2003)
+- panel_save_subgraph rewrites legacy proxyWidgets object/null metadata to the string-tuple schema before publishing, and refuses with the affected inner node/widget and a demote repair when that mapping cannot be proved lossless (#2005)
 
 ## [0.15.144] - 2026-08-30
 
 ### Fixed
 - panel_set_widget acknowledges an inner-subgraph widget write once readback matches, instead of waiting out the 90s relay on a hanging widget callback or parent-rail restore (#2001)
 - panel_promote_widget refuses canvas-only callback widgets (control_after_generate) and writes only [nodeId, widgetName] string pairs through the legacy promotion store, so saved workflows stay loadable (#2002)
-- panel_save_subgraph rewrites legacy proxyWidgets object/null metadata to the string-tuple schema before publishing, and refuses with the affected inner node/widget and a demote repair when that mapping cannot be proved lossless (#2005)
 
 
 ## [0.15.143] - 2026-08-30

--- a/browser_tests/unit/subgraph-proxy-widgets.test.mjs
+++ b/browser_tests/unit/subgraph-proxy-widgets.test.mjs
@@ -1,0 +1,322 @@
+// #2005 — panel_save_subgraph must accept promoted legacy proxyWidgets
+// object/null metadata by rewriting it to the string-tuple schema the
+// frontend publisher validates, or refuse with a repair action before
+// publishSubgraph is invoked.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  classifyLegacyProxyWidgetEntry,
+  legacyProxyWidgetsRefusalMessage,
+  normalizeLegacyProxyWidgets,
+  prepareSubgraphProxyWidgetsForPublish,
+} from "../../web/js/lib/subgraph-proxy-widgets.js";
+
+function inner(id, widgetNames) {
+  return {
+    id,
+    type: "KSamplerAdvanced",
+    widgets: widgetNames.map((name) => ({ name, value: `${name}-inner` })),
+  };
+}
+
+function subgraphNode(proxyWidgets, { nodes = [inner(6, ["seed", "control_after_generate"])], widgets = [], inputs = [] } = {}) {
+  const byId = new Map(nodes.map((node) => [String(node.id), node]));
+  return {
+    id: 10,
+    title: "Sampling Core",
+    widgets: [...widgets],
+    inputs: [...inputs],
+    properties: { proxyWidgets },
+    subgraph: {
+      _nodes: nodes,
+      getNodeById(id) {
+        return byId.get(String(id)) ?? null;
+      },
+    },
+  };
+}
+
+test("#2005 already-canonical string tuples pass through unchanged", () => {
+  const raw = [
+    ["6", "seed"],
+    ["6", "control_after_generate"],
+  ];
+  const result = normalizeLegacyProxyWidgets(raw, {
+    subgraphNode: subgraphNode(raw),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.tuples, raw);
+});
+
+test("#2005 numeric node ids coerce to the string schema", () => {
+  const node = subgraphNode([[6, "seed"]]);
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.tuples, [["6", "seed"]]);
+});
+
+test("#2005 a 3-string tuple is kept (the publisher accepts it)", () => {
+  const raw = [["6", "seed", "INT"]];
+  const result = normalizeLegacyProxyWidgets(raw, { subgraphNode: subgraphNode(raw) });
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.tuples, raw);
+});
+
+test("#2005 absent proxyWidgets is a no-op, not an empty rewrite", () => {
+  const node = subgraphNode(undefined);
+  delete node.properties.proxyWidgets;
+  const result = prepareSubgraphProxyWidgetsForPublish(node);
+  assert.equal(result.changed, false);
+  assert.equal(node.properties.proxyWidgets, undefined);
+});
+
+test("#2005 the reported legacy-store shape [sourceObject, null] resolves", () => {
+  const source = { sourceNodeId: "6", sourceWidgetName: "control_after_generate" };
+  const node = subgraphNode([["6", "seed"], ["6", "steps"], ["6", "cfg"], [source, null]], {
+    nodes: [inner(6, ["seed", "steps", "cfg", "control_after_generate"])],
+  });
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.equal(result.resolved, 1);
+  assert.deepEqual(result.tuples[3], ["6", "control_after_generate"]);
+});
+
+test("#2005 interiorNodeId/widgetName objects resolve the same way", () => {
+  const node = subgraphNode([[{ interiorNodeId: 6, widgetName: "seed" }, null]]);
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.tuples, [["6", "seed"]]);
+});
+
+test("#2005 null placeholders are dropped, not rewritten into empty strings", () => {
+  const node = subgraphNode([["6", "seed"], null, [null, null], []]);
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.equal(result.dropped, 3);
+  assert.deepEqual(result.tuples, [["6", "seed"]]);
+});
+
+test("#2005 a live widget object is resolved by identity, not by guessing .id", () => {
+  const control = { name: "control_after_generate", type: "combo", value: "randomize", id: "widget-uuid" };
+  const ksampler = { id: 6, type: "KSamplerAdvanced", widgets: [{ name: "seed", value: 1 }, control] };
+  const node = subgraphNode([[control, null]], { nodes: [ksampler] });
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.tuples, [["6", "control_after_generate"]]);
+});
+
+test("#2005 a widget object's own .id is never treated as the inner node id", () => {
+  const classified = classifyLegacyProxyWidgetEntry(
+    [{ name: "control_after_generate", id: "widget-uuid" }, null],
+    subgraphNode([["6", "seed"]], { nodes: [inner(6, ["seed"])] }),
+  );
+  assert.equal(classified.kind, "refuse");
+  assert.notEqual(classified.nodeId, "widget-uuid");
+});
+
+test("#2005 [innerNode, widgetName] resolves from the node object", () => {
+  const ksampler = inner(6, ["seed", "control_after_generate"]);
+  ksampler.name = "KSampler Advanced";
+  const node = subgraphNode([[ksampler, "control_after_generate"]], { nodes: [ksampler] });
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.tuples, [["6", "control_after_generate"]]);
+});
+
+test("#2005 an object that names a missing inner widget refuses", () => {
+  const node = subgraphNode([[{ sourceNodeId: "6", sourceWidgetName: "does_not_exist" }, null]]);
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, false);
+  assert.equal(result.affected[0].nodeId, "6");
+  assert.equal(result.affected[0].widgetName, "does_not_exist");
+  assert.match(result.affected[0].reason, /not on the live subgraph/);
+});
+
+test("#2005 an unreadable object without identifiers refuses at that index", () => {
+  const node = subgraphNode([["6", "seed"], [{}, null]]);
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, false);
+  assert.equal(result.affected[0].index, 1);
+  assert.match(legacyProxyWidgetsRefusalMessage(result.affected), /index 1/);
+  assert.match(
+    legacyProxyWidgetsRefusalMessage(result.affected),
+    /panel_promote_widget|demote/,
+  );
+});
+
+test("#2005 an ambiguous inner widget name is not guessed", () => {
+  const widget = { name: "seed", type: "INT", value: 1 };
+  const node = subgraphNode([[widget, null]], {
+    nodes: [
+      { id: 6, widgets: [{ name: "seed", value: 1 }] },
+      { id: 7, widgets: [{ name: "seed", value: 2 }] },
+    ],
+  });
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, false);
+  assert.match(result.affected[0].reason, /not which inner node|no inner node id/i);
+});
+
+test("#2005 a unique inner widget name is enough when the object has no node id", () => {
+  const node = subgraphNode([[{ name: "control_after_generate" }, null]]);
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.tuples, [["6", "control_after_generate"]]);
+});
+
+test("#2005 a four-slot tuple is unreadable, not silently trimmed", () => {
+  const node = subgraphNode([["6", "seed", "INT", "extra"]]);
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, false);
+  assert.match(result.affected[0].reason, /more than three/);
+});
+
+test("#2005 a non-array proxyWidgets property refuses rather than inventing []", () => {
+  const result = normalizeLegacyProxyWidgets("seed", { subgraphNode: subgraphNode(["seed"]) });
+  assert.equal(result.ok, false);
+  assert.match(result.affected[0].reason, /not an array/);
+});
+
+test("#2005 already-canonical tuples are not re-proved against the inner graph", () => {
+  // A quarantined promotion can remain as a string tuple after load. Save must
+  // still publish it — re-checking would refuse graphs the frontend is holding.
+  const raw = [["99", "ghost"]];
+  const result = normalizeLegacyProxyWidgets(raw, { subgraphNode: subgraphNode(raw) });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.tuples, raw);
+});
+
+test("#2005 prepare writes the string tuples onto the live node", () => {
+  const source = { sourceNodeId: "6", sourceWidgetName: "control_after_generate" };
+  const node = subgraphNode([
+    ["6", "seed"],
+    [source, null],
+    null,
+  ]);
+  const result = prepareSubgraphProxyWidgetsForPublish(node);
+  assert.equal(result.changed, true);
+  assert.equal(result.resolved, 1);
+  assert.equal(result.dropped, 1);
+  assert.deepEqual(node.properties.proxyWidgets, [
+    ["6", "seed"],
+    ["6", "control_after_generate"],
+  ]);
+});
+
+test("#2005 prepare is a no-op when the metadata is already string tuples", () => {
+  const node = subgraphNode([["6", "seed"]]);
+  const original = node.properties.proxyWidgets;
+  const result = prepareSubgraphProxyWidgetsForPublish(node);
+  assert.equal(result.changed, false);
+  assert.equal(node.properties.proxyWidgets, original);
+});
+
+test("#2005 prepare refuses and restores when rewriting would drop a rail value", () => {
+  const source = { sourceNodeId: "6", sourceWidgetName: "seed" };
+  const node = subgraphNode([[source, null]], {
+    widgets: [{ name: "seed", value: "before" }],
+  });
+  let stored = node.properties.proxyWidgets;
+  Object.defineProperty(node.properties, "proxyWidgets", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return stored;
+    },
+    set(next) {
+      stored = next;
+      node.widgets = [];
+    },
+  });
+  assert.throws(
+    () => prepareSubgraphProxyWidgetsForPublish(node),
+    (err) => {
+      assert.match(err.message, /would not preserve promoted values or rail bindings/);
+      return true;
+    },
+  );
+  assert.equal(stored[0][0], source);
+});
+
+test("#2005 prepare refuses an unproven mapping before any write", () => {
+  const node = subgraphNode([[{ sourceNodeId: "6", sourceWidgetName: "missing" }, null]]);
+  const original = node.properties.proxyWidgets;
+  assert.throws(
+    () => prepareSubgraphProxyWidgetsForPublish(node),
+    (err) => {
+      assert.match(err.message, /panel_save_subgraph cannot publish/);
+      assert.match(err.message, /inner node 6 widget "missing"/);
+      assert.match(err.message, /panel_promote_widget\(\{node_id: "6", widget: "missing", demote: true\}\)/);
+      return true;
+    },
+  );
+  assert.equal(node.properties.proxyWidgets, original);
+});
+
+test("#2005 additive host widgets after a successful rewrite are not a loss", () => {
+  const source = { sourceNodeId: "6", sourceWidgetName: "control_after_generate" };
+  const node = subgraphNode([["6", "seed"], [source, null]], {
+    widgets: [{ name: "seed", value: 111 }],
+    inputs: [{ name: "seed", link: 9, widgetId: "w-seed" }],
+  });
+  const result = prepareSubgraphProxyWidgetsForPublish(node);
+  assert.equal(result.changed, true);
+  assert.equal(node.widgets[0].value, 111);
+  assert.equal(node.inputs[0].link, 9);
+});
+
+test("#2005 host-level -1 promotions coerce without looking up an inner node", () => {
+  const node = subgraphNode([[-1, "seed"]], {
+    widgets: [{ name: "seed", value: 1 }],
+    nodes: [inner(6, ["steps"])],
+  });
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.tuples, [["-1", "seed"]]);
+});
+
+test("#2005 mixed canonical and legacy entries keep order of the real promotions", () => {
+  const node = subgraphNode([
+    ["6", "seed"],
+    [{ sourceNodeId: "6", sourceWidgetName: "control_after_generate" }, null],
+    null,
+    ["6", "cfg"],
+  ], {
+    nodes: [inner(6, ["seed", "cfg", "control_after_generate"])],
+  });
+  const result = normalizeLegacyProxyWidgets(node.properties.proxyWidgets, { subgraphNode: node });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.tuples, [
+    ["6", "seed"],
+    ["6", "control_after_generate"],
+    ["6", "cfg"],
+  ]);
+});
+
+// ── wiring: the production save path actually runs this before publish ──────
+
+const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+const saveSite = src.slice(
+  src.indexOf("async graph_save_subgraph("),
+  src.indexOf("graph_list_subgraphs({ filter, limit } = {})"),
+);
+
+test("#2005 graph_save_subgraph imports the proxyWidgets preparer", () => {
+  assert.match(
+    src,
+    /import \{ prepareSubgraphProxyWidgetsForPublish \} from "\.\/lib\/subgraph-proxy-widgets\.js";/,
+  );
+});
+
+test("#2005 graph_save_subgraph rewrites proxyWidgets before either publish call", () => {
+  const prepareAt = saveSite.indexOf("prepareSubgraphProxyWidgetsForPublish(target)");
+  assert.ok(prepareAt >= 0, "the save path must call the preparer on the subgraph node");
+  const overwritePublish = saveSite.indexOf("store.publishSubgraph(finalName)");
+  const firstPublish = saveSite.indexOf("await store.publishSubgraph(finalName);");
+  assert.ok(overwritePublish > prepareAt, "rewrite must happen before the overwrite publish");
+  assert.ok(firstPublish > prepareAt, "rewrite must happen before the first-publish call");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -494,6 +494,7 @@ import {
   subgraphSaveCollisionAction,
   withBlueprintOverwriteConfirm,
 } from "./lib/subgraph-blueprint-overwrite.js";
+import { prepareSubgraphProxyWidgetsForPublish } from "./lib/subgraph-proxy-widgets.js";
 import {
   threadMatchesCurrentWorkflow,
   currentWorkflowIdentityKeys,
@@ -25052,6 +25053,10 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     const finalName =
       typeof name === "string" && name.trim() ? name.trim() : target.title || "Subgraph";
+    // #2005 — the publisher validates properties.proxyWidgets as string
+    // tuples. A legacy-store promote leaves [object, null] entries the
+    // schema rejects. Rewrite them first, or refuse with a repair action.
+    prepareSubgraphProxyWidgetsForPublish(target);
     const prefix = store.typePrefix ?? "SubgraphBlueprint.";
     const fullType = `${prefix}${finalName}`;
     // #636: the collision preflight must not depend on reconstructing the store's own

--- a/web/js/lib/subgraph-proxy-widgets.js
+++ b/web/js/lib/subgraph-proxy-widgets.js
@@ -1,0 +1,624 @@
+/**
+ * #2005 — `panel_save_subgraph` publishes through ComfyUI's subgraph store,
+ * which validates `properties.proxyWidgets` as an array of string tuples
+ * (`[nodeId, widgetName]` or `[nodeId, widgetName, extra]`). A legacy-store
+ * promote — the path `panel_promote_widget` takes when the widget has no
+ * connectable slot — writes `[{ sourceNodeId, sourceWidgetName }, null]`
+ * instead, and publish throws:
+ *
+ *   Invalid assignment for properties.proxyWidgets: Validation error:
+ *   Expected string, received object at "[n][0]"; Expected string,
+ *   received null at "[n][1]"
+ *
+ * The publisher is the frontend; this module cannot change its schema. It
+ * rewrites the live node's metadata to the string form the schema wants,
+ * but only when that rewrite is a proven lossless mapping of the same
+ * promotions. A guess would publish a blueprint whose promoted widgets are
+ * not the ones the instance actually has.
+ *
+ * Null placeholders are dropped. Object entries are resolved to a concrete
+ * inner node id and widget name. If either step cannot be proved against the
+ * live subgraph, the save is refused with the affected names and a repair
+ * action — before `publishSubgraph` is invoked.
+ */
+
+function asNodeId(value) {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function asWidgetName(value) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function cloneValue(value) {
+  if (value == null || typeof value !== "object") return value;
+  try {
+    if (typeof structuredClone === "function") return structuredClone(value);
+  } catch {
+    /* JSON fallback below */
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
+}
+
+function valuesMatch(a, b) {
+  if (Object.is(a, b)) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function innerNodes(subgraphNode) {
+  const subgraph = subgraphNode?.subgraph;
+  if (!subgraph || typeof subgraph !== "object") return [];
+  if (Array.isArray(subgraph._nodes)) return subgraph._nodes;
+  if (Array.isArray(subgraph.nodes)) return subgraph.nodes;
+  return [];
+}
+
+function innerNodeById(subgraphNode, nodeId) {
+  if (nodeId == null) return null;
+  const subgraph = subgraphNode?.subgraph;
+  if (subgraph && typeof subgraph.getNodeById === "function") {
+    try {
+      const found = subgraph.getNodeById(nodeId);
+      if (found) return found;
+    } catch {
+      /* fall through to a numeric / list lookup */
+    }
+    if (typeof nodeId === "string" && /^-?(?:0|[1-9]\d*)$/.test(nodeId)) {
+      try {
+        const byNumber = subgraph.getNodeById(Number(nodeId));
+        if (byNumber) return byNumber;
+      } catch {
+        /* list lookup below */
+      }
+    }
+  }
+  const want = String(nodeId);
+  return innerNodes(subgraphNode).find((node) => String(node?.id) === want) ?? null;
+}
+
+function nodeHasWidget(node, widgetName) {
+  if (!node || !asWidgetName(widgetName)) return false;
+  try {
+    return (node.widgets ?? []).some((widget) => widget?.name === widgetName);
+  } catch {
+    return false;
+  }
+}
+
+function looksLikeGraphNode(obj) {
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) return false;
+  if (Array.isArray(obj.widgets) || Array.isArray(obj.inputs) || obj.subgraph) return true;
+  return false;
+}
+
+function identifiersFromObject(obj) {
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) return null;
+  // A live graph node often has a title `name` that is NOT a widget. Never
+  // take obj.name as a widget identifier on that shape — the paired tuple
+  // slot (or sourceWidgetName/widgetName) is the widget.
+  if (looksLikeGraphNode(obj)) {
+    const fromNode = asNodeId(obj.id);
+    const widgetName = asWidgetName(obj.sourceWidgetName ?? obj.widgetName);
+    if (fromNode && widgetName) return { nodeId: fromNode, widgetName };
+    if (fromNode) return { nodeId: fromNode, widgetName: null };
+  }
+  const nodeId = asNodeId(
+    obj.sourceNodeId ?? obj.interiorNodeId ?? obj.nodeId ?? obj.node?.id,
+  );
+  const widgetName = asWidgetName(obj.sourceWidgetName ?? obj.widgetName ?? obj.name);
+  if (nodeId && widgetName) return { nodeId, widgetName };
+  if (nodeId || widgetName) return { nodeId, widgetName };
+  return null;
+}
+
+function findWidgetByIdentity(subgraphNode, widgetObj) {
+  if (!widgetObj || typeof widgetObj !== "object") return [];
+  const hits = [];
+  for (const node of innerNodes(subgraphNode)) {
+    let widgets;
+    try {
+      widgets = node?.widgets;
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(widgets)) continue;
+    for (const widget of widgets) {
+      if (widget === widgetObj && asNodeId(node?.id) && asWidgetName(widget?.name)) {
+        hits.push({ nodeId: asNodeId(node.id), widgetName: widget.name });
+      }
+    }
+  }
+  return hits;
+}
+
+function findWidgetByUniqueName(subgraphNode, widgetName) {
+  const name = asWidgetName(widgetName);
+  if (!name) return null;
+  const hits = [];
+  const seen = new Set();
+  for (const node of innerNodes(subgraphNode)) {
+    const nodeId = asNodeId(node?.id);
+    if (!nodeId || !nodeHasWidget(node, name)) continue;
+    const key = `${nodeId}:${name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    hits.push({ nodeId, widgetName: name });
+  }
+  return hits.length === 1 ? hits[0] : null;
+}
+
+function isNullPlaceholder(entry) {
+  if (entry == null) return true;
+  if (!Array.isArray(entry)) return false;
+  if (entry.length === 0) return true;
+  return entry.every((slot) => slot == null);
+}
+
+function canonicalTuple(nodeId, widgetName, extra) {
+  const id = asNodeId(nodeId);
+  const name = asWidgetName(widgetName);
+  if (!id || !name) return null;
+  if (extra === undefined || extra == null) return [id, name];
+  if (typeof extra === "string") return [id, name, extra];
+  return null;
+}
+
+function tupleFromCanonicalSlots(entry) {
+  if (!Array.isArray(entry) || entry.length < 2 || entry.length > 3) return null;
+  if (entry.length === 3) return canonicalTuple(entry[0], entry[1], entry[2]);
+  return canonicalTuple(entry[0], entry[1]);
+}
+
+/**
+ * Resolve one proxyWidgets entry to a string tuple, or classify it as a
+ * droppable placeholder / unreadable.
+ *
+ * @returns {{
+ *   kind: "keep" | "drop" | "resolve" | "refuse",
+ *   tuple?: string[],
+ *   nodeId?: string | null,
+ *   widgetName?: string | null,
+ *   reason?: string,
+ * }}
+ */
+export function classifyLegacyProxyWidgetEntry(entry, subgraphNode) {
+  if (isNullPlaceholder(entry)) return { kind: "drop" };
+
+  const already = tupleFromCanonicalSlots(entry);
+  if (already) {
+    const changed =
+      already[0] !== entry[0] ||
+      already[1] !== entry[1] ||
+      (already.length === 3 && already[2] !== entry[2]) ||
+      already.length !== entry.length;
+    return {
+      kind: changed ? "resolve" : "keep",
+      tuple: already,
+      nodeId: already[0],
+      widgetName: already[1],
+    };
+  }
+
+  if (!Array.isArray(entry)) {
+    if (entry && typeof entry === "object") {
+      const identified = resolveObjectEntry(entry, null, subgraphNode);
+      if (identified?.tuple) {
+        return {
+          kind: "resolve",
+          tuple: identified.tuple,
+          nodeId: identified.nodeId,
+          widgetName: identified.widgetName,
+        };
+      }
+      return {
+        kind: "refuse",
+        nodeId: identified?.nodeId ?? null,
+        widgetName: identified?.widgetName ?? null,
+        reason: identified?.reason ?? "legacy object entry had no inner node id and widget name",
+      };
+    }
+    return { kind: "refuse", reason: "proxyWidgets entry was not a [nodeId, widgetName] tuple" };
+  }
+
+  if (entry.length > 3) {
+    return { kind: "refuse", reason: "proxyWidgets tuple had more than three slots" };
+  }
+
+  const first = entry[0];
+  const second = entry[1] === undefined ? null : entry[1];
+  const extra = entry.length === 3 ? entry[2] : undefined;
+
+  if (first != null && typeof first === "object" && !Array.isArray(first)) {
+    const identified = resolveObjectEntry(first, second, subgraphNode);
+    if (identified?.tuple) {
+      const tuple =
+        extra === undefined || extra == null
+          ? identified.tuple
+          : canonicalTuple(identified.tuple[0], identified.tuple[1], extra);
+      if (!tuple) {
+        return {
+          kind: "refuse",
+          nodeId: identified.nodeId,
+          widgetName: identified.widgetName,
+          reason: "legacy object entry resolved, but the third tuple slot was not a string",
+        };
+      }
+      return {
+        kind: "resolve",
+        tuple,
+        nodeId: identified.nodeId,
+        widgetName: identified.widgetName,
+      };
+    }
+    return {
+      kind: "refuse",
+      nodeId: identified?.nodeId ?? asNodeId(second) ?? null,
+      widgetName: identified?.widgetName ?? asWidgetName(second) ?? null,
+      reason: identified?.reason ?? "legacy object/null entry could not be resolved to [innerNodeId, widgetName]",
+    };
+  }
+
+  if (second != null && typeof second === "object" && !Array.isArray(second)) {
+    const nodeId = asNodeId(first);
+    const identified = resolveObjectEntry(second, null, subgraphNode);
+    const widgetName = identified?.widgetName ?? asWidgetName(second?.name);
+    const tuple = canonicalTuple(nodeId ?? identified?.nodeId, widgetName, extra);
+    if (tuple) {
+      return {
+        kind: "resolve",
+        tuple,
+        nodeId: tuple[0],
+        widgetName: tuple[1],
+      };
+    }
+    return {
+      kind: "refuse",
+      nodeId: nodeId ?? identified?.nodeId ?? null,
+      widgetName: widgetName ?? null,
+      reason: "legacy [id, object] entry could not be resolved to a widget name",
+    };
+  }
+
+  const coerced = canonicalTuple(first, second, extra);
+  if (coerced) {
+    return {
+      kind: "resolve",
+      tuple: coerced,
+      nodeId: coerced[0],
+      widgetName: coerced[1],
+    };
+  }
+
+  return {
+    kind: "refuse",
+    nodeId: asNodeId(first),
+    widgetName: asWidgetName(second),
+    reason: "proxyWidgets entry was not a string tuple and could not be coerced",
+  };
+}
+
+function resolveObjectEntry(obj, pairedSlot, subgraphNode) {
+  const identityHits = findWidgetByIdentity(subgraphNode, obj);
+  if (identityHits.length === 1) {
+    const pairedName = asWidgetName(pairedSlot);
+    if (pairedName && pairedName !== identityHits[0].widgetName) {
+      return { reason: "live widget object disagreed with the paired widget name" };
+    }
+    return {
+      tuple: [identityHits[0].nodeId, identityHits[0].widgetName],
+      nodeId: identityHits[0].nodeId,
+      widgetName: identityHits[0].widgetName,
+    };
+  }
+  if (identityHits.length > 1) {
+    return { reason: "live widget object matched more than one inner node" };
+  }
+
+  const extracted = identifiersFromObject(obj);
+  const pairedName = asWidgetName(pairedSlot);
+  const pairedId = asNodeId(pairedSlot);
+  const nodeId = extracted?.nodeId ?? pairedId;
+  const widgetName = extracted?.widgetName ?? pairedName;
+  if (nodeId && widgetName) {
+    return { tuple: [nodeId, widgetName], nodeId, widgetName };
+  }
+
+  if (widgetName && !nodeId) {
+    const unique = findWidgetByUniqueName(subgraphNode, widgetName);
+    if (unique) return { tuple: [unique.nodeId, unique.widgetName], ...unique };
+    return { widgetName, reason: "object named a widget but not which inner node owns it" };
+  }
+  if (nodeId && !widgetName) {
+    return { nodeId, reason: "object named an inner node but not which widget to promote" };
+  }
+  return { reason: "legacy object entry had no inner node id and widget name" };
+}
+
+function liveProof(subgraphNode, nodeId, widgetName) {
+  const inner = innerNodeById(subgraphNode, nodeId);
+  if (inner && nodeHasWidget(inner, widgetName)) return true;
+  // Host-level promotions persist as node id "-1". They have no inner node;
+  // the parent rail of that name is the proof.
+  if (String(nodeId) === "-1") {
+    try {
+      const rails = subgraphNode?.widgets;
+      if (Array.isArray(rails) && rails.some((rail) => rail?.name === widgetName)) return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Normalize `properties.proxyWidgets` to the string-only schema.
+ *
+ * @param {unknown} raw
+ * @param {{ subgraphNode?: object, requireLiveProof?: boolean }} [opts]
+ * @returns {{
+ *   ok: true,
+ *   tuples: string[][],
+ *   changed: boolean,
+ *   resolved: number,
+ *   dropped: number,
+ * } | {
+ *   ok: false,
+ *   affected: Array<{ index: number, nodeId: string | null, widgetName: string | null, reason: string }>,
+ * }}
+ */
+export function normalizeLegacyProxyWidgets(raw, { subgraphNode, requireLiveProof = true } = {}) {
+  if (raw == null) {
+    return { ok: true, tuples: [], changed: false, resolved: 0, dropped: 0 };
+  }
+  if (!Array.isArray(raw)) {
+    return {
+      ok: false,
+      affected: [
+        {
+          index: -1,
+          nodeId: null,
+          widgetName: null,
+          reason: "properties.proxyWidgets was present but not an array",
+        },
+      ],
+    };
+  }
+
+  const tuples = [];
+  const affected = [];
+  let resolved = 0;
+  let dropped = 0;
+  let changed = false;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const classified = classifyLegacyProxyWidgetEntry(raw[index], subgraphNode);
+    if (classified.kind === "drop") {
+      dropped += 1;
+      changed = true;
+      continue;
+    }
+    if (classified.kind === "refuse" || !classified.tuple) {
+      affected.push({
+        index,
+        nodeId: classified.nodeId ?? null,
+        widgetName: classified.widgetName ?? null,
+        reason: classified.reason ?? "unreadable proxyWidgets entry",
+      });
+      continue;
+    }
+    // Already-canonical tuples are the live node's own metadata — do not
+    // re-prove them. Live proof is for a rewrite we are about to invent.
+    if (
+      classified.kind === "resolve" &&
+      requireLiveProof &&
+      subgraphNode &&
+      !liveProof(subgraphNode, classified.tuple[0], classified.tuple[1])
+    ) {
+      affected.push({
+        index,
+        nodeId: classified.tuple[0],
+        widgetName: classified.tuple[1],
+        reason:
+          "resolved to [innerNodeId, widgetName] but that inner widget is not on the live subgraph, so the mapping is not proven",
+      });
+      continue;
+    }
+    if (classified.kind === "resolve") {
+      resolved += 1;
+      changed = true;
+    }
+    tuples.push(classified.tuple);
+  }
+
+  if (affected.length) return { ok: false, affected };
+  return { ok: true, tuples, changed, resolved, dropped };
+}
+
+function snapshotPromotedBindings(node) {
+  const widgets = [];
+  const inputs = [];
+  try {
+    const rails = node?.widgets;
+    if (Array.isArray(rails)) {
+      for (const rail of rails) {
+        if (!rail || typeof rail.name !== "string" || !rail.name) continue;
+        let value;
+        try {
+          value = cloneValue(rail.value);
+        } catch {
+          return null;
+        }
+        let widgetId = null;
+        try {
+          widgetId = typeof rail.widgetId === "string" && rail.widgetId ? rail.widgetId : null;
+        } catch {
+          widgetId = null;
+        }
+        widgets.push({ name: rail.name, value, widgetId });
+      }
+    }
+  } catch {
+    return null;
+  }
+  try {
+    const slots = node?.inputs;
+    if (Array.isArray(slots)) {
+      for (const slot of slots) {
+        if (!slot || typeof slot.name !== "string" || !slot.name) continue;
+        inputs.push({
+          name: slot.name,
+          link: slot.link ?? null,
+          widgetId: typeof slot.widgetId === "string" && slot.widgetId ? slot.widgetId : null,
+        });
+      }
+    }
+  } catch {
+    return null;
+  }
+  return { widgets, inputs };
+}
+
+function bindingsPreserved(before, after) {
+  if (!before || !after) return false;
+  for (const rail of before.widgets) {
+    const found = after.widgets.find((entry) => entry.name === rail.name);
+    if (!found) return false;
+    if (!valuesMatch(found.value, rail.value)) return false;
+    if (rail.widgetId && found.widgetId && found.widgetId !== rail.widgetId) return false;
+  }
+  for (const slot of before.inputs) {
+    const found = after.inputs.find((entry) => entry.name === slot.name);
+    if (!found) return false;
+    if (!Object.is(found.link, slot.link)) return false;
+    if (slot.widgetId && found.widgetId && found.widgetId !== slot.widgetId) return false;
+  }
+  return true;
+}
+
+function readRawProxyWidgets(node) {
+  try {
+    return node?.properties?.proxyWidgets;
+  } catch {
+    return { unreadable: true };
+  }
+}
+
+function writeProxyWidgets(node, tuples) {
+  if (!node.properties || typeof node.properties !== "object") {
+    node.properties = { proxyWidgets: tuples };
+    return;
+  }
+  node.properties.proxyWidgets = tuples;
+}
+
+export function legacyProxyWidgetsRefusalMessage(affected) {
+  const named = (affected ?? [])
+    .map((entry) => {
+      const indexBit = entry.index >= 0 ? `index ${entry.index}` : "the whole property";
+      const who =
+        entry.nodeId && entry.widgetName
+          ? `inner node ${entry.nodeId} widget "${entry.widgetName}"`
+          : entry.nodeId
+            ? `inner node ${entry.nodeId}`
+            : entry.widgetName
+              ? `widget "${entry.widgetName}"`
+              : "an unnamed entry";
+      return `${who} (${indexBit}: ${entry.reason})`;
+    })
+    .join("; ");
+  const repairTargets = (affected ?? []).filter((entry) => entry.nodeId && entry.widgetName);
+  const repair =
+    repairTargets.length > 0
+      ? `Repair: panel_enter_subgraph on this subgraph node, then ` +
+        repairTargets
+          .map(
+            (entry) =>
+              `panel_promote_widget({node_id: ${JSON.stringify(entry.nodeId)}, widget: ${JSON.stringify(entry.widgetName)}, demote: true})`,
+          )
+          .join(" and ") +
+        ` to drop the invalid promotion, then retry panel_save_subgraph.`
+      : `Repair: panel_enter_subgraph on this subgraph node, demote widgets that were promoted via the legacy store, then retry panel_save_subgraph.`;
+  return (
+    `panel_save_subgraph cannot publish this subgraph: properties.proxyWidgets has ` +
+    `legacy object/null metadata that could not be mapped losslessly to [innerNodeId, widgetName] ` +
+    `strings${named ? `: ${named}` : ""}. ${repair} ` +
+    `Do not publish until the metadata is string tuples.`
+  );
+}
+
+/**
+ * Rewrite a subgraph node's `properties.proxyWidgets` to the string-only
+ * schema, or throw a repairable refusal. No-op when the property is absent
+ * or already canonical. Restores the previous value if applying the rewrite
+ * would drop a promoted value or rail binding.
+ *
+ * @param {object} subgraphNode
+ * @returns {{ changed: boolean, resolved: number, dropped: number }}
+ */
+export function prepareSubgraphProxyWidgetsForPublish(subgraphNode) {
+  const raw = readRawProxyWidgets(subgraphNode);
+  if (raw && typeof raw === "object" && raw.unreadable) {
+    throw new Error(
+      `panel_save_subgraph cannot publish this subgraph: properties.proxyWidgets could not be read, ` +
+        `so the blueprint validator's string-tuple schema cannot be proved. Repair: inspect the ` +
+        `subgraph node's properties.proxyWidgets, demote any legacy promotions, then retry.`,
+    );
+  }
+  if (raw === undefined) return { changed: false, resolved: 0, dropped: 0 };
+
+  const normalized = normalizeLegacyProxyWidgets(raw, { subgraphNode, requireLiveProof: true });
+  if (!normalized.ok) {
+    throw new Error(legacyProxyWidgetsRefusalMessage(normalized.affected));
+  }
+  if (!normalized.changed) return { changed: false, resolved: 0, dropped: 0 };
+
+  const before = snapshotPromotedBindings(subgraphNode);
+  if (!before) {
+    throw new Error(
+      `panel_save_subgraph cannot publish this subgraph: promoted widget values and rail bindings ` +
+        `could not be snapshotted, so rewriting properties.proxyWidgets cannot be proved lossless. ` +
+        `Repair: panel_enter_subgraph on this node, demote widgets promoted via the legacy store, ` +
+        `then retry panel_save_subgraph.`,
+    );
+  }
+
+  try {
+    writeProxyWidgets(subgraphNode, normalized.tuples);
+  } catch (error) {
+    throw new Error(
+      `panel_save_subgraph cannot publish this subgraph: writing the normalized string-tuple ` +
+        `properties.proxyWidgets failed (${error instanceof Error ? error.message : String(error)}). ` +
+        `Repair: panel_enter_subgraph on this node, demote widgets promoted via the legacy store, ` +
+        `then retry panel_save_subgraph.`,
+    );
+  }
+
+  const after = snapshotPromotedBindings(subgraphNode);
+  if (!after || !bindingsPreserved(before, after)) {
+    try {
+      writeProxyWidgets(subgraphNode, raw);
+    } catch {
+      /* restore is best-effort; the refusal still stands */
+    }
+    throw new Error(
+      `panel_save_subgraph cannot publish this subgraph: normalizing properties.proxyWidgets to ` +
+        `string tuples would not preserve promoted values or rail bindings. ` +
+        `Repair: panel_enter_subgraph on this node, demote widgets promoted via the legacy store, ` +
+        `then retry panel_save_subgraph.`,
+    );
+  }
+
+  return { changed: true, resolved: normalized.resolved, dropped: normalized.dropped };
+}


### PR DESCRIPTION
panel_save_subgraph published a live subgraph through ComfyUI's blueprint validator, which requires properties.proxyWidgets to be string tuples. A legacy-store promote (the path panel_promote_widget takes when the widget has no connectable slot) writes [{ sourceNodeId, sourceWidgetName }, null] instead, and publish throws: Expected string, received object at [n][0]; Expected string, received null at [n][1].

Before publishSubgraph, the save path now rewrites those entries to [innerNodeId, widgetName] when the mapping is proven against the live subgraph, drops null placeholders, and checks that promoted values and rail bindings are preserved. If the mapping cannot be proved lossless, it refuses with the affected inner node/widget and a demote repair action rather than invoking the publisher.

Fixes #2005