### PR TITLE
fix(2022): do not false-negative an applied tmp: open after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_open_workflow of a listed unsaved tmp: tab after reconnect no longer false-negatives: it rechecks the active routing key before failing, and an applied switch that is still unreadable returns the receipt rather than a hard error (#2022)
+
 ## [0.15.142] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -55,6 +55,12 @@ import {
   describeInputLink,
   verifyDisconnect,
 } from "../../web/js/lib/disconnect-verify.js";
+import {
+  appliedTmpOpenShouldFailClosed,
+  isUnsavedTmpOpenSelector,
+  settleOwnedOpenedTmpRoutingKey,
+  settleOwnedOpenedWorkflowActive,
+} from "../../web/js/lib/settle-open-active.js";
 
 // --- Mirror the shared bounded-step edge (#648) --------------------------------------
 // run-completion-frame.js and media-preview.js BOTH import withTimeout from here. If
@@ -124,6 +130,13 @@ test("panel ↔ disconnect-verify.js module edge links (#668)", () => {
   assert.equal(typeof snapshotGraphState, "function");
   assert.equal(typeof describeInputLink, "function");
   assert.equal(typeof verifyDisconnect, "function");
+});
+
+test("panel ↔ settle-open-active.js tmp: reconnect edges link (#2022)", () => {
+  assert.equal(typeof settleOwnedOpenedWorkflowActive, "function");
+  assert.equal(typeof settleOwnedOpenedTmpRoutingKey, "function");
+  assert.equal(typeof isUnsavedTmpOpenSelector, "function");
+  assert.equal(typeof appliedTmpOpenShouldFailClosed, "function");
 });
 
 /**

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -4,7 +4,10 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import {
+  appliedTmpOpenShouldFailClosed,
+  isUnsavedTmpOpenSelector,
   settleOpenedWorkflowActive,
+  settleOwnedOpenedTmpRoutingKey,
   settleOwnedOpenedWorkflowActive,
 } from "../../web/js/lib/settle-open-active.js";
 import { settleOpenedWorkflowReadable } from "../../web/js/lib/settle-open-readable.js";
@@ -152,6 +155,10 @@ function productionExecutor(methodName, environment) {
     graphRootWorkflowUuidMatches,
     graphRootWorkflowUuidMismatches,
     describeLiveCanvasBinding: productionDescribeLiveCanvasBinding(environment),
+    isUnsavedTmpOpenSelector,
+    appliedTmpOpenShouldFailClosed,
+    settleOwnedOpenedTmpRoutingKey,
+    readExistingWorkflowTabId: (wf) => (wf?.path ? `wf:${wf.path}` : null),
     ...environment,
   };
   const scope = new Proxy(sandbox, {

--- a/browser_tests/unit/open-unsaved-tmp-after-reconnect.test.mjs
+++ b/browser_tests/unit/open-unsaved-tmp-after-reconnect.test.mjs
@@ -1,6 +1,6 @@
 // #2022 — panel_open_workflow of a listed unsaved tmp: tab immediately after
 // reconnect applied the switch but returned a hard error because it could not
-// immediately prove the active workflow. ~7s later list_workflows showed
+// immediately prove the active workflow. ~7s later panel_list_workflows showed
 // active_confirmed:true and last_open.applied:true for the same command.
 //
 // That is a verification race / false-negative, not a failed switch. When the

--- a/browser_tests/unit/open-unsaved-tmp-after-reconnect.test.mjs
+++ b/browser_tests/unit/open-unsaved-tmp-after-reconnect.test.mjs
@@ -1,0 +1,401 @@
+// #2022 — panel_open_workflow of a listed unsaved tmp: tab immediately after
+// reconnect applied the switch but returned a hard error because it could not
+// immediately prove the active workflow. ~7s later list_workflows showed
+// active_confirmed:true and last_open.applied:true for the same command.
+//
+// That is a verification race / false-negative, not a failed switch. When the
+// open already applied a tmp: key, wait/recheck the live routing key before
+// failing, and if it is still unreadable return the applied receipt rather than
+// throwing. Tests below fail on the old throw-on-unknown path.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  appliedTmpOpenShouldFailClosed,
+  isUnsavedTmpOpenSelector,
+  settleOpenedTmpRoutingKey,
+  settleOwnedOpenedTmpRoutingKey,
+  settleOwnedOpenedWorkflowActive,
+} from "../../web/js/lib/settle-open-active.js";
+import {
+  graphRootMatchesState,
+  graphRootWorkflowUuidMatches,
+  graphRootWorkflowUuidMismatches,
+} from "../../web/js/lib/graph-binding.js";
+import {
+  decideLiveCanvasCapture,
+  installActivePointerWatch,
+  POINTER_WATCH_UNAVAILABLE_NOTICE,
+} from "../../web/js/lib/live-canvas-capture-gate.js";
+import {
+  workflowOpenReadinessRefusalError,
+  readWorkflowOpenReadinessRefusal,
+} from "../../web/js/lib/reconnect-recovery.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const TMP_KEY = "tmp:11ce5a34-0a2a-4b62-9bbc-731f6f1460be";
+
+function fakeClock() {
+  let time = 0;
+  return {
+    now: () => time,
+    wait: async (ms) => {
+      time += ms;
+    },
+  };
+}
+
+test("#2022 tmp: selector is only a canonical unsaved handle", () => {
+  assert.equal(isUnsavedTmpOpenSelector(TMP_KEY), true);
+  assert.equal(isUnsavedTmpOpenSelector("tmp:not-a-uuid"), false);
+  assert.equal(isUnsavedTmpOpenSelector("workflows/a.json"), false);
+  assert.equal(isUnsavedTmpOpenSelector("Unsaved Workflow"), false);
+  assert.equal(isUnsavedTmpOpenSelector(null), false);
+});
+
+test("#2022 fail-closed only on a POSITIVE routing-key mismatch", () => {
+  assert.equal(appliedTmpOpenShouldFailClosed({ routingSettle: { status: "different" } }), true);
+  assert.equal(appliedTmpOpenShouldFailClosed({ routingSettle: { status: "unknown" } }), false);
+  assert.equal(appliedTmpOpenShouldFailClosed({ routingSettle: { status: "settled" } }), false);
+  assert.equal(appliedTmpOpenShouldFailClosed({ routingSettle: { status: "superseded" } }), false);
+  assert.equal(appliedTmpOpenShouldFailClosed({}), false);
+});
+
+test("#2022 delayed tmp: routing-key proof settles instead of failing closed", async () => {
+  const clock = fakeClock();
+  const target = { routingKey: TMP_KEY };
+  let active = null;
+  const result = await settleOpenedTmpRoutingKey({
+    requestedKey: TMP_KEY,
+    readActive: () => active,
+    workflowTabId: (wf) => wf?.routingKey ?? null,
+    wait: async (ms) => {
+      await clock.wait(ms);
+      if (clock.now() >= 50) active = target;
+    },
+    now: clock.now,
+    budgetMs: 200,
+    pollMs: 25,
+  });
+  assert.equal(result.status, "settled");
+  assert.equal(result.routingKey, TMP_KEY);
+  assert.ok(clock.now() >= 50, "the probe must wait rather than fail the first unreadable read");
+});
+
+test("#2022 an unreadable tmp: routing key stays unknown, never different", async () => {
+  const clock = fakeClock();
+  const result = await settleOpenedTmpRoutingKey({
+    requestedKey: TMP_KEY,
+    readActive: () => null,
+    workflowTabId: () => {
+      throw new Error("must not mint");
+    },
+    wait: clock.wait,
+    now: clock.now,
+    budgetMs: 40,
+    pollMs: 20,
+  });
+  assert.equal(result.status, "unknown");
+  assert.equal(appliedTmpOpenShouldFailClosed({ routingSettle: result }), false);
+});
+
+test("#2022 a different live routing key is a real mismatch", async () => {
+  const clock = fakeClock();
+  const result = await settleOpenedTmpRoutingKey({
+    requestedKey: TMP_KEY,
+    readActive: () => ({ routingKey: "tmp:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+    workflowTabId: (wf) => wf.routingKey,
+    wait: clock.wait,
+    now: clock.now,
+    budgetMs: 20,
+    pollMs: 10,
+  });
+  assert.equal(result.status, "different");
+  assert.equal(appliedTmpOpenShouldFailClosed({ routingSettle: result }), true);
+});
+
+test("#2022 routing-key probe must not treat a minted handle as evidence", async () => {
+  const clock = fakeClock();
+  let minted = 0;
+  const result = await settleOpenedTmpRoutingKey({
+    requestedKey: TMP_KEY,
+    readActive: () => ({}),
+    workflowTabId: () => {
+      minted += 1;
+      return minted === 1 ? null : "tmp:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    },
+    wait: clock.wait,
+    now: clock.now,
+    budgetMs: 20,
+    pollMs: 10,
+  });
+  assert.notEqual(result.status, "settled", "a freshly minted tmp: id is not the listed tab");
+});
+
+function balancedFrom(src, marker, openAt = null) {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `missing marker: ${marker}`);
+  const open = openAt ?? src.indexOf("{", start + marker.length);
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === "/" && src[i + 1] === "/") {
+      i = src.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "*") {
+      i = src.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < src.length; i += 1) {
+        if (src[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (src[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated block: ${marker}`);
+}
+
+const RELOAD_GUARD_SOURCE = SRC.match(
+  /let workflowReloadGuard = null;[\s\S]*?function activeWorkflowReloadGuard\(\) \{[\s\S]*?\n\}/,
+);
+assert.ok(RELOAD_GUARD_SOURCE, "could not locate the production reload guard block");
+const PINIA_STORE_HELPER_SOURCE = balancedFrom(SRC, "function getPiniaStore(id)");
+
+function productionOpen(environment) {
+  const signature = "async workflow_open({";
+  const sigStart = SRC.indexOf(signature);
+  assert.notEqual(sigStart, -1, "workflow_open not found");
+  const bodyBrace = SRC.indexOf(") {", sigStart) + 1;
+  const methodSource = balancedFrom(SRC, signature, bodyBrace).replace(
+    /^async workflow_open\(/,
+    "async function workflow_open(",
+  );
+  const factory = new Function(
+    "sandbox",
+    `with (sandbox) {\n${RELOAD_GUARD_SOURCE[0]}\n${PINIA_STORE_HELPER_SOURCE}\n${methodSource}\n` +
+      `return { method: workflow_open, proofs: () => ({ active: activeWorkflowResyncEpoch, post: postReconnectBindingProofEpoch }) };\n}`,
+  );
+  const sandbox = {
+    decideLiveCanvasCapture,
+    installActivePointerWatch,
+    POINTER_WATCH_UNAVAILABLE_NOTICE,
+    workflowOpenReadinessRefusalError,
+    readWorkflowOpenReadinessRefusal,
+    graphRootMatchesState,
+    graphRootWorkflowUuidMatches,
+    graphRootWorkflowUuidMismatches,
+    isUnsavedTmpOpenSelector,
+    appliedTmpOpenShouldFailClosed,
+    settleOwnedOpenedWorkflowActive,
+    settleOwnedOpenedTmpRoutingKey,
+    ...environment,
+  };
+  const scope = new Proxy(sandbox, {
+    has: () => true,
+    get(target, key) {
+      if (key === Symbol.unscopables) return undefined;
+      return Object.prototype.hasOwnProperty.call(target, key) ? target[key] : globalThis[key];
+    },
+  });
+  return factory(scope);
+}
+
+function tmpOpenEnvironment({ routingSettle, objectSettle = { status: "unknown" } }) {
+  const target = {
+    path: "Unsaved Workflow",
+    filename: "Unsaved Workflow",
+    isPersisted: false,
+    isTemporary: true,
+    isModified: false,
+    routingKey: TMP_KEY,
+    changeTracker: { activeState: { nodes: [], links: [], groups: [], last_node_id: 0 } },
+  };
+  const receipts = [];
+  const root = { _nodes: [], extra: {}, serialize: () => ({ nodes: [], links: [], groups: [] }) };
+  let active = target;
+  const uuid = "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
+  return {
+    target,
+    receipts,
+    environment: {
+      backendReconnectEpoch: 4,
+      activeWorkflowResyncEpoch: 3,
+      postReconnectBindingProofEpoch: 3,
+      app: {
+        rootGraph: root,
+        graph: root,
+        canvas: {},
+        loadGraphData: async () => {},
+        extensionManager: {
+          workflow: {
+            openWorkflows: [target],
+            workflows: [],
+            getWorkflowByPath: () => null,
+            openWorkflow: async () => {
+              active = target;
+            },
+          },
+        },
+      },
+      activeWorkflowRef: () => active,
+      sameWorkflowObject: (a, b) => a === b,
+      workflowTabId: () => TMP_KEY,
+      readExistingWorkflowTabId: (wf) => wf?.routingKey ?? null,
+      workflowRecordMatchesSelector: (_w, sel) => sel === TMP_KEY,
+      waitForReconnectHandshakeBeforeOpen: async () => "ready",
+      comfyBackendIsDown: () => false,
+      postReconnectBindingSettleWindow: () => false,
+      nodeDefRefreshInFlight: null,
+      flushSourceCanvasBeforeSwitch: async () => {},
+      claimActiveWorkflowMove: () => {},
+      acquireCanvasInteractionLock: () => "lock",
+      releaseCanvasInteractionLock: () => {},
+      MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+      settleOpenedWorkflowTarget: async () => ({ target, loaded: false }),
+      installNodeConfigureIsolation: () => ({ failures: [], restore: () => {} }),
+      installGraphConfigureWatch: () => ({ restore: () => {} }),
+      loadRestoreCompleted: () => true,
+      retryNodeRestores: async () => ({ restored: [], failed: [], recovered: [] }),
+      liteGraphGlobal: () => null,
+      getGraphCtx: () => ({ graph: root, rootGraph: root }),
+      describeLiveCanvasBinding: () => "unknown",
+      applySavedNodePresentation: () => {},
+      applySavedSubgraphHostWidgets: () => {},
+      decideOpenStaleness: () => ({ stale: false, reload: false }),
+      clearSpuriousOpenModified: async () => {},
+      withDeadline: async (promise) => promise,
+      staleReadFlight: { run: (_key, start) => start() },
+      workflowDiskContent: async () => null,
+      canvasFileDivergence: () => null,
+      OPEN_DISK_READ_BUDGET_MS: 1,
+      describeRepaintSourceBinding: () => "unknown",
+      graphRootCarriesOpenProof: () => true,
+      graphRootWorkflowUuidMatches: () => true,
+      graphRootReproducesStateContent: () => ({ proven: true, presentationOnly: false, normalizedOnly: false, exact: true }),
+      describeGraphStateDifference: () => ({ comparable: true, surfaces: [], accountedSurfaces: [], nodeDifference: null }),
+      openContentDifferenceIsDefinitionsOnly: () => false,
+      resolveOpenRebindVerdict: () => ({ status: "proven" }),
+      describeOpenRebindOutcome: () => "",
+      OPEN_REBIND_STATUS: { PROVEN: "proven", CONTENT_UNVERIFIED: "content-unverified", UNPROVEN: "unproven" },
+      GRAPH_TOOL_EXECUTORS: { graph_outline: () => ({ node_count: 0, outline: "", detail_level: "full" }) },
+      settleOpenedWorkflowReadable: async () => ({ status: "settled-readable" }),
+      settleOwnedOpenedWorkflowActive: async () => objectSettle,
+      settleOwnedOpenedTmpRoutingKey: async () => routingSettle,
+      noteOpenAttempt: (entry) => {
+        receipts.push(entry);
+        return { seq: receipts.length, ...entry };
+      },
+      backendSocketReplyFields: () => ({}),
+      activeWorkflowUuidForOpenReply: () => uuid,
+      describeOpenActiveBinding: ({ targetRoutingKey, activeRoutingKey }) => ({
+        active_routing_key: activeRoutingKey ?? null,
+        active_matches_target: targetRoutingKey && activeRoutingKey ? targetRoutingKey === activeRoutingKey : null,
+      }),
+      canvasFileDivergenceNote: () => null,
+      failOpenRebindUnknown: (error) => error,
+      coerceMessageText: (value) => String(value ?? ""),
+      workflowObjectUuid: () => uuid,
+      workflowStableUuid: () => uuid,
+      WORKFLOW_META_NAMESPACE: "comfyui_mcp",
+      WORKFLOW_UUID_FIELD: "workflow_uuid",
+      WORKFLOW_PATH_FIELD: "workflow_path",
+      OPEN_PROOF_FIELD: "open_proof",
+    },
+  };
+}
+
+test("#2022 production workflow_open succeeds when tmp: routing key lands after an unknown object settle", async () => {
+  const { receipts, environment } = tmpOpenEnvironment({
+    objectSettle: { status: "unknown", reason: "active workflow was unreadable" },
+    routingSettle: { status: "settled", routingKey: TMP_KEY },
+  });
+  const panel = productionOpen(environment);
+  const result = await panel.method({ path: TMP_KEY, rid: "rid-2022-settled" });
+  assert.equal(result.routing_key, TMP_KEY);
+  assert.equal(result.opened.path, null, "a tmp: open must not report a native unsaved path as a filename alias");
+  assert.equal(result.opened.filename, null);
+  assert.equal(result.opened.routing_key, TMP_KEY);
+  assert.equal(receipts.at(-1)?.applied, true);
+  assert.deepEqual(panel.proofs(), { active: 4, post: 4 });
+});
+
+test("#2022 production workflow_open does not throw when an applied tmp: switch is still unreadable", async () => {
+  const { receipts, environment } = tmpOpenEnvironment({
+    objectSettle: { status: "unknown", reason: "active workflow was unreadable" },
+    routingSettle: { status: "unknown", reason: "active routing key was unreadable" },
+  });
+  const panel = productionOpen(environment);
+  const result = await panel.method({ path: TMP_KEY, rid: "rid-2022-unknown" });
+  assert.equal(result.routing_key, TMP_KEY);
+  assert.equal(result.opened.path, null);
+  assert.equal(receipts.at(-1)?.applied, true, "the switch applied; do not journal a failure");
+  assert.equal(receipts.at(-1)?.error, undefined);
+  assert.deepEqual(
+    panel.proofs(),
+    { active: 4, post: 3 },
+    "list confirmation may close; the mutation gate stays closed until the bind is proven",
+  );
+});
+
+test("#2022 production workflow_open still fails closed on a different tmp: routing key", async () => {
+  const { receipts, environment } = tmpOpenEnvironment({
+    objectSettle: { status: "unknown" },
+    routingSettle: { status: "different", routingKey: "tmp:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
+  });
+  const panel = productionOpen(environment);
+  await assert.rejects(
+    () => panel.method({ path: TMP_KEY, rid: "rid-2022-different" }),
+    /did not leave the requested workflow as the stable active canvas/,
+  );
+  assert.equal(receipts.at(-1)?.applied, "unknown");
+});
+
+test("#2022 wiring: workflow_open rechecks tmp: routing key before the hard error", () => {
+  const openAt = SRC.indexOf("async workflow_open({ path, rid }) {");
+  const objectSettleAt = SRC.indexOf("const activeSettle = await settleOwnedOpenedWorkflowActive({", openAt);
+  const tmpSettleAt = SRC.indexOf("tmpRoutingSettle = await settleOwnedOpenedTmpRoutingKey({", openAt);
+  const failAt = SRC.indexOf("throw failOpenRebindUnknown(rebindFailed);", openAt);
+  const openedAt = SRC.indexOf("opened: {", tmpSettleAt);
+  assert.ok(objectSettleAt > openAt);
+  assert.ok(tmpSettleAt > objectSettleAt, "the routing-key recheck follows the object settle");
+  assert.ok(failAt > tmpSettleAt, "do not throw before the tmp: recheck");
+  assert.match(
+    SRC.slice(tmpSettleAt, failAt),
+    /readExistingWorkflowTabId/,
+    "the recheck must read existing tmp: handles, never mint a new one",
+  );
+  assert.match(
+    SRC.slice(tmpSettleAt, failAt),
+    /tmpOpenAppliedUnproven/,
+    "an applied tmp: open that is still unreadable must not take the hard-error path",
+  );
+  assert.match(
+    SRC.slice(openedAt, openedAt + 500),
+    /openedForTmp \? null : target\.path/,
+    "tmp: replies must not publish a native unsaved path as opened.path",
+  );
+});
+
+test("#2022 wiring: panel imports the shipped tmp: helpers, not a local copy", () => {
+  assert.match(
+    SRC,
+    /import \{[\s\S]*?appliedTmpOpenShouldFailClosed,[\s\S]*?isUnsavedTmpOpenSelector,[\s\S]*?settleOwnedOpenedTmpRoutingKey,[\s\S]*?settleOwnedOpenedWorkflowActive,[\s\S]*?\} from "\.\/lib\/settle-open-active\.js"/,
+  );
+});

--- a/browser_tests/unit/open-workflow-after-restart.test.mjs
+++ b/browser_tests/unit/open-workflow-after-restart.test.mjs
@@ -358,6 +358,9 @@ function productionOpen(environment) {
     installActivePointerWatch,
     workflowOpenReadinessRefusalError,
     readWorkflowOpenReadinessRefusal,
+    isUnsavedTmpOpenSelector: () => false,
+    appliedTmpOpenShouldFailClosed: () => false,
+    settleOwnedOpenedTmpRoutingKey: async () => ({ status: "unknown" }),
     ...environment,
   };
   const scope = new Proxy(sandbox, {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -651,7 +651,12 @@ import {
 import { decideBoundRestart, normalizeBoundOrigin } from "./lib/bound-restart-witness.js";
 import { decideDesktopRestartRestore, resolveDesktopRestore } from "./lib/desktop-restart-restore.js";
 import { settleOpenedWorkflowTarget } from "./lib/settle-open-target.js";
-import { settleOwnedOpenedWorkflowActive } from "./lib/settle-open-active.js";
+import {
+  appliedTmpOpenShouldFailClosed,
+  isUnsavedTmpOpenSelector,
+  settleOwnedOpenedTmpRoutingKey,
+  settleOwnedOpenedWorkflowActive,
+} from "./lib/settle-open-active.js";
 import { settleOpenedWorkflowReadable } from "./lib/settle-open-readable.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext, stripAgentDirectedBlocks } from "./lib/chat-serialize.js";
 import { generatedImageMediaItems, generatedImageRemainderText } from "./lib/generated-image.js";
@@ -5070,6 +5075,16 @@ function workflowTabId(wf = activeWorkflowRef()) {
     if (!priorTempWorkflowId(wf)) setPriorTempWorkflowId(wf, id);
   }
   return id;
+}
+
+// #2022 — READ, never mint. Post-open routing-key settle must not invent a
+// fresh tmp: handle on a restored object; that would look like a different tab
+// and fail a switch that already applied.
+function readExistingWorkflowTabId(wf = activeWorkflowRef()) {
+  if (!wf) return null;
+  const saved = savedWorkflowPath(wf);
+  if (saved) return savedWorkflowHandle(saved);
+  return tempWorkflowInstanceId(wf) || priorTempWorkflowId(wf) || null;
 }
 
 // #640 — the BRIDGE ROUTE for a workflow: the `tab_id` this panel puts on the
@@ -23317,11 +23332,38 @@ const GRAPH_TOOL_EXECUTORS = {
           ownsStep: () => ownsWorkflowReloadGuard(reloadGuardToken),
           endStep: () => endWorkflowReloadStep(reloadGuardToken),
         });
-        if (activeSettle.status !== "settled") {
+        // #2022 — after reconnect, an applied open of a listed tmp: tab can still
+        // look unproven: the restored object is briefly unreadable, or object
+        // identity has not caught up with the switch. Recheck the live routing
+        // key before treating that as a failed switch. A still-unknown result
+        // keeps the receipt (applied:true) rather than throwing a hard error.
+        let tmpRoutingSettle = null;
+        if (
+          activeSettle.status !== "settled" &&
+          isUnsavedTmpOpenSelector(path) &&
+          !openFailed
+        ) {
+          tmpRoutingSettle = await settleOwnedOpenedTmpRoutingKey({
+            requestedKey: path,
+            readActive: activeWorkflowRef,
+            workflowTabId: readExistingWorkflowTabId,
+            beginStep: () => beginWorkflowReloadStep(reloadGuardToken),
+            ownsStep: () => ownsWorkflowReloadGuard(reloadGuardToken),
+            endStep: () => endWorkflowReloadStep(reloadGuardToken),
+          });
+        }
+        const tmpOpenSettled = tmpRoutingSettle?.status === "settled";
+        const tmpOpenAppliedUnproven =
+          isUnsavedTmpOpenSelector(path) &&
+          !openFailed &&
+          activeSettle.status !== "settled" &&
+          !tmpOpenSettled &&
+          !appliedTmpOpenShouldFailClosed({ routingSettle: tmpRoutingSettle });
+        if (activeSettle.status !== "settled" && !tmpOpenSettled && !tmpOpenAppliedUnproven) {
           rebindFailed = new Error(
-            activeSettle.status === "different"
+            activeSettle.status === "different" || tmpRoutingSettle?.status === "different"
               ? "workflow_open did not leave the requested workflow as the stable active canvas"
-              : activeSettle.status === "superseded"
+              : activeSettle.status === "superseded" || tmpRoutingSettle?.status === "superseded"
                 ? "workflow_open lost ownership of its reload window while the active canvas was settling"
                 : "workflow_open could not prove that the requested workflow remained the stable active canvas",
           );
@@ -23332,9 +23374,12 @@ const GRAPH_TOOL_EXECUTORS = {
         // gate for this reconnect epoch. Failed/unknown/superseded opens leave both
         // proofs invalidated below instead of allowing an immediate list or mutation to
         // trust a prior open's proof.
+        // #2022 — an applied tmp: open that is still racing its routing-key proof
+        // DID re-point `active`, so the list's `active_confirmed` window may close.
+        // The mutation gate stays closed until the binding is actually proven.
         if (!rebindFailed && backendReconnectEpoch === openedForEpoch) {
           activeWorkflowResyncEpoch = openedForEpoch;
-          postReconnectBindingProofEpoch = openedForEpoch;
+          if (!tmpOpenAppliedUnproven) postReconnectBindingProofEpoch = openedForEpoch;
         }
       }
       }
@@ -23457,8 +23502,19 @@ const GRAPH_TOOL_EXECUTORS = {
         }
       })(),
     });
+    // #2022 — a tmp: request is not a filename alias. Reporting the native
+    // `path`/`filename` ("Unsaved Workflow", a leftover disk path on an
+    // unpersisted tab) makes the orchestrator corroborate it as a saved
+    // identity and fail the already-applied open when `active_confirmed` is
+    // still catching up. Keep those fields null for unsaved selectors; the
+    // routing key is the identity.
+    const openedForTmp = isUnsavedTmpOpenSelector(path);
     return {
-      opened: { path: target.path, filename: target.filename },
+      opened: {
+        path: openedForTmp ? null : target.path,
+        filename: openedForTmp ? null : target.filename,
+        ...(targetRoutingKeyAtReply ? { routing_key: targetRoutingKeyAtReply } : {}),
+      },
       routing_key: targetRoutingKeyAtReply,
       ...openActiveBinding,
       // #1325 — `panel_set_workflow_target({mode:"current"})` lands here and

--- a/web/js/lib/settle-open-active.js
+++ b/web/js/lib/settle-open-active.js
@@ -13,6 +13,19 @@ const DEFAULT_BUDGET_MS = 1200;
 const DEFAULT_POLL_MS = 50;
 const DEFAULT_STABLE_MS = 100;
 
+/** Same bound as the object-identity settle. The tmp: reconnect race is a
+ *  verification lag, not a second-long restore. */
+export const TMP_OPEN_ROUTING_BUDGET_MS = DEFAULT_BUDGET_MS;
+export const TMP_OPEN_ROUTING_POLL_MS = DEFAULT_POLL_MS;
+
+const TMP_OPEN_SELECTOR_RE =
+  /^tmp:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** True when `panel_open_workflow` was asked for an unsaved per-tab handle. */
+export function isUnsavedTmpOpenSelector(value) {
+  return typeof value === "string" && TMP_OPEN_SELECTOR_RE.test(value);
+}
+
 const defaultNow = () =>
   typeof performance !== "undefined" && typeof performance.now === "function"
     ? performance.now()
