### PR TITLE
fix(2024): name Manager getmappings transport failure and retry legacy route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_search_nodes retries the legacy `/customnode/getmappings` route when the browser never gets an HTTP response from `/v2/customnode/getmappings`, and the structured miss names that transport failure instead of a bare Failed to fetch (#2024)
 - panel_connect by Autogrow name keeps later MiniMax H3 slots on their original wires (#2008)
-
 
 ## [0.15.132] - 2026-08-30
 

--- a/browser_tests/unit/catalogue-no-match-provenance.test.mjs
+++ b/browser_tests/unit/catalogue-no-match-provenance.test.mjs
@@ -110,7 +110,8 @@ test("#890 the parser itself is unchanged — the note is added at the search bo
 
 test("#890 source guard: the search route still asks for the cache the note describes", () => {
   const src = readFileSync(new URL("../../web/js/lib/manager-install.js", import.meta.url), "utf8");
-  assert.match(src, /const route = "customnode\/getmappings\?mode=cache";/, "the route the note reads");
+  assert.match(src, /export const SEARCH_MAPPINGS_ROUTE = "customnode\/getmappings\?mode=cache";/);
+  assert.match(src, /const route = SEARCH_MAPPINGS_ROUTE;/, "the route the note reads");
   assert.match(
     src,
     /parsed\.count === 0 \? \{ \.\.\.parsed, \.\.\.cachedCatalogueNoMatch\(query, parsed\.catalogue_size, route\) \} : parsed/,

--- a/browser_tests/unit/manager-fetch-failure.test.mjs
+++ b/browser_tests/unit/manager-fetch-failure.test.mjs
@@ -12,6 +12,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import {
+  isManagerTransportWrap,
   isTransportFailure,
   managerFetchFailureMessage,
 } from "../../web/js/lib/manager-fetch-failure.js";
@@ -164,6 +165,38 @@ test("#1472 'fetch failed' stays EXACT because a prefix match collides", () => {
   // Where a prefix is ambiguous, exactness wins; where it is not, tolerance wins.
   assert.equal(isTransportFailure(new Error("fetch failed")), true);
   assert.equal(isTransportFailure(new Error("fetch failed for upstream registry")), false);
+});
+
+test("#2024 managerFetchFailureMessage prefix names the absolute path, not /v2/", () => {
+  const msg = managerFetchFailureMessage(
+    "customnode/getmappings?mode=cache",
+    new TypeError("Failed to fetch"),
+    { prefix: "/" },
+  );
+  assert.match(msg, /\/customnode\/getmappings\?mode=cache/);
+  assert.doesNotMatch(msg, /\/v2\/customnode/);
+  assert.match(msg, /did not complete: Failed to fetch/);
+});
+
+test("#2024 isManagerTransportWrap matches the wrap and a bare Failed to fetch", () => {
+  const cause = new TypeError("Failed to fetch");
+  const wrap = new Error(managerFetchFailureMessage("customnode/getmappings?mode=cache", cause), {
+    cause,
+  });
+  assert.equal(isManagerTransportWrap(cause), true);
+  assert.equal(isManagerTransportWrap(wrap), true);
+  assert.equal(isManagerTransportWrap(new Error("Manager customnode/getmappings: HTTP 500")), false);
+  assert.equal(isManagerTransportWrap(new Error("fetch failed for upstream registry")), false);
+});
+
+test("#2024 WIRING: managerCall names the ABSOLUTE route, not /v2/", () => {
+  const src = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+  const at = src.indexOf("async function managerCall(");
+  assert.ok(at > 0, "managerCall must exist");
+  const endOfCatch = src.indexOf("if (!res) {", at);
+  assert.ok(endOfCatch > at, "managerCall's catch must be followed by the no-response check");
+  const body = src.slice(at, endOfCatch);
+  assert.match(body, /managerFetchFailureMessage\(route, err, \{ prefix: "\/" \}\)/);
 });
 
 test("#1472 WIRING: the source comment no longer claims a re-send verdict", () => {

--- a/browser_tests/unit/manager-search-transport.test.mjs
+++ b/browser_tests/unit/manager-search-transport.test.mjs
@@ -1,0 +1,207 @@
+/**
+ * #2024 — panel_search_nodes returned supported:false / managerReachable:false
+ * for a browser-origin "Failed to fetch" on /v2/customnode/getmappings?mode=cache,
+ * with no HTTP response. The agent saw an opaque transport failure and could not
+ * tell a missing pack from a panel-origin fetch that never completed.
+ *
+ * The shipped behaviour:
+ *   1. A tagged/wrapped transport failure still retries the ABSOLUTE legacy
+ *      `/customnode/getmappings?mode=cache` route (the wrap does not contain
+ *      "not reachable", which used to skip that rung).
+ *   2. When BOTH routes fail with transport, the structured miss is not a bare
+ *      "Failed to fetch": `message` starts with the #1472 wrap so MCP #2492's
+ *      host-HTTP fallback can extractText() it, names both mapping routes, and
+ *      does not diagnose this as merely a disabled Manager.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  isManagerTransportWrap,
+  managerFetchFailureMessage,
+} from "../../web/js/lib/manager-fetch-failure.js";
+import {
+  isManagerUnreachable,
+  markManagerUnreachable,
+  managerUnavailableResult,
+  SEARCH_MAPPINGS_ROUTE,
+  SEARCH_MAPPINGS_ROUTES,
+  searchNodesVia,
+} from "../../web/js/lib/manager-install.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const GETMAPPINGS_MAP = {
+  "https://github.com/1038lab/ComfyUI-RMBG": [
+    ["RMBG"],
+    { title: "ComfyUI-RMBG", description: "Background removal" },
+  ],
+};
+
+const OBJECT_INFO = {
+  KSampler: { display_name: "KSampler", category: "sampling", description: "" },
+};
+
+function transportWrap(route = SEARCH_MAPPINGS_ROUTE, { prefix, tag = true } = {}) {
+  const cause = new TypeError("Failed to fetch");
+  const err = new Error(managerFetchFailureMessage(route, cause, prefix ? { prefix } : undefined), {
+    cause,
+  });
+  return tag ? markManagerUnreachable(err) : err;
+}
+
+/**
+ * Mirror of comfyui-mcp `isManagerTransportFetchFailure` (MCP #2492). The panel
+ * result's extractable `message` must match this or the orchestrator host-HTTP
+ * fallback never fires on a successful structured miss.
+ */
+function extractText(value) {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  if (value && typeof value === "object" && typeof value.message === "string") return value.message;
+  return "";
+}
+
+function isMcpHostHttpTransportFailure(value) {
+  const text = extractText(value).replace(/^(?:Error:\s*)+/i, "").trim();
+  if (!text) return false;
+  const match = /^ComfyUI-Manager request to (\S+) did not complete:\s*([\s\S]+)$/i.exec(text);
+  if (!match) return false;
+  const path = match[1] ?? "";
+  const cause = (match[2] ?? "").trim();
+  if (!/\/(?:v2\/)?customnode\/(?:getmappings|installed)(?:\?|$)/i.test(path)) return false;
+  if (/^AbortError\b/i.test(cause)) return false;
+  if (/\bHTTP\s*\d{3}\b/.test(cause)) return false;
+  return (
+    /^(?:TypeError:\s*)?Failed to fetch\b/i.test(cause) ||
+    /^fetch failed\.?$/i.test(cause) ||
+    /^NetworkError\b/i.test(cause)
+  );
+}
+
+test("#2024 a transport Failed to fetch is never the only outcome", async () => {
+  const wrap = transportWrap();
+  const boom = async () => {
+    throw wrap;
+  };
+  const res = await searchNodesVia(boom, boom, { query: "Spectrum MiniMax H3" });
+
+  assert.equal(res.supported, false);
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.transportFailure, true);
+  assert.equal(res.query, "Spectrum MiniMax H3");
+  assert.notEqual(res.reason, "Failed to fetch");
+  assert.notEqual(res.message, "Failed to fetch");
+  assert.notEqual(res.message, wrap.message, "message must add the search-route diagnostics");
+  assert.match(res.reason, /customnode\/getmappings/);
+  assert.match(res.message, /customnode\/getmappings/);
+  assert.match(res.message, /did not complete/);
+  assert.match(res.message, /TRANSPORT failure/);
+  assert.match(res.message, /no HTTP/);
+  assert.deepEqual(res.routesAttempted, SEARCH_MAPPINGS_ROUTES);
+  assert.match(res.message, /panel_list_nodes/);
+  assert.doesNotMatch(res.message, /^Failed to fetch/);
+});
+
+test("#2024 the structured miss is visible to MCP #2492 host-HTTP fallback", async () => {
+  const wrap = transportWrap();
+  const res = await searchNodesVia(
+    async () => {
+      throw wrap;
+    },
+    async () => {
+      throw wrap;
+    },
+    { query: "Spectrum MiniMax H3" },
+  );
+  assert.equal(
+    isMcpHostHttpTransportFailure(res),
+    true,
+    "extractText(result) must start with the wrap so searchPanelNodes host-HTTP-falls-back",
+  );
+  assert.match(res.message, /^ComfyUI-Manager request to \S+ did not complete:\s*(?:TypeError:\s*)?Failed to fetch\b/);
+  assert.match(res.message, /not proof Manager is disabled/);
+  assert.match(res.message, /not proof the pack is missing/);
+  assert.match(res.message, /legacy absolute route/);
+  assert.match(res.message, /host HTTP/);
+});
+
+test("#2024 a bare tagged Failed to fetch is reconstructed into the wrap, not left opaque", () => {
+  const err = markManagerUnreachable(new TypeError("Failed to fetch"));
+  const res = managerUnavailableResult("Spectrum MiniMax H3", err);
+  assert.equal(res.transportFailure, true);
+  assert.equal(isMcpHostHttpTransportFailure(res), true);
+  assert.notEqual(res.message, "Failed to fetch");
+  assert.match(res.message, /\/v2\/customnode\/getmappings\?mode=cache/);
+});
+
+test("#2024 v2 transport wrap still uses the absolute legacy getmappings route", async () => {
+  const wrap = transportWrap(SEARCH_MAPPINGS_ROUTE);
+  assert.equal(isManagerUnreachable(wrap), true);
+  assert.ok(!/not reachable/i.test(wrap.message), "the reporter wrap is not the 404 wording");
+  let legacyRoute;
+  const res = await searchNodesVia(
+    async () => {
+      throw wrap;
+    },
+    async (route) => {
+      legacyRoute = route;
+      return GETMAPPINGS_MAP;
+    },
+    { query: "RMBG" },
+  );
+  assert.equal(legacyRoute, SEARCH_MAPPINGS_ROUTE);
+  assert.equal(res.count, 1);
+  assert.equal(res.results[0].title, "ComfyUI-RMBG");
+  assert.equal(res.supported, undefined);
+  assert.equal(res.transportFailure, undefined);
+});
+
+test("#2024 an UNTAGGED wrap still opens the legacy GET fallback", async () => {
+  const wrap = transportWrap(SEARCH_MAPPINGS_ROUTE, { tag: false });
+  assert.equal(wrap.managerTransportUnreachable, undefined);
+  assert.equal(isManagerTransportWrap(wrap), true);
+  assert.equal(isManagerUnreachable(wrap), true);
+  const res = await searchNodesVia(
+    async () => {
+      throw wrap;
+    },
+    async () => GETMAPPINGS_MAP,
+    { query: "RMBG" },
+  );
+  assert.equal(res.count, 1);
+});
+
+test("#2024 object_info still wins when installed nodes match the query", async () => {
+  const wrap = transportWrap();
+  const boom = async () => {
+    throw wrap;
+  };
+  const res = await searchNodesVia(boom, boom, {
+    query: "KSampler",
+    objectInfoGet: async () => OBJECT_INFO,
+  });
+  assert.equal(res.supported, true);
+  assert.equal(res.source, "object_info");
+  assert.equal(res.installedOnly, true);
+  assert.equal(res.count, 1);
+  assert.equal(res.transportFailure, undefined);
+});
+
+test("#2024 a genuine HTTP 500 still propagates", async () => {
+  const boom = async () => {
+    throw new Error("Manager customnode/getmappings: HTTP 500");
+  };
+  await assert.rejects(() => searchNodesVia(boom, boom, { query: "x" }), /HTTP 500/);
+});
+
+test("#2024 WIRING: nodes_search still goes through searchNodesVia", () => {
+  const src = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+  const fnMatch = src.match(/async nodes_search\(\{ query, limit \}\) \{[\s\S]*?\n  \},/);
+  assert.ok(fnMatch, "could not locate the production nodes_search handler");
+  assert.match(fnMatch[0], /return searchNodesVia\(managerGet, managerCall,/);
+  assert.match(fnMatch[0], /objectInfoGet: fetchObjectInfo/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8195,7 +8195,7 @@ async function managerCall(route, { method = "GET", body, signal } = {}) {
     // the LEGACY transport, i.e. the very rung the ladder falls back TO.
     if (err?.name === "AbortError") throw err;
     throw markManagerUnreachable(
-      new Error(managerFetchFailureMessage(route, err), { cause: err }),
+      new Error(managerFetchFailureMessage(route, err, { prefix: "/" }), { cause: err }),
     );
   }
   if (!res) {
@@ -26140,7 +26140,8 @@ const GRAPH_TOOL_EXECUTORS = {
     // unreachable it falls back to an INSTALLED-node search over the connected
     // ComfyUI's /object_info (#426) so a legacy/disabled Manager still returns
     // usable, already-installed matches; on a miss it returns the structured
-    // {supported:false,…} capability result.
+    // {supported:false,…} capability result. A browser-origin transport wrap
+    // (#2024) is kept as the message so it is not a bare Failed to fetch.
     const budgetSignal = AbortSignal.timeout(NODES_SEARCH_COMMAND_BUDGET_MS);
     return searchNodesVia(managerGet, managerCall, {
       query,

--- a/web/js/lib/manager-fetch-failure.js
+++ b/web/js/lib/manager-fetch-failure.js
@@ -86,11 +86,14 @@ const TRANSPORT_MESSAGES = [
 /**
  * What to say when a Manager call threw before any response arrived.
  *
- * `route` is the path that was attempted (without the `/v2/` prefix the caller adds).
+ * `route` is the path that was attempted (without the prefix). Default prefix is
+ * `/v2/` (managerV2). managerCall passes `{ prefix: "/" }` so a legacy absolute
+ * fetch is not labelled as a v2 route (#2024).
  */
-export function managerFetchFailureMessage(route, err) {
+export function managerFetchFailureMessage(route, err, { prefix = "/v2/" } = {}) {
   const raw = err instanceof Error ? err.message : String(err ?? "");
-  const path = `/v2/${String(route ?? "").replace(/^\/+/, "")}`;
+  const base = String(prefix ?? "/v2/");
+  const path = `${base.endsWith("/") ? base : `${base}/`}${String(route ?? "").replace(/^\/+/, "")}`;
   if (!isTransportFailure(err)) {
     // Not a transport failure — keep whatever it actually was, plus the route it was
     // attempted against. Never relabel an error whose shape is not recognised.
@@ -108,4 +111,23 @@ export function managerFetchFailureMessage(route, err) {
     `MUTATING call (install, update, delete, queue), check the current state first — a ` +
     `blind retry can apply it twice. A read-only call is safe to repeat.`
   );
+}
+
+/**
+ * Is this the panel's Manager transport wrap (#1472), or the browser's own
+ * no-response throw that wrap is built from?
+ *
+ * panel_search_nodes uses this to keep the wrap at the front of `message` so
+ * MCP #2492's host-HTTP fallback can still extractText() it, instead of
+ * replacing it with "Manager is disabled".
+ */
+export function isManagerTransportWrap(err) {
+  if (isTransportFailure(err)) return true;
+  if (err && typeof err === "object" && isTransportFailure(err.cause)) return true;
+  const msg = (err instanceof Error ? err.message : String(err ?? ""))
+    .trim()
+    .replace(/^(?:Error:\s*)+/i, "");
+  const match = /^ComfyUI-Manager request to (\S+) did not complete:\s*([\s\S]+)$/i.exec(msg);
+  if (!match) return false;
+  return isTransportFailure(match[2]);
 }

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -6,6 +6,11 @@
 // installCustomNode / looksLikeGitUrl / gitCheckoutDir logic
 // (src/services/node-management.ts).
 
+import {
+  isManagerTransportWrap,
+  managerFetchFailureMessage,
+} from "./manager-fetch-failure.js";
+
 /** Does `s` look like a bare "author/repo" GitHub shorthand — no protocol/scp
  *  prefix, no ".git" suffix, exactly one "/", plausible path-segment chars on
  *  both sides? Distinguishes it from a slash-free registry id (e.g.
@@ -572,6 +577,10 @@ export function isManagerUnreachable(err) {
   if (err?.managerSecurityRefusal === true) return false;
   if (isManagerRouteMissing(err)) return true;
   if (err?.managerTransportUnreachable === true) return true;
+  // #2024 — the #1472 wrap does not contain "not reachable", so an untagged
+  // "Failed to fetch" used to skip the legacy getmappings retry. Safe here:
+  // this predicate only gates idempotent GET fallbacks.
+  if (isManagerTransportWrap(err)) return true;
   const msg = String(err?.message ?? err ?? "");
   return /not reachable/i.test(msg) || /HTTP\s*404\b/.test(msg);
 }
@@ -684,6 +693,14 @@ export function matchesAllTerms(hay, terms) {
  * DISCLOSES the clamp as `limit_cap` whenever it bit.
  */
 export const SEARCH_LIMIT_CAP = 40;
+
+/** Route tail `managerGet`/`managerCall` prefix; v2 adds `/v2/`, legacy adds `/`. */
+export const SEARCH_MAPPINGS_ROUTE = "customnode/getmappings?mode=cache";
+
+export const SEARCH_MAPPINGS_ROUTES = [
+  `/v2/${SEARCH_MAPPINGS_ROUTE}`,
+  `/${SEARCH_MAPPINGS_ROUTE}`,
+];
 
 /**
  * Normalize a ComfyUI-Manager `/customnode/getmappings` payload into the
@@ -859,25 +876,51 @@ export async function objectInfoSearchFallback(
  */
 export function managerUnavailableResult(query, err) {
   const timedOut = err?.managerSearchTimedOut === true;
-  return {
+  const reason = String(err?.message ?? err ?? "ComfyUI-Manager not reachable");
+  const transport = !timedOut && isManagerTransportWrap(err);
+  const result = {
     supported: false,
     managerReachable: false,
     count: 0,
     results: [],
     query: query == null ? "" : String(query),
-    reason: String(err?.message ?? err ?? "ComfyUI-Manager not reachable"),
+    reason,
     message: timedOut
       ? "Node-registry search timed out before ComfyUI-Manager replied. No canvas " +
         "workflow was changed. Retry the search; if the Manager remains slow or " +
         "unresponsive, enable/check the built-in Manager and continue with nodes " +
         "already installed via panel_list_nodes or the current graph via " +
         "panel_query_graph."
-      : "Node-registry search is unavailable: the built-in ComfyUI-Manager could not " +
-        "be reached on this ComfyUI (it may be disabled, or a legacy/partial Manager " +
-        "build without the search endpoint). Enable the built-in Manager to search the " +
-        "registry, or continue with the nodes already installed — inspect them with " +
-        "panel_list_nodes and the current graph with panel_query_graph.",
+      : transport
+        ? managerSearchTransportMessage(reason)
+        : "Node-registry search is unavailable: the built-in ComfyUI-Manager could not " +
+          "be reached on this ComfyUI (it may be disabled, or a legacy/partial Manager " +
+          "build without the search endpoint). Enable the built-in Manager to search the " +
+          "registry, or continue with the nodes already installed — inspect them with " +
+          "panel_list_nodes and the current graph with panel_query_graph.",
   };
+  if (transport) {
+    result.transportFailure = true;
+    result.routesAttempted = SEARCH_MAPPINGS_ROUTES.slice();
+  }
+  return result;
+}
+
+/** Keep the #1472 wrap at the FRONT of `message`. MCP #2492 extractText()s that
+ *  field and only host-HTTP-falls-back when it starts with the wrap. */
+function managerSearchTransportMessage(reason) {
+  const wrap = /^ComfyUI-Manager request to \S+ did not complete:/i.test(reason)
+    ? reason
+    : managerFetchFailureMessage(SEARCH_MAPPINGS_ROUTE, reason);
+  return (
+    `${wrap} Both the v2 mappings route (${SEARCH_MAPPINGS_ROUTES[0]}) and the ` +
+    `legacy absolute route (${SEARCH_MAPPINGS_ROUTES[1]}) were attempted from this ` +
+    `browser tab and neither produced an HTTP response. Live canvas reads can still ` +
+    `work — this is a panel-origin transport failure, not proof Manager is disabled ` +
+    `and not proof the pack is missing. The MCP host may still reach those same ` +
+    `mappings over host HTTP. Already-installed nodes remain available via ` +
+    `panel_list_nodes and the current graph via panel_query_graph.`
+  );
 }
 
 /** #1908 — Manager search is a canvas-independent read, but its command still
@@ -1055,7 +1098,9 @@ export function emptyCatalogueResult(query) {
  *   3. if the absolute route is ALSO unreachable, try the installed-node
  *      /object_info search (#426) via the injected `objectInfoGet`; on a miss,
  *      return the structured {supported:false,…} capability result instead of
- *      throwing.
+ *      throwing. A browser-origin transport wrap (#2024, "Failed to fetch" with
+ *      no HTTP response) stays at the front of `message` so it is not a bare
+ *      fetch failure and MCP host-HTTP fallback can still see it.
  * Any non-"unreachable" error still propagates.
  */
 export async function searchNodesVia(
@@ -1063,7 +1108,7 @@ export async function searchNodesVia(
   managerCall,
   { query, limit, objectInfoGet, signal, budgetSignal, timeoutMs } = {},
 ) {
-  const route = "customnode/getmappings?mode=cache";
+  const route = SEARCH_MAPPINGS_ROUTE;
   const requestSignal = managerSearchRequestSignal(signal, budgetSignal);
   const requestOptions = requestSignal ? { signal: requestSignal } : undefined;
   throwIfManagerSearchCallerAborted(signal);


### PR DESCRIPTION
## Summary

`panel_search_nodes` could not reach `/v2/customnode/getmappings?mode=cache` from the browser and returned `supported:false` / `managerReachable:false` with a buried "Failed to fetch" and a generic "Manager is disabled" message. That hid the #1472 transport wrap from MCP #2492's host-HTTP fallback, and skipped the legacy absolute mappings route unless the error happened to say "not reachable".

## Fix

- Retry `/customnode/getmappings?mode=cache` on a browser-origin transport wrap (tagged or not), not only on 404 / "not reachable".
- When both mapping routes fail with no HTTP response, keep the wrap at the front of `message`, name both routes, and say this is a panel-origin transport failure — not a disabled Manager and not a missing pack.
- `managerCall` labels the absolute path (`/customnode/...`), not `/v2/...`.

## Tests

`node --test` on:

- `browser_tests/unit/manager-search-transport.test.mjs` (new; fails on a bare Failed-to-fetch)
- `browser_tests/unit/manager-fetch-failure.test.mjs`
- `browser_tests/unit/manager-install.test.mjs`
- `browser_tests/unit/manager-catalogue-empty.test.mjs`
- `browser_tests/unit/catalogue-no-match-provenance.test.mjs`
- `browser_tests/unit/manager-fallback-i18n.test.mjs`
- `browser_tests/unit/manager-dialect.test.mjs`
- `browser_tests/unit/nodes-list-manager-unreachable.test.mjs`

**245 passed, 0 failed.**

Fixes #2024
