### PR TITLE
fix(2008): panel_connect by Autogrow name keeps later MiniMax H3 slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_connect by Autogrow name keeps later MiniMax H3 slots on their original wires (#2008)
+
+
 ## [0.15.132] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/connect-collateral-wiring.test.mjs
+++ b/browser_tests/unit/connect-collateral-wiring.test.mjs
@@ -91,6 +91,20 @@ test("both paths surface the verdict to the caller", () => {
 
 });
 
+test("#2008 graph_connect reconciles dotted Autogrow names after the mutation", () => {
+  const snap = CONNECT_BODY.indexOf("const namedSlotsBefore = captureNamedSlotLinks(target);");
+  assert.ok(snap > 0, "no name→link snapshot on the connect path");
+  const mutate = CONNECT_BODY.indexOf("origin[\"connect\"](outIdx, target, inIdx)");
+  assert.ok(mutate > 0, "the connect mutation site moved — re-anchor this pin");
+  assert.ok(snap < mutate, "the name snapshot must be taken BEFORE the wire is made");
+  const reconcile = CONNECT_BODY.indexOf("const reconciled = reconcileDynamicPrefixSlots({");
+  assert.ok(reconcile > mutate, "reconcile must re-read AFTER onConnectionsChange");
+  assert.ok(
+    /beforeNames: inputNamesBefore/.test(CONNECT_BODY),
+    "verifyConnect must receive the pre-mutation names so an Autogrow index shift is not collateral",
+  );
+});
+
 test("the verdict never REFUSES — the mutation has already happened", () => {
   // #1272's lesson: reporting failure for a connect that landed invites a destructive
   // retry. A `throw` keyed on the collateral verdict would reintroduce exactly that.

--- a/browser_tests/unit/connect-collateral.test.mjs
+++ b/browser_tests/unit/connect-collateral.test.mjs
@@ -24,6 +24,7 @@ import { snapshotGraphState } from "../../web/js/lib/disconnect-verify.js";
 import {
   verifyConnect,
   snapshotInputSlotLinks,
+  snapshotInputSlotNames,
   connectCollateralBullets,
   connectCollateralWarning,
 } from "../../web/js/lib/connect-verify.js";
@@ -423,4 +424,47 @@ test("#2380 identity across types still holds where it is NEEDED — the address
     beforeSlots,
   });
   assert.deepEqual(v.collateralReslottedInputs, [], "the addressed slot got what was asked for");
+});
+
+test("#2008 an Autogrow index shift of the SAME named slot is not collateral", () => {
+  const n136 = node(
+    136,
+    [
+      { name: "ref_images.ref_image_4", link: null },
+      { name: "ref_videos.ref_video_0", link: 20 },
+      { name: "prompt", link: 21 },
+    ],
+    [],
+  );
+  const src = node(1, [], [{ name: "IMAGE", links: [] }]);
+  const g = mockGraph([src, n136], {
+    20: { id: 20, origin_id: 99, origin_slot: 0, target_id: 136, target_slot: 1 },
+    21: { id: 21, origin_id: 98, origin_slot: 0, target_id: 136, target_slot: 2 },
+  });
+  const before = snapshotGraphState(g);
+  const beforeSlots = snapshotInputSlotLinks(g);
+  const beforeNames = snapshotInputSlotNames(g);
+
+  n136.inputs.splice(1, 0, { name: "ref_images.ref_image_5", link: null });
+  g.links[22] = { id: 22, origin_id: 1, origin_slot: 0, target_id: 136, target_slot: 0 };
+  n136.inputs[0].link = 22;
+  g.links[20].target_slot = 2;
+  g.links[21].target_slot = 3;
+
+  const naive = verifyConnect(g, before, {
+    intendedLinkIds: [22],
+    beforeSlots,
+    intendedSlots: new Set(["136#0"]),
+  });
+  assert.equal(naive.ok, false, "index-only comparison still sees the shift");
+
+  const v = verifyConnect(g, before, {
+    intendedLinkIds: [22],
+    beforeSlots,
+    intendedSlots: new Set(["136#0"]),
+    beforeNames,
+  });
+  assert.equal(v.ok, true, "the names kept their wires; only the indices moved");
+  assert.deepEqual(v.collateralMovedLinks, []);
+  assert.deepEqual(v.collateralReslottedInputs, []);
 });