@@ -117,18 +130,118 @@ export async function settleOpenedWorkflowActive({
 }
 
 /**
+ * #2022 — wait until the live active workflow's EXISTING routing key equals the
+ * requested `tmp:<uuid>`.
+ *
+ * Object-identity settle can miss immediately after reconnect: the restored tab
+ * is briefly unreadable, or `sameWorkflowObject` cannot yet see the tracker.
+ * The switch already ran; failing closed on that race is the reported
+ * false-negative. A missing/throwing read is UNKNOWN, never a mismatch. The
+ * caller MUST pass a non-minting `workflowTabId` — minting a fresh tmp: handle
+ * on a restored object would invent a different key and fail a working switch.
+ *
+ * @returns {Promise<{
+ *   status: "settled"|"different"|"unknown",
+ *   active?: unknown,
+ *   routingKey?: string|null,
+ *   reason?: string
+ * }>}
+ */
+export async function settleOpenedTmpRoutingKey({
+  requestedKey,
+  readActive,
+  workflowTabId,
+  wait = defaultWait,
+  now = defaultNow,
+  budgetMs = TMP_OPEN_ROUTING_BUDGET_MS,
+  pollMs = TMP_OPEN_ROUTING_POLL_MS,
+} = {}) {
+  if (
+    !isUnsavedTmpOpenSelector(requestedKey) ||
+    typeof readActive !== "function" ||
+    typeof workflowTabId !== "function"
+  ) {
+    return { status: "unknown", reason: "tmp routing-key probe was unavailable" };
+  }
+
+  const budget = Number.isFinite(budgetMs) && budgetMs > 0 ? budgetMs : 0;
+  const poll = Number.isFinite(pollMs) && pollMs > 0 ? pollMs : 1;
+  const maxAttempts = Math.max(1, Math.ceil(budget / poll) + 1);
+  let started;
+  try {
+    started = now();
+  } catch {
+    return { status: "unknown", reason: "tmp routing-key clock was unreadable" };
+  }
+
+  let lastObservation = { status: "unknown", reason: "no tmp routing-key observation" };
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    let current;
+    try {
+      current = readActive();
+    } catch {
+      lastObservation = { status: "unknown", reason: "active workflow was unreadable" };
+      current = undefined;
+    }
+
+    if (current !== undefined) {
+      if (!current) {
+        lastObservation = { status: "unknown", reason: "active workflow was unreadable" };
+      } else {
+        let routingKey = null;
+        try {
+          const read = workflowTabId(current);
+          routingKey = typeof read === "string" && read ? read : null;
+        } catch {
+          routingKey = null;
+        }
+        if (!routingKey) {
+          lastObservation = { status: "unknown", reason: "active routing key was unreadable" };
+        } else if (routingKey === requestedKey) {
+          return { status: "settled", active: current, routingKey };
+        } else {
+          lastObservation = { status: "different", active: current, routingKey };
+        }
+      }
+    }
+
+    let currentTime;
+    try {
+      currentTime = now();
+    } catch {
+      return { status: "unknown", reason: "tmp routing-key clock was unreadable" };
+    }
+    if (currentTime - started >= budget || attempt + 1 >= maxAttempts) break;
+    try {
+      await wait(Math.min(poll, Math.max(0, budget - (currentTime - started))));
+    } catch {
+      return { status: "unknown", reason: "tmp routing-key wait failed" };
+    }
+  }
+
+  return lastObservation.status === "different"
+    ? lastObservation
+    : { status: "unknown", reason: lastObservation.reason ?? "tmp routing key did not settle" };
+}
+
+/**
+ * #2022 — fail closed on an APPLIED tmp: open only when a positive observation
+ * names a different routing key. Unreadable object identity, or an object-level
+ * "different" without routing-key confirmation, is the reconnect race — not a
+ * failed switch.
+ */
+export function appliedTmpOpenShouldFailClosed({ routingSettle } = {}) {
+  return routingSettle?.status === "different";
+}
+
+/**
  * Run the active-binding probe as one owned reload-guard step.
  *
  * A superseding open may replace the guard while the timer-backed probe is
  * waiting. In that case the result is not allowed to authorize this open,
  * even if its last active read happened to name the target.
  */
