### PR TITLE
fix(2057): resolve loaded subgraph promoted widgets via inner input rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_set_widget no longer refuses a loaded subgraph's promoted combo or number that outline already lists: the host rail resolves to its inner input-rail terminal so the promoted-terminal witness completes (#2057)
 - panel_add_node can add a class from a type-scoped /object_info read when the full dump misses its fixed budget on a large install, without treating a stale whole cache as verified (#2050)
 - relay fixed `/object_info` reads for the headless MCP fallback when the configured ComfyUI route is unreachable (#2283)
 

--- a/browser_tests/unit/promoted-terminal-load-witness.test.mjs
+++ b/browser_tests/unit/promoted-terminal-load-witness.test.mjs
@@ -1,0 +1,207 @@
+/**
+ * #2057 — after load, outline lists promoted host rails (clip_name / width /
+ * height) while `_subgraphSlot.linkIds` is still empty. The inner widgets are
+ * already driven by input-rail terminals (-10). panel_set_widget must resolve
+ * those terminals and write without unpacking.
+ *
+ * Drives the shipped `resolvePromotedInnerTarget` / `applyWidgetWrite` and the
+ * production `promotedTerminalWitnesses` extractor graph_get_subgraph publishes.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { isPromotedContainer } from "../../web/js/lib/graph-read.js";
+import {
+  applyWidgetWrite,
+  followPromotionToConcrete,
+  MAX_PROMOTION_CHAIN_DEPTH,
+  promotedInputAliases,
+  resolvePromotedInnerTarget,
+} from "../../web/js/lib/widget-write.js";
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+
+function extractPromotedTerminalWitnesses() {
+  const helperStart = PANEL_SRC.indexOf("function resolveSubgraphLink(");
+  const helperEnd = PANEL_SRC.indexOf("\nfunction findPromotedHostInput", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production promotion helper range must remain extractable");
+  return new Function(
+    "resolvePromotedInnerTarget",
+    "followPromotionToConcrete",
+    "MAX_PROMOTION_CHAIN_DEPTH",
+    "promotedInputAliases",
+    "isPromotedContainer",
+    `${PANEL_SRC.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
+  )(
+    resolvePromotedInnerTarget,
+    followPromotionToConcrete,
+    MAX_PROMOTION_CHAIN_DEPTH,
+    promotedInputAliases,
+    isPromotedContainer,
+  );
+}
+
+/** Loaded Z-Image-Turbo subgraph host: rails on the wrapper, inner widgets
+ * wired from -10, host inputs not yet rebound with `_subgraphSlot` / linkIds. */
+function makeLoadedZImageHost({ includeHostInputs = true, stubSubgraphSlot = false } = {}) {
+  const clipOptions = ["qwen_3_4b.safetensors", "other.safetensors"];
+  const clipRail = {
+    name: "clip_name",
+    type: "combo",
+    options: { values: clipOptions },
+    value: "qwen_3_4b.safetensors",
+    widgetId: "root:57:clip_name",
+  };
+  const widthRail = { name: "width", type: "INT", value: 1024, widgetId: "root:57:width" };
+  const heightRail = { name: "height", type: "INT", value: 1024, widgetId: "root:57:height" };
+
+  const clipInner = { name: "clip_name", type: "combo", options: { values: clipOptions }, value: "qwen_3_4b.safetensors" };
+  const widthInner = { name: "width", type: "INT", value: 1024 };
+  const heightInner = { name: "height", type: "INT", value: 1024 };
+
+  const clipLoader = {
+    id: 12,
+    type: "CLIPLoader",
+    inputs: [{ name: "clip_name", widget: { name: "clip_name" }, type: "COMBO", link: 1 }],
+    widgets: [clipInner],
+  };
+  const latent = {
+    id: 8,
+    type: "EmptySD3LatentImage",
+    inputs: [
+      { name: "width", widget: { name: "width" }, type: "INT", link: 2 },
+      { name: "height", widget: { name: "height" }, type: "INT", link: 3 },
+    ],
+    widgets: [widthInner, heightInner],
+  };
+
+  const links = {
+    1: { id: 1, origin_id: -10, origin_slot: 6, target_id: 12, target_slot: 0 },
+    2: { id: 2, origin_id: -10, origin_slot: 1, target_id: 8, target_slot: 0 },
+    3: { id: 3, origin_id: -10, origin_slot: 2, target_id: 8, target_slot: 1 },
+  };
+  const subgraphInputs = [
+    { name: "model", linkIds: [] },
+    { name: "width", linkIds: [] },
+    { name: "height", linkIds: [] },
+    { name: "batch_size", linkIds: [] },
+    { name: "seed", linkIds: [] },
+    { name: "steps", linkIds: [] },
+    { name: "clip_name", linkIds: [] },
+  ];
+  const subgraph = {
+    _nodes: [clipLoader, latent],
+    inputs: subgraphInputs,
+    inputNode: { id: -10, slots: subgraphInputs },
+    links,
+    getNodeById: (id) => {
+      if (String(id) === "12") return clipLoader;
+      if (String(id) === "8") return latent;
+      return null;
+    },
+    getLink: (id) => links[id] ?? null,
+  };
+
+  const hostInput = (name) => {
+    const input = { name };
+    if (stubSubgraphSlot) input._subgraphSlot = { name, linkIds: [] };
+    return input;
+  };
+  const host = {
+    id: 57,
+    type: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    subgraph,
+    inputs: includeHostInputs ? [hostInput("clip_name"), hostInput("width"), hostInput("height")] : [],
+    widgets: [clipRail, widthRail, heightRail],
+  };
+  return { host, clipLoader, latent, clipRail, widthRail, heightRail, clipInner, widthInner, heightInner };
+}
+
+test("#2057 after load, a host clip_name combo with no _subgraphSlot resolves to CLIPLoader via -10", () => {
+  const { host, clipLoader, clipInner } = makeLoadedZImageHost();
+  const res = resolvePromotedInnerTarget(host, "clip_name", () => null);
+  assert.equal(res.promoted, true);
+  assert.equal(res.target.node, clipLoader);
+  assert.equal(res.target.widget, clipInner);
+  assert.equal(res.target.parentWidget?.name, "clip_name");
+});
+
+test("#2057 after load, host width/height numbers resolve to EmptySD3LatentImage via -10", () => {
+  const { host, latent, widthInner, heightInner } = makeLoadedZImageHost();
+  const width = resolvePromotedInnerTarget(host, "width", () => null);
+  assert.equal(width.promoted, true);
+  assert.equal(width.target.node, latent);
+  assert.equal(width.target.widget, widthInner);
+  const height = resolvePromotedInnerTarget(host, "height", () => null);
+  assert.equal(height.promoted, true);
+  assert.equal(height.target.node, latent);
+  assert.equal(height.target.widget, heightInner);
+});
+
+test("#2057 after load, a stub _subgraphSlot with empty linkIds still resolves the inner rail", () => {
+  const { host, clipLoader } = makeLoadedZImageHost({ stubSubgraphSlot: true });
+  const res = resolvePromotedInnerTarget(host, "clip_name", () => null);
+  assert.equal(res.promoted, true);
+  assert.equal(res.target.node, clipLoader);
+  assert.equal(res.target.widget.name, "clip_name");
+});
+
+test("#2057 after load, outline-only host widgets (no host inputs) still resolve via the inner rail", () => {
+  const { host, clipLoader } = makeLoadedZImageHost({ includeHostInputs: false });
+  const res = resolvePromotedInnerTarget(host, "clip_name", () => null);
+  assert.equal(res.promoted, true);
+  assert.equal(res.target.node, clipLoader);
+  assert.equal(res.target.parentWidget?.name, "clip_name");
+});
+
+test("#2057 after load, applyWidgetWrite sets the promoted combo without unpacking", () => {
+  const { host, clipInner, clipRail } = makeLoadedZImageHost();
+  const set = applyWidgetWrite(host, "clip_name", "other.safetensors", { resolveSource: () => null });
+  assert.equal(set.value, "other.safetensors");
+  assert.equal(set.promoted_from.subgraph_node_id, 57);
+  assert.equal(set.promoted_from.inner_node_id, 12);
+  assert.equal(clipInner.value, "other.safetensors");
+  assert.equal(clipRail.value, "other.safetensors");
+});
+
+test("#2057 after load, applyWidgetWrite sets promoted width/height without unpacking", () => {
+  const { host, widthInner, heightInner, widthRail, heightRail } = makeLoadedZImageHost();
+  const width = applyWidgetWrite(host, "width", 1280, { resolveSource: () => null });
+  const height = applyWidgetWrite(host, "height", 720, { resolveSource: () => null });
+  assert.equal(width.value, 1280);
+  assert.equal(height.value, 720);
+  assert.equal(widthInner.value, 1280);
+  assert.equal(heightInner.value, 720);
+  assert.equal(widthRail.value, 1280);
+  assert.equal(heightRail.value, 720);
+});
+
+test("#2057 production witness completes for loaded clip_name / width / height", () => {
+  const makeWitnesses = extractPromotedTerminalWitnesses();
+  const { host } = makeLoadedZImageHost();
+  const entries = makeWitnesses(host);
+  for (const name of ["clip_name", "width", "height"]) {
+    const witness = entries.find((entry) => entry.widget === name);
+    assert.ok(witness, `missing witness for ${name}`);
+    assert.equal(witness.error, undefined, `${name} must not publish an incomplete witness`);
+    assert.equal(witness.parent_rail?.authoritative, true);
+    assert.equal(witness.terminal_widget, name);
+    assert.equal(typeof witness.terminal_node_type, "string");
+    assert.ok(Array.isArray(witness.terminal_inputs));
+  }
+  assert.equal(entries.find((entry) => entry.widget === "clip_name")?.terminal_node_type, "CLIPLoader");
+  assert.equal(entries.find((entry) => entry.widget === "width")?.terminal_node_type, "EmptySD3LatentImage");
+});
+
+test("#2057 a promoted host input with no inner rail terminal still refuses", () => {
+  const { host } = makeLoadedZImageHost();
+  host.inputs.push({ name: "scheduler" });
+  const res = resolvePromotedInnerTarget(host, "scheduler", () => null);
+  assert.equal(res.promoted, true);
+  assert.equal(res.target, null);
+  assert.match(res.error ?? "", /_subgraphSlot missing|no resolvable inner link/i);
+});

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1398,7 +1398,258 @@ function liveHostPromotedWidgets(subgraphNode, hostInput, innerWidget) {
     (widget) => widget && widget !== innerWidget,
   );
   if (current.length) return current;
-  return rematerializeHostPromotedWidgets(subgraphNode, hostInput, innerWidget);
+  const rematerialized = rematerializeHostPromotedWidgets(subgraphNode, hostInput, innerWidget);
+  if (rematerialized.length) return rematerialized;
+  return recoverHostPromotedWidgetsAfterLoad(subgraphNode, hostInput, innerWidget);
+}
+
+/**
+ * #2057 — after `loadGraphData`, host rails exist on `node.widgets` (outline
+ * lists them) while `input._widget` may still be unbound. Instance-scoped rails
+ * carry a widgetId; a same-named decoy does not, so it cannot win (#366).
+ */
+function recoverHostPromotedWidgetsAfterLoad(subgraphNode, hostInput, innerWidget) {
+  if (!subgraphNode || !hostInput || hostInput.link != null) return [];
+  const widgets = Array.isArray(subgraphNode.widgets) ? subgraphNode.widgets : [];
+  const wantedName =
+    typeof hostInput.name === "string" && hostInput.name.length > 0
+      ? hostInput.name.toLowerCase()
+      : null;
+  if (!wantedName) return [];
+  const named = [];
+  for (const widget of widgets) {
+    if (!widget || widget === innerWidget) continue;
+    if (typeof widget.name !== "string" || widget.name.toLowerCase() !== wantedName) continue;
+    let widgetId = null;
+    try {
+      widgetId = typeof widget.widgetId === "string" && widget.widgetId.length > 0 ? widget.widgetId : null;
+    } catch {
+      widgetId = null;
+    }
+    if (!widgetId) continue;
+    named.push(widget);
+  }
+  return named.length === 1 ? named : [];
+}
+
+/** LiteGraph subgraph input-rail id. Same constant as subgraph-scope.js; kept
+ * local so this resolver does not take a graph-binding dependency. */
+const SUBGRAPH_INPUT_RAIL_ID = -10;
+
+function subgraphIoSlots(subgraph) {
+  if (Array.isArray(subgraph?.inputs) && subgraph.inputs.length) return subgraph.inputs;
+  if (Array.isArray(subgraph?.inputNode?.slots) && subgraph.inputNode.slots.length) {
+    return subgraph.inputNode.slots;
+  }
+  return [];
+}
+
+function slotLinkIds(slot) {
+  const ids = slot?.linkIds;
+  if (!ids) return [];
+  return Array.isArray(ids) ? ids : [...ids];
+}
+
+function subgraphNodeById(subgraph, id) {
+  if (id == null || !subgraph) return null;
+  if (typeof subgraph.getNodeById === "function") {
+    try {
+      const found = subgraph.getNodeById(id);
+      if (found) return found;
+    } catch {
+      /* fall through to the live node list */
+    }
+  }
+  return (subgraph._nodes ?? subgraph.nodes ?? []).find((node) => String(node?.id) === String(id)) ?? null;
+}
+
+function readSubgraphLink(subgraph, linkId) {
+  if (linkId == null || !subgraph) return null;
+  if (typeof subgraph.getLink === "function") {
+    try {
+      const link = subgraph.getLink(linkId);
+      if (link) return link;
+    } catch {
+      /* try the raw stores below */
+    }
+  }
+  const links = subgraph.links ?? subgraph._links;
+  if (!links) return null;
+  if (typeof links.get === "function") return links.get(linkId) ?? null;
+  if (Array.isArray(links)) {
+    return links.find((entry) => Number(entry?.id ?? entry?.[0]) === Number(linkId)) ?? null;
+  }
+  return links[linkId] ?? null;
+}
+
+function enumerateSubgraphLinks(subgraph) {
+  const links = subgraph?.links ?? subgraph?._links;
+  if (!links) return [];
+  if (typeof links.values === "function") return [...links.values()];
+  if (Array.isArray(links)) return links;
+  return Object.values(links);
+}
+
+function originIsInputRail(originId, subgraph) {
+  if (originId == null) return false;
+  if (Number(originId) === SUBGRAPH_INPUT_RAIL_ID) return true;
+  const inputNode = subgraph?.inputNode;
+  return inputNode != null && String(inputNode.id) === String(originId);
+}
+
+function sourceFromResolvedLink(subgraph, link) {
+  if (!link) return null;
+  const targetId = link.target_id ?? link[3];
+  const targetSlot = link.target_slot ?? link[4];
+  const innerNode = subgraphNodeById(subgraph, targetId);
+  if (!innerNode) return null;
+  const targetInput = Number.isInteger(targetSlot) ? innerNode.inputs?.[targetSlot] : null;
+  let targetWidget = null;
+  if (typeof innerNode.getWidgetFromSlot === "function" && targetInput) {
+    try {
+      targetWidget = innerNode.getWidgetFromSlot(targetInput);
+    } catch {
+      targetWidget = null;
+    }
+  }
+  if (!targetWidget && targetInput) {
+    const widgetName = targetInput.widget?.name ?? targetInput.name;
+    targetWidget = (innerNode.widgets ?? []).find((widget) => widget?.name === widgetName) ?? null;
+  }
+  const sourceWidgetName = targetWidget?.name ?? targetInput?.name;
+  if (typeof sourceWidgetName !== "string" || sourceWidgetName.length === 0) return null;
+  return { sourceNodeId: String(innerNode.id), sourceWidgetName };
+}
+
+function uniqueSlotMatchingAliases(subgraph, aliases) {
+  const wanted = new Set(
+    (aliases ?? []).map((alias) => String(alias).toLowerCase()).filter((alias) => alias.length > 0),
+  );
+  if (!wanted.size) return null;
+  const hits = [];
+  for (const slot of subgraphIoSlots(subgraph)) {
+    const names = [slot?.name, slot?.label]
+      .filter((value) => value != null && String(value).length > 0)
+      .map((value) => String(value).toLowerCase());
+    if (names.some((name) => wanted.has(name))) hits.push(slot);
+  }
+  return hits.length === 1 ? hits[0] : null;
+}
+
+function liveSlotForHostInput(subgraphNode, hostInput, subgraphInput) {
+  const subgraph = subgraphNode?.subgraph;
+  const aliases = promotedInputAliases(hostInput, subgraphInput);
+  const byName = uniqueSlotMatchingAliases(subgraph, aliases);
+  if (byName) return byName;
+  const hostInputs = Array.isArray(subgraphNode?.inputs) ? subgraphNode.inputs : [];
+  const index = hostInputs.indexOf(hostInput);
+  const slots = subgraphIoSlots(subgraph);
+  if (index >= 0 && index < slots.length && hostInputs.length === slots.length) return slots[index];
+  return subgraphInput ?? null;
+}
+
+/**
+ * After load, SubgraphInput.linkIds can still be empty while inner widgets are
+ * already wired from the input rail (-10). Walk those known terminals instead of
+ * treating the promotion as unresolved (#2057).
+ */
+function sourcesFromInputRailSlot(subgraph, slot) {
+  const sources = [];
+  const seen = new Set();
+  const add = (source) => {
+    if (!source) return;
+    const key = `${source.sourceNodeId}\0${source.sourceWidgetName}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    sources.push(source);
+  };
+  for (const linkId of slotLinkIds(slot)) add(sourceFromResolvedLink(subgraph, readSubgraphLink(subgraph, linkId)));
+  const slots = subgraphIoSlots(subgraph);
+  const slotIndex = slots.indexOf(slot);
+  if (slotIndex < 0) return sources;
+  for (const link of enumerateSubgraphLinks(subgraph)) {
+    const originId = link?.origin_id ?? link?.[1];
+    const originSlot = link?.origin_slot ?? link?.[2];
+    if (!originIsInputRail(originId, subgraph) || Number(originSlot) !== slotIndex) continue;
+    add(sourceFromResolvedLink(subgraph, link));
+  }
+  for (const node of subgraph?._nodes ?? subgraph?.nodes ?? []) {
+    if (!node) continue;
+    for (const input of node.inputs ?? []) {
+      if (input?.link == null) continue;
+      const link = readSubgraphLink(subgraph, input.link);
+      if (!link) continue;
+      const originId = link.origin_id ?? link[1];
+      const originSlot = link.origin_slot ?? link[2];
+      if (!originIsInputRail(originId, subgraph) || Number(originSlot) !== slotIndex) continue;
+      add(sourceFromResolvedLink(subgraph, link));
+    }
+  }
+  return sources;
+}
+
+function uniqueRailBackedInnerWidget(subgraph, widgetName) {
+  const wanted = String(widgetName).toLowerCase();
+  if (!wanted) return null;
+  const hits = [];
+  for (const node of subgraph?._nodes ?? subgraph?.nodes ?? []) {
+    if (!node) continue;
+    const widget = (node.widgets ?? []).find((candidate) => candidate?.name?.toLowerCase() === wanted);
+    if (!widget) continue;
+    const input = (node.inputs ?? []).find((slot) => {
+      if (!slot || slot.link == null) return false;
+      const name = slot.name ?? slot.widget?.name;
+      if (typeof name !== "string" || name.toLowerCase() !== wanted) return false;
+      const link = readSubgraphLink(subgraph, slot.link);
+      if (!link) return false;
+      return originIsInputRail(link.origin_id ?? link[1], subgraph);
+    });
+    if (input) hits.push({ sourceNodeId: String(node.id), sourceWidgetName: widget.name });
+  }
+  return hits.length === 1 ? hits[0] : null;
+}
+
+function resolveWidgetOnlyLoadedPromotion(subgraphNode, widgetName) {
+  const subgraph = subgraphNode?.subgraph;
+  const wanted = String(widgetName).toLowerCase();
+  const widgets = Array.isArray(subgraphNode?.widgets) ? subgraphNode.widgets : [];
+  const hostHits = widgets.filter(
+    (widget) => widget && typeof widget.name === "string" && widget.name.toLowerCase() === wanted,
+  );
+  if (hostHits.length !== 1) return { promoted: false };
+  const source = uniqueRailBackedInnerWidget(subgraph, widgetName);
+  if (!source) return { promoted: false };
+  const innerNode = subgraphNodeById(subgraph, source.sourceNodeId);
+  const innerWidget = (innerNode?.widgets ?? []).find((widget) => widget?.name === source.sourceWidgetName);
+  if (!innerNode || !innerWidget) return { promoted: false };
+  const input = { name: hostHits[0].name, _widget: hostHits[0], widget: hostHits[0] };
+  const parentWidgets = liveHostPromotedWidgets(subgraphNode, input, innerWidget);
+  const parentWidget = parentWidgets[0] ?? null;
+  if (!parentWidget) return { promoted: false };
+  return { promoted: true, target: { node: innerNode, widget: innerWidget, input, parentWidget, parentWidgets } };
+}
+
+function resolveLoadedPromotionSource(subgraphNode, hostInput, subgraphInput, widgetName, resolveSource) {
+  const subgraph = subgraphNode?.subgraph;
+  const liveSlot = liveSlotForHostInput(subgraphNode, hostInput, subgraphInput);
+  if (liveSlot && typeof resolveSource === "function") {
+    // #1560 — a throwing resolver is a malformed promotion, not a missing
+    // mapping. Swallowing it let collectPromotionIntermediates keep walking
+    // and return a partial type list. Incomplete (null) results still fall
+    // through to the inner-rail walk (#2057).
+    const resolved = resolveSource(subgraphNode, liveSlot);
+    if (resolved?.sourceNodeId != null && typeof resolved.sourceWidgetName === "string") return resolved;
+  }
+  if (liveSlot) {
+    const sources = sourcesFromInputRailSlot(subgraph, liveSlot);
+    if (sources.length === 1) return sources[0];
+    if (sources.length > 1) {
+      return {
+        error: `promoted widget "${widgetName}" is ambiguous — ${sources.length} inner rail terminals match; refusing to guess.`,
+      };
+    }
+  }
+  return uniqueRailBackedInnerWidget(subgraph, widgetName);
 }
 
 /**
@@ -1646,8 +1897,11 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
     if (aliases.includes(wanted)) matches.push({ input, subgraphInput });
   }
 
-  // No matching host input at all ⇒ a genuine non-promoted own-widget.
-  if (matches.length === 0) return { promoted: false };
+  // No matching host input at all ⇒ usually a genuine non-promoted own-widget.
+  // After load, outline can still list the host rail while configure has not
+  // rebound `_subgraphSlot` onto a host input; a unique inner input-rail
+  // terminal of the same name is that promotion (#2057).
+  if (matches.length === 0) return resolveWidgetOnlyLoadedPromotion(subgraphNode, widgetName);
   if (matches.length > 1) {
     return {
       promoted: true,
@@ -1657,23 +1911,29 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
   }
 
   const { input, subgraphInput } = matches[0];
-  // It IS a promoted widget, but its backing subgraph slot is absent — we
-  // cannot reach the inner target, so refuse rather than corrupt the parent.
-  if (!subgraphInput) {
+  const liveSlot = liveSlotForHostInput(subgraphNode, input, subgraphInput);
+  // It IS a promoted widget. Prefer the live subgraph-input / input-rail slot
+  // (which may exist even when `_subgraphSlot` was not rebound after load).
+  // Still fail closed when neither that slot nor a unique inner rail terminal
+  // can name the inner (node, widget) — never write the shifted parent slot.
+  const source = resolveLoadedPromotionSource(subgraphNode, input, liveSlot, widgetName, resolveSource);
+  if (source?.error) {
+    return { promoted: true, target: null, error: source.error };
+  }
+  if (!liveSlot && !source) {
     return {
       promoted: true,
       target: null,
       error: `promoted widget "${widgetName}" has no backing subgraph slot (_subgraphSlot missing) — cannot resolve inner target.`,
     };
   }
-  if (typeof resolveSource !== "function") {
+  if (!source && typeof resolveSource !== "function") {
     return {
       promoted: true,
       target: null,
       error: `no resolver available for promoted widget "${widgetName}".`,
     };
   }
-  const source = resolveSource(subgraphNode, subgraphInput);
   if (!source) {
     return {
       promoted: true,
@@ -1681,10 +1941,7 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
       error: `promoted widget "${widgetName}" has no resolvable inner link (stale/empty linkIds).`,
     };
   }
-  const innerNode =
-    typeof subgraph.getNodeById === "function"
-      ? subgraph.getNodeById(source.sourceNodeId)
-      : (subgraph._nodes ?? []).find((n) => String(n?.id) === String(source.sourceNodeId));
+  const innerNode = subgraphNodeById(subgraph, source.sourceNodeId);
   if (!innerNode) {
     return {
       promoted: true,


### PR DESCRIPTION
## Summary

`panel_set_widget` on a loaded subgraph host (Z-Image-Turbo node 57 `clip_name` / `width` / `height`) refused with `promoted-terminal witness was incomplete or unresolved` even though `panel_graph_outline` already listed those rails and `panel_enter_subgraph` showed the inner widgets driven by input-rail terminals (`CLIPLoader.clip_name <- -10.6`).

After `loadGraphData`, host `_subgraphSlot.linkIds` can still be empty while the inner graph already has links from the `-10` rail. The witness producer treated that as unresolvable, so MCP never dispatched `graph_set_widget`.

`resolvePromotedInnerTarget` now completes that mapping from the known inner input-rail terminals (and instance-scoped `widgetId` host rails) so the advertised `promoted_terminals` witness is complete and the write can land without unpacking.

## Tests

```
node --test browser_tests/unit/promoted-terminal-load-witness.test.mjs
node --test browser_tests/unit/widget-write.test.mjs browser_tests/unit/subgraph-value-provenance.test.mjs browser_tests/unit/graph-set-widget-target-fence.test.mjs
```

Covers: after load, a host subgraph promoted combo/number that outline already shows is writable without unpacking; missing inner-rail terminals still refuse; #366 name-only decoys still fail closed.

Fixes #2057
