### PR TITLE
fix(2020): do not hang panel_set_widget on AnimaPromptPlus custom text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [0.15.136] - 2026-08-30
 
 ### Fixed
+- panel_set_widget writes AnimaPromptPlus custom textarea widgets (quality_prompt) through the live editor / store setValue path instead of waiting on a widget callback that never settles (#2020)
 - panel_refresh_nodes refuses a stale browser bundle with a Ctrl+Shift+R remedy instead of clearing last-known schema (#2027)
 - panel_refresh_nodes publishes the workflow UUID of the canvas it refreshed, and refuses a retryable route-registration miss if the active route moves, instead of returning refreshed:true with another UUID (#2026)
 - panel_set_widget no longer reports outcome-unknown after the value has landed: the handler ack is flushed once graph_set_widget resolves, and a timeout after delivery returns applied and verified from an idempotent readback (#2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - omit private combo option values from panel_set_widget refusal diagnostics while preserving the invalid-value verdict and option count (#2547)
+- panel_set_widget writes AnimaPromptPlus custom textarea widgets (quality_prompt) through the live editor / store setValue path instead of waiting on a widget callback that never settles (#2020)
 
 ## [0.15.136] - 2026-08-30
 
 ### Fixed
-- panel_set_widget writes AnimaPromptPlus custom textarea widgets (quality_prompt) through the live editor / store setValue path instead of waiting on a widget callback that never settles (#2020)
 - panel_refresh_nodes refuses a stale browser bundle with a Ctrl+Shift+R remedy instead of clearing last-known schema (#2027)
 - panel_refresh_nodes publishes the workflow UUID of the canvas it refreshed, and refuses a retryable route-registration miss if the active route moves, instead of returning refreshed:true with another UUID (#2026)
 - panel_set_widget no longer reports outcome-unknown after the value has landed: the handler ack is flushed once graph_set_widget resolves, and a timeout after delivery returns applied and verified from an idempotent readback (#2025)

--- a/browser_tests/unit/anima-prompt-plus-widget.test.mjs
+++ b/browser_tests/unit/anima-prompt-plus-widget.test.mjs
@@ -1,0 +1,175 @@
+/**
+ * #2020 — panel_set_widget on AnimaPromptPlus `quality_prompt` (and other
+ * customtext textareas) stalled indefinitely. ComfyUI's DOM widget setter is
+ * `set value(v) { options.setValue?.(v); callback?.(this.value) }`, and the
+ * write path then invoked the 5-arg callback again. Those callbacks can fail
+ * to settle; the RPC stayed in-flight until the client timed out and the
+ * canvas never changed.
+ *
+ * The shipped write must:
+ *   - land the string on the live textarea / getValue store
+ *   - not invoke (and therefore not await) a non-resolving widget.callback
+ *   - settle well inside the client timeout
+ *
+ * These drive applyWidgetWrite() / runSetWidget(), the SAME functions
+ * graph_set_widget uses — not a parallel reimplementation.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyWidgetWrite } from "../../web/js/lib/widget-write.js";
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+
+const HOOKS = {};
+const NEW_PROMPT = "masterpiece, best quality, score_7, safe";
+const HANG_MS = 200;
+
+function neverSettles() {
+  return new Promise(() => {});
+}
+
+function withHangBudget(work) {
+  return Promise.race([
+    Promise.resolve().then(work),
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error(`#2020 hung: write did not settle in ${HANG_MS}ms`)), HANG_MS);
+    }),
+  ]);
+}
+
+/** AnimaPromptPlus.quality_prompt after ComfyUI addDOMWidget + bindMultilineTextareaWidget. */
+function makeAnimaQualityPrompt(initial = "") {
+  const store = { value: initial };
+  const textarea = {
+    tagName: "TEXTAREA",
+    value: initial,
+    dispatched: [],
+    dispatchEvent(ev) {
+      this.dispatched.push(ev?.type ?? ev);
+      // ComfyUI bindMultilineTextareaWidget: input assigns widget.value,
+      // which re-enters the setter and the callback.
+      widget.value = this.value;
+      widget.callback?.(widget.value);
+      return true;
+    },
+  };
+  const options = {
+    getValue() {
+      return store.value ?? textarea.value;
+    },
+    setValue(v) {
+      textarea.value = String(v);
+      store.value = String(v);
+    },
+  };
+  let callbackCalls = 0;
+  const widget = {
+    name: "quality_prompt",
+    type: "customtext",
+    inputEl: textarea,
+    element: textarea,
+    options,
+    callback() {
+      callbackCalls += 1;
+      return neverSettles();
+    },
+    get value() {
+      return options.getValue();
+    },
+    set value(v) {
+      options.setValue(v);
+      this.callback?.(this.value);
+    },
+  };
+  const node = { id: 181, type: "AnimaPromptPlus", widgets: [widget] };
+  return {
+    node,
+    widget,
+    textarea,
+    store,
+    callbackCalls: () => callbackCalls,
+  };
+}
+
+test("#2020: AnimaPromptPlus quality_prompt lands without invoking a never-settling callback", async () => {
+  const { node, widget, textarea, store, callbackCalls } = makeAnimaQualityPrompt("old");
+
+  const set = await withHangBudget(() => applyWidgetWrite(node, "quality_prompt", NEW_PROMPT, HOOKS));
+
+  assert.equal(set.value, NEW_PROMPT);
+  assert.equal(set.widget, "quality_prompt");
+  assert.equal(store.value, NEW_PROMPT);
+  assert.equal(textarea.value, NEW_PROMPT);
+  assert.equal(widget.value, NEW_PROMPT);
+  assert.equal(callbackCalls(), 0, "must not invoke the unacked customtext callback");
+  assert.equal(textarea.dispatched.length, 0, "input would re-enter the hanging callback via widget.value");
+});
+
+test("#2020: a second isolated quality_prompt write also settles (the reporter's retry)", async () => {
+  const { node, textarea, callbackCalls } = makeAnimaQualityPrompt("old");
+
+  const first = await withHangBudget(() => applyWidgetWrite(node, "quality_prompt", NEW_PROMPT, HOOKS));
+  const second = await withHangBudget(() =>
+    applyWidgetWrite(node, "quality_prompt", "1girl, long hair", HOOKS),
+  );
+
+  assert.equal(first.value, NEW_PROMPT);
+  assert.equal(second.value, "1girl, long hair");
+  assert.equal(textarea.value, "1girl, long hair");
+  assert.equal(callbackCalls(), 0);
+});
+
+test("#2020: a thenable customtext callback on a plain widget is not awaited", async () => {
+  const widget = {
+    name: "quality_prompt",
+    type: "customtext",
+    value: "old",
+    callback() {
+      return neverSettles();
+    },
+  };
+  const node = { id: 181, type: "AnimaPromptPlus", widgets: [widget] };
+
+  const set = await withHangBudget(() => applyWidgetWrite(node, "quality_prompt", NEW_PROMPT, HOOKS));
+
+  assert.equal(set.value, NEW_PROMPT);
+  assert.equal(widget.value, NEW_PROMPT);
+});
+
+test("#2020: runSetWidget on AnimaPromptPlus quality_prompt does not hang the RPC", async () => {
+  const { node, textarea, store, callbackCalls } = makeAnimaQualityPrompt("old");
+  const registry = { AnimaPromptPlus: {} };
+
+  const res = await withHangBudget(() =>
+    runSetWidget(node, "quality_prompt", NEW_PROMPT, {
+      registry,
+      getFreshObjectInfo: async () => ({ AnimaPromptPlus: {} }),
+    }),
+  );
+
+  assert.equal(res.set.value, NEW_PROMPT);
+  assert.equal(res.set.previous, "old");
+  assert.equal(store.value, NEW_PROMPT);
+  assert.equal(textarea.value, NEW_PROMPT);
+  assert.equal(callbackCalls(), 0);
+  assert.equal(res.applied, true);
+});
+
+test("#2020: a plain customtext without a DOM editor still fires its callback", () => {
+  let calls = 0;
+  const widget = {
+    name: "text",
+    type: "customtext",
+    value: "keep me",
+    callback() {
+      calls += 1;
+    },
+  };
+  const node = { id: 1, type: "CLIPTextEncode", widgets: [widget] };
+
+  const set = applyWidgetWrite(node, "text", "plain write", HOOKS);
+
+  assert.equal(set.value, "plain write");
+  assert.equal(widget.value, "plain write");
+  assert.equal(calls, 1, "core string widgets keep the 5-arg callback");
+});

--- a/browser_tests/unit/widget-bound-property.test.mjs
+++ b/browser_tests/unit/widget-bound-property.test.mjs
@@ -228,10 +228,10 @@ test("a bound NUMERIC widget the node normalizes still succeeds", () => {
 test("a bound widget whose `value` is an ACCESSOR still verifies", () => {
   // ComfyUI's DOM widgets define `value` as an accessor —
   // `set value(v) { options.setValue?.(v); callback?.(this.value) }` — so `setProperty`'s
-  // copy-back runs that setter a second time. The write must still verify, and the
-  // widget's own callback must not be able to turn the extra invocation into a failure.
-  // Counted, because the count is the thing that changes for a BOUND widget, and it is
-  // the same count `BaseWidget.setValue` produces for an on-canvas edit of one.
+  // copy-back runs that setter. The write must still verify, and the widget's own
+  // callback must not be able to turn that copy-back into a failure.
+  // #2020 skips the DOM `.value` setter and the 5-arg widget.callback for live
+  // customtext (those are the hang). Only setProperty's copy-back remains.
   let store = "old";
   let callbacks = 0;
   const widget = {
@@ -257,7 +257,7 @@ test("a bound widget whose `value` is an ACCESSOR still verifies", () => {
   assert.equal(store, "new");
   assert.equal(node.properties.prompt, "new");
   assert.deepEqual(set.bound_property, { name: "prompt", previous: "old" });
-  assert.equal(callbacks, 3);
+  assert.equal(callbacks, 1, "#2020: live customtext skips setter/callback; only setProperty copy-back fires");
 });
 
 test("#1735: an accessor-backed BooleanWidget copy-back deletion is recovered only after both stores retain", () => {

--- a/browser_tests/unit/widget-normalization.test.mjs
+++ b/browser_tests/unit/widget-normalization.test.mjs
@@ -94,9 +94,12 @@ test("#805 WIRING: normalization suppresses the failure AND is disclosed on the 
   // widget, the promoted inner widget, or — on an instance-scoped promoted write — the
   // wrapper's own rail. The read-back and the normalization explanation must be taken
   // from the SAME widget, or a normalizing rail is reported as a failed write.
-  assert.match(src, /const normalization = matchesExpected\(valueWidget\.value\)/)
+  // #2020 — read-back goes through `widgetMatchesExpected` so a live customtext can
+  // match on the textarea / getValue store. For numeric widgets that helper is still
+  // `matchesExpected(widget.value)`, so the #805 grid check is unchanged.
+  assert.match(src, /const normalization = widgetMatchesExpected\(valueWidget\)/)
   assert.match(src, /explainNumericNormalization\(expected, valueWidget\.value, valueWidget\)/)
-  assert.match(src, /if \(!matchesExpected\(valueWidget\.value\) && !normalization\) \{/)
+  assert.match(src, /if \(!widgetMatchesExpected\(valueWidget\) && !normalization\) \{/)
   // …and the caller must be TOLD, or a silently-changed value is its own defect.
   assert.match(src, /normalized: true/)
   assert.match(src, /requested_value: expected/)

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1724,7 +1724,7 @@ function dispatchDomEvent(el, type) {
   }
 }
 
-function writeLiveTextEditor(el, text) {
+function writeLiveTextEditor(el, text, { events = true } = {}) {
   const tag = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
   const editable =
     el.isContentEditable === true ||
@@ -1741,15 +1741,71 @@ function writeLiveTextEditor(el, text) {
   }
   // StringMultilineTagEditor's input listener copies getPlainText() into state
   // and localStorage; without this event the canvas shows the new text and a
-  // reload restores the old one.
-  dispatchDomEvent(el, "input");
-  dispatchDomEvent(el, "change");
+  // reload restores the old one. Skipped when the widget store already holds
+  // the value: ComfyUI's customtext input handler assigns `widget.value`, and
+  // that setter re-enters a callback that may never settle (#2020).
+  if (events) {
+    dispatchDomEvent(el, "input");
+    dispatchDomEvent(el, "change");
+  }
   return true;
 }
 
 function widgetHoldsValue(widget, coerced) {
   try {
     return Object.is(widget.value, coerced);
+  } catch {
+    return false;
+  }
+}
+
+function readLiveTextEditorValue(el) {
+  try {
+    const tag = typeof el?.tagName === "string" ? el.tagName.toUpperCase() : "";
+    if (tag === "TEXTAREA" || tag === "INPUT") return el.value;
+    if (
+      el?.isContentEditable === true ||
+      el?.contentEditable === true ||
+      el?.contentEditable === "true" ||
+      el?.contentEditable === "" ||
+      (typeof el?.className === "string" && /\bcomfy-multiline-input\b/.test(el.className))
+    ) {
+      return el.textContent;
+    }
+  } catch {
+    /* unreadable editor is simply absent */
+  }
+  return undefined;
+}
+
+/**
+ * #2020 — a STRING widget whose live value is a textarea / contenteditable /
+ * `options.getValue` store, not a plain `.value` field.
+ *
+ * ComfyUI `addDOMWidget` (customtext) implements
+ * `set value(v) { options.setValue?.(v); callback?.(this.value) }`. Vue and
+ * AnimaPromptPlus callbacks on that path can fail to settle, so a programmatic
+ * write must not assign `.value` or await the callback.
+ */
+function isLiveCustomTextWidget(widget) {
+  if (!widget || typeof widget !== "object") return false;
+  if (liveTextEditorElement(widget)) return true;
+  const t = String(widget.type ?? "").toLowerCase();
+  if (t !== "customtext" && t !== "textarea" && t !== "text" && t !== "string") return false;
+  try {
+    const opts = widget.options;
+    return !!(opts && (typeof opts.getValue === "function" || typeof opts.setValue === "function"));
+  } catch {
+    return false;
+  }
+}
+
+function customTextHolds(widget, coerced) {
+  if (widgetHoldsValue(widget, coerced)) return true;
+  const el = liveTextEditorElement(widget);
+  if (!el) return false;
+  try {
+    return Object.is(readLiveTextEditorValue(el), coerced);
   } catch {
     return false;
   }
@@ -1764,8 +1820,47 @@ function syncDomBackedTextIfNeeded(widget, coerced) {
   writeLiveTextEditor(el, coerced);
 }
 
+/**
+ * Drive a live customtext widget without the DOM `.value` setter.
+ *
+ * `options.setValue` updates the widget-value store (what serializes). The
+ * visible textarea is written directly. `input`/`change` fire only when the
+ * store did not take the value, which is the #1997 no-op-setValue case.
+ */
+function assignLiveCustomText(widget, coerced) {
+  let setValueStuck = false;
+  try {
+    const setValue = widget.options?.setValue;
+    if (typeof setValue === "function") {
+      setValue.call(widget, coerced);
+      setValueStuck = widgetHoldsValue(widget, coerced);
+    }
+  } catch {
+    /* verification below still decides whether the value stuck */
+  }
+  const el = liveTextEditorElement(widget);
+  if (el) {
+    try {
+      writeLiveTextEditor(el, coerced, { events: !setValueStuck });
+    } catch {
+      /* verification below still decides whether the value stuck */
+    }
+  }
+  if (!customTextHolds(widget, coerced)) {
+    try {
+      widget.value = coerced;
+    } catch {
+      /* verification below still decides whether the value stuck */
+    }
+  }
+}
+
 /** Assign a widget value and drive options.setValue when present (store-backed rails). */
 function assignWidgetValue(widget, coerced) {
+  if (typeof coerced === "string" && isLiveCustomTextWidget(widget)) {
+    assignLiveCustomText(widget, coerced);
+    return;
+  }
   widget.value = coerced;
   try {
     const setValue = widget.options?.setValue;
@@ -1782,12 +1877,7 @@ function assignWidgetValue(widget, coerced) {
 
 /** Restore a captured prior value, including a DOM-backed editor this write updated. */
 function restoreWidgetValue(widget, previous) {
-  widget.value = previous;
-  try {
-    syncDomBackedTextIfNeeded(widget, previous);
-  } catch {
-    /* restore best-effort; read-back below is authoritative */
-  }
+  assignWidgetValue(widget, previous);
 }
 
 /**
@@ -2562,6 +2652,19 @@ export function applyWidgetWrite(
         typeof actual === "object" &&
         Object.keys(expected).every((k) => JSON.stringify(actual[k]) === JSON.stringify(expected[k]))
       : actual === expected;
+  // #2020 — a live customtext may serialize from the textarea / getValue store
+  // even when a Vue `.value` accessor has not caught up. Read the editor too.
+  const widgetMatchesExpected = (widget) => {
+    let actual;
+    try {
+      actual = widget?.value;
+    } catch {
+      actual = undefined;
+    }
+    if (matchesExpected(actual)) return true;
+    return typeof expected === "string" && isLiveCustomTextWidget(widget) && customTextHolds(widget, expected);
+  };
+  const liveCustomTextWrite = typeof coerced === "string" && isLiveCustomTextWidget(valueWidget);
 
   // Snapshot the PRIOR values AND deep clones of them. Rollback restores the prior
   // OBJECT REFERENCE (`previous`), but a subsequent afterChange hook could mutate
@@ -2818,13 +2921,22 @@ export function applyWidgetWrite(
     // non-callable callback still throws a TypeError exactly as before, and it takes
     // the argument list without spreading — no `Symbol.iterator` to poison either.
     // `reflectApply` is captured at module load for the same reason.
-    if (!fastBypasserAction) {
+    // #2020 — do not invoke (and therefore cannot await) a custom textarea's
+    // widget.callback. ComfyUI DOM widgets already fire it from the `.value`
+    // setter; AnimaPromptPlus / Vue customtext callbacks can fail to settle,
+    // which wedged panel_set_widget until the client timed out. The live
+    // editor + options.setValue path above is what serializes; read-back
+    // still decides whether the write stuck.
+    if (!fastBypasserAction && !liveCustomTextWrite) {
       widgetCallback = valueWidget.callback;
       if (widgetCallback !== null && widgetCallback !== undefined) {
         const callbackArgs = [coerced, canvas, valueNode, valueNode.pos, undefined];
         threwFromCallback = true;
-        reflectApply(widgetCallback, valueWidget, callbackArgs);
+        const callbackResult = reflectApply(widgetCallback, valueWidget, callbackArgs);
         threwFromCallback = false; // reached only when it RETURNED — a throw leaves it set
+        // A thenable is an unacked frontend callback. Never wait for it: a
+        // customtext Promise that never settles is the #2020 hang.
+        void callbackResult;
       }
     }
     // #1533 — AFTER the callback, still inside this envelope so afterChange
@@ -2902,7 +3014,7 @@ export function applyWidgetWrite(
   // Only an EXACTLY reproducible snap counts. If the config does not explain the
   // observed value, this stays the failure it was — no tolerance, because a
   // tolerance would eventually swallow a real revert that landed nearby.
-  const normalization = matchesExpected(valueWidget.value)
+  const normalization = widgetMatchesExpected(valueWidget)
     ? null
     : explainNumericNormalization(expected, valueWidget.value, valueWidget);
   // comfyui-mcp#1707 — the SHARED DEFINITION must be exactly as it was.
@@ -2917,7 +3029,7 @@ export function applyWidgetWrite(
   // did not perform. Compared structurally against the pre-mutation clone, so a
   // callback mutating a captured object in place is caught too.
   const definitionMoved = instanceScoped && !structurallyEqual(w.value, previousClone);
-  if (!matchesExpected(valueWidget.value) && !normalization) {
+  if (!widgetMatchesExpected(valueWidget) && !normalization) {
     failure =
       `Widget "${valueWidget.name}" on node ${valueNode.id} (${valueNode.type}) did not retain the ` +
       `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(valueWidget.value)}.` +
@@ -2965,7 +3077,7 @@ export function applyWidgetWrite(
       actual: boundPropertyActual,
       unreadable: boundPropertyActual === UNREADABLE_PROPERTY,
     });
-  } else if (parentWidget && parentWidget !== valueWidget && !matchesExpected(parentWidget.value)) {
+  } else if (parentWidget && parentWidget !== valueWidget && !widgetMatchesExpected(parentWidget)) {
     // comfyui-mcp#1707 — `parentWidget !== valueWidget` because on an instance-scoped
     // promoted write the rail IS the widget this write assigned, and the branch above
     // has already verified it — with the #805 normalization allowance this one does not
@@ -2978,11 +3090,11 @@ export function applyWidgetWrite(
       `the requested value: wrote ${JSON.stringify(expected)} but it became ` +
       `${JSON.stringify(parentWidget.value)}. Refusing to report success with a stale rail that ` +
       `would render the OLD value (#366).`;
-  } else if (displayWidgets.some((dw) => !matchesExpected(dw.value))) {
+  } else if (displayWidgets.some((dw) => !widgetMatchesExpected(dw))) {
     // #477: a parent-facing display proxy did not retain the value. Fail closed +
     // roll back rather than report success while the parent node still shows/queries
     // the OLD value (the exact stale-outer-widget symptom).
-    const bad = displayWidgets.find((dw) => !matchesExpected(dw.value));
+    const bad = displayWidgets.find((dw) => !widgetMatchesExpected(dw));
     failure =
       `Promoted display widget "${bad.name}" on subgraph node ${node.id} did not retain the ` +
       `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(bad.value)}. ` +


### PR DESCRIPTION
Fixes #2020

panel_set_widget stalled indefinitely on AnimaPromptPlus custom textarea widgets (quality_prompt). ComfyUI DOM customtext implements `set value(v) { options.setValue?.(v); callback?.(this.value) }`, and the write path then invoked the 5-arg callback again. Those callbacks can fail to settle, so the RPC stayed in-flight until the client timed out (~50s) and the canvas never changed.

The write now goes through the live textarea / `options.setValue` store (the same path as other DOM-backed text widgets) and does not invoke or await that callback. Read-back still decides whether the value stuck. Core string widgets without a live editor keep the existing callback path.

Tests: `node --test browser_tests/unit/anima-prompt-plus-widget.test.mjs` (5 pass).