--- a/browser_tests/unit/connect-dynamic-prefix.test.mjs
+++ b/browser_tests/unit/connect-dynamic-prefix.test.mjs
@@ -1,0 +1,539 @@
+/**
+ * #2008 — `panel_connect` by dotted Autogrow name (`ref_images.ref_image_4`)
+ * can re-address later MiniMaxH3ReferenceToVideo slots.
+ *
+ * MECHANISM, read from the node schema rather than inferred:
+ *
+ *   MiniMaxH3ReferenceToVideo (comfy_extras/nodes_minimax_h3.py) declares
+ *   four `io.Autogrow.Input` families with TemplatePrefix children:
+ *     ref_images.ref_image_N, ref_videos.ref_video_N,
+ *     ref_video_audios.ref_video_audio_N, ref_audios.ref_audio_N
+ *   plus stable widget inputs prompt / width / height / length.
+ *
+ *   Connecting to a dotted child runs the family's onConnectionsChange, which
+ *   inserts a new sibling and shifts every later input. Logical identity is
+ *   the NAME (`ref_images.ref_image_4`), not the index. Index-aligned
+ *   `slots_rewritten` / `collateral_changes` then reported later families as
+ *   re-addressed, making the next name-based edit hazardous.
+ *
+ * Two fixtures transcribe the hook rather than paraphrasing it:
+ *
+ *   - INSERT: splice a new sibling, keep slot objects, bump later target_slot.
+ *     This is honest Autogrow growth. The connect must stay silent.
+ *   - REBUILD: replace the inputs array with new objects and copy links BY
+ *     POSITION, landing later names on the wrong wires. Reconcile must put
+ *     each surviving name's original link back.
+ *
+ * These tests run the REAL shipped `graph_connect`, extracted from
+ * web/js/comfyui-mcp-panel.js — same technique as connect-slot-rename.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  isLinkPersisted,
+  removePhantomLink,
+  isWidgetBackedInput,
+  inputLinkIds,
+  railSlotLinkIds,
+  linkIdExclusionSet,
+  findLandedInboundLink,
+  findLandedRailLink,
+  isRailLinkPersisted,
+  landedAfterThrowWarning,
+  verifyConnect,
+  snapshotInputSlotLinks,
+  snapshotInputSlotNames,
+  connectCollateralBullets,
+  connectCollateralWarning,
+} from "../../web/js/lib/connect-verify.js";
+import { snapshotGraphState } from "../../web/js/lib/disconnect-verify.js";
+import { findExistingRailSlot, refuseConnectToRawRail } from "../../web/js/lib/rail-slot.js";
+import {
+  captureNodeTitles,
+  describeTitleRewrites,
+  titleRewriteWarning,
+} from "../../web/js/lib/node-title-rewrite.js";
+import {
+  captureSlotNames,
+  describeSlotRewrites,
+  slotRewriteWarning,
+} from "../../web/js/lib/slot-rename-disclosure.js";
+import {
+  isDynamicPrefixSlotName,
+  captureNamedSlotLinks,
+  findSlotIndexByName,
+  reconcileDynamicPrefixSlots,
+} from "../../web/js/lib/dynamic-slot-reconcile.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+function sliceMethod(signature) {
+  const lines = panelSrc.split("\n");
+  const start = lines.findIndex((l) => l === signature);
+  assert.ok(start >= 0, `could not locate "${signature}" in the panel source`);
+  const end = lines.findIndex((l, i) => i > start && l === "  },");
+  assert.ok(end > start, `could not locate the end of "${signature}"`);
+  return lines.slice(start, end + 1).join("\n");
+}
+
+const connectSrc = sliceMethod(
+  "  graph_connect({ from_node_id, from_output, to_node_id, to_input, auto_match }) {",
+);
+
+function resolveNode(graph, id) {
+  const n = graph.getNodeById(id);
+  if (!n) throw new Error(`No node with id ${id}`);
+  return n;
+}
+
+function resolveSlot(slots, ref, kind) {
+  const list = slots ?? [];
+  if (typeof ref === "number") {
+    if (ref < 0 || ref >= list.length) throw new Error(`no ${kind} slot ${ref}`);
+    return ref;
+  }
+  const i = list.findIndex((s) => s?.name === ref);
+  if (i === -1) throw new Error(`no ${kind} named ${ref}`);
+  return i;
+}
+
+const railIntent = () => null;
+const resolveRail = () => null;
+const isEmptyRailSlotRef = (ref) => ref == null || ref === "";
+const slotDiagnostic = () => "slot diagnostic";
+const loopbackRefusalReason = () => "loopback";
+const findSubgraphHostNode = () => null;
+const uniqueSubgraphOutputName = (_g, base) => base;
+const uniqueSubgraphInputName = (_g, base) => base;
+
+function buildConnect(graph, overrides = {}) {
+  const deps = {
+    getGraphCtx: () => ({ graph, canvas: {}, app: {}, rootGraph: graph, LG: {} }),
+    resolveNode,
+    resolveSlot,
+    resolveRail,
+    railIntent,
+    isEmptyRailSlotRef,
+    findExistingRailSlot,
+    refuseConnectToRawRail,
+    findSubgraphHostNode,
+    autoMatchSlots: (origin, target, from_output, to_input) => ({
+      outIdx: resolveSlot(origin.outputs, from_output ?? 0, "output"),
+      inIdx: resolveSlot(target.inputs, to_input ?? 0, "input"),
+      autoMatched: [],
+    }),
+    slotDiagnostic,
+    loopbackRefusalReason,
+    uniqueSubgraphOutputName,
+    uniqueSubgraphInputName,
+    isLinkPersisted,
+    removePhantomLink,
+    isWidgetBackedInput,
+    inputLinkIds,
+    railSlotLinkIds,
+    linkIdExclusionSet,
+    findLandedInboundLink,
+    findLandedRailLink,
+    isRailLinkPersisted,
+    landedAfterThrowWarning,
+    snapshotGraphState,
+    snapshotInputSlotLinks,
+    snapshotInputSlotNames,
+    verifyConnect,
+    connectCollateralBullets,
+    connectCollateralWarning,
+    captureNodeTitles,
+    describeTitleRewrites,
+    titleRewriteWarning,
+    captureSlotNames,
+    describeSlotRewrites,
+    slotRewriteWarning,
+    isDynamicPrefixSlotName,
+    captureNamedSlotLinks,
+    findSlotIndexByName,
+    reconcileDynamicPrefixSlots,
+    ...overrides,
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const GRAPH_TOOL_EXECUTORS = {
+${connectSrc}
+};
+return GRAPH_TOOL_EXECUTORS.graph_connect;`,
+  );
+  return factory(...names.map((n) => deps[n]));
+}
+
+function mkLinkStore() {
+  const isIndex = (prop) => typeof prop === "string" && /^(?:0|[1-9]\d*)$/.test(prop);
+  const map = new Map();
+  const proxy = new Proxy(map, {
+    get(target, prop) {
+      if (isIndex(prop)) return target.get(Number(prop));
+      const v = Reflect.get(target, prop, target);
+      return typeof v === "function" ? v.bind(target) : v;
+    },
+    has: (target, prop) => (isIndex(prop) ? target.has(Number(prop)) : Reflect.has(target, prop)),
+    ownKeys: (target) => [...target.keys()].map(String),
+    getOwnPropertyDescriptor(target, prop) {
+      if (isIndex(prop) && target.has(Number(prop))) {
+        return { value: target.get(Number(prop)), enumerable: true, configurable: true, writable: true };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  });
+  return { map, proxy };
+}
+
+function mkGraph() {
+  const store = mkLinkStore();
+  const nodes = [];
+  const graph = {
+    lastLinkId: 0,
+    _links: store.map,
+    links: store.proxy,
+    nodes,
+    _nodes: nodes,
+    outputs: [],
+    inputs: [],
+    getNodeById: (id) => nodes.find((n) => String(n.id) === String(id)) ?? null,
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+    getLink: (id) => store.map.get(id) ?? null,
+  };
+  return graph;
+}
+
+const MINIMAX_INPUTS = () => [
+  { name: "clip", type: "CLIP", link: null },
+  { name: "vae", type: "VAE", link: null },
+  { name: "audio_vae", type: "VAE", link: null },
+  { name: "prompt", type: "STRING", link: 801 },
+  { name: "width", type: "INT", link: null },
+  { name: "height", type: "INT", link: null },
+  { name: "length", type: "INT", link: null },
+  { name: "ref_image_size", type: "COMBO", link: null },
+  { name: "ref_images.ref_image_0", type: "IMAGE", link: 802 },
+  { name: "ref_images.ref_image_1", type: "IMAGE", link: 803 },
+  { name: "ref_images.ref_image_2", type: "IMAGE", link: 804 },
+  { name: "ref_images.ref_image_3", type: "IMAGE", link: 805 },
+  { name: "ref_images.ref_image_4", type: "IMAGE", link: null },
+  { name: "ref_videos.ref_video_0", type: "IMAGE", link: 806 },
+  { name: "ref_audios.ref_audio_0", type: "AUDIO", link: 807 },
+];
+
+function seedPreexistingLinks(graph, targetId) {
+  const rows = [
+    [801, 90, 3],
+    [802, 91, 8],
+    [803, 92, 9],
+    [804, 93, 10],
+    [805, 94, 11],
+    [806, 95, 13],
+    [807, 96, 14],
+  ];
+  for (const [id, originId, targetSlot] of rows) {
+    graph._links.set(id, {
+      id,
+      origin_id: originId,
+      origin_slot: 0,
+      target_id: targetId,
+      target_slot: targetSlot,
+    });
+  }
+}
+
+function familyEnd(inputs, family) {
+  let last = -1;
+  for (let i = 0; i < inputs.length; i++) {
+    if (typeof inputs[i]?.name === "string" && inputs[i].name.startsWith(`${family}.`)) last = i;
+  }
+  return last;
+}
+
+/** Honest Autogrow: splice a new sibling, keep later slot objects, bump target_slot. */
+function autogrowInsert(node, graph, { index, connected }) {
+  if (!connected) return;
+  const name = node.inputs[index]?.name;
+  if (!isDynamicPrefixSlotName(name)) return;
+  const family = name.slice(0, name.indexOf("."));
+  const last = familyEnd(node.inputs, family);
+  if (last < 0) return;
+  const used = node.inputs
+    .filter((s) => typeof s?.name === "string" && s.name.startsWith(`${family}.`))
+    .map((s) => Number(String(s.name).split("_").pop()))
+    .filter((n) => Number.isFinite(n));
+  const next = Math.max(-1, ...used) + 1;
+  const child = name.slice(name.indexOf(".") + 1).replace(/\d+$/, "");
+  const slot = { name: `${family}.${child}${next}`, type: node.inputs[index].type, link: null };
+  node.inputs.splice(last + 1, 0, slot);
+  for (const rec of graph._links.values()) {
+    if (rec.target_id === node.id && rec.target_slot > last) rec.target_slot += 1;
+  }
+}
+
+/**
+ * Hostile rebuild: new slot objects, links copied BY POSITION so later names
+ * inherit the previous index's wire. This is the scramble reconcile must undo.
+ */
+function autogrowRebuild(node, graph, { index, connected }) {
+  if (!connected) return;
+  const name = node.inputs[index]?.name;
+  if (!isDynamicPrefixSlotName(name)) return;
+  const family = name.slice(0, name.indexOf("."));
+  const last = familyEnd(node.inputs, family);
+  const used = node.inputs
+    .filter((s) => typeof s?.name === "string" && s.name.startsWith(`${family}.`))
+    .map((s) => Number(String(s.name).split("_").pop()))
+    .filter((n) => Number.isFinite(n));
+  const next = Math.max(-1, ...used) + 1;
+  const child = name.slice(name.indexOf(".") + 1).replace(/\d+$/, "");
+  const names = node.inputs.map((s) => s.name);
+  names.splice(last + 1, 0, `${family}.${child}${next}`);
+  const types = node.inputs.map((s) => s.type);
+  types.splice(last + 1, 0, node.inputs[index].type);
+  const oldLinks = node.inputs.map((s) => s.link);
+  node.inputs = names.map((n, i) => ({
+    name: n,
+    type: types[i],
+    link: i < oldLinks.length ? oldLinks[i] : null,
+  }));
+  for (const rec of graph._links.values()) {
+    if (rec.target_id === node.id && rec.target_slot > last) rec.target_slot += 1;
+  }
+}
+
+function attachConnect(node, { onChange, throwAfterWrite = false } = {}) {
+  node.connect = (outIdx, target, inIdx) => {
+    const graph = node.graph;
+    const prev = target.inputs[inIdx]?.link;
+    if (prev != null) {
+      graph._links.delete(prev);
+      target.inputs[inIdx].link = null;
+      onChange?.({ index: inIdx, connected: false });
+    }
+    const id = ++graph.lastLinkId;
+    const link = { id, origin_id: node.id, origin_slot: outIdx, target_id: target.id, target_slot: inIdx };
+    graph._links.set(id, link);
+    (node.outputs[outIdx].links ??= []).push(id);
+    target.inputs[inIdx].link = id;
+    onChange?.({ index: inIdx, connected: true });
+    if (throwAfterWrite) throw new Error("autogrow hook threw");
+    return link;
+  };
+}
+
+function minimaxFixture({ mode = "insert", throwAfterWrite = false } = {}) {
+  const graph = mkGraph();
+  const source = {
+    id: 1,
+    title: "LoadImage",
+    graph,
+    inputs: [],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+  };
+  graph.nodes.push(source);
+  const mm = {
+    id: 136,
+    type: "MiniMaxH3ReferenceToVideo",
+    title: "MiniMax H3 Reference to Video",
+    graph,
+    inputs: MINIMAX_INPUTS(),
+    outputs: [{ name: "positive", type: "CONDITIONING", links: [] }],
+  };
+  graph.nodes.push(mm);
+  seedPreexistingLinks(graph, 136);
+  const hook = mode === "rebuild" ? autogrowRebuild : autogrowInsert;
+  attachConnect(source, {
+    throwAfterWrite,
+    onChange: ({ index, connected }) => hook(mm, graph, { index, connected }),
+  });
+  return { graph, source, mm };
+}
+
+function nameLink(node, name) {
+  const slot = node.inputs.find((s) => s.name === name);
+  return slot?.link ?? null;
+}
+
+test("#2008 dotted-name helper is the Autogrow child shape, not positional packs", () => {
+  assert.equal(isDynamicPrefixSlotName("ref_images.ref_image_4"), true);
+  assert.equal(isDynamicPrefixSlotName("input3"), false);
+  assert.equal(isDynamicPrefixSlotName("prompt"), false);
+  assert.equal(isDynamicPrefixSlotName(null), false);
+});
+
+test("#2008 INSERT: connecting to ref_images.ref_image_4 keeps later names and stays silent", () => {
+  const { graph, mm } = minimaxFixture({ mode: "insert" });
+  const videoLink = nameLink(mm, "ref_videos.ref_video_0");
+  const audioLink = nameLink(mm, "ref_audios.ref_audio_0");
+  const promptLink = nameLink(mm, "prompt");
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({
+    from_node_id: 1,
+    from_output: 0,
+    to_node_id: 136,
+    to_input: "ref_images.ref_image_4",
+  });
+
+  assert.equal(res.connected.to.node_id, 136);
+  assert.equal(res.connected.to.input, "ref_images.ref_image_4");
+  assert.ok(nameLink(mm, "ref_images.ref_image_4") != null, "the requested dotted slot holds the new wire");
+  assert.ok(mm.inputs.some((s) => s.name === "ref_images.ref_image_5"), "Autogrow grew a sibling");
+  assert.equal(nameLink(mm, "ref_videos.ref_video_0"), videoLink);
+  assert.equal(nameLink(mm, "ref_audios.ref_audio_0"), audioLink);
+  assert.equal(nameLink(mm, "prompt"), promptLink);
+  assert.equal(res.slots_rewritten, undefined, "an index shift of intact names is not a rewrite");
+  assert.ok(!("collateral_changes" in res), "nor collateral");
+  assert.equal(res.warning, undefined);
+});
+
+test("#2008 REBUILD: later names that inherited the wrong link are restored", () => {
+  const { graph, mm } = minimaxFixture({ mode: "rebuild" });
+  const videoLink = nameLink(mm, "ref_videos.ref_video_0");
+  const audioLink = nameLink(mm, "ref_audios.ref_audio_0");
+  const promptLink = nameLink(mm, "prompt");
+  const image3 = nameLink(mm, "ref_images.ref_image_3");
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({
+    from_node_id: 1,
+    from_output: 0,
+    to_node_id: 136,
+    to_input: "ref_images.ref_image_4",
+  });
+
+  assert.equal(res.connected.to.input, "ref_images.ref_image_4");
+  assert.ok(nameLink(mm, "ref_images.ref_image_4") != null);
+  assert.equal(nameLink(mm, "ref_videos.ref_video_0"), videoLink, "video family must keep its wire");
+  assert.equal(nameLink(mm, "ref_audios.ref_audio_0"), audioLink);
+  assert.equal(nameLink(mm, "prompt"), promptLink);
+  assert.equal(nameLink(mm, "ref_images.ref_image_3"), image3);
+  assert.ok(!("collateral_changes" in res), "restored names must not read as bystander damage");
+});
+
+test("#2008 REBUILD restore is produced by reconcile, not by the fixture", () => {
+  const { graph, mm } = minimaxFixture({ mode: "rebuild" });
+  const videoLink = nameLink(mm, "ref_videos.ref_video_0");
+  const graph_connect = buildConnect(graph, { reconcileDynamicPrefixSlots: () => null });
+
+  const res = graph_connect({
+    from_node_id: 1,
+    from_output: 0,
+    to_node_id: 136,
+    to_input: "ref_images.ref_image_4",
+  });
+
+  assert.equal(res.connected.to.node_id, 136, "the wire still lands");
+  assert.notEqual(
+    nameLink(mm, "ref_videos.ref_video_0"),
+    videoLink,
+    "without reconcile the positional copy leaves the video family on the wrong wire",
+  );
+});
+
+test("#2008 positional ImpactSwitch names are not reconciled", () => {
+  const before = captureNamedSlotLinks({
+    inputs: [{ name: "input3", link: 1 }],
+  });
+  const node = { id: 2, inputs: [{ name: "input2", link: 9 }] };
+  const res = reconcileDynamicPrefixSlots({
+    graph: { links: new Map() },
+    node,
+    before: { ...before, node },
+    intendedName: "input3",
+    intendedLinkId: 9,
+    replacedLinkId: null,
+  });
+  assert.equal(res, null);
+  assert.equal(node.inputs[0].name, "input2", "positional packs keep the pack's names");
+});
+
+test("#2008 INSERT disclosure uses object identity — a helper-only pin", () => {
+  const { mm } = minimaxFixture({ mode: "insert" });
+  const snap = captureSlotNames([mm]);
+  autogrowInsert(mm, mm.graph, { index: 12, connected: true });
+  const rewrites = describeSlotRewrites(snap);
+  assert.deepEqual(rewrites, [], "surviving objects that kept their names are not rewrites");
+});
+
+test("#2008 the throw path still reports a landed dotted-prefix wire", () => {
+  const { graph, mm } = minimaxFixture({ mode: "insert", throwAfterWrite: true });
+  const videoLink = nameLink(mm, "ref_videos.ref_video_0");
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({
+    from_node_id: 1,
+    from_output: 0,
+    to_node_id: 136,
+    to_input: "ref_images.ref_image_4",
+  });
+
+  assert.equal(res.connected.to.node_id, 136);
+  assert.equal(res.connected.to.input, "ref_images.ref_image_4");
+  assert.equal(nameLink(mm, "ref_videos.ref_video_0"), videoLink);
+  assert.match(res.warning, /Do NOT retry this connect/);
+  assert.ok(!("collateral_changes" in res));
+});
+
+test("#2008 reconcile never throws — a hostile slot cannot fail a landed wire", () => {
+  const node = {
+    id: 136,
+    inputs: [
+      {
+        get name() {
+          throw new Error("hostile name");
+        },
+        get link() {
+          throw new Error("hostile link");
+        },
+      },
+    ],
+  };
+  assert.equal(isDynamicPrefixSlotName("ref_images.ref_image_4"), true);
+  assert.doesNotThrow(() => captureNamedSlotLinks(node));
+  assert.doesNotThrow(() =>
+    reconcileDynamicPrefixSlots({
+      graph: {
+        get links() {
+          throw new Error("hostile store");
+        },
+      },
+      node,
+      before: { node, pairable: true, slots: [{ name: "ref_images.ref_image_4", index: 0, link: 1 }] },
+      intendedName: "ref_images.ref_image_4",
+      intendedLinkId: 2,
+      replacedLinkId: null,
+    }),
+  );
+});
+
+test("#2008 an ordinary non-dotted connect is unchanged", () => {
+  const graph = mkGraph();
+  const source = {
+    id: 1,
+    graph,
+    inputs: [],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+  };
+  const dst = {
+    id: 2,
+    graph,
+    inputs: [{ name: "images", type: "IMAGE", link: null }],
+    outputs: [],
+  };
+  graph.nodes.push(source, dst);
+  attachConnect(source, {});
+  const graph_connect = buildConnect(graph);
+  const res = graph_connect({ from_node_id: 1, from_output: 0, to_node_id: 2, to_input: "images" });
+  assert.equal(res.connected.to.input, "images");
+  assert.equal(res.slots_rewritten, undefined);
+  assert.equal(res.warning, undefined);
+});

