### PR TITLE
fix(2012): surface the Manager install traceback in panel_install_node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_install_node surfaces the Manager install traceback instead of hiding it behind a generic "Installation failed" pointer to the server log (#2012)
 - panel_refresh_nodes refuses a stale browser bundle with a Ctrl+Shift+R remedy instead of clearing last-known schema (#2027)
 - panel_refresh_nodes publishes the workflow UUID of the canvas it refreshed, and refuses a retryable route-registration miss if the active route moves, instead of returning refreshed:true with another UUID (#2026)
 - panel_set_widget no longer reports outcome-unknown after the value has landed: the handler ack is flushed once graph_set_widget resolves, and a timeout after delivery returns applied and verified from an idempotent readback (#2025)

--- a/browser_tests/unit/install-terminal-failure.test.mjs
+++ b/browser_tests/unit/install-terminal-failure.test.mjs
@@ -29,6 +29,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import * as ManagerInstall from "../../web/js/lib/manager-install.js";
+import { isGenericManagerInstallError } from "../../web/js/lib/manager-install-traceback.js";
 const { classifyInstallOutcome, taskFailureReason, parseTaskHistoryItem, queueDrained } =
   ManagerInstall;
 
@@ -120,6 +121,12 @@ function buildVerifyInstalled({ routes, calls = [], budgetMs }) {
     // on purpose: these tests pin the HTTP history path, and an empty log proves
     // the capture cannot short-circuit or alter it.
     managerTaskResults: ManagerInstall.createManagerTaskResultLog(),
+    // #2012 — the verifier reads the log only on a generic "Installation failed"
+    // sentence. These tests pin the history path with a specific registry-miss
+    // reason, so the log read must stay quiet.
+    isGenericManagerInstallError,
+    readInstallTraceback: async () => null,
+    api: { fileURL: (r) => r },
   };
   const factory = new Function(
     ...Object.keys(deps),

--- a/browser_tests/unit/manager-install-traceback.test.mjs
+++ b/browser_tests/unit/manager-install-traceback.test.mjs
@@ -1,0 +1,403 @@
+// panel#2012 — panel_install_node hid the Manager install cause behind
+//
+//   rgthree-comfy install FAILED: ... Installation failed. The install did
+//   NOT complete — check the ComfyUI server log for the full traceback.
+//
+// Manager's do_install (glob/manager_server.py) RETURNS that one-liner as the
+// task result and prints the real evidence only to the server log:
+//
+//   * ManagedResult failure logs
+//     [ComfyUI-Manager] Installation failed:\n{res.msg}
+//   * Exception path calls traceback.print_exc() and returns
+//     "Installation failed:\n{node_spec_str}" — the spec is the pack, not the cause.
+//
+// These tests pin the extractor against those two wire shapes, then drive the
+// SHIPPED verifyInstalled so a missing bind (the helper existing but never
+// called) fails here instead of in the browser.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  classifyInstallOutcome,
+  taskFailureReason,
+  parseTaskHistoryItem,
+  queueDrained,
+  createManagerTaskResultLog,
+} from "../../web/js/lib/manager-install.js";
+import {
+  extractInstallTraceback,
+  isGenericManagerInstallError,
+  readInstallTraceback,
+  INSTALL_TRACEBACK_MAX_LINES,
+  INSTALL_TRACEBACK_LINE_CAP,
+} from "../../web/js/lib/manager-install-traceback.js";
+
+const PACK = "rgthree-comfy";
+const GENERIC = "Installation failed";
+const GENERIC_SPEC = "Installation failed:\nrgthree-comfy@nightly";
+
+const ESC = String.fromCharCode(27);
+
+// Verbatim shapes from ComfyUI-Manager's do_install. The KeyError is what the
+// exception arm prints when cnr_map does not have the pack; the Installation
+// failed + res.msg block is what the ManagedResult arm logs.
+const EXCEPTION_TB = [
+  "Traceback (most recent call last):",
+  `  File "C:\\Users\\Artokun\\ComfyUI\\custom_nodes\\ComfyUI-Manager\\glob\\manager_server.py", line 545, in do_install`,
+  "    res = await core.unified_manager.install_by_id(node_name, version_spec, channel, mode, return_postinstall=skip_post_install)",
+  "          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+  `KeyError: '${PACK}'`,
+].join("\n");
+
+const DETAILED_ERROR = [
+  `[ComfyUI-Manager] Installation failed:`,
+  `Failed to clone repo: https://github.com/rgthree/${PACK}`,
+].join("\n");
+
+const GIT_TB = [
+  "Traceback (most recent call last):",
+  `  File "C:\\Users\\Artokun\\ComfyUI\\custom_nodes\\ComfyUI-Manager\\glob\\manager_core.py", line 1800, in install_by_id`,
+  "    git.Repo.clone_from(url, path)",
+  "git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)",
+  "  cmdline: git clone",
+  `  stderr: 'fatal: destination path 'custom_nodes/${PACK}' already exists'`,
+].join("\n");
+
+const GENERIC_ITEM = {
+  ui_id: "u-2012",
+  client_id: "comfyui-mcp-panel",
+  kind: "install",
+  result: GENERIC,
+  status: { status_str: "error", completed: true, messages: [GENERIC] },
+  params: { id: PACK, selected_version: "nightly" },
+};
+
+const DRAINED = { total_count: 1, done_count: 1, is_processing: false };
+const INSTALLED_LIST = { "some-other-pack": { ver: "1.0", cnr_id: "some-other-pack" } };
+
+function readPanelSource() {
+  return readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+}
+
+function pick(src, re, name) {
+  const m = src.match(re);
+  assert.ok(m, `could not locate ${name} in panel source`);
+  return m[0];
+}
+
+// ---------------------------------------------------------------------------
+// Pure classifier of the generic sentence
+// ---------------------------------------------------------------------------
+
+test("#2012 the generic Manager sentence is recognised, and only that sentence", () => {
+  assert.equal(isGenericManagerInstallError(GENERIC), true);
+  assert.equal(isGenericManagerInstallError(GENERIC_SPEC), true);
+  assert.equal(isGenericManagerInstallError("Installation failed: rgthree-comfy"), true);
+  assert.equal(isGenericManagerInstallError("Installation failed: rgthree-comfy@nightly"), true);
+  assert.equal(
+    isGenericManagerInstallError("the Manager reported the task as failed (no detail provided)"),
+    true,
+  );
+  // A cause already in the task result must not pay for a log read.
+  assert.equal(
+    isGenericManagerInstallError("Installation failed: Failed to clone repo: https://github.com/rgthree/rgthree-comfy"),
+    false,
+  );
+  assert.equal(
+    isGenericManagerInstallError("Node 'rgthree-comfy@nightly' not found in [ManagerChannel.dev, ManagerDatabaseSource.cache]"),
+    false,
+  );
+  assert.equal(
+    isGenericManagerInstallError("Cannot resolve install target: 'rgthree-comfy@nightly'"),
+    false,
+  );
+  assert.equal(isGenericManagerInstallError(null), false);
+  assert.equal(isGenericManagerInstallError(""), false);
+});
+
+// ---------------------------------------------------------------------------
+// Pure extractor
+// ---------------------------------------------------------------------------
+
+test("#2012 extract: exception-arm traceback (no Installation-failed line in the log)", () => {
+  // The exception arm print_exc()s and returns the generic sentence without
+  // logging it. The traceback naming the pack / do_install is the whole record.
+  const got = extractInstallTraceback(EXCEPTION_TB, PACK);
+  assert.match(got, /KeyError: 'rgthree-comfy'/);
+  assert.match(got, /do_install/);
+  assert.doesNotMatch(got, /check the ComfyUI server log/);
+});
+
+test("#2012 extract: ManagedResult arm keeps the res.msg lines", () => {
+  const got = extractInstallTraceback(DETAILED_ERROR, PACK);
+  assert.match(got, /Failed to clone repo/);
+  assert.match(got, /rgthree-comfy/);
+  assert.match(got, /Installation failed/);
+});
+
+test("#2012 extract: traceback immediately above the generic ERROR is kept WITH the ERROR", () => {
+  const log = `${GIT_TB}\n${DETAILED_ERROR}`;
+  const got = extractInstallTraceback(log, PACK);
+  assert.match(got, /GitCommandError/);
+  assert.match(got, /already exists/);
+  assert.match(got, /Failed to clone repo/);
+});
+
+test("#2012 extract: colour codes do not defeat the match, or leak into the result", () => {
+  const coloured =
+    `${ESC}[31m[ERROR]${ESC}[0m ${DETAILED_ERROR}`;
+  const got = extractInstallTraceback(coloured, PACK);
+  assert.match(got, /Failed to clone repo/);
+  assert.ok(!got.includes(ESC), "an escape byte must never reach the reader");
+});
+
+test("#2012 extract: another pack's failure is NEVER attributed to this install", () => {
+  const other = [
+    "Traceback (most recent call last):",
+    "  File \"manager_server.py\", line 1, in do_install",
+    "KeyError: 'somebody-else'",
+    "[ComfyUI-Manager] Installation failed:",
+    "Failed to clone repo: https://github.com/other/somebody-else",
+  ].join("\n");
+  assert.equal(extractInstallTraceback(other, PACK), null);
+  // A prefix of this pack's name is not this pack.
+  assert.equal(extractInstallTraceback(EXCEPTION_TB, "rgthree"), null);
+});
+
+test("#2012 extract: the LAST matching failure wins", () => {
+  const log = [
+    "Traceback (most recent call last):",
+    "  File \"manager_server.py\", line 1, in do_install",
+    "PermissionError: first attempt",
+    `[ComfyUI-Manager] Installation failed:`,
+    `Failed to clone repo: https://github.com/rgthree/${PACK}`,
+    "Traceback (most recent call last):",
+    "  File \"manager_server.py\", line 1, in do_install",
+    "OSError: retry",
+    `[ComfyUI-Manager] Installation failed:`,
+    `pip install failed for https://github.com/rgthree/${PACK}`,
+  ].join("\n");
+  const got = extractInstallTraceback(log, PACK);
+  assert.match(got, /OSError: retry/);
+  assert.match(got, /pip install failed/);
+  assert.doesNotMatch(got, /PermissionError/);
+});
+
+test("#2012 extract: junk / empty / missing pack is not a verdict", () => {
+  assert.equal(extractInstallTraceback("", PACK), null);
+  assert.equal(extractInstallTraceback("unrelated info log\n", PACK), null);
+  assert.equal(extractInstallTraceback(EXCEPTION_TB, ""), null);
+  assert.equal(extractInstallTraceback(null, PACK), null);
+  assert.equal(extractInstallTraceback(EXCEPTION_TB, null), null);
+});
+
+test("#2012 extract: a long traceback is capped, and the cap is disclosed", () => {
+  const lines = ["Traceback (most recent call last):"];
+  for (let i = 0; i < INSTALL_TRACEBACK_MAX_LINES + 10; i++) {
+    lines.push(`  File "x.py", line ${i}, in do_install`);
+  }
+  lines.push(`KeyError: '${PACK}'`);
+  const got = extractInstallTraceback(lines.join("\n"), PACK);
+  assert.match(got, /truncated to last/);
+  assert.match(got, new RegExp(`KeyError: '${PACK}'`));
+  assert.ok(got.split(/\n/).length <= INSTALL_TRACEBACK_MAX_LINES + 2);
+});
+
+test("#2012 extract: a huge traceback LINE is capped", () => {
+  const huge = "x".repeat(INSTALL_TRACEBACK_LINE_CAP + 80);
+  const log = [
+    "Traceback (most recent call last):",
+    `  File "manager_server.py", line 1, in do_install`,
+    `KeyError: '${PACK}' ${huge}`,
+  ].join("\n");
+  const got = extractInstallTraceback(log, PACK);
+  assert.ok(got.includes("…"));
+  assert.ok(!got.includes(huge));
+});
+
+test("#2012 readInstallTraceback uses fileURL, not /api, and never throws", async () => {
+  const calls = [];
+  const realFetch = globalThis.fetch;
+  const api = { fileURL: (r) => `/base${r}` };
+  try {
+    globalThis.fetch = async (url) => {
+      calls.push(String(url));
+      return { ok: true, json: async () => ({ entries: [{ m: EXCEPTION_TB }] }) };
+    };
+    const got = await readInstallTraceback(PACK, api);
+    assert.match(got, /KeyError: 'rgthree-comfy'/);
+    assert.deepEqual(calls, ["/base/internal/logs/raw"], "fileURL is honoured, /api is not");
+    assert.ok(!calls[0].includes("/api/"), "the /api prefix is what 404s");
+
+    globalThis.fetch = async () => ({ ok: false, status: 404 });
+    assert.equal(await readInstallTraceback(PACK, api), null);
+    globalThis.fetch = async () => {
+      throw new Error("offline");
+    };
+    assert.equal(await readInstallTraceback(PACK, api), null);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.equal(await readInstallTraceback(PACK, undefined), null);
+});
+
+// ---------------------------------------------------------------------------
+// classifyInstallOutcome — the message the tool actually throws
+// ---------------------------------------------------------------------------
+
+test("#2012 classifyInstallOutcome attaches the traceback and drops the 'check the log' pointer", () => {
+  const outcome = classifyInstallOutcome({
+    target: PACK,
+    dialect: "v2",
+    status: DRAINED,
+    installed: INSTALLED_LIST,
+    taskFailure: GENERIC,
+    traceback: EXCEPTION_TB,
+  });
+  assert.equal(outcome.state, "failed");
+  assert.match(outcome.message, /FAILED/);
+  assert.match(outcome.message, /KeyError: 'rgthree-comfy'/);
+  assert.match(outcome.message, /Manager traceback/);
+  assert.doesNotMatch(outcome.message, /check the ComfyUI server log for the full traceback/);
+});
+
+test("#2012 classifyInstallOutcome without a traceback still points at the log", () => {
+  // Honest miss: we looked, the log did not yield one. The existing #1539
+  // wording stays so a specific Manager exception (already in `reason`) is
+  // unchanged when no extra traceback is supplied.
+  const outcome = classifyInstallOutcome({
+    target: PACK,
+    dialect: "v2",
+    status: DRAINED,
+    installed: INSTALLED_LIST,
+    taskFailure: GENERIC,
+  });
+  assert.equal(outcome.state, "failed");
+  assert.match(outcome.message, /check the ComfyUI server log for the full traceback/);
+  assert.doesNotMatch(outcome.message, /Manager traceback/);
+});
+
+// ---------------------------------------------------------------------------
+// SHIPPED PATH — the real verifyInstalled, extracted
+// ---------------------------------------------------------------------------
+
+function buildVerifyInstalled(deps) {
+  const src = readPanelSource();
+  const boundDeps = {
+    managerGet: async () => {
+      throw new Error("unstubbed managerGet");
+    },
+    managerV2: async () => {
+      throw new Error("unstubbed managerV2");
+    },
+    managerCall: async () => {
+      throw new Error("unstubbed managerCall");
+    },
+    queueDrained,
+    taskFailureReason,
+    parseTaskHistoryItem,
+    classifyInstallOutcome,
+    MANAGER_FETCH_TIMEOUT_MS: 15000,
+    INSTALL_VERIFY_BUDGET_MS: 4000,
+    AbortSignal,
+    setTimeout,
+    managerTaskResults: createManagerTaskResultLog(),
+    isGenericManagerInstallError,
+    readInstallTraceback: async () => null,
+    api: { fileURL: (r) => r },
+    ...deps,
+  };
+  const factory = new Function(
+    ...Object.keys(boundDeps),
+    `${pick(src, /function boundedDelay\(ms, deadline\) \{[\s\S]*?\n\}/, "boundedDelay")}
+${pick(src, /async function waitForQueueDrain\(\{[\s\S]*?\n\}/, "waitForQueueDrain")}
+${pick(src, /async function verifyInstalled\(target, dialect, \{[\s\S]*?\n\}/, "verifyInstalled")}
+return { verifyInstalled };`,
+  );
+  return factory(...Object.values(boundDeps));
+}
+
+test("#2012 verifyInstalled CALLS readInstallTraceback on a generic Manager failure", () => {
+  // Without this the helper is dead code: a source-only test of the extractor
+  // would pass just as happily with verifyInstalled never reading the log.
+  const method = pick(
+    readPanelSource(),
+    /async function verifyInstalled\(target, dialect, \{[\s\S]*?\n\}/,
+    "verifyInstalled",
+  );
+  assert.match(method, /readInstallTraceback/);
+  assert.match(method, /isGenericManagerInstallError/);
+  assert.match(method, /traceback/);
+});
+
+test("#2012 shipped verifyInstalled surfaces the traceback, not a pointer to the log", async () => {
+  let readFor = null;
+  const { verifyInstalled } = buildVerifyInstalled({
+    managerV2: async (route) => {
+      if (route.startsWith("manager/queue/history")) return { history: GENERIC_ITEM };
+      if (route.startsWith("manager/queue/status")) return DRAINED;
+      if (route.startsWith("customnode/installed")) return INSTALLED_LIST;
+      throw new Error(`unstubbed route: ${route}`);
+    },
+    readInstallTraceback: async (packId) => {
+      readFor = packId;
+      return extractInstallTraceback(`${EXCEPTION_TB}\n${DETAILED_ERROR}`, packId);
+    },
+  });
+
+  const outcome = await verifyInstalled(PACK, "v2", {
+    budgetMs: 4000,
+    ui_id: "u-2012",
+  });
+  assert.equal(outcome.state, "failed");
+  assert.match(outcome.message, /FAILED/);
+  assert.match(outcome.message, /KeyError: 'rgthree-comfy'/);
+  assert.match(outcome.message, /do_install/);
+  assert.match(outcome.message, /Failed to clone repo/);
+  assert.doesNotMatch(
+    outcome.message,
+    /check the ComfyUI server log for the full traceback/,
+    "the tool result is the traceback, not a pointer to it",
+  );
+  assert.equal(readFor, PACK, "the log read is for the pack we asked to install");
+});
+
+test("#2012 shipped verifyInstalled does NOT read the log for a specific Manager exception", async () => {
+  // The #1539 registry-miss is already in status.messages. Fetching the log
+  // would only add latency; the reason is already the traceback.
+  let reads = 0;
+  const specific = {
+    ...GENERIC_ITEM,
+    status: {
+      status_str: "error",
+      completed: true,
+      messages: [
+        "Node 'rgthree-comfy@nightly' not found in [ManagerChannel.dev, ManagerDatabaseSource.cache]",
+      ],
+    },
+  };
+  const { verifyInstalled } = buildVerifyInstalled({
+    managerV2: async (route) => {
+      if (route.startsWith("manager/queue/history")) return { history: specific };
+      if (route.startsWith("manager/queue/status")) return DRAINED;
+      if (route.startsWith("customnode/installed")) return INSTALLED_LIST;
+      throw new Error(`unstubbed route: ${route}`);
+    },
+    readInstallTraceback: async () => {
+      reads += 1;
+      return "SHOULD NOT BE ATTACHED";
+    },
+  });
+
+  const outcome = await verifyInstalled(PACK, "v2", { budgetMs: 4000, ui_id: "u-2012" });
+  assert.equal(outcome.state, "failed");
+  assert.match(outcome.message, /not found in/);
+  assert.doesNotMatch(outcome.message, /SHOULD NOT BE ATTACHED/);
+  assert.equal(reads, 0, "a specific Manager exception does not pay for a log read");
+});

--- a/browser_tests/unit/manager-task-broadcast.test.mjs
+++ b/browser_tests/unit/manager-task-broadcast.test.mjs
@@ -30,6 +30,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import * as ManagerInstall from "../../web/js/lib/manager-install.js";
+import { isGenericManagerInstallError } from "../../web/js/lib/manager-install-traceback.js";
 const {
   classifyInstallOutcome,
   collectInProgressTasks,
@@ -232,6 +233,12 @@ function buildVerifyInstalled({ routes, calls = [], managerTaskResults }) {
     INSTALL_VERIFY_BUDGET_MS: 4000,
     AbortSignal,
     setTimeout,
+    // #2012 — the verifier reads the log only on a generic "Installation failed"
+    // sentence. These tests pin a specific resolve-target reason, so the log
+    // read must stay quiet.
+    isGenericManagerInstallError,
+    readInstallTraceback: async () => null,
+    api: { fileURL: (r) => r },
   };
   const factory = new Function(
     ...Object.keys(deps),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -300,6 +300,7 @@ import {
 } from "./lib/unpack-link-verify.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { isGenericManagerUpdateError, readUpdateTraceback } from "./lib/manager-update-traceback.js";
+import { isGenericManagerInstallError, readInstallTraceback } from "./lib/manager-install-traceback.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
 import { readActiveSidebarTab, shouldDetachPanelRoot, findSidebarTabButton } from "./lib/active-sidebar-tab.js";
 import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
@@ -8819,8 +8820,18 @@ async function verifyInstalled(target, dialect, { batchFailed, renameProne, budg
       listError = true;
     }
   }
+  // #2012 — Manager's do_install records only "Installation failed" (plus an
+  // optional node spec) and prints the real traceback / res.msg to the server
+  // log. When the stored reason is that generic sentence, fetch the log and
+  // attach the traceback so the tool result is the evidence, not a pointer to
+  // it. A specific Manager exception already in the task record does not pay
+  // for a log read.
+  let traceback;
+  if (taskFailure && isGenericManagerInstallError(taskFailure)) {
+    traceback = await readInstallTraceback(target, api);
+  }
   return classifyInstallOutcome({
-    target, dialect, status, installed, listError, batchFailed, renameProne, taskFailure,
+    target, dialect, status, installed, listError, batchFailed, renameProne, taskFailure, traceback,
   });
 }
 

--- a/web/js/lib/manager-install-traceback.js
+++ b/web/js/lib/manager-install-traceback.js
@@ -1,0 +1,222 @@
+import { readComfyLogText } from "./comfy-log.js";
+
+/**
+ * #2012 — `panel_install_node` hid the Manager install cause behind a
+ * generic sentence.
+ *
+ * ComfyUI-Manager's `do_install` (glob/manager_server.py) has two failure
+ * arms that leave the HTTP history almost empty:
+ *
+ *   * ManagedResult failure logs
+ *     `[ComfyUI-Manager] Installation failed:\n{res.msg}`
+ *     and returns `res.msg`. When `res.msg` itself is empty or just
+ *     "Installation failed", the task result is that one-liner.
+ *   * Exception path calls `traceback.print_exc()` and returns
+ *     `Installation failed:\n{node_spec_str}` — the spec is the pack id,
+ *     not the cause. The traceback is the whole record.
+ *
+ * The task-history helpers in manager-install.js correctly surface whatever
+ * the Manager stored. That store is the generic sentence. This module reads
+ * `/internal/logs/raw` (same transport as #1320/#771/#775) and pulls out the
+ * traceback / `res.msg` so the tool result is the evidence, not a pointer
+ * to the log.
+ *
+ * Never throws. A miss is `null` / `""`, which the caller reports as "we
+ * could not find a traceback" rather than inventing a cause.
+ */
+
+// Built from the code point, never written as a literal escape. Same reason
+// as pack-import-failures.js / userdata-failure-cause.js / manager-update-traceback.js:
+// a raw 0x1B in the source is invisible in a diff and one mangling edit away
+// from matching nothing.
+const ANSI = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+
+/** Caps so a noisy log cannot overflow the tool result. Fixed; no parameter
+ *  raises them. The full traceback remains in the ComfyUI server console. */
+export const INSTALL_TRACEBACK_MAX_LINES = 40;
+export const INSTALL_TRACEBACK_LINE_CAP = 500;
+
+/**
+ * Is this the one-liner Manager stores as the task result — i.e. the case
+ * where the real evidence is only in the server log?
+ *
+ * Matches "Installation failed" alone, or with only a node spec after the
+ * colon (`rgthree-comfy`, `rgthree-comfy@nightly`). A sentence that already
+ * carries a cause ("Installation failed: Failed to clone repo: …") is NOT
+ * generic — fetching the log would only add latency.
+ */
+export function isGenericManagerInstallError(reason) {
+  if (typeof reason !== "string" || !reason) return false;
+  const s = reason.trim();
+  if (/^installation failed(?:\s*:\s*[\w.@/-]+)?\.?$/i.test(s)) return true;
+  return /reported the task as failed \(no detail provided\)/i.test(s);
+}
+
+function stripAnsi(line) {
+  return typeof line === "string" ? line.replace(ANSI, "") : "";
+}
+
+function isTracebackStart(line) {
+  return /Traceback \(most recent call last\):/.test(line);
+}
+
+/** A line that continues a Python traceback (indented frames, chained-exception
+ *  markers, or the `SomeError: message` terminator). Deliberately does NOT
+ *  match Manager's `ERROR: … Installation failed` log line — that is a logging
+ *  level, not a Python exception type (`Error` vs `ERROR`). */
+function isTracebackContinuation(line) {
+  const s = stripAnsi(line);
+  if (!s.trim()) return true;
+  if (/^\s/.test(s)) return true;
+  if (isTracebackStart(s)) return true;
+  if (/During handling of the above exception/.test(s)) return true;
+  if (/The above exception was the direct cause/.test(s)) return true;
+  return /^[A-Za-z_][\w.]*(Error|Exception|Exit|Warning|Interrupt):/.test(s.trim());
+}
+
+function collectTracebackAt(lines, start) {
+  if (start < 0 || start >= lines.length || !isTracebackStart(lines[start])) return null;
+  const out = [lines[start]];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (!isTracebackContinuation(lines[i])) break;
+    out.push(lines[i]);
+  }
+  while (out.length && !out[out.length - 1].trim()) out.pop();
+  return out.length ? out : null;
+}
+
+function boundTraceback(text) {
+  const raw = text.split(/\r?\n/);
+  const sliced = raw.length > INSTALL_TRACEBACK_MAX_LINES ? raw.slice(-INSTALL_TRACEBACK_MAX_LINES) : raw;
+  const lines = sliced.map((l) =>
+    l.length > INSTALL_TRACEBACK_LINE_CAP ? `${l.slice(0, INSTALL_TRACEBACK_LINE_CAP)}…` : l,
+  );
+  let out = lines.join("\n").trim();
+  if (!out) return null;
+  if (raw.length > INSTALL_TRACEBACK_MAX_LINES) {
+    out = `(traceback truncated to last ${INSTALL_TRACEBACK_MAX_LINES} lines)\n${out}`;
+  }
+  return out;
+}
+
+function mentionsPack(block, packId) {
+  // Quoted (`KeyError: 'pack'`), a node spec (`pack@nightly`), or a path
+  // segment. A bare substring would attribute `rgthree-comfy-extra`'s crash
+  // to a pack named `rgthree`.
+  const id = packId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `(?:['"\`]${id}(?:@[\\w.-]+)?['"\`]|[\\\\/]${id}(?:[\\\\/.'"\`]|$)|\\b${id}@)`,
+    "i",
+  ).test(Array.isArray(block) ? block.join("\n") : String(block ?? ""));
+}
+
+function mentionsInstallHandler(block) {
+  return /\bdo_install\b|\binstall_by_id\b/.test(
+    Array.isArray(block) ? block.join("\n") : String(block ?? ""),
+  );
+}
+
+function isInstallFailedLine(line) {
+  const s = stripAnsi(line);
+  return /\[ComfyUI-Manager\]\s*Installation failed/i.test(s) ||
+    /(?:^|\bERROR:)\s*.*Installation failed/i.test(s);
+}
+
+/** The ERROR line plus the `res.msg` Manager logged on the following lines. */
+function collectFailedBlock(lines, start) {
+  const out = [lines[start]];
+  for (let i = start + 1; i < lines.length && i <= start + 15; i++) {
+    const s = stripAnsi(lines[i]);
+    if (isTracebackStart(s)) break;
+    if (isInstallFailedLine(s)) break;
+    if (/^\s*(?:\d{4}-\d{2}-\d{2}.+)?(?:ERROR|WARNING|INFO|DEBUG)\b/.test(s) &&
+      !/Installation failed/i.test(s)) break;
+    if (/\[ComfyUI-Manager\]/.test(s) && !/Installation failed/i.test(s)) break;
+    out.push(lines[i]);
+  }
+  while (out.length && !out[out.length - 1].trim()) out.pop();
+  return out;
+}
+
+/**
+ * The last traceback / Installation-failed block in `logText` that belongs
+ * to an install of `packId`.
+ *
+ * Correlation, in order:
+ *   1. The last `[ComfyUI-Manager] Installation failed` line whose following
+ *      `res.msg` lines (or a traceback immediately above) NAME this pack.
+ *      Keep the traceback and the failed block — the block carries `res.msg`.
+ *   2. Otherwise the last traceback that NAMES this pack (quoted, as a path
+ *      segment, or as `pack@version`). A frame that merely says `do_install`
+ *      is not enough — that would steal a neighbour's crash.
+ *
+ * @param {string} logText raw /internal/logs feed
+ * @param {string} packId the pack we asked Manager to install
+ * @returns {string|null}
+ */
+export function extractInstallTraceback(logText, packId) {
+  if (typeof logText !== "string" || !logText) return null;
+  if (typeof packId !== "string" || !packId) return null;
+
+  const lines = logText.split(/\r?\n/).map(stripAnsi);
+
+  let anchor = -1;
+  let anchorTbStart = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (!isInstallFailedLine(lines[i])) continue;
+    const block = collectFailedBlock(lines, i);
+    let tbStart = -1;
+    for (let j = i; j >= 0 && j >= i - 80; j--) {
+      if (isTracebackStart(lines[j])) {
+        tbStart = j;
+        break;
+      }
+    }
+    const tb = tbStart >= 0 ? collectTracebackAt(lines, tbStart) : null;
+    // The ERROR line itself does not name the pack (unlike do_update). A
+    // nearby traceback that does not name it either is somebody else's.
+    if (mentionsPack(block, packId) || (tb && mentionsPack(tb, packId))) {
+      anchor = i;
+      anchorTbStart = tb && (mentionsPack(tb, packId) || mentionsInstallHandler(tb) || tbStart >= i - 15)
+        ? tbStart
+        : -1;
+    }
+  }
+
+  if (anchor >= 0) {
+    const parts = [];
+    if (anchorTbStart >= 0) {
+      const block = collectTracebackAt(lines, anchorTbStart);
+      if (block) parts.push(block.join("\n").trimEnd());
+    }
+    const failed = collectFailedBlock(lines, anchor);
+    const detail = failed.join("\n").trim();
+    if (detail && !parts.some((p) => p.includes(detail))) parts.push(detail);
+    return boundTraceback(parts.join("\n"));
+  }
+
+  let last = null;
+  for (let i = 0; i < lines.length; i++) {
+    if (!isTracebackStart(lines[i])) continue;
+    const block = collectTracebackAt(lines, i);
+    // No Installation-failed line for THIS pack: only a traceback that NAMES
+    // the pack is ours. Matching any do_install frame would steal a neighbour's
+    // crash (the exception arm prints the pack in the KeyError / fail text
+    // when it has one).
+    if (block && mentionsPack(block, packId)) last = block;
+  }
+  return last ? boundTraceback(last.join("\n")) : null;
+}
+
+/**
+ * Fetch the log and pull out this pack's install traceback. Never throws.
+ *
+ * @param {string} packId
+ * @param {{ fileURL?: (route: string) => string }} api
+ * @returns {Promise<string|null>}
+ */
+export async function readInstallTraceback(packId, api) {
+  const text = await readComfyLogText(api);
+  if (!text) return null;
+  return extractInstallTraceback(text, packId);
+}

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -421,7 +421,8 @@ export function queueFailureSignal(status, batchFailed, target) {
  *      signal / stale batchFailed. A genuine renamed-dir install (codex round 3)
  *      lands here, never "failed".
  * @param {{ target:string, dialect?:string, status:unknown, installed:unknown,
- *           listError?:boolean, batchFailed?:unknown, renameProne?:boolean }} input
+ *           listError?:boolean, batchFailed?:unknown, renameProne?:boolean,
+ *           taskFailure?:unknown, traceback?:string }} input
  */
 export function classifyInstallOutcome({
   target,
@@ -432,6 +433,7 @@ export function classifyInstallOutcome({
   batchFailed,
   renameProne = false,
   taskFailure = null,
+  traceback = null,
 }) {
   // #1539 — the Manager's OWN terminal verdict for the task we submitted (keyed
   // by our ui_id) outranks every proxy below, and is checked before the
@@ -448,14 +450,22 @@ export function classifyInstallOutcome({
   // reported `queued: true, pending: true`. The record said "failed" the whole
   // time; nothing read it.
   if (taskFailure) {
+    // #2012 — Manager's do_install often stores only "Installation failed" and
+    // prints the real traceback / res.msg to the server log. When the caller
+    // managed to read that log, the tool result IS the traceback; do not also
+    // send the reader to the log they can no longer see from here.
+    const tb = typeof traceback === "string" && traceback.trim() ? traceback.trim() : "";
     return {
       state: "failed",
       status,
+      taskFailure,
       message:
         `"${target}" install FAILED: the ComfyUI-Manager task terminated with an error` +
         (dialect ? ` (dialect ${dialect})` : "") +
-        `: ${taskFailure}. The install did NOT complete — check the ComfyUI server log ` +
-        `for the full traceback.` +
+        `: ${taskFailure}. The install did NOT complete` +
+        (tb
+          ? `. Manager traceback:\n${tb}`
+          : ` — check the ComfyUI server log for the full traceback.`) +
         // The registry-miss case has a specific, verified way forward (#920), and
         // it is worth far more HERE than on a later poll: this is the reply to the
         // install call itself, so the caller learns it without having to know to


### PR DESCRIPTION
## Report

`panel_install_node({id:'rgthree-comfy'})` failed and returned only:

```
rgthree-comfy install FAILED: the ComfyUI-Manager task terminated with an error (dialect v2): Installation failed. The install did NOT complete — check the ComfyUI server log for the full traceback.
```

The tool promised a traceback and did not include it, so the caller had no actionable cause.

## Root cause

[#1539](https://github.com/artokun/comfyui-mcp-panel/issues/1539) already made `panel_install_node` report a Manager task failure instead of an honest-but-useless pending. The reason it reports is whatever ComfyUI-Manager stored on the task.

Manager's `do_install` (glob/manager_server.py) has two failure arms that leave that store almost empty:

* ManagedResult failure logs `[ComfyUI-Manager] Installation failed:\n{res.msg}` and returns `res.msg`. When `res.msg` is empty or itself "Installation failed", the task result is that one-liner.
* Exception path calls `traceback.print_exc()` and returns `Installation failed:\n{node_spec_str}` — the spec is the pack id, not the cause. The traceback never enters the history record.

The panel was faithfully forwarding that store, then pointing at the log.

This is the install-side twin of [#1320](https://github.com/artokun/comfyui-mcp-panel/issues/1320).

## Fix

On a generic Manager install failure, `verifyInstalled` reads `/internal/logs/raw` (same transport as [#1320](https://github.com/artokun/comfyui-mcp-panel/issues/1320)/[#771](https://github.com/artokun/comfyui-mcp-panel/issues/771)/[#775](https://github.com/artokun/comfyui-mcp-panel/issues/775)) and attaches the traceback — or the `res.msg` ERROR block when there is no traceback — to the thrown error. A specific Manager exception (the [#1539](https://github.com/artokun/comfyui-mcp-panel/issues/1539) registry-miss) is left alone; that reason already is the traceback.

Another pack's crash is not attributed to this install. A miss still points at the log.

Fixes #2012

## Test plan

```
node --test browser_tests/unit/manager-install-traceback.test.mjs \
  browser_tests/unit/install-terminal-failure.test.mjs \
  browser_tests/unit/manager-task-broadcast.test.mjs \
  browser_tests/unit/manager-install.test.mjs \
  browser_tests/unit/manager-dialect.test.mjs
```

16/16 of the new file pass, including the shipped `verifyInstalled`:

* exception-arm traceback (`KeyError: 'rgthree-comfy'` / `do_install`) is attached
* ManagedResult `Failed to clone repo` block is kept
* the "check the ComfyUI server log for the full traceback" pointer is dropped when the traceback is present
* another pack's `do_install` crash is not attributed to this install
* a specific Manager exception does not pay for a log read
