### PR TITLE
fix(2050): panel_add_node type-scoped fallback when whole object_info times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_add_node can add a class from a type-scoped /object_info read when the full dump misses its fixed budget on a large install, without treating a stale whole cache as verified (#2050)
+
+
 ## [0.15.133] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -1335,12 +1335,18 @@ test("#1192: a /object_info read that eats the budget leaves the add a bound, no
   // The whole-schema fetch draws `budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS)`. With the
   // command nearly spent that is a small number, and the add fails closed on the path an
   // unreadable schema already takes — rather than parking on a 10s bound the command cannot
-  // afford.
+  // afford. Both live routes must hang: #2050 asks `/object_info/<Type>` after the whole
+  // dump is silent, and a working per-class route is the success path for that issue.
   const comfy = makeComfy();
   const built = realGraphAddNode({
     comfy,
     budgetMs: 200,
-    getNodeDefs: () => new Promise(() => {}), // half-open: never answers, never fails
+    overrides: {
+      api: {
+        getNodeDefs: () => new Promise(() => {}),
+        fetchApi: () => new Promise(() => {}),
+      },
+    },
   });
   const started = Date.now();
   await assert.rejects(
@@ -1623,4 +1629,174 @@ test("#1351: with NO refresh in flight the add still stops waiting on its own ru
     `the add took ${elapsed}ms against a 280ms bound — the own run is unbounded again`,
   );
   assert.equal(comfy.graph._nodes.length, 0, "the graph was not touched");
+});
+
+// ---------------------------------------------------------------------------
+// #2050: after a large-node install the whole /object_info dump misses its fixed
+// budget, but GET /object_info/<Type> still answers. panel_add_node must add from
+// that live per-class read rather than refuse as #458 "object_info is unavailable",
+// and must not treat a stale whole snapshot as verified membership.
+// ---------------------------------------------------------------------------
+
+function perClassApi(defs, { whole = NODE_DEFS_NO_ANSWER, missing = [] } = {}) {
+  const absent = new Set(missing);
+  return {
+    getNodeDefs: async () => whole,
+    async fetchApi(route) {
+      const classType = decodeURIComponent(String(route).replace("/object_info/", ""));
+      if (absent.has(classType)) return { status: 200, json: async () => ({}) };
+      return {
+        status: 200,
+        json: async () =>
+          Object.prototype.hasOwnProperty.call(defs, classType) ? { [classType]: defs[classType] } : {},
+      };
+    },
+  };
+}
+
+test("#2050: an unregistered class adds from /object_info/<Type> when the whole dump cannot land", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  const objectInfoCache = createObjectInfoCache();
+  assert.equal(
+    snapshot.record(defs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
+    true,
+    "a previous whole map is held — the add must not record a one-class payload over it",
+  );
+  let comboCalls = 0;
+  comfy.app.refreshComboInNodes = async () => {
+    comboCalls += 1;
+  };
+  const api = perClassApi(defs);
+  const productionRegister = realRegisterComfyNodeDefs({
+    app: comfy.app,
+    api,
+    objectInfoCache,
+    objectInfoSnapshot: snapshot,
+    verifiedNodeDefCache,
+  });
+  const built = realGraphAddNode({
+    comfy,
+    budgetMs: 4000,
+    productionRegister,
+    overrides: {
+      api,
+      objectInfoCache,
+      objectInfoSnapshot: snapshot,
+      verifiedNodeDefCache,
+    },
+  });
+
+  const started = Date.now();
+  const { added } = await built.graph_add_node({ class_type: "NewNode" });
+  assert.equal(added.type, "NewNode");
+  assert.equal(comfy.graph._nodes.length, 1, "the type-scoped add landed");
+  assert.ok(Date.now() - started < 2000, "the fallback must not wait out a whole-dump budget");
+  assert.equal(comboCalls, 0, "a one-class registration must not re-fetch whole /object_info");
+  assert.equal(snapshot.peek().held, true, "the last whole snapshot is still held");
+  assert.equal(snapshot.isReplacementPending(), false, "a one-class add does not fence the snapshot");
+  const fallback = snapshot.authorize({
+    epoch: 0,
+    generation: verifiedNodeDefCache.generation(),
+    outcomes: [{ kind: TRANSPORT_OUTCOME.NO_ANSWER }],
+  });
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(fallback.defs ?? {}, "ExistingNode"),
+    true,
+    "sibling types from the last whole map remain — the one-class payload was not recorded as whole",
+  );
+  assert.ok(
+    verifiedNodeDefCache.get("NewNode", {
+      epoch: 0,
+      context: built.verifiedSchemaContext,
+      generation: verifiedNodeDefCache.generation(),
+    }),
+    "the type-scoped add files per-class proof for a later silent whole dump",
+  );
+});
+
+test("#2050: type-scoped absence is an unknown type, not a stale whole-cache authorization", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  const snapshot = createObjectInfoSnapshot();
+  assert.equal(
+    snapshot.record(defs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
+    true,
+  );
+  const built = realGraphAddNode({
+    comfy,
+    budgetMs: 4000,
+    overrides: {
+      api: perClassApi(defs, { missing: ["ReActorFaceSwap"] }),
+      objectInfoSnapshot: snapshot,
+    },
+  });
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "ReActorFaceSwap" }),
+    /Unknown node type "ReActorFaceSwap"|does not provide it/i,
+    "a live per-class empty map is absence, not 'object_info is unavailable'",
+  );
+  assert.equal(comfy.graph._nodes.length, 0, "nothing was added");
+  assert.equal(snapshot.peek().held, true, "the last whole snapshot was not trusted as this class");
+});
+
+test("#2050: a held whole snapshot is not verified membership when both live routes are silent", async () => {
+  const comfy = makeComfy();
+  const defs = backendObjectInfo();
+  const snapshot = createObjectInfoSnapshot();
+  assert.equal(
+    snapshot.record(defs, {
+      observedAtEpoch: 0,
+      currentEpoch: 0,
+      observedAtGeneration: 0,
+      currentGeneration: 0,
+      whole: true,
+    }),
+    true,
+    "the snapshot even lists NewNode — add_node must still not treat that as a live verify",
+  );
+  const built = realGraphAddNode({
+    comfy,
+    budgetMs: 400,
+    overrides: {
+      api: {
+        getNodeDefs: () => new Promise(() => {}),
+        fetchApi: () => new Promise(() => {}),
+      },
+      objectInfoSnapshot: snapshot,
+    },
+  });
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    /cannot verify node type|object_info is unavailable|Refusing to add/i,
+    "silence on both live routes still fails closed; the whole snapshot is not an add oracle",
+  );
+  assert.equal(comfy.graph._nodes.length, 0);
+});
+
+test("#2050: graph_add_node asks the per-class route after a silent whole dump", () => {
+  const body = addNodeMatch[0];
+  const cacheAt = body.indexOf("const cachedDef = verifiedNodeDefCache.get(class_type");
+  assert.ok(cacheAt > 0, "the #1709 verified-proof lookup is still present");
+  const scopedAt = body.indexOf("fetchSingleNodeInfo(class_type", cacheAt);
+  assert.ok(scopedAt > cacheAt, "the type-scoped fallback is reached after the verified-proof lookup");
+  assert.match(
+    body.slice(cacheAt, scopedAt + 200),
+    /wholeUsable[\s\S]*!isRegisteredNodeType/,
+    "the fallback is gated on a silent whole dump AND an unregistered class",
+  );
 });

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -212,11 +212,13 @@ test("#767 WIRING: the fast path is gated on the type ALREADY being registered",
     /NODE_DEFS_NO_ANSWER \? null :/,
     "…and a call that never answers must degrade to 'no defs', not park the add",
   );