-export async function settleOwnedOpenedWorkflowActive({
-  beginStep,
-  ownsStep,
-  endStep,
-  ...probeOptions
-} = {}) {
+async function settleOwnedOpenProbe(runProbe, { beginStep, ownsStep, endStep } = {}) {
   let started = false;
   try {
     started = typeof beginStep === "function" && beginStep() === true;
@@ -140,7 +253,7 @@ export async function settleOwnedOpenedWorkflowActive({
   }
 
   try {
-    const result = await settleOpenedWorkflowActive(probeOptions);
+    const result = await runProbe();
     let stillOwns = false;
     try {
       stillOwns = typeof ownsStep === "function" && ownsStep() === true;
@@ -159,4 +272,30 @@ export async function settleOwnedOpenedWorkflowActive({
       // Guard cleanup is best-effort; the production token remains owner-checked.
     }
   }
+}
+
+export async function settleOwnedOpenedWorkflowActive({
+  beginStep,
+  ownsStep,
+  endStep,
+  ...probeOptions
+} = {}) {
+  return settleOwnedOpenProbe(() => settleOpenedWorkflowActive(probeOptions), {
+    beginStep,
+    ownsStep,
+    endStep,
+  });
+}
+
+export async function settleOwnedOpenedTmpRoutingKey({
+  beginStep,
+  ownsStep,
+  endStep,
+  ...probeOptions
+} = {}) {
+  return settleOwnedOpenProbe(() => settleOpenedTmpRoutingKey(probeOptions), {
+    beginStep,
+    ownsStep,
+    endStep,
+  });
 }


### PR DESCRIPTION
Fixes #2022.

After a ComfyUI restart, `panel_list_workflows` returns the unsaved tab as `tmp:<uuid>`. `panel_open_workflow` with that listed key applied the switch, then threw because object-identity settle could not immediately prove the active canvas. A list ~7s later showed `active_confirmed:true` and `last_open.applied:true` for the same command. Verification race, not a failed switch.

The orchestrator then turned the hard error into:

> workflow_open: tmp:* was reported applied, but the panel could not prove that the panel returned an unconfirmed active workflow after resolving this filename. The active canvas is UNKNOWN.

### Fix
- After an applied `tmp:` open whose object settle is not yet proven, recheck the **existing** live routing key for a short bound (do not mint a fresh `tmp:` id).
- If the routing key matches, treat the open as settled.
- If it is still unreadable, keep `applied:true` and return the receipt instead of throwing. Stamp list confirmation (`active_confirmed`) but leave the mutation gate closed until the bind is proven.
- `opened.path` / `opened.filename` stay null for unsaved selectors so the orchestrator does not treat `tmp:` as a filename alias.

### Tests
`browser_tests/unit/open-unsaved-tmp-after-reconnect.test.mjs` fails on the old throw-on-unknown path and passes on this one: delayed routing-key proof succeeds, still-unreadable applied switch does not throw, a different routing key still fails closed.
