### PR TITLE
fix(2006): a root PrimitiveNode is not a promoted container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_set_widget no longer refuses a root PrimitiveNode as an unclassifiable promoted container: leftover `.subgraph` (even a live-looking inner graph or a throwing getter) keeps `is_subgraph:false` and graph_get_subgraph throws the definitive "is not a subgraph" line (#2006)
 - the pre-publish registry parity scan now inspects the packaged archive rather than the repo, is wired into the publish job, and refuses to treat a Pending registry status as a pass (#1886)
 
 

--- a/browser_tests/unit/graph-find-nodes.test.mjs
+++ b/browser_tests/unit/graph-find-nodes.test.mjs
@@ -14,7 +14,7 @@ import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
 import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
 import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
-import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
+import { drivenWidgetsFor, isPromotedContainer } from "../../web/js/lib/graph-read.js";
 import { redactWidgetValue } from "../../web/js/lib/widget-secret-redaction.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -58,6 +58,7 @@ const summarizeNode = (() => {
     "drivenWidgetsFor",
     "redactWidgetValue",
     "nodeInstanceIdentity",
+    "isPromotedContainer",
     `${source}; return summarizeNode;`,
   )(
     virtualFedInputs,
@@ -69,6 +70,7 @@ const summarizeNode = (() => {
     drivenWidgetsFor,
     redactWidgetValue,
     nodeInstanceIdentity,
+    isPromotedContainer,
   );
 })();
 

--- a/browser_tests/unit/graph-get-subgraph-root-container.test.mjs
+++ b/browser_tests/unit/graph-get-subgraph-root-container.test.mjs
@@ -19,6 +19,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
+import { isPromotedContainer } from "../../web/js/lib/graph-read.js";
+
 const PANEL_SRC = readFileSync(
   new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
   "utf8",
@@ -50,6 +52,7 @@ function loadGetSubgraph() {
       "fixedCapNote",
       "summarizeNode",
       "promotedTerminalWitnesses",
+      "isPromotedContainer",
       `return ({${method}}).graph_get_subgraph;`,
     )(
       () => ({ graph: {} }),
@@ -62,6 +65,7 @@ function loadGetSubgraph() {
       () => "truncation note",
       (inner) => ({ id: inner.id, type: inner.type }),
       () => [],
+      isPromotedContainer,
     );
 }
 
@@ -148,6 +152,45 @@ test("#1941 a missing type still throws the canonical line", () => {
       return true;
     },
   );
+});
+
+test("#2006 a root PrimitiveNode throws the definitive non-container line", () => {
+  assertDefinitiveNonContainer({
+    id: 198,
+    type: "PrimitiveNode",
+    isVirtualNode: true,
+    widgets: [{ name: "value", value: "a prompt" }],
+  });
+});
+
+test("#2006 a PrimitiveNode leftover subgraph that looks live is still not a container", () => {
+  // The unfixed predicate treated any live-looking `.subgraph` as a container.
+  // PrimitiveNode is a frontend value source: leftover `_nodes` / getNodeById
+  // must not skip the definitive throw, or MCP refuses the ordinary `value` write.
+  for (const leftover of [
+    { _nodes: [{ id: 1, type: "CLIPTextEncode" }] },
+    { nodes: [{ id: 1, type: "CLIPTextEncode" }] },
+    { getNodeById() { return null; } },
+  ]) {
+    assertDefinitiveNonContainer({
+      id: 198,
+      type: "PrimitiveNode",
+      isVirtualNode: true,
+      subgraph: leftover,
+    });
+  }
+});
+
+test("#2006 a PrimitiveNode whose subgraph getter throws still uses the definitive line", () => {
+  const node = {
+    id: 198,
+    type: "PrimitiveNode",
+    isVirtualNode: true,
+    get subgraph() {
+      throw new Error("subgraph accessor exploded");
+    },
+  };
+  assertDefinitiveNonContainer(node);
 });
 
 test("#1941 a live inner graph is still a container — the throw does not fire", () => {

--- a/browser_tests/unit/graph-query-detail-budget.test.mjs
+++ b/browser_tests/unit/graph-query-detail-budget.test.mjs
@@ -21,6 +21,7 @@ import {
   drivenWidgetsFor,
   fitDetailLine,
   isLineProtected,
+  isPromotedContainer,
   truncationTail,
 } from "../../web/js/lib/graph-read.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
@@ -146,6 +147,7 @@ const dependencyNames = [
   "clipLine",
   "compactClipNote",
   "redactWidgetValue",
+  "isPromotedContainer",
 ];
 const graphQuery = new Function(
   ...dependencyNames,
@@ -176,6 +178,7 @@ const graphQuery = new Function(
   clipLine,
   compactClipNote,
   redactWidgetValue,
+  isPromotedContainer,
 );
 
 function detailRows(result) {
@@ -303,6 +306,30 @@ test("#2478 one-ID compact probes publish a bounded identity-bearing witness", (
       },
     ]);
     assert.ok(JSON.stringify(result.nodes).length <= 500, "identity witness must remain bounded");
+  } finally {
+    graph._nodes.pop();
+  }
+});
+
+test("#2006 a root PrimitiveNode stays is_subgraph:false even with leftover live subgraph", () => {
+  const node = {
+    id: 198,
+    type: "PrimitiveNode",
+    title: "prompt",
+    isVirtualNode: true,
+    widgets: [{ name: "value", value: "a MiniMax prompt" }],
+    inputs: [],
+    outputs: [],
+    subgraph: { _nodes: [{ id: 1, type: "CLIPTextEncode" }], getNodeById() { return null; } },
+  };
+  graph._nodes.push(node);
+  try {
+    const result = query({ ids: [198], fields: "detail" });
+    const row = detailRows(result)[0];
+    assert.equal(row.is_subgraph, false);
+    assert.equal(result.nodes?.[0]?.is_subgraph, false);
+    assert.equal(result.nodes?.[0]?.type, "PrimitiveNode");
+    assert.equal(result.viewing?.scope, "root");
   } finally {
     graph._nodes.pop();
   }

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -42,6 +42,7 @@ import {
   MAX_CHARS_CEILING,
   // #1748
   NOTE_NODE_TYPES,
+  isPromotedContainer,
 } from "../../web/js/lib/graph-read.js";
 
 // ---- #607: link-driven widget detection -----------------------------------
@@ -745,4 +746,67 @@ test("liveLinkTargetInput never throws on malformed nodes (#342)", () => {
   // Holes in the inputs array are skipped, not crashed on.
   assert.equal(liveLinkTargetInput({ inputs: [null, undefined] }, 3), null);
   assert.deepEqual(liveLinkTargetInput({ inputs: [null, { link: 3 }] }, 3), { index: 1, name: undefined });
+});
+
+// ---- #2006: PrimitiveNode is never a promoted container --------------------
+
+test("#2006 a root PrimitiveNode is not a promoted container", () => {
+  assert.equal(
+    isPromotedContainer({ id: 198, type: "PrimitiveNode", isVirtualNode: true, widgets: [{ name: "value" }] }),
+    false,
+  );
+});
+
+test("#2006 leftover live-looking subgraph on PrimitiveNode is still not a container", () => {
+  assert.equal(
+    isPromotedContainer({
+      id: 198,
+      type: "PrimitiveNode",
+      subgraph: { _nodes: [{ id: 1 }], getNodeById() { return null; } },
+    }),
+    false,
+  );
+});
+
+test("#2006 a throwing subgraph getter is not a container", () => {
+  assert.equal(
+    isPromotedContainer({
+      id: 198,
+      type: "PrimitiveNode",
+      get subgraph() {
+        throw new Error("boom");
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isPromotedContainer({
+      id: 74,
+      type: "VHS_VideoCombine",
+      get subgraph() {
+        throw new Error("boom");
+      },
+    }),
+    false,
+  );
+});
+
+test("#2006 a live inner graph is still a container", () => {
+  assert.equal(
+    isPromotedContainer({ id: 4, type: "SubgraphNode", subgraph: { _nodes: [{ id: 12 }] } }),
+    true,
+  );
+  assert.equal(
+    isPromotedContainer({ id: 4, type: "SubgraphNode", subgraph: { nodes: [] } }),
+    true,
+  );
+  assert.equal(
+    isPromotedContainer({ id: 4, type: "SubgraphNode", subgraph: { getNodeById() { return null; } } }),
+    true,
+  );
+});
+
+test("#1941 leftover subgraph that is not a live inner graph is not a container", () => {
+  assert.equal(isPromotedContainer({ id: 74, type: "VHS_VideoCombine", subgraph: {} }), false);
+  assert.equal(isPromotedContainer({ id: 74, type: "VHS_VideoCombine", subgraph: { name: "not-a-graph" } }), false);
 });

--- a/browser_tests/unit/graph-view-identity.test.mjs
+++ b/browser_tests/unit/graph-view-identity.test.mjs
@@ -127,6 +127,6 @@ test("#1925 pinpoint detail publishes a structured is_subgraph row", () => {
   const queryEnd = PANEL_SRC.indexOf("graph_find_nodes({", queryStart);
   const query = PANEL_SRC.slice(queryStart, queryEnd);
   assert.match(query, /pinpointNodes/);
-  assert.match(query, /is_subgraph: !!matched\[0\]\.subgraph/);
+  assert.match(query, /is_subgraph: isPromotedContainer\(matched\[0\]\)/);
   assert.match(query, /\.\.\.\(pinpointNodes \? \{ nodes: pinpointNodes \} : \{\}\)/);
 });

--- a/browser_tests/unit/read-surface-accuracy.test.mjs
+++ b/browser_tests/unit/read-surface-accuracy.test.mjs
@@ -16,7 +16,7 @@ import { displayLabel, boundaryInputLabel, widgetLabelMap } from "../../web/js/l
 import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
 import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
-import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
+import { drivenWidgetsFor, isPromotedContainer } from "../../web/js/lib/graph-read.js";
 import { redactWidgetValue } from "../../web/js/lib/widget-secret-redaction.js";
 import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 
@@ -59,6 +59,7 @@ const summarizeNode = (() => {
     "drivenWidgetsFor",
     "redactWidgetValue",
     "nodeInstanceIdentity",
+    "isPromotedContainer",
     `${fn}; return summarizeNode;`,
   )(
     virtualFedInputs,
@@ -70,6 +71,7 @@ const summarizeNode = (() => {
     drivenWidgetsFor,
     redactWidgetValue,
     nodeInstanceIdentity,
+    isPromotedContainer,
   );
 })();
 

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { isPromotedContainer } from "../../web/js/lib/graph-read.js";
 import { graphViewIdentityFor } from "../../web/js/lib/graph-view-identity.js";
 import { subgraphValueProvenance } from "../../web/js/lib/subgraph-value-provenance.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
@@ -94,10 +95,12 @@ test("WIRING: production graph_get_subgraph gives MCP a definitive non-promoted 
   const getSubgraph = new Function(
     "getGraphCtx",
     "resolveNode",
+    "isPromotedContainer",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph: {} }),
     (_graph, id) => ({ id, type: "OrdinaryNode" }),
+    isPromotedContainer,
   );
 
   assert.throws(
@@ -142,6 +145,7 @@ test("WIRING: production graph_get_subgraph publishes the terminal nested-promot
     "fixedCapNote",
     "summarizeNode",
     "promotedTerminalWitnesses",
+    "isPromotedContainer",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph }),
@@ -154,6 +158,7 @@ test("WIRING: production graph_get_subgraph publishes the terminal nested-promot
     () => "truncation note",
     (node) => ({ id: node.id, type: node.type }),
     () => [terminal],
+    isPromotedContainer,
   );
 
   const out = getSubgraph({ node_id: 78 });
@@ -180,6 +185,7 @@ test("WIRING: production graph_get_subgraph publishes an explicit empty witness 
     "fixedCapNote",
     "summarizeNode",
     "promotedTerminalWitnesses",
+    "isPromotedContainer",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph: {} }),
@@ -192,6 +198,7 @@ test("WIRING: production graph_get_subgraph publishes an explicit empty witness 
     () => "truncation note",
     (node) => ({ id: node.id, type: node.type }),
     () => [],
+    isPromotedContainer,
   );
 
   assert.deepEqual(getSubgraph({ node_id: 78 }).promoted_terminals, []);
@@ -208,12 +215,14 @@ test("WIRING: production alias witness keeps outer, immediate, and terminal name
     "followPromotionToConcrete",
     "MAX_PROMOTION_CHAIN_DEPTH",
     "promotedInputAliases",
+    "isPromotedContainer",
     `${src.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
   )(
     resolvePromotedInnerTarget,
     followPromotionToConcrete,
     MAX_PROMOTION_CHAIN_DEPTH,
     promotedInputAliases,
+    isPromotedContainer,
   );
 
   const cases = [
@@ -336,12 +345,14 @@ test("WIRING: production witness refuses an externally-linked parent rail", asyn
     "followPromotionToConcrete",
     "MAX_PROMOTION_CHAIN_DEPTH",
     "promotedInputAliases",
+    "isPromotedContainer",
     `${src.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
   )(
     resolvePromotedInnerTarget,
     followPromotionToConcrete,
     MAX_PROMOTION_CHAIN_DEPTH,
     promotedInputAliases,
+    isPromotedContainer,
   );
   const rail = { name: "quality_prompt", value: "old" };
   const inner = {
@@ -383,12 +394,14 @@ test("WIRING: production witness re-evaluates parent authority after a promotion
     "followPromotionToConcrete",
     "MAX_PROMOTION_CHAIN_DEPTH",
     "promotedInputAliases",
+    "isPromotedContainer",
     `${src.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
   )(
     resolvePromotedInnerTarget,
     followPromotionToConcrete,
     MAX_PROMOTION_CHAIN_DEPTH,
     promotedInputAliases,
+    isPromotedContainer,
   );
   const rail = { name: "quality_prompt", value: "old" };
   const input = {
@@ -433,12 +446,14 @@ test("WIRING: production witness refuses to publish [] for an unenumerable proxy
     "followPromotionToConcrete",
     "MAX_PROMOTION_CHAIN_DEPTH",
     "promotedInputAliases",
+    "isPromotedContainer",
     `${src.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
   )(
     resolvePromotedInnerTarget,
     followPromotionToConcrete,
     MAX_PROMOTION_CHAIN_DEPTH,
     promotedInputAliases,
+    isPromotedContainer,
   );
 
   const entries = makeWitnesses({
@@ -498,6 +513,7 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     "fixedCapNote",
     "summarizeNode",
     "promotedTerminalWitnesses",
+    "isPromotedContainer",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph }),
@@ -510,6 +526,7 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     () => "truncation note",
     (node) => ({ id: node.id, mode: node.mode, inputs: node.inputs, outputs: node.outputs }),
     () => [],
+    isPromotedContainer,
   );
 
   const out = getSubgraph({ node_id: 173 });

--- a/browser_tests/unit/summarize-duplicate-widgets.test.mjs
+++ b/browser_tests/unit/summarize-duplicate-widgets.test.mjs
@@ -26,7 +26,7 @@ import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
 import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
 import { nodeInstanceIdentity } from "../../web/js/lib/node-identity.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
-import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
+import { drivenWidgetsFor, isPromotedContainer } from "../../web/js/lib/graph-read.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -60,6 +60,7 @@ const summarizeNode = (() => {
     "drivenWidgetsFor",
     "redactWidgetValue",
     "nodeInstanceIdentity",
+    "isPromotedContainer",
     `${fn}; return summarizeNode;`,
   )(
     virtualFedInputs,
@@ -71,6 +72,7 @@ const summarizeNode = (() => {
     drivenWidgetsFor,
     redactWidgetValue,
     nodeInstanceIdentity,
+    isPromotedContainer,
   );
 })();
 

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -616,7 +616,7 @@ test("#560 SAFETY: dotted addressing on a SUBGRAPH parent is refused (never a ra
   const node = {
     id: 47,
     type: "MySubgraph",
-    subgraph: {},
+    subgraph: { _nodes: [] },
     inputs: [],
     widgets: [{ name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1 } }],
   };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -469,6 +469,7 @@ import {
   outlineFloorRefusal,
   outlineValueClipNote,
   clipOutlineTitle,
+  isPromotedContainer,
 } from "./lib/graph-read.js";
 import { slotRenameLines } from "./lib/slot-rename-diff.js";
 import { describeRenameFailure } from "./lib/workflow-rename-error.js";
@@ -10085,7 +10086,7 @@ function promotedTerminalWitnesses(subgraphNode) {
       terminal?.cycle ||
       terminal?.error ||
       terminal?.terminalVirtual ||
-      terminalNode.subgraph ||
+      isPromotedContainer(terminalNode) ||
       terminal?.depth === undefined ||
       !Number.isSafeInteger(terminal.depth) ||
       terminal.depth < 0 ||
@@ -12417,10 +12418,17 @@ function summarizeNode(node) {
   };
   // Subgraphs summarize SHALLOWLY — boundary slots + widgets only, plus an
   // inner node count. Drill in with graph_get_subgraph when needed.
-  if (node.subgraph) {
+  // #2006 — same live-container predicate as graph_get_subgraph / pinpoint
+  // is_subgraph: leftover `.subgraph` on a PrimitiveNode is not a container.
+  if (isPromotedContainer(node)) {
     summary.is_subgraph = true;
-    summary.subgraph_node_count =
-      node.subgraph._nodes?.length ?? node.subgraph.nodes?.length ?? 0;
+    let innerCount = 0;
+    try {
+      innerCount = node.subgraph._nodes?.length ?? node.subgraph.nodes?.length ?? 0;
+    } catch {
+      innerCount = 0;
+    }
+    summary.subgraph_node_count = innerCount;
   }
   return summary;
 }
@@ -14810,7 +14818,7 @@ const GRAPH_TOOL_EXECUTORS = {
           // #2314 — MCP must distinguish a definitive ordinary node from an
           // older Panel whose detail projection cannot classify promotion.
           // Positive-only emission made missing capability look like false.
-          is_subgraph: !!n.subgraph,
+          is_subgraph: isPromotedContainer(n),
         };
         line = JSON.stringify(summary);
         // Final guard: if the fully-capped detail STILL exceeds max_chars (a node with
@@ -14904,11 +14912,11 @@ const GRAPH_TOOL_EXECUTORS = {
               ...(typeof summarized.node_identity === "string"
                 ? { node_identity: summarized.node_identity }
                 : {}),
-              is_subgraph: !!matched[0].subgraph,
+              is_subgraph: isPromotedContainer(matched[0]),
             }
           : {
               ...capSummaryWidgets(summarized, detailWidgetCap, maxChars),
-              is_subgraph: !!matched[0].subgraph,
+              is_subgraph: isPromotedContainer(matched[0]),
             };
       const fitted = fitDetailLine(
         JSON.stringify(summary),
@@ -14934,7 +14942,7 @@ const GRAPH_TOOL_EXECUTORS = {
             ...(typeof summary.node_identity === "string"
               ? { node_identity: summary.node_identity }
               : {}),
-            is_subgraph: !!matched[0].subgraph,
+            is_subgraph: isPromotedContainer(matched[0]),
           },
         ];
       }
@@ -15345,24 +15353,22 @@ const GRAPH_TOOL_EXECUTORS = {
   graph_get_subgraph({ node_id }) {
     const { graph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
-    const sub = node.subgraph;
     // #1941 — MCP's promoted-write probe treats anything other than this exact
     // "is not a subgraph" line as indeterminate and refuses the write. A root
     // node is not a promoted container: only a live inner graph (nodes list or
     // getNodeById) is one. A truthy leftover `subgraph` used to skip the throw
     // and look like an unclassifiable container. Nested parentheses in `type`
     // also made the orchestrator miss its own definitive form, so flatten them.
-    const isContainer =
-      !!sub &&
-      typeof sub === "object" &&
-      (Array.isArray(sub._nodes) || Array.isArray(sub.nodes) || typeof sub.getNodeById === "function");
-    if (!isContainer) {
+    // #2006 — a root PrimitiveNode is never a container, even when leftover
+    // `.subgraph` looks live or its getter throws a non-definitive error.
+    if (!isPromotedContainer(node)) {
       const rawType = typeof node.type === "string" ? node.type : "";
       const type = rawType.replace(/[()]/g, " ").replace(/\s+/g, " ").trim();
       throw new Error(
         type ? `Node ${node.id} (${type}) is not a subgraph` : `Node ${node.id} is not a subgraph`,
       );
     }
+    const sub = node.subgraph;
     const inner = [...(sub._nodes ?? sub.nodes ?? [])];
     const promotedTerminals = promotedTerminalWitnesses(node);
     // #1729 — provenance is a second structured-read path: its raw instance_widgets

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -50,6 +50,38 @@ export const COMPACT_VALUE_CLIP = 60;
 export const NOTE_NODE_TYPES = new Set(["Note", "MarkdownNote"]);
 
 /**
+ * True when `node` is a live promoted-widget container (a SubgraphNode with an
+ * inner graph). MCP's panel_set_widget probe treats a boolean `is_subgraph` and
+ * graph_get_subgraph's "is not a subgraph" line as the ordinary-vs-container
+ * classification. Two leftovers must not look like a container:
+ *
+ *   #1941 — a truthy `.subgraph` that is not a live inner graph (`{}`, a name
+ *           bag) used to skip the definitive throw.
+ *   #2006 — a root PrimitiveNode is a frontend-only value source. It is never
+ *           a subgraph container, even when a leftover `.subgraph` looks live
+ *           or its getter throws. Treating it as one makes graph_get_subgraph
+ *           return a malformed envelope (or a non-definitive throw), and MCP
+ *           then refuses the ordinary `value` write.
+ *
+ * Never throws: an unreadable subgraph accessor is not a container.
+ */
+export function isPromotedContainer(node) {
+  try {
+    if (!node || typeof node !== "object") return false;
+    if (node.type === "PrimitiveNode") return false;
+    const sub = node.subgraph;
+    if (!sub || typeof sub !== "object") return false;
+    return (
+      Array.isArray(sub._nodes) ||
+      Array.isArray(sub.nodes) ||
+      typeof sub.getNodeById === "function"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * #809 (codex gate): "raise `X` up to N" is ITSELF a dead retry when the caller is
  * already at N, and "raise `X`" with no ceiling leaves them guessing how far. Both cost
  * the round trip this issue exists to prevent. One helper so every marker — inline or

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -45,7 +45,7 @@ import {
 } from "./node-resolve.js";
 import { controlAfterGenerateWarning, controlEntryForWidget } from "./control-after-generate.js";
 import { isTypeScopedObjectInfo } from "./scoped-object-info.js";
-import { linkDrivenWidgets, drivenTag } from "./graph-read.js";
+import { isPromotedContainer, linkDrivenWidgets, drivenTag } from "./graph-read.js";
 import { refreshDynamicInputsAfterWrite } from "./dynamic-inputs-refresh.js";
 import { refreshCustomGeneratedWidgetsAfterWrite } from "./custom-generated-widgets-refresh.js";
 import { REFRESH_JOIN_ABANDONED } from "./refresh-coalesce.js";
@@ -479,7 +479,7 @@ export async function runSetWidget(
 
   // Resolve the promoted inner target ONCE (PURE — no coercion/mutation). Threaded
   // into applyWidgetWrite so the write never re-resolves to a different node.
-  const promotedResolution = node?.subgraph
+  const promotedResolution = isPromotedContainer(node)
     ? resolvePromotedInnerTarget(node, widgetName, resolveSource)
     : null;
   const isResolvedPromotion = !!(
@@ -595,16 +595,17 @@ export async function runSetWidget(
   let concreteWidgetName;
   // #1126 — is the promotion NESTED (outer → intermediate subgraph → … → concrete), as
   // opposed to a single hop straight to the concrete node? Keyed on exactly what
-  // followPromotionToConcrete's own `while (node && node.subgraph)` loop keys on, so the
-  // two can never disagree about whether the chain continues past the immediate target.
-  // Read only by the #1126 unreadable fallback; see its refusal for why it matters.
+  // followPromotionToConcrete's own `while (node && isPromotedContainer(node))` loop
+  // keys on, so the two can never disagree about whether the chain continues past
+  // the immediate target. Read only by the #1126 unreadable fallback; see its
+  // refusal for why it matters.
   let nestedPromotion = false;
   if (promotedButUnresolvable) {
     authTarget = null;
   } else if (isResolvedPromotion) {
-    nestedPromotion = Boolean(promotedResolution.target?.node?.subgraph);
+    nestedPromotion = isPromotedContainer(promotedResolution.target?.node);
     const concrete = followPromotionToConcrete(promotedResolution.target, resolveSource);
-    if (concrete.node && !concrete.node.subgraph && typeof concrete.node.type === "string") {
+    if (concrete.node && !isPromotedContainer(concrete.node) && typeof concrete.node.type === "string") {
       // Reached a genuine concrete backend node WITH a real type string — authorize it.
       // (assertTypeAgainstFreshBackend below then always runs for a promoted write.)
       authTarget = concrete.node;
@@ -666,7 +667,7 @@ export async function runSetWidget(
     //
     // "Could not determine whether this is a promoted widget on a subgraph" is not
     // "determined it is not" — the same fold this cluster exists to correct.
-    if (node?.subgraph && isVirtualSubgraphContainer(node)) {
+    if (isPromotedContainer(node) && isVirtualSubgraphContainer(node)) {
       const containerVerdict = backendHistoryVerdict(node?.type, wasTypeEverDefined);
       // An UNAVAILABLE map is could-not-determine, NOT "the backend lacks this type" —
       // freshBackendDefinesType returns false for both, so the two must be told apart

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -2,6 +2,7 @@ import { fireNodeWidgetChanged } from "./node-widget-changed.js";
 import { missingWidgetMessage } from "./missing-widget.js";
 import { explainNumericNormalization, normalizationNote } from "./widget-normalization.js";
 import { isNonSerializingValueSource } from "./virtual-source-promotion.js";
+import { isPromotedContainer } from "./graph-read.js";
 import {
   boundPropertyFailure,
   boundPropertyState,
@@ -1742,7 +1743,7 @@ export function followPromotionToConcrete(target, resolveSource) {
   let widget = target?.widget ?? null;
   const seen = new Set();
   let depth = 0;
-  while (node && node.subgraph) {
+  while (node && isPromotedContainer(node)) {
     if (seen.has(node)) return { node, widget, cycle: true };
     if (depth >= MAX_PROMOTION_CHAIN_DEPTH) {
       return {
@@ -1797,7 +1798,7 @@ export function collectPromotionIntermediates(target, resolveSource) {
   let widget = target?.widget ?? null;
   const seen = new Set();
   let depth = 0;
-  while (node && node.subgraph) {
+  while (node && isPromotedContainer(node)) {
     if (seen.has(node)) break;
     if (depth >= MAX_PROMOTION_CHAIN_DEPTH) break;
     seen.add(node);
@@ -1837,8 +1838,8 @@ export function resolveWidgetWrite(
   // name contains a dot is never hijacked.
   let subFieldPath = null;
 
-  if (node?.subgraph) {
-    // Reuse a promotion resolution the caller already computed (graph_set_widget
+  if (isPromotedContainer(node)) {
+    // Reuse a promotion resolution the caller already computed (graph_set_widget)
     // resolves it ONCE up front to fresh-authorize the inner target, #458), so the
     // write targets the IDENTICAL inner node it authorized — a relink between the
     // async /object_info fetch and the write can't swap in an unauthorized target.
@@ -1929,7 +1930,7 @@ export function resolveWidgetWrite(
     // all) always wins — the split is never taken when an exact match exists.
     widget = resolveWidgetByName(targetNode, widgetName);
   }
-  if (!widget && node?.subgraph) {
+  if (!widget && isPromotedContainer(node)) {
     // #560 SAFETY: on a SUBGRAPH parent, a dotted name that did not resolve as a
     // promotion alias must NOT fall through to the base-name dotted fallback below —
     // that would write the parent's projected RAIL widget DIRECTLY, bypassing the


### PR DESCRIPTION
Fixes #2006.

## Root cause

`panel_set_widget` probes `graph_get_subgraph` when it cannot prove the addressed node is an ordinary root node. The only reply MCP treats as "not a promoted container" is:

```
Error: Node <id> (<type>) is not a subgraph
```

Anything else is rewritten as:

> panel_set_widget refused the promoted "value" write because graph_get_subgraph could not determine whether the addressed node is a promoted container. No graph_set_widget was dispatched.

#1941 already made leftover empty `subgraph` objects throw that line. A root `PrimitiveNode` still failed: leftover `.subgraph` that looked live (`_nodes` / `getNodeById`), or a getter that threw, skipped the definitive throw or made the query report `is_subgraph:true`. PrimitiveNode is a frontend-only value source and is never a container.

## Fix

- Shared `isPromotedContainer()`: PrimitiveNode is never a container; leftover `.subgraph` must be a live inner graph; a throwing getter is not a container.
- Pinpoint / detail `is_subgraph` and `graph_get_subgraph` use that predicate, so a root PrimitiveNode stays `is_subgraph:false` and throws the definitive non-container line.
- The write path uses the same predicate so leftover `.subgraph` cannot hijack a PrimitiveNode as a promoted wrapper.

## Tests

- `browser_tests/unit/graph-get-subgraph-root-container.test.mjs` — root PrimitiveNode, leftover live-looking subgraph, throwing getter.
- `browser_tests/unit/graph-query-detail-budget.test.mjs` — pinpoint `is_subgraph:false` for PrimitiveNode 198.
- `browser_tests/unit/graph-read.test.mjs` — the shared predicate.

**Suite:** `npm run test:unit` → 7529 tests, **7528 pass, 0 fail** (1 pre-existing todo).

Do not merge from this PR — parent merges after the swarm.