-  // And the snapshot must be taken on BOTH paths — #700 turns on it.
+  // And the snapshot must be taken on every path that can hand a def to refresh —
+  // #700 turns on it. The third site is #2050's unregistered fallback after a silent
+  // whole dump; a one-class payload reaching registerNodesFromDefs is the same poison.
   assert.equal(
     (body.match(/snapshotBackendDef\(freshDefs, class_type\)/g) ?? []).length,
-    2,
-    "both the fast and full paths must snapshot the backend def before any refresh mutates it",
+    3,
+    "the fast path, the whole-schema path, and the #2050 type-scoped fallback must snapshot the backend def before any refresh mutates it",
   );
 });
 
@@ -635,10 +637,11 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
   // same slow backend), so this term shrinks rather than grows. The command budget caps
   // what the add PAYS either way, not what a run inside it may cost.
   const runWait = run;
-  // NOT REGISTERED: no fast path (it is gated on already-registered), then the whole-schema
-  // fetch, then the resolver hands the payload to refreshComfyNodeDefs — which waits for
-  // any in-flight run and then performs its own, so the run wait is paid twice.
-  const unregisteredPath = seed + single + runWait + runWait + registration;
+  // NOT REGISTERED: no first-attempt fast path (it is gated on already-registered), then
+  // the whole-schema fetch, then — if that dump is silent — a bounded type-scoped fallback
+  // (#2050), then the resolver hands the payload to refreshComfyNodeDefs. A whole payload
+  // waits for any in-flight run and then performs its own, so the run wait is paid twice.
+  const unregisteredPath = seed + single + single + runWait + runWait + registration;
   const naiveSum = Math.max(registeredPath, unregisteredPath);
   // The tracked-ceiling ratchet this replaces was scoped "while #1192 is open" and said to
   // swap in the FITS assertion once the fix landed. This is that assertion: the naive sum

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1741,29 +1741,36 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
       ? runOpts.runBudgetMs
       : NODE_DEFS_RUN_BUDGET_MS;
   let runDeadline = monotonicNow() + runBudgetMs;