--- a/browser_tests/unit/connect-raw-rail-refuse.test.mjs
+++ b/browser_tests/unit/connect-raw-rail-refuse.test.mjs
@@ -39,6 +39,7 @@ import {
   landedAfterThrowWarning,
   verifyConnect,
   snapshotInputSlotLinks,
+  snapshotInputSlotNames,
   connectCollateralBullets,
   connectCollateralWarning,
 } from "../../web/js/lib/connect-verify.js";
@@ -54,6 +55,12 @@ import {
   describeSlotRewrites,
   slotRewriteWarning,
 } from "../../web/js/lib/slot-rename-disclosure.js";
+import {
+  isDynamicPrefixSlotName,
+  captureNamedSlotLinks,
+  findSlotIndexByName,
+  reconcileDynamicPrefixSlots,
+} from "../../web/js/lib/dynamic-slot-reconcile.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -247,6 +254,7 @@ function buildConnect(graph, exposeCalls) {
     landedAfterThrowWarning,
     snapshotGraphState,
     snapshotInputSlotLinks,
+    snapshotInputSlotNames,
     verifyConnect,
     connectCollateralBullets,
     connectCollateralWarning,
@@ -256,6 +264,10 @@ function buildConnect(graph, exposeCalls) {
     captureSlotNames,
     describeSlotRewrites,
     slotRewriteWarning,
+    isDynamicPrefixSlotName,
+    captureNamedSlotLinks,
+    findSlotIndexByName,
+    reconcileDynamicPrefixSlots,
     exposeCalls,
   };
   const names = Object.keys(deps);

