### PR TITLE
fix(2009): serialize typed PrimitiveNode STRING widgets from the live graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. This project adheres to
 - panel_strip_workflow no longer fails when a newer MCP requires the panel's node schema: graph_get_object_info is a canvas-independent read (not a mutation), and graph_serialize keeps extra schema fields while attaching name-keyed widget values so conversion does not depend on positional schema agreement (#1996)
 - scoped panel_run keeps the run-to-node target when a queuePrompt wrapper drops the third argument, instead of relying only on request-body repair (#1998)
 - panel_restart_comfyui uses ComfyUI Desktop's restartCore/restartApp to restore the backend after stop, and refuses a Manager reboot when no Desktop relaunch path is available, so a Desktop instance is not left stopped (#1999)
+- panel_run serializes a freshly typed PrimitiveNode STRING widget from the live graph instead of rejecting it as a missing dynamic widget (#2009)
 
 ## [0.15.140] - 2026-08-30
 

--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -69,6 +69,7 @@ test("#1931 an unnamed DynamicCombo throw does not send the caller to a named wi
   assert.doesNotMatch(msg, /inspect the named widget/i);
   assert.match(msg, /did not name a node or widget/);
   assert.match(msg, /format\.codec/);
+  assert.match(msg, /PrimitiveNode STRING widget/);
 });
 
 test("#1931 a named DynamicCombo throw keeps the inspect-the-named-widget remedy", () => {
@@ -77,6 +78,15 @@ test("#1931 a named DynamicCombo throw keeps the inspect-the-named-widget remedy
   );
   assert.match(msg, /inspect the named widget/i);
   assert.match(msg, /SaveVideo node 71/);
+});
+
+test("#2009 a named PrimitiveNode throw keeps the inspect-the-named-widget remedy", () => {
+  const msg = graphToPromptFailureRefusal(
+    new Error("Dynamic widget doesn't exist on node: PrimitiveNode node 12 has typed STRING value widget"),
+  );
+  assert.match(msg, /inspect the named widget/i);
+  assert.match(msg, /PrimitiveNode node 12/);
+  assert.match(msg, /STRING value widget/);
 });
 
 test("#1654 serializer refusal rendering is total and bounded for hostile throws", () => {

--- a/browser_tests/unit/primitive-dynamic-widgets.test.mjs
+++ b/browser_tests/unit/primitive-dynamic-widgets.test.mjs
@@ -1,0 +1,246 @@
+// #2009 — panel_run rejects a freshly typed PrimitiveNode dynamic STRING widget.
+//
+// PrimitiveNode is frontend-only: connecting its generic output to a STRING
+// widget input re-addresses it and mints a live `value` widget. Reads and writes
+// see that widget; graphToPrompt then throws "Dynamic widget doesn't exist on
+// node" because the serializer walks a widget-store schema captured before the
+// node was typed. These tests drive the live-widget registrar the wrap uses —
+// not a parallel reimplementation of graphToPrompt.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isTypedPrimitiveNode,
+  livePrimitiveDynamicWidgets,
+  registerLivePrimitiveWidgets,
+  resyncLivePrimitiveWidgets,
+  describeTypedPrimitiveWidgets,
+} from "../../web/js/lib/primitive-dynamic-widgets.js";
+import {
+  isDynamicWidgetMissingError,
+  installGraphToPromptDynamicReconcile,
+} from "../../web/js/lib/dynamic-widget-reconcile.js";
+
+function widgetStoreKey(nodeId, widget) {
+  return `${nodeId}:${widget.name}`;
+}
+
+function makeValueWidget({ name = "value", value = "", registered = false } = {}) {
+  let current = value;
+  let boundNodeId = registered ? 12 : null;
+  const store = new Map();
+  const widget = {
+    name,
+    type: "customtext",
+    get value() {
+      return boundNodeId == null ? current : (store.get(widgetStoreKey(boundNodeId, widget)) ?? current);
+    },
+    set value(next) {
+      current = next;
+      if (boundNodeId != null) store.set(widgetStoreKey(boundNodeId, widget), next);
+    },
+    get widgetId() {
+      return boundNodeId == null ? null : widgetStoreKey(boundNodeId, widget);
+    },
+    setNodeId(nodeId) {
+      boundNodeId = nodeId;
+      store.set(widgetStoreKey(nodeId, widget), current);
+    },
+  };
+  return { widget, store, isRegistered: () => boundNodeId != null };
+}
+
+function makePrimitiveNode({
+  id = 12,
+  outputType = "STRING",
+  widgets = [],
+  recreate,
+} = {}) {
+  const node = {
+    id,
+    type: "PrimitiveNode",
+    isVirtualNode: true,
+    outputs: [{ name: outputType === "*" ? "connect to widget input" : outputType, type: outputType }],
+    widgets,
+    recreateWidget:
+      recreate ??
+      function recreateWidget() {
+        return this.widgets?.[0];
+      },
+  };
+  return node;
+}
+
+test("#2009: an untyped PrimitiveNode is not a live dynamic widget source", () => {
+  const node = makePrimitiveNode({ outputType: "*", widgets: [] });
+  assert.equal(isTypedPrimitiveNode(node), false);
+  assert.deepEqual(livePrimitiveDynamicWidgets({ _nodes: [node] }), []);
+});
+
+test("#2009: a STRING-typed PrimitiveNode with a live value widget is the reported shape", () => {
+  const { widget } = makeValueWidget({ value: "a cat walks into frame" });
+  const node = makePrimitiveNode({ widgets: [widget] });
+  assert.equal(isTypedPrimitiveNode(node), true);
+  const live = livePrimitiveDynamicWidgets({ _nodes: [node] });
+  assert.equal(live.length, 1);
+  assert.equal(live[0].outputType, "STRING");
+  assert.equal(live[0].widgetName, "value");
+  assert.equal(live[0].nodeId, 12);
+});
+
+test("#2009: registerLivePrimitiveWidgets uses the live widget list, not nodeData", () => {
+  const { widget, isRegistered } = makeValueWidget({ registered: false });
+  const node = makePrimitiveNode({ widgets: [widget] });
+  node.constructor = { nodeData: null };
+
+  assert.equal(isRegistered(), false);
+  const result = registerLivePrimitiveWidgets({ _nodes: [node] });
+  assert.equal(result.registered, 1);
+  assert.equal(result.nodes, 1);
+  assert.equal(isRegistered(), true);
+  assert.equal(widget.widgetId, "12:value");
+});
+
+test("#2009: nested subgraph PrimitiveNodes are registered too", () => {
+  const { widget, isRegistered } = makeValueWidget({ registered: false });
+  const inner = makePrimitiveNode({ id: 7, widgets: [widget] });
+  const host = { id: 1, type: "Subgraph", widgets: [], subgraph: { _nodes: [inner] } };
+  registerLivePrimitiveWidgets({ nodes: [host] });
+  assert.equal(isRegistered(), true);
+});
+
+test("#2009: resync recreates from the live connection then re-registers", () => {
+  const first = makeValueWidget({ value: "prompt a", registered: false });
+  const second = makeValueWidget({ value: "prompt a", registered: false });
+  const node = makePrimitiveNode({
+    widgets: [first.widget],
+    recreate() {
+      this.widgets = [second.widget];
+      return second.widget;
+    },
+  });
+
+  const result = resyncLivePrimitiveWidgets({ _nodes: [node] });
+  assert.equal(result.recreated, 1);
+  assert.equal(result.registered, 1);
+  assert.equal(node.widgets[0], second.widget);
+  assert.equal(second.isRegistered(), true);
+  assert.equal(first.isRegistered(), false);
+});
+
+test("#2009: describeTypedPrimitiveWidgets names the STRING value widget", () => {
+  const { widget } = makeValueWidget({ value: "hello" });
+  const node = makePrimitiveNode({ widgets: [widget] });
+  assert.deepEqual(describeTypedPrimitiveWidgets({ _nodes: [node] }), [
+    { nodeId: 12, nodeType: "PrimitiveNode", outputType: "STRING", widgetName: "value" },
+  ]);
+});
+
+test("#2009: a hostile PrimitiveNode does not hide a sibling", () => {
+  const { widget } = makeValueWidget();
+  const good = makePrimitiveNode({ id: 13, widgets: [widget] });
+  const hostile = new Proxy(
+    { type: "PrimitiveNode", id: 1 },
+    {
+      get() {
+        throw new Error("hostile getter");
+      },
+    },
+  );
+  const live = livePrimitiveDynamicWidgets({ _nodes: [hostile, good] });
+  assert.equal(live.length, 1);
+  assert.equal(live[0].nodeId, 13);
+});
+
+test("#2009: registering live widgets makes a store-keyed serialize succeed", async () => {
+  const { widget, isRegistered } = makeValueWidget({
+    value: "<Picture 1> walks through the door",
+    registered: false,
+  });
+  const node = makePrimitiveNode({ widgets: [widget] });
+  const app = {
+    graph: { _nodes: [node] },
+    graphToPrompt() {
+      if (!widget.widgetId) throw new Error("Dynamic widget doesn't exist on node");
+      return { output: { 15: { class_type: "DenoMiniMaxH3ReferenceToVideo", inputs: { prompt: widget.value } } } };
+    },
+  };
+
+  assert.equal(isRegistered(), false);
+  assert.equal(installGraphToPromptDynamicReconcile(app), true);
+  const prompt = await app.graphToPrompt();
+  assert.equal(isRegistered(), true);
+  assert.equal(prompt.output[15].inputs.prompt, "<Picture 1> walks through the door");
+});
+
+test("#2009: a first-serialize throw is retried after PrimitiveNode resync", async () => {
+  const first = makeValueWidget({ value: "first", registered: false });
+  const second = makeValueWidget({ value: "first", registered: false });
+  const node = makePrimitiveNode({
+    widgets: [first.widget],
+    recreate() {
+      this.widgets = [second.widget];
+      return second.widget;
+    },
+  });
+  let calls = 0;
+  const app = {
+    graph: { _nodes: [node] },
+    graphToPrompt() {
+      calls += 1;
+      const live = node.widgets[0];
+      if (calls === 1 || live !== second.widget || !live.widgetId) {
+        throw new Error("Dynamic widget doesn't exist on node");
+      }
+      return { output: { 15: { class_type: "DenoMiniMaxH3ReferenceToVideo", inputs: { prompt: live.value } } } };
+    },
+  };
+
+  installGraphToPromptDynamicReconcile(app);
+  const prompt = await app.graphToPrompt();
+  assert.equal(calls, 2);
+  assert.equal(node.widgets[0], second.widget);
+  assert.equal(second.isRegistered(), true);
+  assert.equal(prompt.output[15].inputs.prompt, "first");
+});
+
+test("#2009: a persistent serializer throw names the PrimitiveNode and its STRING widget", async () => {
+  const { widget } = makeValueWidget({ value: "hello", registered: true });
+  const node = makePrimitiveNode({ widgets: [widget] });
+  const app = {
+    graph: { _nodes: [node] },
+    graphToPrompt() {
+      throw new Error("Dynamic widget doesn't exist on node");
+    },
+  };
+  installGraphToPromptDynamicReconcile(app);
+  assert.throws(
+    () => app.graphToPrompt(),
+    (error) => {
+      assert.equal(isDynamicWidgetMissingError(error), true);
+      assert.match(error.message, /PrimitiveNode node 12/);
+      assert.match(error.message, /typed STRING value widget/);
+      return true;
+    },
+  );
+});
+
+test("#2009: an untyped PrimitiveNode is not blamed for a serializer throw", async () => {
+  const node = makePrimitiveNode({ outputType: "*", widgets: [] });
+  const app = {
+    graph: { _nodes: [node] },
+    graphToPrompt() {
+      throw new Error("Dynamic widget doesn't exist on node");
+    },
+  };
+  installGraphToPromptDynamicReconcile(app);
+  assert.throws(
+    () => app.graphToPrompt(),
+    (error) => {
+      assert.equal(error.message, "Dynamic widget doesn't exist on node");
+      assert.doesNotMatch(error.message, /PrimitiveNode node/);
+      return true;
+    },
+  );
+});

--- a/web/js/lib/dynamic-widget-reconcile.js
+++ b/web/js/lib/dynamic-widget-reconcile.js
@@ -1,3 +1,9 @@
+import {
+  describeTypedPrimitiveWidgets,
+  registerLivePrimitiveWidgets,
+  resyncLivePrimitiveWidgets,
+} from "./primitive-dynamic-widgets.js";
+
 const DYNAMIC_COMBO_V3 = "COMFY_DYNAMICCOMBO_V3";
 const DYNAMIC_WIDGET_MISSING_RE = /Dynamic widget doesn't exist on node/i;
 const GRAPH_TO_PROMPT_RECONCILE = Symbol.for("comfyui-mcp.graphToPromptDynamicReconcile");
@@ -517,21 +523,28 @@ export function describeOrphanDynamicWidgets(graph) {
 }
 
 function namedDynamicWidgetError(error, graph) {
-  const candidates = describeOrphanDynamicWidgets(graph);
+  const orphans = describeOrphanDynamicWidgets(graph);
+  const primitives = describeTypedPrimitiveWidgets(graph);
+  const listedParts = [
+    ...orphans.map(
+      (entry) => `${entry.nodeType} node ${entry.nodeId} has ${entry.nested} and orphan ${entry.orphan}`,
+    ),
+    ...primitives.map(
+      (entry) =>
+        `${entry.nodeType} node ${entry.nodeId} has typed ${entry.outputType} ${entry.widgetName} widget`,
+    ),
+  ];
   let base = "";
   try {
     base = error instanceof Error ? error.message : String(error ?? "");
   } catch {
     base = "";
   }
-  if (!candidates.length) {
+  if (!listedParts.length) {
     return error instanceof Error ? error : new Error(base || "Dynamic widget doesn't exist on node");
   }
-  const listed = candidates
-    .slice(0, 8)
-    .map((entry) => `${entry.nodeType} node ${entry.nodeId} has ${entry.nested} and orphan ${entry.orphan}`)
-    .join("; ");
-  const extra = candidates.length > 8 ? ` (${candidates.length - 8} more)` : "";
+  const listed = listedParts.slice(0, 8).join("; ");
+  const extra = listedParts.length > 8 ? ` (${listedParts.length - 8} more)` : "";
   const message =
     DYNAMIC_WIDGET_MISSING_RE.test(base) && !/\bnode\s+\d+/i.test(base)
       ? `Dynamic widget doesn't exist on node: ${listed}${extra}`
@@ -541,11 +554,44 @@ function namedDynamicWidgetError(error, graph) {
   return named;
 }
 
+function prepareLiveDynamicWidgets(graph) {
+  try {
+    registerLivePrimitiveWidgets(graph);
+  } catch {
+    // Best-effort: a hostile PrimitiveNode must not block serialization.
+  }
+  try {
+    // #2031 — wrap before native serialize: graphToPrompt re-assigns DynamicCombo
+    // roots, which would otherwise rebuild dotted children from spec defaults.
+    wrapGraphDynamicComboSetters(graph);
+    reconcileGraphDynamicWidgets(graph);
+  } catch {
+    // Best-effort: a hostile node must not block serialization.
+  }
+}
+
+function retryLiveDynamicWidgets(graph) {
+  try {
+    resyncLivePrimitiveWidgets(graph);
+  } catch {
+    // Retry with whatever widgets are still live.
+  }
+  try {
+    wrapGraphDynamicComboSetters(graph);
+    reconcileGraphDynamicWidgets(graph);
+  } catch {
+    // Retry with whatever state we could clean.
+  }
+}
+
 /**
- * Reconcile nested DynamicCombo leftovers immediately before every prompt build,
- * and retry once if the frontend still throws the unnamed SaveVideo serializer
- * error. add_node/load already clean what they can; 0.15.124 recurrences still
- * queued a graph that grew the orphan back (set_widget, restore, restart).
+ * Reconcile nested DynamicCombo leftovers and register live PrimitiveNode
+ * widgets immediately before every prompt build, and retry once if the frontend
+ * still throws the unnamed serializer error. add_node/load already clean what
+ * they can; 0.15.124 recurrences still queued a graph that grew the orphan back
+ * (set_widget, restore, restart). #2009 recurrences mint a PrimitiveNode
+ * STRING widget after graph.add(), which reads and writes but is absent from
+ * the serializer's widget-store schema.
  *
  * @param {object} app
  * @returns {boolean}
@@ -557,22 +603,10 @@ export function installGraphToPromptDynamicReconcile(app) {
   const orig = (...args) => rawApply(graphToPromptFn, app, args);
   app.graphToPrompt = function reconcileThenGraphToPrompt(graph, ...rest) {
     const target = graph ?? app.rootGraph ?? app.graph ?? null;
-    try {
-      // #2031 — wrap before native serialize: graphToPrompt re-assigns DynamicCombo
-      // roots, which would otherwise rebuild dotted children from spec defaults.
-      wrapGraphDynamicComboSetters(target);
-      reconcileGraphDynamicWidgets(target);
-    } catch {
-      // Best-effort: a hostile node must not block serialization.
-    }
+    prepareLiveDynamicWidgets(target);
     const retry = (error) => {
       if (!isDynamicWidgetMissingError(error)) throw error;
-      try {
-        wrapGraphDynamicComboSetters(target);
-        reconcileGraphDynamicWidgets(target);
-      } catch {
-        // Retry with whatever state we could clean.
-      }
+      retryLiveDynamicWidgets(target);
       try {
         const retried = orig(graph, ...rest);
         if (retried && typeof retried.then === "function") {

--- a/web/js/lib/missing-node-preflight.js
+++ b/web/js/lib/missing-node-preflight.js
@@ -156,7 +156,8 @@ export function graphToPromptFailureRefusal(error) {
     /Dynamic widget doesn't exist on node/i.test(detail) && !namesAWidget;
   const inspect = unnamedDynamic
     ? `The serializer did not name a node or widget; look for a DynamicCombo node that ` +
-      `carries both a nested child (format.codec) and a bare duplicate (codec).`
+      `carries both a nested child (format.codec) and a bare duplicate (codec), or a ` +
+      `freshly typed PrimitiveNode STRING widget.`
     : `Inspect the named widget or extension before retrying.`;
   return (
     `NOT queued: this workflow could not be serialized into a prompt because ` +

--- a/web/js/lib/primitive-dynamic-widgets.js
+++ b/web/js/lib/primitive-dynamic-widgets.js
@@ -1,0 +1,180 @@
+/**
+ * #2009 — panel_run rejects a freshly typed PrimitiveNode dynamic STRING widget.
+ *
+ * PrimitiveNode starts with a generic `*` output and no widgets. Connecting that
+ * output to a STRING widget input (DenoMiniMaxH3ReferenceToVideo.prompt in the
+ * report) re-addresses the node and mints a live `value` widget. panel_query_graph
+ * and panel_set_widget see that widget; graphToPrompt then throws
+ * "Dynamic widget doesn't exist on node".
+ *
+ * ComfyUI's DynamicCombo serializer looks widgets up by object identity / widget
+ * store, which is captured from the node-definition schema. PrimitiveNode has no
+ * backend schema — its widgets exist only on the live node, and a widget minted
+ * after `graph.add()` can miss `setNodeId` registration. Reads and writes go
+ * through the live widget; queue serialization does not.
+ *
+ * Before every prompt build, register the LIVE PrimitiveNode widgets (the graph's
+ * own widget list, not constructor.nodeData). If the named serializer throw still
+ * fires, recreate those widgets from the live connection and retry. A persistent
+ * throw is named so the caller is not sent to a SaveVideo orphan hunt.
+ *
+ * Read-mostly and dependency-free so it can be unit-tested in isolation.
+ */
+
+function graphNodes(graph) {
+  if (Array.isArray(graph?._nodes) && graph._nodes.length) return graph._nodes;
+  if (Array.isArray(graph?.nodes)) return graph.nodes;
+  return [];
+}
+
+function outputType(node) {
+  try {
+    const type = node?.outputs?.[0]?.type;
+    return typeof type === "string" && type && type !== "*" ? type : null;
+  } catch {
+    return null;
+  }
+}
+
+function widgetName(widget) {
+  try {
+    return typeof widget?.name === "string" && widget.name ? widget.name : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `node` is a PrimitiveNode whose generic output has been re-addressed
+ * by a connection and which now carries the live widgets that connection minted.
+ */
+export function isTypedPrimitiveNode(node) {
+  if (!node || typeof node !== "object") return false;
+  try {
+    if (node.type !== "PrimitiveNode") return false;
+  } catch {
+    return false;
+  }
+  if (!outputType(node)) return false;
+  try {
+    return Array.isArray(node.widgets) && node.widgets.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Live PrimitiveNode dynamic widgets across `graph` and nested subgraphs.
+ *
+ * @param {object} graph
+ * @returns {Array<{node: object, nodeId: unknown, outputType: string, widgetName: string, widget: object}>}
+ */
+export function livePrimitiveDynamicWidgets(graph) {
+  const found = [];
+  const seen = new Set();
+  const walk = (g) => {
+    if (!g || typeof g !== "object" || seen.has(g)) return;
+    seen.add(g);
+    for (const node of graphNodes(g)) {
+      try {
+        if (isTypedPrimitiveNode(node)) {
+          const typed = outputType(node);
+          for (const widget of node.widgets) {
+            const name = widgetName(widget);
+            if (!name) continue;
+            found.push({
+              node,
+              nodeId: node.id,
+              outputType: typed,
+              widgetName: name,
+              widget,
+            });
+          }
+        }
+        if (node?.subgraph) walk(node.subgraph);
+      } catch {
+        // A hostile node must not hide the rest of the graph.
+      }
+    }
+  };
+  walk(graph);
+  return found;
+}
+
+function registerWidget(node, widget) {
+  try {
+    if (typeof widget?.setNodeId !== "function" || node?.id == null) return false;
+    widget.setNodeId(node.id);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Register every live PrimitiveNode widget against the node it already sits on.
+ *
+ * This is the live-graph widget schema: `node.widgets`, not `constructor.nodeData`.
+ * `setNodeId` is what `graph.add()` would have called had the widget existed then.
+ *
+ * @param {object} graph
+ * @returns {{registered: number, nodes: number}}
+ */
+export function registerLivePrimitiveWidgets(graph) {
+  const live = livePrimitiveDynamicWidgets(graph);
+  const nodes = new Set();
+  let registered = 0;
+  for (const entry of live) {
+    if (registerWidget(entry.node, entry.widget)) {
+      registered += 1;
+      nodes.add(entry.node);
+    }
+  }
+  return { registered, nodes: nodes.size };
+}
+
+/**
+ * Recreate typed PrimitiveNode widgets from the live connection, then re-register.
+ *
+ * `recreateWidget` is PrimitiveNode's own resync (it tears down and rebuilds from
+ * the connected target config). Used on the serializer retry so a widget minted
+ * after `graph.add()` is the object identity graphToPrompt walks.
+ *
+ * @param {object} graph
+ * @returns {{recreated: number, registered: number}}
+ */
+export function resyncLivePrimitiveWidgets(graph) {
+  const seen = new Set();
+  let recreated = 0;
+  for (const entry of livePrimitiveDynamicWidgets(graph)) {
+    if (seen.has(entry.node)) continue;
+    seen.add(entry.node);
+    try {
+      if (typeof entry.node.recreateWidget === "function") {
+        entry.node.recreateWidget();
+        recreated += 1;
+      }
+    } catch {
+      // A recreate that the frontend rejects is not a reason to skip registration
+      // of whatever widgets are still live.
+    }
+  }
+  const { registered } = registerLivePrimitiveWidgets(graph);
+  return { recreated, registered };
+}
+
+/**
+ * Typed PrimitiveNode widgets, for naming a serializer throw that otherwise
+ * says only "Dynamic widget doesn't exist on node".
+ *
+ * @param {object} graph
+ * @returns {Array<{nodeId: unknown, nodeType: string, outputType: string, widgetName: string}>}
+ */
+export function describeTypedPrimitiveWidgets(graph) {
+  return livePrimitiveDynamicWidgets(graph).map((entry) => ({
+    nodeId: entry.nodeId,
+    nodeType: "PrimitiveNode",
+    outputType: entry.outputType,
+    widgetName: entry.widgetName,
+  }));
+}


### PR DESCRIPTION
Fixes #2009.

## Root cause

`PrimitiveNode` starts with a generic `*` output and no widgets. Connecting that output to a STRING widget input (the reporter's case: `DenoMiniMaxH3ReferenceToVideo.prompt`) re-addresses the node and mints a live `value` widget.

`panel_query_graph` and `panel_set_widget` see that widget. `panel_run` then throws:

```
Error: Dynamic widget doesn't exist on node
```

ComfyUI's DynamicCombo serializer looks widgets up by object identity / widget-store schema captured from `constructor.nodeData`. PrimitiveNode has no backend schema — its widgets exist only on the live node, and a widget minted after `graph.add()` can miss `setNodeId` registration. Reads and writes go through the live widget; queue serialization does not.

## Fix

- Before every `graphToPrompt`, register live PrimitiveNode widgets from `node.widgets` (the live graph schema, not `nodeData`).
- On the existing DynamicCombo retry, recreate those widgets from the live connection (`recreateWidget`) and re-register.
- A persistent throw names the PrimitiveNode (`PrimitiveNode node 12 has typed STRING value widget`) so the caller is not sent to a SaveVideo orphan hunt.

## Tests

- `browser_tests/unit/primitive-dynamic-widgets.test.mjs` — typed vs untyped PrimitiveNode, live-list registration, subgraph walk, resync, serializer success/retry/naming.
- `browser_tests/unit/graph-to-prompt-failure.test.mjs` — named PrimitiveNode throw keeps the inspect-the-named-widget remedy; unnamed fallback also mentions PrimitiveNode STRING.

Do not merge from this PR — parent merges after the swarm.
