### PR TITLE
fix(#2003): recover live graph reads after a manual canvas edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_set_widget acknowledges an inner-subgraph widget write once readback matches, instead of waiting out the 90s relay on a hanging widget callback or parent-rail restore (#2001)
 - panel_promote_widget refuses canvas-only callback widgets (control_after_generate) and writes only [nodeId, widgetName] string pairs through the legacy promotion store, so saved workflows stay loadable (#2002)
+- live graph reads recover after a manual canvas edit: a hung panel_graph_outline no longer pins retries, tracker snapshot flush stays mutation-only, and image/canvas widget values are clipped without a full stringify that could miss the 20s RPC window (#2003)
 
 
 ## [0.15.143] - 2026-08-30
@@ -18,7 +19,6 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
 - panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
-- live graph reads recover after a manual canvas edit: a hung panel_graph_outline no longer pins retries, tracker snapshot flush stays mutation-only, and image/canvas widget values are clipped without a full stringify that could miss the 20s RPC window (#2003)
 
 
 ## [0.15.142] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
 - panel_copy_nodes with explicit node_ids no longer copies a leftover additive canvas selection (#2004)
+- live graph reads recover after a manual canvas edit: a hung panel_graph_outline no longer pins retries, tracker snapshot flush stays mutation-only, and image/canvas widget values are clipped without a full stringify that could miss the 20s RPC window (#2003)
 
 
 ## [0.15.142] - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- live graph reads recover after a manual canvas edit: a hung panel_graph_outline no longer pins retries, tracker snapshot flush stays mutation-only, and image/canvas widget values are clipped without a full stringify that could miss the 20s RPC window (#2003)
+
 ## [0.15.144] - 2026-08-30
 
 ### Fixed
 - panel_set_widget acknowledges an inner-subgraph widget write once readback matches, instead of waiting out the 90s relay on a hanging widget callback or parent-rail restore (#2001)
 - panel_promote_widget refuses canvas-only callback widgets (control_after_generate) and writes only [nodeId, widgetName] string pairs through the legacy promotion store, so saved workflows stay loadable (#2002)
-- live graph reads recover after a manual canvas edit: a hung panel_graph_outline no longer pins retries, tracker snapshot flush stays mutation-only, and image/canvas widget values are clipped without a full stringify that could miss the 20s RPC window (#2003)
 
 
 ## [0.15.143] - 2026-08-30

--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -173,10 +173,17 @@ test("#1723 flush swallows a capture failure like the deferred path does", () =>
 test("#1723 wires the flush BEFORE the graph-binding fence in the dispatch path", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
-  const flush = source.indexOf("flushPendingChangeTrackerSnapshot(");
+  const gate = source.indexOf("if (msg.cmd.startsWith(\"graph_\") && !commandIsCanvasIndependent(msg.cmd))");
   const fence = source.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd))");
+  assert.ok(gate >= 0, "the graph dispatch gate must exist");
+  assert.ok(fence > gate, "the binding fence still runs for graph commands");
+  const region = source.slice(gate, fence);
+  const flush = region.indexOf("flushPendingChangeTrackerSnapshot(");
   assert.ok(flush >= 0, "the dispatch path flushes a pending tracker snapshot");
-  assert.ok(fence > flush, "the flush lands before the binding fence reads the tracker");
+  // #2003 — the flush is mutation-only. Reads that serialize here miss the 20s
+  // graph_outline window after a PreviewImage/canvas edit.
+  const mutate = region.lastIndexOf("if (graphCommandMayMutateWorkflow(msg.cmd))", flush);
+  assert.ok(mutate >= 0 && mutate < flush, "the flush must sit inside the mutation branch, before the fence");
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -29,6 +29,8 @@ import {
   // #809
   clipCompactValue,
   compactClipNote,
+  isHeavyLiveWidgetValue,
+  HEAVY_WIDGET_PLACEHOLDER,
   OUTLINE_DETAIL_LEVELS,
   OUTLINE_MAX_CHARS_DEFAULT,
   OUTLINE_MAX_CHARS_FLOOR,
@@ -659,6 +661,29 @@ test("#1634 the clip note names the cap actually in force", () => {
     assert.equal(named, String(cap), `the note must name the cap in force (${cap})`);
   }
   assert.equal(compactClipNote(0, WIDGET_VALUE_CAP), "", "still silent when nothing clipped");
+});
+
+test("#2003 clipCompactValue does not stringify pixel buffers or canvas-like values", () => {
+  const pixels = new Uint8ClampedArray(1024 * 1024 * 4);
+  assert.equal(isHeavyLiveWidgetValue(pixels), true);
+  const started = Date.now();
+  const clipped = clipCompactValue({ width: 1024, height: 1024, data: pixels });
+  const elapsed = Date.now() - started;
+  assert.equal(clipped.clipped, true);
+  assert.equal(clipped.text, HEAVY_WIDGET_PLACEHOLDER);
+  assert.ok(elapsed < 50, `pixel bags must clip without a full stringify (${elapsed}ms)`);
+
+  const huge = new Array(8_000).fill(7);
+  const arrStarted = Date.now();
+  const arr = clipCompactValue(huge);
+  const arrElapsed = Date.now() - arrStarted;
+  assert.equal(arr.clipped, true);
+  assert.equal(arr.text, HEAVY_WIDGET_PLACEHOLDER);
+  assert.ok(arrElapsed < 50, `long arrays must not be JSON.stringified (${arrElapsed}ms)`);
+
+  assert.equal(isHeavyLiveWidgetValue("a short prompt"), false);
+  assert.equal(isHeavyLiveWidgetValue({ seed: 42 }), false);
+  assert.equal(capWidgetValue({ data: pixels }), HEAVY_WIDGET_PLACEHOLDER);
 });
 
 test("#1634 clipCompactValue honours a raised cap for a pinpoint read", () => {

--- a/browser_tests/unit/graph-rpc-liveness.test.mjs
+++ b/browser_tests/unit/graph-rpc-liveness.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * #2003 — live graph RPC recovers after a manual canvas edit.
+ *
+ * panel_graph_outline timed out three consecutive times after a PreviewImage
+ * widget/canvas edit. The tab stayed registered; every retry was silence.
+ *
+ * Two panel-owned rules this file pins:
+ *   * a hung READ must not pin retry_of to the original (mutations still must);
+ *   * the recovery names panel_open_workflow, not a browser refresh and not
+ *     panel_set_workflow_target.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  GRAPH_RPC_REBIND_ACTION,
+  shouldJoinInFlightGraphReply,
+  ledgerReplyIsInFlight,
+  graphRpcTimeoutRecovery,
+} from "../../web/js/lib/graph-rpc-liveness.js";
+import { graphCommandMayMutateWorkflow } from "../../web/js/lib/graph-binding.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+test("#2003 a settled reply still joins — the ledger's idempotent path is unchanged", () => {
+  assert.equal(
+    shouldJoinInFlightGraphReply({ cmd: "graph_outline", priorInFlight: false }),
+    true,
+  );
+  assert.equal(shouldJoinInFlightGraphReply({ cmd: "graph_add_node" }), true);
+  assert.equal(shouldJoinInFlightGraphReply({}), true);
+});
+
+test("#2003 an in-flight READ does not join — retries execute fresh", () => {
+  for (const cmd of ["graph_outline", "graph_query", "graph_get_state", "graph_get_errors"]) {
+    assert.equal(graphCommandMayMutateWorkflow(cmd), false, cmd);
+    assert.equal(
+      shouldJoinInFlightGraphReply({ cmd, priorInFlight: true }),
+      false,
+      `${cmd} must not wait for a hung original`,
+    );
+  }
+});
+
+test("#2003 an in-flight MUTATION still joins — double-apply remains closed", () => {
+  for (const cmd of ["graph_add_node", "graph_set_widget", "graph_remove_node", "graph_run"]) {
+    assert.equal(graphCommandMayMutateWorkflow(cmd), true, cmd);
+    assert.equal(
+      shouldJoinInFlightGraphReply({ cmd, priorInFlight: true }),
+      true,
+      `${cmd} must still wait so a timeout-plus-retry cannot land twice`,
+    );
+  }
+});
+
+test("#2003 ledgerReplyIsInFlight is a thenable check, not a guess about the payload", () => {
+  assert.equal(ledgerReplyIsInFlight(Promise.resolve({ ok: true })), true);
+  assert.equal(ledgerReplyIsInFlight({ then: () => {} }), true);
+  assert.equal(ledgerReplyIsInFlight({ rid: "r1", ok: true, result: {} }), false);
+  assert.equal(ledgerReplyIsInFlight(undefined), false);
+  assert.equal(ledgerReplyIsInFlight(null), false);
+});
+
+test("#2003 recovery names a canvas rebind, not a refresh or a session retarget", () => {
+  assert.equal(GRAPH_RPC_REBIND_ACTION, "panel_open_workflow");
+  const text = graphRpcTimeoutRecovery({ cmd: "graph_outline" });
+  assert.match(text, /panel_open_workflow/);
+  assert.match(text, /no browser refresh/);
+  assert.match(text, /panel_set_workflow_target is NOT a remedy/);
+  assert.match(text, /graph_outline/);
+});
+
+test("#2003 WIRING: hung-read retries fall through to a fresh executor", () => {
+  assert.match(SRC, /import \{ shouldJoinInFlightGraphReply, ledgerReplyIsInFlight \} from "\.\/lib\/graph-rpc-liveness\.js";/);
+  const skip = SRC.indexOf("!shouldJoinInFlightGraphReply({");
+  assert.ok(skip >= 0, "the dispatch path must consult the join rule");
+  const wait = SRC.indexOf("dupReply = await awaitDuplicateReply(priorRidReply, msg.rid, msg.timeout_ms);");
+  assert.ok(wait > skip, "the skip must land before the unbounded duplicate wait");
+  const clear = SRC.slice(skip, wait);
+  assert.match(clear, /priorRidReply = undefined/);
+  assert.match(clear, /retryOfHit = false/);
+});
+
+test("#2003 WIRING: tracker snapshot flush is mutation-only", () => {
+  // The #1723 flush still runs before the mutation fence. A graph_outline must
+  // not pay captureCanvasState — that serialize is what outlives the 20s window
+  // after a PreviewImage/canvas edit.
+  const gate = SRC.indexOf("if (msg.cmd.startsWith(\"graph_\") && !commandIsCanvasIndependent(msg.cmd))");
+  assert.ok(gate >= 0, "the graph dispatch gate must exist");
+  const fence = SRC.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd))", gate);
+  assert.ok(fence > gate, "the binding fence still runs for graph commands");
+  const region = SRC.slice(gate, fence);
+  const flush = region.indexOf("flushPendingChangeTrackerSnapshot(");
+  assert.ok(flush >= 0, "mutations still flush");
+  const mutate = region.lastIndexOf("if (graphCommandMayMutateWorkflow(msg.cmd))", flush);
+  assert.ok(mutate >= 0 && mutate < flush, "the flush must sit inside the mutation branch");
+});

--- a/browser_tests/unit/panel-graph-outline-redaction.test.mjs
+++ b/browser_tests/unit/panel-graph-outline-redaction.test.mjs
@@ -9,6 +9,7 @@ import { dirname, join } from "node:path";
 
 import { displayLabel } from "../../web/js/lib/slot-labels.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
+import { clipCompactValue, HEAVY_WIDGET_PLACEHOLDER } from "../../web/js/lib/graph-read.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -29,8 +30,10 @@ function productionFormatter(body) {
   return new Function(
     "redactWidgetValue",
     "NOTE_NODE_TYPES",
+    "clipCompactValue",
+    "COMPACT_VALUE_CLIP",
     `let outlineClipped = 0; let outlineClippedNoteIds = []; ${source}; return fmtVal;`,
-  )(redactWidgetValue, new Set(["Note", "MarkdownNote"]));
+  )(redactWidgetValue, new Set(["Note", "MarkdownNote"]), clipCompactValue, 60);
 }
 
 function productionRenderNodeLines(body, fmtVal, node) {
@@ -102,6 +105,24 @@ test("#1729 graph_outline redacts a bypassed API-key widget in its live node ren
   assert.match(lines[0], new RegExp(`api_key="?${escapeRegex(REDACTED_WIDGET_VALUE)}"?`));
   assert.match(lines[0], /prompt=visible prompt/, "ordinary visible widget values remain intact");
   assert.ok(!lines.join("\n").includes(secret), "the credential is absent from the outline text");
+});
+
+test("#2003 graph_outline clips ImageData-like widget values without a full stringify", () => {
+  const body = handlerBody(readFileSync(PANEL_JS, "utf8"), "graph_outline({");
+  assert.match(body, /clipCompactValue\(safeValue, COMPACT_VALUE_CLIP\)/, "the outline formatter must use the bounded clip");
+  const pixels = new Uint8ClampedArray(256 * 256 * 4);
+  const node = {
+    id: 2003,
+    type: "PreviewImage",
+    widgets: [{ name: "image", value: { width: 256, height: 256, data: pixels } }],
+    inputs: [],
+    outputs: [],
+  };
+  const started = Date.now();
+  const lines = productionRenderNodeLines(body, productionFormatter(body), node);
+  const elapsed = Date.now() - started;
+  assert.match(lines.join("\n"), new RegExp(`image="${HEAVY_WIDGET_PLACEHOLDER.replace(/[[\]]/g, "\\$&")}"`));
+  assert.ok(elapsed < 50, `PreviewImage pixel bags must not stall the outline (${elapsed}ms)`);
 });
 
 function escapeRegex(value) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -905,6 +905,7 @@ import {
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
 import { createRehelloGate, routeIsStale } from "./lib/rehello-gate.js";
+import { shouldJoinInFlightGraphReply, ledgerReplyIsInFlight } from "./lib/graph-rpc-liveness.js";
 /** #1095 — control frames that must arrive AFTER the hello that establishes their route,
  *  and whose senders ignore the return value. Those two properties together are what makes
  *  a frame queueable: a queued frame's outcome is not yet known, so it may only be queued
@@ -14511,17 +14512,18 @@ const GRAPH_TOOL_EXECUTORS = {
      */
     const fmtVal = (v, node, widgetName) => {
       const safeValue = redactWidgetValue(widgetName, v);
-      const s = String(typeof safeValue === "string" ? safeValue : JSON.stringify(safeValue) ?? "").replace(/\s+/g, " ");
-      let clipped = s;
-      if (s.length > 60) {
+      // #2003 — clipCompactValue refuses to JSON.stringify ImageData / typed arrays /
+      // canvas elements, which is how a PreviewImage widget edit stalled this read.
+      const clippedValue = clipCompactValue(safeValue, COMPACT_VALUE_CLIP);
+      if (clippedValue.clipped) {
         outlineClipped++;
         // #1748: a clipped NOTE value is lost instructions, not a re-queryable detail —
         // remember the node so the footer can name it (the row's own 60-char clip reads
         // as the whole note otherwise).
         if (NOTE_NODE_TYPES.has(node?.type) && !outlineClippedNoteIds.includes(node.id))
           outlineClippedNoteIds.push(node.id);
-        clipped = s.slice(0, 57) + "…";
       }
+      const clipped = clippedValue.text;
       if (!/[[\]]/.test(clipped)) return clipped;
       // Escape backslashes first, then quotes, so the escape introduced for a quote is
       // not doubled — and the closing quote cannot be swallowed by a trailing backslash.
@@ -28455,6 +28457,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             retryOfHit = true;
           }
         }
+        // #2003 — a hung READ must not pin retries. The ledger joins an in-flight
+        // original so a mutation cannot land twice (#517/#694). graph_outline cannot
+        // double-apply, and after a manual canvas edit the original may never settle
+        // inside the 20s window; joining it is how every retry_of stays silent.
+        // Settled replies still join. Mutations still join.
+        if (
+          priorRidReply !== undefined &&
+          !shouldJoinInFlightGraphReply({
+            cmd: msg.cmd,
+            priorInFlight: ledgerReplyIsInFlight(priorRidReply),
+          })
+        ) {
+          priorRidReply = undefined;
+          retryOfHit = false;
+        }
         if (priorRidReply !== undefined) {
           // #1095 — THIS PATH WAITS, AND THEN REPLIES, so it holds the route exactly like an
           // executing command does and must be marked exactly like one.
@@ -28807,15 +28824,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
                 });
                 if (reconnectGate) throw reconnectRefusalError(reconnectGate);
               }
-              // comfyui-mcp#1723 — a successful command defers its tracker snapshot
-              // past the reply (#581); a back-to-back command from the same burst
+              const { graph, rootGraph, canvas } = getGraphCtx();
+              // comfyui-mcp#1723 — a successful MUTATION defers its tracker snapshot
+              // past the reply (#581); a back-to-back write from the same burst
               // reaches the fence on the stale pre-command fingerprint and refuses
               // the RIGHT canvas. Flush the capture already committed to (same
               // tracker only — a different active tracker means the tab moved).
-              flushPendingChangeTrackerSnapshot(
-                app?.extensionManager?.workflow?.activeWorkflow?.changeTracker ?? null,
-              );
-              const { graph, rootGraph, canvas } = getGraphCtx();
+              // #2003 — reads must not flush; captureCanvasState can miss the 20s window.
+              if (graphCommandMayMutateWorkflow(msg.cmd)) {
+                flushPendingChangeTrackerSnapshot(
+                  app?.extensionManager?.workflow?.activeWorkflow?.changeTracker ?? null,
+                );
+              }
               assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
               if (graphCommandMayMutateWorkflow(msg.cmd)) {
                 visibleMutationTarget = { graph, canvas, rootGraph };

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -43,6 +43,60 @@ export const MAX_CHARS_FLOOR = 500;
 /** Widget values are clipped to this in the `compact` projection (a FIXED cap). */
 export const COMPACT_VALUE_CLIP = 60;
 
+/** Placeholder for a widget value that must not be JSON.stringified on a live read. */
+export const HEAVY_WIDGET_PLACEHOLDER = "[binary]";
+
+/**
+ * #2003 — values a live graph read must NEVER fully serialize.
+ *
+ * PreviewImage / VHS videopreview / canvas widgets can hold ImageData, a typed
+ * array of pixels, or a canvas element. `JSON.stringify` of those walks every
+ * byte into a JSON number array and is how `panel_graph_outline` misses its 20s
+ * RPC window after a manual canvas edit — then every retry does the same walk.
+ *
+ * Positive evidence only: a small plain object or a short string is not heavy.
+ * One own-property level is enough for the `{ width, height, data }` ImageData
+ * shape; a nested pixel bag still trips via `data`.
+ */
+function heavyPayload(value) {
+  if (value == null || typeof value !== "object") return false;
+  if (ArrayBuffer.isView(value)) return true;
+  if (typeof ArrayBuffer !== "undefined" && value instanceof ArrayBuffer) return true;
+  // Pixel bags land as long primitive arrays. ResolutionMaster-style preset
+  // lists are arrays of objects and must still stringify so #609 can clip them.
+  if (Array.isArray(value) && value.length > 256) {
+    const first = value[0];
+    return first == null || typeof first === "number" || typeof first === "string" || typeof first === "boolean";
+  }
+  if (typeof value.byteLength === "number" && Number(value.byteLength) > 256) return true;
+  if (typeof value.toDataURL === "function" || typeof value.getContext === "function") return true;
+  const name = value.constructor?.name;
+  return (
+    name === "ImageData" ||
+    name === "HTMLCanvasElement" ||
+    name === "OffscreenCanvas" ||
+    name === "ImageBitmap"
+  );
+}
+
+export function isHeavyLiveWidgetValue(value) {
+  if (value == null || typeof value !== "object") return false;
+  try {
+    if (heavyPayload(value)) return true;
+    // ImageData-shaped bags expose pixels on `data` without being instanceof ImageData
+    // in this unit-test environment (no DOM). Skip arrays: Object.keys on a long array
+    // is itself the cost this helper exists to avoid.
+    if (Array.isArray(value)) return false;
+    for (const key of Object.keys(value)) {
+      if (heavyPayload(value[key])) return true;
+    }
+    return false;
+  } catch {
+    // Unreadable host object — do not stringify it.
+    return true;
+  }
+}
+
 /** #1748: frontend node types whose widget value IS on-canvas prose — the place
  *  workflow authors put trigger words, download paths and usage instructions. A
  *  clipped value on one of these is lost instructions, not a re-queryable detail,
@@ -173,6 +227,9 @@ export function drivenTag(src) {
  *  naming how many raw chars were dropped. */
 export function capWidgetValue(value, cap = WIDGET_VALUE_CAP, maxChars = Infinity, fixedCap = cap) {
   if (value == null) return value;
+  // #2003 — never JSON.stringify a pixel buffer / canvas / ImageData on the live
+  // read path. The clip below still runs, against the placeholder.
+  if (isHeavyLiveWidgetValue(value)) return HEAVY_WIDGET_PLACEHOLDER;
   const isString = typeof value === "string";
   const s = isString ? value : (() => { try { return JSON.stringify(value); } catch { return String(value); } })();
   if (typeof s !== "string") return value;
@@ -410,8 +467,23 @@ export function truncationTail(shown, matchedCount, hasExplicitIds, truncatedBy,
  *  footer note can name the lever (`fields`:"detail") instead of leaving a bare "…" on
  *  every value. The 60-char clip itself is FIXED; no parameter raises it. */
 export function clipCompactValue(v, n = COMPACT_VALUE_CLIP) {
-  const s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
-  return s.length > n ? { text: s.slice(0, n - 1) + "…", clipped: true } : { text: s, clipped: false };
+  const cap = Number.isFinite(n) && n > 0 ? Math.floor(n) : COMPACT_VALUE_CLIP;
+  // #2003 — clip BEFORE stringify for pixel/canvas values. The outline used to
+  // JSON.stringify the whole ImageData and THEN slice to 60 chars, which is how
+  // a PreviewImage widget edit stalled panel_graph_outline past the 20s RPC window.
+  if (isHeavyLiveWidgetValue(v)) {
+    const text = HEAVY_WIDGET_PLACEHOLDER;
+    return text.length > cap
+      ? { text: text.slice(0, Math.max(1, cap - 1)) + "…", clipped: true }
+      : { text, clipped: true };
+  }
+  let s;
+  try {
+    s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
+  } catch {
+    s = String(v);
+  }
+  return s.length > cap ? { text: s.slice(0, cap - 1) + "…", clipped: true } : { text: s, clipped: false };
 }
 
 /** #809: the one-line footer for compact rows whose values were clipped.

--- a/web/js/lib/graph-rpc-liveness.js
+++ b/web/js/lib/graph-rpc-liveness.js
@@ -1,0 +1,62 @@
+// #2003 — live graph RPC must recover after a manual canvas edit.
+//
+// Field report: panel_graph_outline timed out three consecutive times after the
+// user edited a PreviewImage widget/canvas. The tab stayed registered, so the
+// orchestrator kept targeting it, and every retry produced the same 20s silence.
+//
+// Two panel-owned causes stacked:
+//
+//   1. A READ retry of an in-flight original JOINS that original (#694). The
+//      orchestrator does not put timeout_ms on the frame, so awaitDuplicateReply
+//      waits unbounded. A hung graph_outline then pins every retry_of forever —
+//      "stays timed out". Mutations must still join (#517: double-apply). Reads
+//      cannot double-apply, so a hung read must not pin the next one.
+//
+//   2. Recovery after that silence has to name a CANVAS rebind, not a session
+//      retarget. panel_set_workflow_target does not restore the live graph
+//      (same rule as graphBindingRefusalMessage). panel_open_workflow does.
+//
+// Pure (no DOM, no sockets) so the join rule and the recovery sentence stay
+// unit-testable with plain values.
+
+import { graphCommandMayMutateWorkflow } from "./graph-binding.js";
+
+/** Public recovery named when a live graph read cannot finish. Not a session retarget. */
+export const GRAPH_RPC_REBIND_ACTION = "panel_open_workflow";
+
+/**
+ * Should this delivery wait for an already-running same command?
+ *
+ * Settled replies always join (idempotent, and the ledger exists to return them).
+ * An IN-FLIGHT mutation must join so a timeout-plus-retry cannot land twice.
+ * An in-flight READ must NOT: waiting is how graph_outline stays silent after
+ * a canvas edit that made the original hang (#2003).
+ *
+ * `priorInFlight` is a POSITIVE signal. Anything else (settled object, missing,
+ * unreadable) keeps today's join path.
+ */
+export function shouldJoinInFlightGraphReply({ cmd, priorInFlight } = {}) {
+  if (priorInFlight !== true) return true;
+  return graphCommandMayMutateWorkflow(cmd);
+}
+
+/** True when `prior` is the ledger's in-flight thenable, not a settled reply. */
+export function ledgerReplyIsInFlight(prior) {
+  return prior != null && typeof prior.then === "function";
+}
+
+/**
+ * Agent-facing recovery when a live graph read did not finish. Names the action
+ * that rebinds the canvas in place; explicitly not a browser refresh, and
+ * explicitly not panel_set_workflow_target.
+ */
+export function graphRpcTimeoutRecovery({ cmd } = {}) {
+  const name = typeof cmd === "string" && cmd.trim() ? cmd.trim() : "graph_outline";
+  return (
+    `The live graph did not finish "${name}" in time after a canvas change, so this ` +
+    `reply is a recovery rather than a graph read. The tab is still connected. Rebind ` +
+    `the live canvas with ${GRAPH_RPC_REBIND_ACTION} on the active workflow (no browser ` +
+    `refresh), then retry the read. panel_set_workflow_target is NOT a remedy — it ` +
+    `re-points the session, it does not rebind the canvas.`
+  );
+}


### PR DESCRIPTION
Fixes #2003.

`panel_graph_outline` could stay silent for the whole 20s RPC window after a manual PreviewImage/canvas widget edit. The tab stayed registered, so retries produced the same timeout instead of a graph or a recovery.

**What was going wrong**
- A hung *read* joined `retry_of` against the original. Mutations must still do that (#517/#694); reads cannot double-apply, and the orchestrator usually omits `timeout_ms`, so the wait was unbounded.
- `captureCanvasState` flushed on every graph command, including reads. After a canvas edit that serialize can outlive the 20s window.
- Outline/query formatted ImageData/typed-array/canvas widget values by `JSON.stringify`-then-clip, walking every pixel before the 60-char budget.

**What this changes**
- In-flight read retries execute fresh; settled replies and in-flight mutations still join.
- Tracker snapshot flush is mutation-only.
- Heavy live widget values clip to `[binary]` without a full stringify.
- Recovery copy names `panel_open_workflow` (canvas rebind, no browser refresh). `panel_set_workflow_target` is not a remedy.

Do not merge — review only.