--- a/browser_tests/unit/connect-slot-rename.test.mjs
+++ b/browser_tests/unit/connect-slot-rename.test.mjs
@@ -54,6 +54,7 @@ import {
   landedAfterThrowWarning,
   verifyConnect,
   snapshotInputSlotLinks,
+  snapshotInputSlotNames,
   connectCollateralBullets,
   connectCollateralWarning,
 } from "../../web/js/lib/connect-verify.js";
@@ -69,6 +70,12 @@ import {
   describeSlotRewrites,
   slotRewriteWarning,
 } from "../../web/js/lib/slot-rename-disclosure.js";
+import {
+  isDynamicPrefixSlotName,
+  captureNamedSlotLinks,
+  findSlotIndexByName,
+  reconcileDynamicPrefixSlots,
+} from "../../web/js/lib/dynamic-slot-reconcile.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -161,6 +168,7 @@ function buildConnect(graph, overrides = {}) {
     landedAfterThrowWarning,
     snapshotGraphState,
     snapshotInputSlotLinks,
+    snapshotInputSlotNames,
     verifyConnect,
     connectCollateralBullets,
     connectCollateralWarning,
@@ -170,6 +178,10 @@ function buildConnect(graph, overrides = {}) {
     captureSlotNames,
     describeSlotRewrites,
     slotRewriteWarning,
+    isDynamicPrefixSlotName,
+    captureNamedSlotLinks,
+    findSlotIndexByName,
+    reconcileDynamicPrefixSlots,
     ...overrides,
   };
   const names = Object.keys(deps);

--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -46,6 +46,7 @@ import {
   readStoredLink,
   verifyConnect,
   snapshotInputSlotLinks,
+  snapshotInputSlotNames,
   connectCollateralBullets,
   connectCollateralWarning,
 } from "../../web/js/lib/connect-verify.js";
@@ -60,6 +61,12 @@ import {
   describeSlotRewrites,
   slotRewriteWarning,
 } from "../../web/js/lib/slot-rename-disclosure.js";
+import {
+  isDynamicPrefixSlotName,
+  captureNamedSlotLinks,
+  findSlotIndexByName,
+  reconcileDynamicPrefixSlots,
+} from "../../web/js/lib/dynamic-slot-reconcile.js";
 import { findExistingRailSlot, refuseConnectToRawRail } from "../../web/js/lib/rail-slot.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -157,6 +164,7 @@ function buildExecutors(graph, canvas = {}) {
     "landedAfterThrowWarning",
     "snapshotGraphState",
     "snapshotInputSlotLinks",
+    "snapshotInputSlotNames",
     "verifyConnect",
     "connectCollateralBullets",
     "connectCollateralWarning",