-  // #716 — drop the widget-write burst cache at the START of this run, not after it
-  // succeeds (codex). This function runs on exactly the events that change the schema —
-  // refresh_nodes, a completed install/download, reconnect — and a refresh that FAILS is
-  // when the schema is most likely to have moved. Invalidating only on success would leave
-  // the pre-change map authorizing writes for the rest of the TTL, where the old code would
-  // have fetched and failed closed. Retiring it up front costs one extra fetch and cannot
-  // be wrong in the dangerous direction.
-  objectInfoCache.invalidate();
-  // #2249 — fence the last-observed snapshot while this replacement is unresolved, but do
-  // not destroy it before the new whole map succeeds. If both whole routes fail, the old
-  // membership-only map is still the only usable evidence for an existing scalar widget;
-  // object-info-snapshot.js re-binds it to the post-invalidation generation only after this
-  // run has conclusively failed. Reconnect handlers still clear it outright because a new
-  // backend process is the one event that can change the type set.
-  objectInfoSnapshot.beginReplacement?.();
-  // #1709 — fence verified per-class proofs the same way. A timeout here is not evidence
-  // the type set moved; destroying them at refresh start turned a busy /object_info into a
-  // #458 refusal of a class this session already added on this connection. Generation still
-  // advances, so an in-flight probe cannot reuse or repopulate under the new fence.
-  if (typeof verifiedNodeDefCache?.beginReplacement === "function") {
-    verifiedNodeDefCache.beginReplacement();
-  } else if (typeof verifiedNodeDefCache !== "undefined") {
-    verifiedNodeDefCache.clear();
+  // Whole-schema start-of-run effects. A one-class payload from graph_add_node is not a
+  // type-set replacement (#2050): fencing the last-observed snapshot and then running
+  // refreshComboInNodes() would re-fetch the same dump that just missed its budget, and
+  // beginReplacement would bump the generation so the add could not file the per-class
+  // proof it just verified.
+  if (replacementMayReplaceWholeSnapshot) {
+    // #716 — drop the widget-write burst cache at the START of this run, not after it
+    // succeeds (codex). This function runs on exactly the events that change the schema —
+    // refresh_nodes, a completed install/download, reconnect — and a refresh that FAILS is
+    // when the schema is most likely to have moved. Invalidating only on success would leave
+    // the pre-change map authorizing writes for the rest of the TTL, where the old code would
+    // have fetched and failed closed. Retiring it up front costs one extra fetch and cannot
+    // be wrong in the dangerous direction.
+    objectInfoCache.invalidate();
+    // #2249 — fence the last-observed snapshot while this replacement is unresolved, but do
+    // not destroy it before the new whole map succeeds. If both whole routes fail, the old
+    // membership-only map is still the only usable evidence for an existing scalar widget;
+    // object-info-snapshot.js re-binds it to the post-invalidation generation only after this
+    // run has conclusively failed. Reconnect handlers still clear it outright because a new
+    // backend process is the one event that can change the type set.
+    objectInfoSnapshot.beginReplacement?.();
+    // #1709 — fence verified per-class proofs the same way. A timeout here is not evidence
+    // the type set moved; destroying them at refresh start turned a busy /object_info into a
+    // #458 refusal of a class this session already added on this connection. Generation still
+    // advances, so an in-flight probe cannot reuse or repopulate under the new fence.
+    if (typeof verifiedNodeDefCache?.beginReplacement === "function") {
+      verifiedNodeDefCache.beginReplacement();
+    } else if (typeof verifiedNodeDefCache !== "undefined") {
+      verifiedNodeDefCache.clear();
+    }
   }
   // #1223 — the epoch this run STARTED on, captured before any fetch. The recording below
   // is refused if a reconnect lands while the fetch is in flight, so a pre-restart schema
@@ -1772,8 +1779,9 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   const runStartedAtGeneration = verifiedNodeDefCache.generation();
   // A refresh is not authoritative while any of its frontend mutation work is still
   // outstanding. Consumers such as collectMissingAssets must fail closed during that
-  // window, even if an earlier run had established trust.
-  nodeDefsRefreshConfirmed = false;
+  // window, even if an earlier run had established trust. A one-class registration is
+  // not that replacement, so it must not drop combo trust the last whole run earned.
+  if (replacementMayReplaceWholeSnapshot) nodeDefsRefreshConfirmed = false;
   let thrown = null;
   // #608 — what EACH transport did in the fetch phase, in order, when none of them produced
   // a payload. The verdict appends it, so a refusal names the routes that were actually
@@ -2251,7 +2259,13 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     // models resolve and stale entries clear (#185/#181/#223).
     phase = "combo";
     comboApiPresent = typeof a.refreshComboInNodes === "function";
-    if (comboApiPresent && comboRebuiltLocally && runOpts?.skipDuplicateComboRefresh === true) {
+    if (!replacementMayReplaceWholeSnapshot) {
+      // #2050 — this run registered one class from `/object_info/<Type>`. The frontend
+      // combo refresh re-fetches the whole `/object_info` document, which is the dump
+      // that just could not land. Skip it; the add's own def already carries this class's
+      // combo lists, and sibling combos stay whatever the last whole run left them.
+      phase = "done";
+    } else if (comboApiPresent && comboRebuiltLocally && runOpts?.skipDuplicateComboRefresh === true) {
       // #1736 — reapplyDefsToLiveNodes() has already rebuilt every live combo from
       // this run's authoritative payload. Calling refreshComboInNodes() here would
       // re-fetch the same schema and can remain pending behind concurrent downloads,
@@ -2528,12 +2542,14 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
       !comfyBackendSocketDown &&
       runStartedAtEpoch === backendReconnectEpoch &&
       runStartedAtGeneration === verifiedNodeDefCache.generation();
-    nodeDefsRefreshConfirmed =
-      runIsCurrent &&
-      !comboCompletionPending &&
-      !didThrow &&
-      !!defs &&
-      (comboRan || (!comboFailed && (comboRebuiltLocally || comboAbandonedAfterRebuild)));
+    if (replacementMayReplaceWholeSnapshot) {
+      nodeDefsRefreshConfirmed =
+        runIsCurrent &&
+        !comboCompletionPending &&
+        !didThrow &&
+        !!defs &&
+        (comboRan || (!comboFailed && (comboRebuiltLocally || comboAbandonedAfterRebuild)));
+    }
   }
   // RETURN this run's own verdict so a caller can trust the combo based on the result
   // of ITS refresh, independent of the shared nodeDefsRefreshConfirmed global — which a
@@ -15516,12 +15532,14 @@ const GRAPH_TOOL_EXECUTORS = {
         // "ghost" nodes appeared — the adds landed after the timeout had already
         // been reported as a failure.
         //
-        // GATED ON ALREADY-REGISTERED, and not for speed. The resolver hands
-        // `freshDefs` to refreshComfyNodeDefs() when a type still needs
+        // GATED ON ALREADY-REGISTERED for the first attempt, and not for speed. The
+        // resolver hands `freshDefs` to refreshComfyNodeDefs() when a type still needs
         // registering, and a single-class payload reaching a whole-schema refresh
         // could deregister everything else. When the type is already registered
         // that branch is unreachable, so the hazard is removed by construction
-        // rather than by remembering not to trip it.
+        // rather than by remembering not to trip it. #2050 asks this route again
+        // after the whole dump is silent, and that path marks the payload
+        // single-class so refresh must not treat it as a type-set replacement.
         //
         // The fast path only ever CONFIRMS or establishes explicit absence. Any doubt — a
         // non-200, an older build without the route, an unparseable body, or a timeout —
@@ -15619,6 +15637,48 @@ const GRAPH_TOOL_EXECUTORS = {
             freshDefs = { [class_type]: cachedDef };
             freshDefsAreSingleClass = true;
             currentDef = cachedDef;
+            return freshDefs;
+          }
+        }
+        const wholeUsable =
+          whole != null &&
+          whole !== NODE_DEFS_NO_ANSWER &&
+          typeof whole === "object" &&
+          !Array.isArray(whole);
+        if (
+          !wholeUsable &&
+          !isRegisteredNodeType(LG?.registered_node_types ?? {}, class_type)
+        ) {
+          // #2050 — the whole dump missed its budget (or never ran) on a large install
+          // while ComfyUI is healthy and GET /object_info/<Type> still answers. Ask
+          // about this class before refusing. A stale whole cache is not consulted:
+          // membership comes from this live per-class read, or from #1709's
+          // same-connection verified proof above.
+          const scopedIssued = {
+            generation: verifiedNodeDefCache.generation(),
+            epoch: backendReconnectEpoch,
+          };
+          const one = await withTimeout(
+            fetchSingleNodeInfo(class_type, (route) => api?.fetchApi?.(route)),
+            budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS),
+            () => null,
+          );
+          if (schemaProbeIsCurrent(scopedIssued) && one?.kind === "absent") {
+            freshDefs = recordObjectInfoTypes({});
+            freshDefsAreSingleClass = true;
+            currentDef = undefined;
+            return freshDefs;
+          }
+          if (schemaProbeIsCurrent(scopedIssued) && one?.kind === "present") {
+            // Do not invalidate() here: that advances the schema generation and would
+            // make a still-held whole snapshot unusable for set_widget. This class had
+            // no verified proof (the lookup above missed) and the last whole map is
+            // not evidence about it either.
+            verifiedSchemaWriteGeneration = verifiedNodeDefCache.generation();
+            verifiedSchemaWriteEpoch = scopedIssued.epoch;
+            freshDefs = recordObjectInfoTypes(one.body);
+            freshDefsAreSingleClass = true;
+            currentDef = snapshotBackendDef(freshDefs, class_type);
             return freshDefs;
           }
         }
@@ -15753,9 +15813,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // render-induced probe timeout reproduced the refusal this issue exists to remove.
     //
     // `freshDefsAreSingleClass` is the panel's OWN record of which question it asked, so it
-    // is the honest wholeness claim; the single-class fast path is only taken for an
-    // already-registered type, and it sets that flag. Mutation by a beforeRegisterNodeDef
-    // hook (#700) is irrelevant here because `record` copies out only the type NAMES.
+    // is the honest wholeness claim. The per-class route is taken for an already-registered
+    // type, and also as a last resort when the whole dump cannot land (#2050). Mutation by
+    // a beforeRegisterNodeDef hook (#700) is irrelevant here because `record` copies out
+    // only the type NAMES.
     if (
       freshDefs &&
       !freshDefsAreSingleClass &&

--- a/web/js/lib/single-node-def.js
+++ b/web/js/lib/single-node-def.js
@@ -45,14 +45,20 @@
  * So: reuse this payload for per-class facts. Anything that ranges over the install needs
  * the whole schema, and the caller must know which one it is holding.
  *
- * The caller additionally gates this on the type ALREADY BEING REGISTERED in
- * LiteGraph, which matters for a reason that is not about speed:
+ * The caller additionally gates the FIRST attempt on the type ALREADY BEING
+ * REGISTERED in LiteGraph, which matters for a reason that is not about speed:
  * `assertAddNodeResolvableRefreshing` passes its `freshDefs` to
  * `refreshComfyNodeDefs()` when a type needs registering, and handing a
  * single-class payload to a whole-schema refresh could deregister everything
  * else. Under that gate the resolver's refresh branch is unreachable, so a
  * partial payload can never get there — the hazard is removed by construction
  * rather than by remembering not to trip it.
+ *
+ * #2050 is the one later exception: after the whole dump misses its budget the
+ * caller asks this route about the unregistered class anyway, and hands the
+ * one-class map to refresh with `preloadedWholeSchema: false` so
+ * `registerComfyNodeDefs` registers that class without fencing the last whole
+ * snapshot or re-fetching `/object_info` via `refreshComboInNodes`.
  */
 
 /** Absence is `{}` with HTTP 200 on this route, not a 404. */


### PR DESCRIPTION
## Summary
- After a large custom-node install and restart, `panel_add_node` refused unregistered classes (e.g. `ReActorFaceSwap`) with the #458 "object_info is unavailable" line even though ComfyUI was healthy. The whole `/object_info` dump cannot finish in the panel's fixed `api.getNodeDefs()` 10s / GET `/object_info` 5s budgets, so schema-guarded adds stayed unusable.
- When that whole dump is silent, `graph_add_node` now asks live `GET /object_info/<Type>`. A present answer registers **only that class** (`preloadedWholeSchema: false`) so refresh does not fence the last whole snapshot or re-fetch the same dump via `refreshComboInNodes`. An empty `{}` is absence (unknown type). Silence on both routes still fails closed.
- A held whole snapshot is not treated as verified membership for add. Per-class proof is filed only after a live type-scoped add succeeds on this connection.

Fixes #2050

## Tests
- `node --test browser_tests/unit/add-node-command-budget.test.mjs browser_tests/unit/single-node-def.test.mjs`
- `npm run test:unit` (7559 pass, 0 fail)