@@ -166,6 +174,10 @@ function buildExecutors(graph, canvas = {}) {
     "captureSlotNames",
     "describeSlotRewrites",
     "slotRewriteWarning",
+    "isDynamicPrefixSlotName",
+    "captureNamedSlotLinks",
+    "findSlotIndexByName",
+    "reconcileDynamicPrefixSlots",
     `const GRAPH_TOOL_EXECUTORS = {
 ${connectSrc}
 ${exposeOutSrc}
@@ -200,6 +212,7 @@ return GRAPH_TOOL_EXECUTORS;`,
     landedAfterThrowWarning,
     snapshotGraphState,
     snapshotInputSlotLinks,
+    snapshotInputSlotNames,
     verifyConnect,
     connectCollateralBullets,
     connectCollateralWarning,
@@ -209,6 +222,10 @@ return GRAPH_TOOL_EXECUTORS;`,
     captureSlotNames,
     describeSlotRewrites,
     slotRewriteWarning,
+    isDynamicPrefixSlotName,
+    captureNamedSlotLinks,
+    findSlotIndexByName,
+    reconcileDynamicPrefixSlots,
   );
 }
 

--- a/browser_tests/unit/connect-title-rewrite.test.mjs
+++ b/browser_tests/unit/connect-title-rewrite.test.mjs
@@ -44,6 +44,7 @@ import {
   landedAfterThrowWarning,
   verifyConnect,
   snapshotInputSlotLinks,
+  snapshotInputSlotNames,
   connectCollateralBullets,
   connectCollateralWarning,
 } from "../../web/js/lib/connect-verify.js";
@@ -59,6 +60,12 @@ import {
   describeSlotRewrites,
   slotRewriteWarning,
 } from "../../web/js/lib/slot-rename-disclosure.js";
+import {
+  isDynamicPrefixSlotName,
+  captureNamedSlotLinks,
+  findSlotIndexByName,
+  reconcileDynamicPrefixSlots,
+} from "../../web/js/lib/dynamic-slot-reconcile.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import {
   applyCurrentDefWidgetValues,
@@ -177,6 +184,7 @@ function buildConnect(graph, titleDeps = {}) {
     landedAfterThrowWarning,
     snapshotGraphState,
     snapshotInputSlotLinks,
+    snapshotInputSlotNames,
     verifyConnect,
     connectCollateralBullets,
     connectCollateralWarning,
@@ -186,6 +194,10 @@ function buildConnect(graph, titleDeps = {}) {
     captureSlotNames,
     describeSlotRewrites,
     slotRewriteWarning,
+    isDynamicPrefixSlotName,
+    captureNamedSlotLinks,
+    findSlotIndexByName,
+    reconcileDynamicPrefixSlots,
     ...titleDeps,
   };
   const names = Object.keys(deps);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -584,6 +584,7 @@ import {
 import { autoMatchSlots, slotDiagnostic, loopbackRefusalReason } from "./lib/connect-match.js";
 import {
   snapshotInputSlotLinks,
+  snapshotInputSlotNames,
   isLinkPersisted,
   removePhantomLink,
   isWidgetBackedInput,
@@ -599,6 +600,12 @@ import {
   connectCollateralBullets,
   connectCollateralWarning,
 } from "./lib/connect-verify.js";
+import {
+  isDynamicPrefixSlotName,
+  captureNamedSlotLinks,
+  findSlotIndexByName,
+  reconcileDynamicPrefixSlots,
+} from "./lib/dynamic-slot-reconcile.js";
 import {
   captureNodeTitles,
   describeTitleRewrites,
@@ -16820,6 +16827,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // time. Captured alongside the titles, for the same reason: the rename
     // happens on the throw path and the success path alike.
     const slotsBefore = captureSlotNames([origin, target]);
+    // #2008 — name→link identity on the TARGET, captured BEFORE Autogrow can
+    // rebuild. Dotted children (`ref_images.ref_image_4`) are addressed by
+    // name; an onConnectionsChange insert that shifts later families must not
+    // steal those names' links or report them as rewrites.
+    const namedSlotsBefore = captureNamedSlotLinks(target);
+    const requestedSlotName =
+      typeof to_input === "string" ? to_input : target.inputs?.[inIdx]?.name ?? null;
+    const inputNamesBefore = snapshotInputSlotNames(graph);
     // #2380 — the whole-graph state, captured BEFORE the wire is made. Every other
     // check on this path is scoped to the two endpoints the command NAMED, so a
     // connect that displaced wiring on a THIRD node returned a clean payload and the
@@ -16852,14 +16867,42 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
+    // #2008 — re-read the target AFTER onConnectionsChange, then put unrelated
+    // named links back (and the intended dotted slot's new wire) so a later
+    // name-based edit still addresses the same logical slots. Runs on both
+    // verdict paths: the hook that rebuilds fires before we know whether
+    // connect() threw.
+    const landedForReconcile = connectErr
+      ? findLandedInboundLink(graph, origin, outIdx, target, inboundLinkIdsBefore)
+      : null;
+    const reconciled = reconcileDynamicPrefixSlots({
+      graph,
+      node: target,
+      before: namedSlotsBefore,
+      intendedName: requestedSlotName,
+      intendedLinkId: landedForReconcile?.linkId ?? link?.id ?? null,
+      replacedLinkId: prevLinkId
+    });
     // #1855 — read the endpoints' titles back the moment the mutation is over,
     // BEFORE the verdict branches: the hook that renames runs on the throw path
     // and the success path alike, so computing this per-branch would report it on
     // one and drop it on the other.
     const titleRewrites = describeTitleRewrites(titlesBefore);
     // #1873 — read back in the SAME place as the titles, before the verdict
-    // branches, so a re-addressed node is disclosed on both of them.
+    // branches, so a re-addressed node is disclosed on both of them. #2008
+    // has already restored unrelated names, so an Autogrow insert that only
+    // shifted indices is silent here.
     const slotRewrites = describeSlotRewrites(slotsBefore);
+    const liveIntendedIndex = () => {
+      if (Number.isInteger(reconciled?.intendedIndex) && reconciled.intendedIndex >= 0) {
+        return reconciled.intendedIndex;
+      }
+      if (isDynamicPrefixSlotName(requestedSlotName)) {
+        const byName = findSlotIndexByName(target, requestedSlotName);
+        if (byName >= 0) return byName;
+      }
+      return inIdx;
+    };
     if (connectErr) {
       const landed = findLandedInboundLink(graph, origin, outIdx, target, inboundLinkIdsBefore);
       if (!landed) {
@@ -16902,7 +16945,12 @@ const GRAPH_TOOL_EXECUTORS = {
         // Both the requested slot and the one a dynamic pack re-slotted onto. Without
         // naming them the intended-id exemption is global, and the same id landing on an
         // untargeted input would be hidden (gate P1).
-        intendedSlots: new Set([`${target.id}#${inIdx}`, `${target.id}#${landed.inputIndex}`]),
+        intendedSlots: new Set([
+          `${target.id}#${inIdx}`,
+          `${target.id}#${landed.inputIndex}`,
+          `${target.id}#${liveIntendedIndex()}`,
+        ]),
+        beforeNames: inputNamesBefore,
       });
       const landedCollateral = landedVerdict.ok ? [] : connectCollateralBullets(landedVerdict);
       return {
@@ -16977,10 +17025,17 @@ const GRAPH_TOOL_EXECUTORS = {
     // persisted wire (the exact ImpactSwitch bug; the same Reroute→select on a real
     // socket like LatentSwitch does persist). Verify the link actually landed on the
     // live graph; if not, clean up the phantom and FAIL HONESTLY.
-    if (!isLinkPersisted(graph, target, inIdx, link)) {
+    let persistIdx = inIdx;
+    if (!isLinkPersisted(graph, target, persistIdx, link)) {
+      const byName = liveIntendedIndex();
+      if (byName !== persistIdx && isLinkPersisted(graph, target, byName, link)) {
+        persistIdx = byName;
+      }
+    }
+    if (!isLinkPersisted(graph, target, persistIdx, link)) {
       // Clean up ONLY the dangling remnant of THIS attempt — never a link a dynamic
       // node re-slotted to another input (removePhantomLink guards that internally).
-      removePhantomLink(graph, target, inIdx, link);
+      removePhantomLink(graph, target, persistIdx, link);
       graph.setDirtyCanvas(true, true);
       const inputSlot = target.inputs?.[inIdx];
       const widgetHint = isWidgetBackedInput(inputSlot)
@@ -17004,7 +17059,8 @@ const GRAPH_TOOL_EXECUTORS = {
       intendedLinkIds: [link?.id],
       replacedLinkId: prevLinkId,
       beforeSlots: inputLinksBefore,
-      intendedSlots: new Set([`${target.id}#${inIdx}`]),
+      intendedSlots: new Set([`${target.id}#${inIdx}`, `${target.id}#${persistIdx}`, `${target.id}#${liveIntendedIndex()}`]),
+      beforeNames: inputNamesBefore,
     });
     const collateral = verdict.ok ? [] : connectCollateralBullets(verdict);
     return {
@@ -17016,8 +17072,8 @@ const GRAPH_TOOL_EXECUTORS = {
         },
         to: {
           node_id: target.id,
-          input: target.inputs?.[inIdx]?.name ?? inIdx,
-          input_index: inIdx,
+          input: target.inputs?.[persistIdx]?.name ?? persistIdx,
+          input_index: persistIdx,
         },
         type: origin.outputs?.[outIdx]?.type,
         ...(autoMatched.length ? { auto_matched: autoMatched } : {}),

--- a/web/js/lib/connect-verify.js
+++ b/web/js/lib/connect-verify.js
@@ -353,32 +353,73 @@ export function landedAfterThrowWarning(err, extra = "") {
  * has shipped against since #668; changing what that returns would alter a verified
  * path this fix has no business touching.
  */
-export function snapshotInputSlotLinks(graph) {
-  const out = new Map();
+function walkInputSlots(graph, visit) {
   const walk = (g, prefix) => {
     for (const n of g?._nodes ?? []) {
       if (n?.id == null) continue;
       const path = prefix + String(n.id);
-      (n.inputs ?? []).forEach((inp, i) => {
-        // RAW, not String()-normalised (gate P1). litegraph's `_links` is a NUMBER-keyed
-        // Map and its `links` proxy binds Map.prototype.get straight through, so a key of
-        // "7" MISSES a record stored under 7 (#1425). Normalising here made `7` and "7"
-        // compare equal, so a hook that retyped an untargeted slot's id left the wire
-        // unresolvable while the verdict read ok:true. Identity against the intended and
-        // replaced ids is normalised at the comparison instead, where it is needed.
-        if (inp?.link != null) out.set(`${path}#${i}`, inp.link);
-      });
+      (n.inputs ?? []).forEach((inp, i) => visit(path, i, inp));
       if (n?.subgraph && Array.isArray(n.subgraph._nodes)) walk(n.subgraph, `${path}>`);
     }
   };
   walk(graph, "");
+}
+
+export function snapshotInputSlotLinks(graph) {
+  const out = new Map();
+  walkInputSlots(graph, (path, i, inp) => {
+    // RAW, not String()-normalised (gate P1). litegraph's `_links` is a NUMBER-keyed
+    // Map and its `links` proxy binds Map.prototype.get straight through, so a key of
+    // "7" MISSES a record stored under 7 (#1425). Normalising here made `7` and "7"
+    // compare equal, so a hook that retyped an untargeted slot's id left the wire
+    // unresolvable while the verdict read ok:true. Identity against the intended and
+    // replaced ids is normalised at the comparison instead, where it is needed.
+    if (inp?.link != null) out.set(`${path}#${i}`, inp.link);
+  });
   return out;
+}
+
+/**
+ * #2008 — the NAME at each input index, captured alongside the link snapshot.
+ *
+ * Autogrow inserts a sibling and later slots shift index while keeping their
+ * names. Index-keyed link comparison then cries collateral for every shifted
+ * family. Pairing by name is how a `ref_videos.ref_video_0` wire that merely
+ * moved from index 13 to 14 is recognised as the same slot.
+ *
+ * Empty slots are recorded too: an inserted empty Autogrow sibling has no
+ * link, and the name is what identifies it as growth rather than a fill.
+ */
+export function snapshotInputSlotNames(graph) {
+  const out = new Map();
+  walkInputSlots(graph, (path, i, inp) => {
+    try {
+      if (typeof inp?.name === "string") out.set(`${path}#${i}`, inp.name);
+    } catch {
+      /* an unreadable name contributes nothing */
+    }
+  });
+  return out;
+}
+
+function slotKeyPath(slot) {
+  const hash = String(slot).lastIndexOf("#");
+  return hash >= 0 ? String(slot).slice(0, hash) : null;
+}
+
+function namesOnSameNode(names, path, name) {
+  if (!(names instanceof Map) || !path || !name) return [];
+  const keys = [];
+  for (const [slot, slotName] of names) {
+    if (slotName === name && slotKeyPath(slot) === path) keys.push(slot);
+  }
+  return keys;
 }
 
 export function verifyConnect(
   graph,
   before,
-  { intendedLinkIds = [], replacedLinkId, beforeSlots, intendedSlots } = {},
+  { intendedLinkIds = [], replacedLinkId, beforeSlots, intendedSlots, beforeNames } = {},
 ) {
   const after = snapshotGraphState(graph);
   const replacedId = replacedLinkId != null ? String(replacedLinkId) : null;
@@ -390,6 +431,7 @@ export function verifyConnect(
 
   const missingNodes = [...(before?.nodeIds ?? [])].filter((id) => !after.nodeIds.has(id));
   const addedNodes = [...after.nodeIds].filter((id) => !(before?.nodeIds?.has(id) ?? false));
+  const afterNames = beforeNames instanceof Map ? snapshotInputSlotNames(graph) : null;
 
   const collateralRemovedLinks = [];
   for (const [id, view] of before?.links ?? []) {
@@ -440,7 +482,18 @@ export function verifyConnect(
       if (intendedSlots === undefined || intendedSlots.has(landedOn)) continue;
     }
     const now = after.links.get(id);
-    if (now && !sameEndpoints(was, now)) collateralMovedLinks.push({ before: was, after: now });
+    if (now && !sameEndpoints(was, now)) {
+      // #2008 — Autogrow shifts later slots on the SAME node. The link still
+      // names the same input; only target_slot moved. That is not bystander
+      // damage. A move onto a differently-named slot, or onto a different
+      // node, still reports.
+      if (afterNames && String(was.target_id) === String(now.target_id)) {
+        const oldName = beforeNames.get(`${was.target_id}#${was.target_slot}`);
+        const newName = afterNames.get(`${now.target_id}#${now.target_slot}`);
+        if (oldName && oldName === newName) continue;
+      }
+      collateralMovedLinks.push({ before: was, after: now });
+    }
   }
 
   // #2380 — the node-side comparison. Only meaningful when the caller captured slots
@@ -461,21 +514,37 @@ export function verifyConnect(
       // retypes an untargeted slot across a single connect, so this cannot false-positive
       // on a bystander the connect never touched.
       if (nowLink === wasLink) continue;
+      // #2008 — the NAME at this index took its link with it, or the NAME
+      // now sitting here arrived with the link it already had. Index-only
+      // Autogrow shifts must not read as reslots.
+      if (afterNames) {
+        const path = slotKeyPath(slot);
+        const beforeName = beforeNames.get(slot);
+        if (beforeName && wasLink != null) {
+          const liveKeys = namesOnSameNode(afterNames, path, beforeName);
+          if (liveKeys.some((key) => (afterSlots.get(key) ?? null) === wasLink)) continue;
+        }
+        const afterName = afterNames.get(slot);
+        if (afterName && nowLink != null) {
+          const priorKeys = namesOnSameNode(beforeNames, path, afterName);
+          if (priorKeys.some((key) => (beforeSlots.get(key) ?? null) === nowLink)) continue;
+        }
+      }
       // The link this connect made (or the one it displaced) landing on a slot is the
       // expected outcome, not bystander damage.
-            // Location-aware, not id-only (gate P1). Exempting an intended id wherever it
-        // appeared meant a hook could assign that id to an UNTARGETED node's input and
-        // the verdict stayed ok:true — hiding the very rewiring this exists to catch.
-        // The exemption now applies only on the slot the connect actually addressed;
-        // an intended id landing anywhere else is collateral.
-        const isAddressedSlot = intendedSlots === undefined || intendedSlots.has(slot);
-        if (
-          nowLink !== null &&
-          isAddressedSlot &&
-          (intended.has(String(nowLink)) || String(nowLink) === replacedId)
-        ) {
-          continue;
-        }
+      // Location-aware, not id-only (gate P1). Exempting an intended id wherever it
+      // appeared meant a hook could assign that id to an UNTARGETED node's input and
+      // the verdict stayed ok:true — hiding the very rewiring this exists to catch.
+      // The exemption now applies only on the slot the connect actually addressed;
+      // an intended id landing anywhere else is collateral.
+      const isAddressedSlot = intendedSlots === undefined || intendedSlots.has(slot);
+      if (
+        nowLink !== null &&
+        isAddressedSlot &&
+        (intended.has(String(nowLink)) || String(nowLink) === replacedId)
+      ) {
+        continue;
+      }
       if (wasLink !== null && String(wasLink) === replacedId) continue;
       collateralReslottedInputs.push({ slot, before: wasLink, after: nowLink });
     }

--- a/web/js/lib/dynamic-slot-reconcile.js
+++ b/web/js/lib/dynamic-slot-reconcile.js
@@ -1,0 +1,250 @@
+/**
+ * #2008 — a connect into a COMFY_AUTOGROW_V3 family can re-address later slots.
+ *
+ * MiniMaxH3ReferenceToVideo (and any Autogrow.TemplatePrefix node) exposes
+ * children as dotted names: `ref_images.ref_image_4`. Connecting to one of
+ * those names runs the family's onConnectionsChange, which inserts a new
+ * sibling and shifts every later input — `ref_videos`, `ref_audios`, prompt,
+ * width, height, length — to a new index. LiteGraph may also rewrite
+ * `target_slot` on the surviving links, or a rebuild may copy links BY
+ * POSITION onto the new array and land them on the wrong names.
+ *
+ * Logical identity for these slots is the NAME, not the index. The caller
+ * addressed `ref_images.ref_image_4`; prompt is still prompt. This module
+ * snapshots name→link before the connect, re-reads after, then:
+ *
+ *   - keeps the intended dotted-prefix slot's new link
+ *   - restores every other surviving name's original link
+ *   - retargets the stored link's `target_slot` to the live index
+ *
+ * It does NOT run for positional packs (ImpactSwitch `input1` / Easy-Use
+ * `image0`). Those rename FROM POSITION on purpose; putting an old name back
+ * would break the `select`/`index` contract (#1873). The gate is a dotted
+ * name on the addressed slot (`family.child`).
+ *
+ * Never throws. A failed restore is left for the existing slots_rewritten /
+ * collateral_changes riders; this must never turn a landed wire into a
+ * reported failure (#1272).
+ */
+
+/** True for Autogrow-style children (`ref_images.ref_image_4`). */
+export function isDynamicPrefixSlotName(name) {
+  return typeof name === "string" && name.includes(".");
+}
+
+/** Family prefix (`ref_images` from `ref_images.ref_image_4`). */
+export function dynamicPrefixFamily(name) {
+  if (!isDynamicPrefixSlotName(name)) return null;
+  const dot = name.indexOf(".");
+  return dot > 0 ? name.slice(0, dot) : null;
+}
+
+function slotName(slot) {
+  try {
+    return typeof slot?.name === "string" ? slot.name : null;
+  } catch {
+    return null;
+  }
+}
+
+function readLink(graph, linkId) {
+  if (linkId == null || !graph) return null;
+  try {
+    const links = graph.links;
+    if (links) {
+      const stored = typeof links.get === "function" ? links.get(linkId) : links[linkId];
+      if (stored != null) return stored;
+    }
+    if (typeof graph.getLink === "function") return graph.getLink(linkId) ?? null;
+    const map = graph._links;
+    if (map && typeof map.get === "function") return map.get(linkId) ?? null;
+  } catch {
+    /* unreadable store is "no link" */
+  }
+  return null;
+}
+
+function writeTargetSlot(stored, nodeId, index) {
+  if (!stored || typeof stored !== "object") return;
+  try {
+    if (Array.isArray(stored)) {
+      stored[3] = nodeId;
+      stored[4] = index;
+      return;
+    }
+    stored.target_id = nodeId;
+    stored.target_slot = index;
+  } catch {
+    /* best-effort retarget */
+  }
+}
+
+/**
+ * Live input index of `name` on `node`, or -1. First match; duplicate names
+ * are unpairable and the caller must treat that as "cannot reconcile".
+ */
+export function findSlotIndexByName(node, name) {
+  if (typeof name !== "string" || !name) return -1;
+  try {
+    const inputs = node?.inputs;
+    if (!Array.isArray(inputs)) return -1;
+    for (let i = 0; i < inputs.length; i++) {
+      if (slotName(inputs[i]) === name) return i;
+    }
+  } catch {
+    return -1;
+  }
+  return -1;
+}
+
+/**
+ * Snapshot one node's inputs as `{ name, index, link }` rows, BEFORE a connect.
+ *
+ * Duplicate names make pairing a guess — those snapshots are marked
+ * `pairable: false` and reconcile becomes a no-op. Never throws.
+ */
+export function captureNamedSlotLinks(node) {
+  const slots = [];
+  const seen = new Set();
+  let pairable = true;
+  try {
+    if (!node || typeof node !== "object" || !Array.isArray(node.inputs)) {
+      return { node, slots, pairable: false };
+    }
+    for (let i = 0; i < node.inputs.length; i++) {
+      const slot = node.inputs[i];
+      let name = null;
+      let link = null;
+      try {
+        name = slotName(slot);
+        link = slot?.link ?? null;
+      } catch {
+        name = null;
+        link = null;
+      }
+      if (name && seen.has(name)) pairable = false;
+      if (name) seen.add(name);
+      slots.push({ name, index: i, link });
+    }
+  } catch {
+    return { node, slots: [], pairable: false };
+  }
+  return { node, slots, pairable };
+}
+
+function sameLink(a, b) {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return a === b;
+}
+
+function familyOf(name) {
+  return dynamicPrefixFamily(name);
+}
+
+/**
+ * Re-seat links on `node` so each surviving NAME keeps the wire it had before
+ * the connect, except the intended dotted-prefix slot which keeps the new one.
+ *
+ * @returns {{ intendedName: string|null, intendedIndex: number, restored: number } | null}
+ *   null when this connect is not a dotted-prefix address, or the snapshot
+ *   cannot be paired honestly. `restored` is the number of names whose live
+ *   link was written back.
+ */
+export function reconcileDynamicPrefixSlots({
+  graph,
+  node,
+  before,
+  intendedName,
+  intendedLinkId,
+  replacedLinkId,
+} = {}) {
+  try {
+    if (!isDynamicPrefixSlotName(intendedName)) return null;
+    if (!node || typeof node !== "object" || !Array.isArray(node.inputs)) return null;
+    if (!before?.pairable || before.node !== node) return null;
+
+    const liveByName = new Map();
+    for (let i = 0; i < node.inputs.length; i++) {
+      const name = slotName(node.inputs[i]);
+      if (!name) continue;
+      if (liveByName.has(name)) return null; // live duplicates — cannot pair
+      liveByName.set(name, i);
+    }
+
+    let intendedIndex = liveByName.has(intendedName) ? liveByName.get(intendedName) : -1;
+    if (intendedIndex < 0 && intendedLinkId != null) {
+      const family = familyOf(intendedName);
+      for (let i = 0; i < node.inputs.length; i++) {
+        const name = slotName(node.inputs[i]);
+        if (!name || familyOf(name) !== family) continue;
+        if (node.inputs[i]?.link === intendedLinkId) {
+          intendedIndex = i;
+          intendedName = name;
+          break;
+        }
+      }
+    }
+
+    if (intendedLinkId != null && intendedIndex >= 0) {
+      const holder = node.inputs[intendedIndex];
+      if (holder && holder.link !== intendedLinkId) {
+        for (let i = 0; i < node.inputs.length; i++) {
+          if (i === intendedIndex) continue;
+          try {
+            if (node.inputs[i]?.link === intendedLinkId) node.inputs[i].link = null;
+          } catch {
+            /* skip a hostile slot */
+          }
+        }
+        holder.link = intendedLinkId;
+        writeTargetSlot(readLink(graph, intendedLinkId), node.id, intendedIndex);
+      } else if (holder?.link === intendedLinkId) {
+        writeTargetSlot(readLink(graph, intendedLinkId), node.id, intendedIndex);
+      }
+    }
+
+    let restored = 0;
+    for (const row of before.slots) {
+      if (!row?.name) continue;
+      if (row.name === intendedName) continue;
+      if (row.link != null && row.link === replacedLinkId) continue;
+      const liveIndex = liveByName.get(row.name);
+      if (liveIndex == null) continue;
+      if (liveIndex === intendedIndex) continue;
+      const live = node.inputs[liveIndex];
+      if (!live) continue;
+      let current;
+      try {
+        current = live.link ?? null;
+      } catch {
+        continue;
+      }
+      if (sameLink(current, row.link)) {
+        if (row.link != null) writeTargetSlot(readLink(graph, row.link), node.id, liveIndex);
+        continue;
+      }
+      if (row.link != null) {
+        for (let i = 0; i < node.inputs.length; i++) {
+          if (i === liveIndex || i === intendedIndex) continue;
+          try {
+            if (node.inputs[i]?.link === row.link) node.inputs[i].link = null;
+          } catch {
+            /* skip */
+          }
+        }
+      }
+      live.link = row.link;
+      if (row.link != null) writeTargetSlot(readLink(graph, row.link), node.id, liveIndex);
+      restored++;
+    }
+
+    return {
+      intendedName: typeof intendedName === "string" ? intendedName : null,
+      intendedIndex,
+      restored,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/web/js/lib/slot-rename-disclosure.js
+++ b/web/js/lib/slot-rename-disclosure.js
@@ -121,6 +121,18 @@ function widgetValues(widgets) {
  * captured once and cannot report itself twice. Non-objects are skipped rather
  * than throwing, for the same reason `captureNodeTitles` skips them.
  */
+function slotObjects(slots) {
+  try {
+    return Array.isArray(slots) ? [...slots] : [];
+  } catch {
+    return [];
+  }
+}
+
+function isDottedName(name) {
+  return typeof name === "string" && name.includes(".");
+}
+
 export function captureSlotNames(nodes) {
   const snapshot = [];
   for (const node of nodes ?? []) {
@@ -131,6 +143,12 @@ export function captureSlotNames(nodes) {
         node,
         inputs: slotNames(node.inputs),
         outputs: slotNames(node.outputs),
+        // Object identity is how #2008 tells Autogrow INSERTION (the slot
+        // object moved, name intact) from ImpactSwitch RENAME (the same
+        // object is still at that index, name rewritten). Spread is a copy
+        // of the refs, not of the slot records.
+        inputSlots: slotObjects(node.inputs),
+        outputSlots: slotObjects(node.outputs),
         widgets: widgetValues(node.widgets),
       });
     } catch {
@@ -138,6 +156,94 @@ export function captureSlotNames(nodes) {
     }
   }
   return snapshot;
+}
+
+/**
+ * Name changes that are rewrites, not Autogrow insertions.
+ *
+ * Compared three ways, in order:
+ *
+ *   1. Slot OBJECT identity, when any before-object is still in the live
+ *      array. ImpactSwitch mutates `input.name` in place (#1873) — the object
+ *      stays, the name changes, that is a rewrite. Autogrow splices a new
+ *      sibling in (#2008) — the later objects move with their names intact,
+ *      that is not.
+ *   2. Insertion-aware alignment, when no object survived (a rebuild) AND
+ *      the before list had a dotted Autogrow name. New names are skipped;
+ *      surviving names that merely shifted index are not reported.
+ *   3. Index-aligned, the original #1873 comparison, for everything else.
+ *
+ * A brand-new trailing slot is never reported in any of the three.
+ */
+function describeNameChanges(kind, before, after, beforeObjs, afterObjs) {
+  const changes = [];
+  const anySurvived = beforeObjs.some((obj) => obj && afterObjs.includes(obj));
+  if (anySurvived) {
+    for (let i = 0; i < before.length; i++) {
+      const obj = beforeObjs[i];
+      const liveIdx = obj ? afterObjs.indexOf(obj) : -1;
+      if (liveIdx >= 0) {
+        const to = liveIdx < after.length ? after[liveIdx] : null;
+        if (before[i] === to) continue;
+        changes.push({
+          kind,
+          index: i,
+          from: safeDisclosureValue(before[i] ?? null),
+          to: safeDisclosureValue(to),
+        });
+        continue;
+      }
+      changes.push({
+        kind,
+        index: i,
+        from: safeDisclosureValue(before[i] ?? null),
+        to: null,
+      });
+    }
+    return changes;
+  }
+  if (before.some(isDottedName)) {
+    let i = 0;
+    let j = 0;
+    while (i < before.length) {
+      if (j < after.length && before[i] === after[j]) {
+        i++;
+        j++;
+        continue;
+      }
+      if (j < after.length && !before.includes(after[j])) {
+        j++;
+        continue;
+      }
+      if (j < after.length && after.indexOf(before[i], j) !== -1) {
+        j++;
+        continue;
+      }
+      const to = j < after.length ? after[j] : null;
+      if (before[i] !== to) {
+        changes.push({
+          kind,
+          index: i,
+          from: safeDisclosureValue(before[i] ?? null),
+          to: safeDisclosureValue(to),
+        });
+      }
+      i++;
+      if (j < after.length) j++;
+    }
+    return changes;
+  }
+  for (let i = 0; i < before.length; i++) {
+    const to = i < after.length ? after[i] : null;
+    if (before[i] === to) continue;
+    changes.push({
+      kind,
+      index: i,
+      from: safeDisclosureValue(before[i] ?? null),
+      to: safeDisclosureValue(to),
+    });
+  }
+  return changes;
 }
 
 /**
@@ -178,17 +284,10 @@ export function describeSlotRewrites(snapshot) {
       for (const kind of ["input", "output"]) {
         const before = (kind === "input" ? entry.inputs : entry.outputs) ?? [];
         const after = slotNames(kind === "input" ? node.inputs : node.outputs);
-        for (let i = 0; i < before.length; i++) {
-          // `i >= after.length` is a REMOVAL, reported as `to: null`. Indices at or
-          // beyond `before.length` are new slots and are deliberately not read.
-          const to = i < after.length ? after[i] : null;
-          if (before[i] === to) continue;
-          slots.push({
-            kind,
-            index: i,
-            from: safeDisclosureValue(before[i] ?? null),
-            to: safeDisclosureValue(to),
-          });
+        const beforeObjs = (kind === "input" ? entry.inputSlots : entry.outputSlots) ?? [];
+        const afterObjs = slotObjects(kind === "input" ? node.inputs : node.outputs);
+        for (const change of describeNameChanges(kind, before, after, beforeObjs, afterObjs)) {
+          slots.push(change);
         }
       }
       const widgets = [];


### PR DESCRIPTION
Fixes #2008.

## What the reporter saw

`panel_connect` targeted `MiniMaxH3ReferenceToVideo` input `ref_images.ref_image_4`. The node's `onConnectionsChange` dynamically rebuilt and shifted later slot names/links. The connect succeeded, but `slots_rewritten` reported `ref_videos` / `ref_audios` / prompt / width / height / length as re-addressed, and `collateral_changes` reported different live links. Sequential name-based edits were then hazardous unless every mutation forced a re-read.

## Root cause

MiniMax H3 Reference to Video declares Autogrow families as dotted children (`ref_images.ref_image_N`, `ref_videos.ref_video_N`, ...). Connecting to one of those names inserts a sibling and shifts every later input.

`panel_connect` already snapshotted slot **indices** (`captureSlotNames`, `snapshotInputSlotLinks`) and disclosed index-aligned rewrites (#1873) and collateral (#2380). Logical identity for Autogrow children is the **NAME**, not the index. An insert that kept `prompt` named `prompt` and kept its wire still looked like a rewrite and a reslot.

Positional packs (ImpactSwitch `input1`) are a different contract — they rename FROM POSITION on purpose. This change is gated on a dotted name (`family.child`).

## The change

1. Snapshot the target's name→link map before the connect.
2. After `onConnectionsChange`, re-read and restore every surviving name's original link except the intended dotted slot (which keeps the new wire). Retarget stored `target_slot` to the live index.
3. Slot-rewrite disclosure uses slot-object identity (or insertion-aware alignment on a rebuild) so an Autogrow insert is silent while an ImpactSwitch in-place rename is still reported.
4. `verifyConnect` treats a same-name index shift as not collateral when `beforeNames` is provided.

Does not refuse after the mutation (#1272): a landed wire is still reported as connected.

## Verification

`node --test` on the connect extraction suite plus the new Autogrow fixtures, and `node scripts/check-panel-scope.mjs`.

No Playwright run — this suite does not start ComfyUI and none was allocated.

## Please look hardest at

- The dotted-name gate: ImpactSwitch positional packs must keep reporting `slots_rewritten`.
- Rebuild restore: a positional copy of links onto new slot objects is the scramble this exists to undo.
- Name-stable collateral exemption: a bystander that keeps its name but changes its **link** must still report (#2380).