### PR TITLE
fix(2026): snapshot refresh_nodes workflow UUID instead of a stale route identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_refresh_nodes publishes the workflow UUID of the canvas it refreshed, and refuses a retryable route-registration miss if the active route moves, instead of returning refreshed:true with another UUID (#2026)
 - panel_set_widget no longer reports outcome-unknown after the value has landed: the handler ack is flushed once graph_set_widget resolves, and a timeout after delivery returns applied and verified from an idempotent readback (#2025)
 
 

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -104,6 +104,12 @@ export const REFRESH_NODES_EXECUTOR_DEPS = Object.freeze({
   // touching the global node-definition refresh. Harnesses inject their own
   // readiness promise; this default preserves the existing refresh-only cases.
   awaitActiveRouteRegistration: async () => {},
+  // #2026 — the executor snapshots the canvas identity it refreshed. Defaults
+  // keep existing refresh-only harnesses from throwing ReferenceError.
+  liveParseableViewingWitness: () => null,
+  workflowStableUuid: () => null,
+  routeRegistrationReadinessRefusalError: (reason) =>
+    new Error(reason || "route registration not ready"),
 });
 
 /** #1413 — the whole-command deadline `graph_set_widget` takes on its first line. */

--- a/browser_tests/unit/reconnect-refresh-route.test.mjs
+++ b/browser_tests/unit/reconnect-refresh-route.test.mjs
@@ -61,7 +61,7 @@ test("#1787 a route-readiness refusal is fail-closed before the refresh consumer
 
 test("#1787 production wiring keeps the readiness gate ahead of refreshComfyNodeDefs", () => {
   const refreshBody = refreshNodesMatch[0];
-  assert.match(refreshBody, /await awaitActiveRouteRegistration\(\);[\s\S]*refreshComfyNodeDefs/);
+  assert.match(refreshBody, /await awaitActiveRouteRegistration\([^)]*\);[\s\S]*refreshComfyNodeDefs/);
   assert.match(PANEL_SRC, /route_registration_readiness/);
   assert.match(PANEL_SRC, /routeRegistrationReadinessRefusalError/);
 });

--- a/browser_tests/unit/refresh-nodes-identity.test.mjs
+++ b/browser_tests/unit/refresh-nodes-identity.test.mjs
@@ -1,0 +1,248 @@
+// #2026 — after panel_open_workflow bound UUID A, panel_refresh_nodes returned
+// refreshed:true with viewing.workflow_uuid B on the same graph_identity, and
+// the next graph_outline was refused by the workflow-instance fence. Drive the
+// shipped awaitActiveRouteRegistration and refresh_nodes bodies: a helper-only
+// test would not prove the executor snapshots the canvas it refreshed, or that
+// the route gate rejects a ready route whose UUID is not the command-bound one.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PANEL_SRC, REFRESH_NODES_EXECUTOR_DEPS } from "./_panel-constants.mjs";
+
+function extractPanelFn(sig) {
+  const start = PANEL_SRC.indexOf(sig);
+  assert.notEqual(start, -1, `${sig} not found in the panel source`);
+  const open = PANEL_SRC.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < PANEL_SRC.length; i += 1) {
+    const ch = PANEL_SRC[i];
+    if (ch === "/" && PANEL_SRC[i + 1] === "/") {
+      i = PANEL_SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && PANEL_SRC[i + 1] === "*") {
+      i = PANEL_SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < PANEL_SRC.length; i += 1) {
+        if (PANEL_SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (PANEL_SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return PANEL_SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated: ${sig}`);
+}
+
+const refreshNodesMatch = PANEL_SRC.match(/\n {2}async refresh_nodes\(\) \{[\s\S]*?\n {2}\},/);
+assert.ok(refreshNodesMatch, "could not locate refresh_nodes in panel source");
+
+const BOUND = {
+  scope: "root",
+  workflow_uuid: "uuid-A",
+  graph_identity: "graph:same",
+};
+const STALE_SAME_GRAPH = {
+  scope: "root",
+  workflow_uuid: "uuid-B",
+  graph_identity: "graph:same",
+};
+const SWITCHED = {
+  scope: "root",
+  workflow_uuid: "uuid-B",
+  graph_identity: "graph:other",
+};
+
+function readyClient({ uuid = "uuid-A" } = {}) {
+  return {
+    isConnected: () => true,
+    isRouteReady: () => true,
+    waitForRouteReady: async () => true,
+    uuid,
+  };
+}
+
+function buildAwaitActiveRouteRegistration({
+  client = readyClient(),
+  workflowStableUuid = () => client.uuid,
+} = {}) {
+  const factory = new Function(
+    "ROUTE_REGISTRATION_WAIT_STEPS_MS",
+    "workflowStableUuid",
+    `let liveBridgeClient = null;
+     const routeRegistrationReadinessRefusals = new WeakSet();
+     ${extractPanelFn("function routeRegistrationReadinessRefusalError")}
+     ${extractPanelFn("function readRouteRegistrationReadinessRefusal")}
+     ${extractPanelFn("function routeWorkflowUuidDiffers")}
+     ${extractPanelFn("async function awaitActiveRouteRegistration")}
+     return {
+       awaitActiveRouteRegistration,
+       setClient(next) { liveBridgeClient = next; },
+       readRefusal: readRouteRegistrationReadinessRefusal,
+     };`,
+  );
+  const built = factory(Object.freeze([0, 0]), workflowStableUuid);
+  built.setClient(client);
+  return built;
+}
+
+function routeRegistrationRefusalError(reason) {
+  const detail =
+    typeof reason === "string" && reason.trim()
+      ? reason.trim()
+      : "the active bridge route is still being registered";
+  return new Error(
+    "panel_refresh_nodes did not run because " +
+      detail +
+      ". Nothing was refreshed; retry after the reconnect settles.",
+  );
+}
+
+function buildRefreshNodes({
+  awaitActiveRouteRegistration = async () => {},
+  refreshComfyNodeDefs,
+  liveParseableViewingWitness,
+  workflowStableUuid = () => BOUND.workflow_uuid,
+} = {}) {
+  let refreshCalls = 0;
+  const deps = {
+    ...REFRESH_NODES_EXECUTOR_DEPS,
+    awaitActiveRouteRegistration,
+    refreshComfyNodeDefs:
+      refreshComfyNodeDefs ||
+      (async () => {
+        refreshCalls += 1;
+        return { refreshed: true, reason: "refreshed" };
+      }),
+    liveParseableViewingWitness,
+    workflowStableUuid,
+    routeRegistrationReadinessRefusalError: routeRegistrationRefusalError,
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${refreshNodesMatch[0]}};
+     return executors.refresh_nodes;`,
+  );
+  return {
+    refresh_nodes: factory(...names.map((name) => deps[name])),
+    get refreshCalls() {
+      return refreshCalls;
+    },
+  };
+}
+
+test("#2026 awaitActiveRouteRegistration refuses a ready route whose UUID is not the command-bound instance", async () => {
+  const built = buildAwaitActiveRouteRegistration({
+    client: readyClient({ uuid: "uuid-B" }),
+  });
+  await assert.rejects(
+    () => built.awaitActiveRouteRegistration("uuid-A"),
+    (err) => {
+      assert.match(err.message, /different workflow instance than the command-bound canvas/);
+      assert.deepEqual(built.readRefusal(err), {
+        code: "route-registration-not-ready",
+        ready: false,
+        applied: false,
+        stage: "pre-refresh",
+        retryable: true,
+      });
+      return true;
+    },
+  );
+});
+
+test("#2026 awaitActiveRouteRegistration accepts a ready route that still names the command-bound UUID", async () => {
+  const built = buildAwaitActiveRouteRegistration({
+    client: readyClient({ uuid: "uuid-A" }),
+  });
+  await built.awaitActiveRouteRegistration("uuid-A");
+});
+
+test("#2026 awaitActiveRouteRegistration still no-ops when the bridge is down", async () => {
+  const built = buildAwaitActiveRouteRegistration({
+    client: {
+      isConnected: () => false,
+      isRouteReady: () => false,
+      uuid: "uuid-B",
+    },
+  });
+  await built.awaitActiveRouteRegistration("uuid-A");
+});
+
+test("#2026 awaitActiveRouteRegistration refuses when the route's UUID moves while waiting to register", async () => {
+  let uuid = "uuid-A";
+  let ready = false;
+  const client = {
+    isConnected: () => true,
+    isRouteReady: () => ready,
+    waitForRouteReady: async () => {
+      uuid = "uuid-B";
+      ready = true;
+      return true;
+    },
+  };
+  const built = buildAwaitActiveRouteRegistration({
+    client,
+    workflowStableUuid: () => uuid,
+  });
+  await assert.rejects(
+    () => built.awaitActiveRouteRegistration("uuid-A"),
+    /different workflow instance than the command-bound canvas/,
+  );
+});
+
+test("#2026 refresh_nodes publishes the snapshotted UUID when a stale workflow object remints the same graph", async () => {
+  const views = [BOUND, STALE_SAME_GRAPH];
+  const uuids = ["uuid-A", "uuid-B"];
+  const built = buildRefreshNodes({
+    liveParseableViewingWitness: () => views.shift() || STALE_SAME_GRAPH,
+    workflowStableUuid: () => uuids.shift() || "uuid-B",
+  });
+  const result = await built.refresh_nodes();
+  assert.equal(result.ok, true);
+  assert.equal(result.refreshed, true);
+  assert.equal(result.viewing.workflow_uuid, "uuid-A");
+  assert.equal(result.viewing.graph_identity, "graph:same");
+});
+
+test("#2026 refresh_nodes refuses instead of refreshed:true when the active route changes during refresh", async () => {
+  const views = [BOUND, SWITCHED];
+  const uuids = ["uuid-A", "uuid-B"];
+  let refreshCalls = 0;
+  const built = buildRefreshNodes({
+    liveParseableViewingWitness: () => views.shift() || SWITCHED,
+    workflowStableUuid: () => uuids.shift() || "uuid-B",
+    refreshComfyNodeDefs: async () => {
+      refreshCalls += 1;
+      return { refreshed: true, reason: "refreshed" };
+    },
+  });
+  await assert.rejects(
+    () => built.refresh_nodes(),
+    /changed to a different workflow instance while node definitions were refreshing/,
+  );
+  assert.equal(refreshCalls, 1, "the refresh may finish; the reply must not claim another UUID");
+});
+
+test("#2026 production refresh_nodes snapshots identity, gates the route on that UUID, and republishes it", () => {
+  const refreshBody = refreshNodesMatch[0];
+  assert.match(refreshBody, /liveParseableViewingWitness\(\)/);
+  assert.match(refreshBody, /await awaitActiveRouteRegistration\([^)]+\);[\s\S]*refreshComfyNodeDefs/);
+  assert.match(
+    refreshBody,
+    /refreshComfyNodeDefs[\s\S]*liveParseableViewingWitness\(\)/,
+    "identity must be re-read after the refresh so a route change can be refused",
+  );
+  assert.match(refreshBody, /viewing: boundIdentity/);
+});

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -120,6 +120,10 @@ function buildRefreshNodes({ refreshComfyNodeDefs, commandBudget = COMMAND_BUDGE
   const deps = {
     refreshComfyNodeDefs,
     awaitActiveRouteRegistration: async () => {},
+    liveParseableViewingWitness: () => null,
+    workflowStableUuid: () => null,
+    routeRegistrationReadinessRefusalError: (reason) =>
+      new Error(reason || "route registration not ready"),
     REFRESH_JOIN_ABANDONED,
     NODE_DEF_REFRESH_REASONS,
     REFRESH_NODES_COMMAND_BUDGET_MS: commandBudget,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13770,13 +13770,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // consumers rather than assuming the verdict flowed through.
     // `ok` stays true and `refreshed` stays true: the refresh did what it claims. The
     // reload flag is advisory, about the canvas, not a failure of the refresh.
-    const stale = verdict != null && typeof verdict === "object" && verdict.requires_reload
-      ? {
-          requires_reload: true,
-          stale_placeholders: verdict.stale_placeholders,
-          stale_placeholders_note: verdict.stale_placeholders_note,
-        }
-      : {};
+    const stale = {
+      ...viewing,
+      ...(verdict != null && typeof verdict === "object" && verdict.requires_reload
+        ? {
+            requires_reload: true,
+            stale_placeholders: verdict.stale_placeholders,
+            stale_placeholders_note: verdict.stale_placeholders_note,
+          }
+        : {}),
+    };
     // #1172 — forwarded through the SAME hole #981 fell into. The `refreshed: true` branch
     // below returns a fixed object literal, so a field the verdict carries but this whitelist
     // does not name is silently dropped on exactly the successful path where the disclosure
@@ -13812,7 +13815,7 @@ const GRAPH_TOOL_EXECUTORS = {
             combo_refresh_note: verdict.combo_refresh_note,
           }
         : {};
-    if (refreshed) return { ok: true, refreshed: true, ...stale, ...emptyCombos, ...restored, ...comboUnconfirmed, ...viewing };
+    if (refreshed) return { ok: true, refreshed: true, ...stale, ...emptyCombos, ...restored, ...comboUnconfirmed };
     return {
       ok: true,
       refreshed: false,
@@ -13825,7 +13828,6 @@ const GRAPH_TOOL_EXECUTORS = {
       remedy:
         verdict?.remedy ??
         "The refresh did not complete and the panel could not determine why. Retry; if it persists, reload the ComfyUI tab.",
-      ...viewing,
     };
   },
   // Full-fidelity capture of the live canvas — ONE JSON object

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5304,10 +5304,31 @@ function readRouteRegistrationReadinessRefusal(error) {
 // replacement-socket handoff. Wait for the live route before starting the
 // global, otherwise-safe refresh; if the bridge is down entirely, preserve the
 // local refresh path and let its existing backend readiness handling decide.
+// #2026 — a ready route is not enough: its workflow UUID must still be the
+// command-bound instance. Accepting a stale object identity here lets
+// refresh_nodes answer refreshed:true with another UUID on the same graph.
 const ROUTE_REGISTRATION_WAIT_STEPS_MS = Object.freeze([100, 250, 500, 1000, 2000]);
-async function awaitActiveRouteRegistration() {
+function routeWorkflowUuidDiffers(expectedWorkflowUuid) {
+  if (typeof expectedWorkflowUuid !== "string" || expectedWorkflowUuid.length === 0) return false;
+  let liveUuid;
+  try {
+    liveUuid = workflowStableUuid();
+  } catch {
+    return true;
+  }
+  return liveUuid !== expectedWorkflowUuid;
+}
+
+async function awaitActiveRouteRegistration(expectedWorkflowUuid) {
   const client = liveBridgeClient;
   if (!client || client.isConnected?.() !== true) return;
+  const refuseStaleUuid = () => {
+    if (!routeWorkflowUuidDiffers(expectedWorkflowUuid)) return;
+    throw routeRegistrationReadinessRefusalError(
+      "the active route reports a different workflow instance than the command-bound canvas",
+    );
+  };
+  refuseStaleUuid();
   if (client.isRouteReady?.() === true) return;
   const ready =
     typeof client.waitForRouteReady === "function"
@@ -5316,6 +5337,7 @@ async function awaitActiveRouteRegistration() {
   if (ready !== true || liveBridgeClient !== client || client.isRouteReady?.() !== true) {
     throw routeRegistrationReadinessRefusalError();
   }
+  refuseStaleUuid();
 }
 
 // Per-tab agent session id + which thread this tab is showing. sessionStorage
@@ -13649,7 +13671,23 @@ const GRAPH_TOOL_EXECUTORS = {
     // #1787 — a stale explicit tab_id can still reach this executor during a
     // replacement-socket handoff. Do not let the global refresh run until the
     // bridge has registered the current active route.
-    await awaitActiveRouteRegistration();
+    // #2026 — snapshot the established identity of the canvas this command is
+    // about to refresh. The reply witness is attached after we return and can
+    // re-read a stale workflow-object UUID for the same graph. Publish the
+    // identity we actually refreshed; if the live route moves to another
+    // instance, refuse instead of refreshed:true with another UUID.
+    const liveViewing = liveParseableViewingWitness();
+    let boundUuid = liveViewing?.workflow_uuid;
+    try {
+      const established = workflowStableUuid();
+      if (typeof established === "string" && established.length > 0) boundUuid = established;
+    } catch {
+      // keep the viewing uuid when the established identity cannot be read
+    }
+    const boundIdentity = liveViewing && boundUuid
+      ? { ...liveViewing, workflow_uuid: boundUuid }
+      : liveViewing;
+    await awaitActiveRouteRegistration(boundUuid);
     const verdict = await refreshComfyNodeDefs(undefined, {
       force: true,
       joinInFlight: true,
@@ -13670,6 +13708,22 @@ const GRAPH_TOOL_EXECUTORS = {
       // installs it exists for. See REFRESH_NODES_RUN_BUDGET_MS for the measurement.
       runBudgetMs: REFRESH_NODES_RUN_BUDGET_MS,
     });
+    const liveIdentity = liveParseableViewingWitness();
+    if (
+      boundIdentity?.workflow_uuid &&
+      liveIdentity?.workflow_uuid &&
+      liveIdentity.workflow_uuid !== boundIdentity.workflow_uuid &&
+      !(
+        boundIdentity.graph_identity &&
+        liveIdentity.graph_identity &&
+        boundIdentity.graph_identity === liveIdentity.graph_identity
+      )
+    ) {
+      throw routeRegistrationReadinessRefusalError(
+        "the active route changed to a different workflow instance while node definitions were refreshing",
+      );
+    }
+    const viewing = boundIdentity ? { viewing: boundIdentity } : {};
     // #1404 — a NAMED verdict, before the generic branch below can call it "unknown".
     //
     // NOTHING FAILED and nothing was left half-done: the coalescer does not cancel the run
@@ -13705,6 +13759,7 @@ const GRAPH_TOOL_EXECUTORS = {
           "it settles pays for one refresh instead of two, which is normally enough; if it " +
           "keeps reporting this, the refresh itself is slower than the budget and reloading " +
           "the ComfyUI tab is the fallback that remains.",
+        ...viewing,
       };
     }
     const refreshed = verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true);
@@ -13757,7 +13812,7 @@ const GRAPH_TOOL_EXECUTORS = {
             combo_refresh_note: verdict.combo_refresh_note,
           }
         : {};
-    if (refreshed) return { ok: true, refreshed: true, ...stale, ...emptyCombos, ...restored, ...comboUnconfirmed };
+    if (refreshed) return { ok: true, refreshed: true, ...stale, ...emptyCombos, ...restored, ...comboUnconfirmed, ...viewing };
     return {
       ok: true,
       refreshed: false,
@@ -13770,6 +13825,7 @@ const GRAPH_TOOL_EXECUTORS = {
       remedy:
         verdict?.remedy ??
         "The refresh did not complete and the panel could not determine why. Retry; if it persists, reload the ComfyUI tab.",
+      ...viewing,
     };
   },
   // Full-fidelity capture of the live canvas — ONE JSON object


### PR DESCRIPTION
## Summary

After `panel_open_workflow` bound a saved workflow with UUID A, `panel_refresh_nodes` returned `ok:true/refreshed:true` but attached `viewing.workflow_uuid` B on the same `graph_identity`. The next `panel_graph_outline` was refused by the workflow-instance fence. That was a stale active-route/workflow-object identity published after refresh, not a real canvas switch.

`panel_refresh_nodes` now snapshots the established identity of the canvas it actually refreshed and publishes that UUID. `awaitActiveRouteRegistration` refuses a ready route whose workflow UUID is not the command-bound instance. If the active route changes during refresh, the command returns a retryable route-registration refusal instead of `refreshed:true` with another UUID.

## Tests

```
node --test browser_tests/unit/refresh-nodes-identity.test.mjs
```

Covers: a ready route whose UUID is not the command-bound instance is refused retryably; the same-graph remint publishes UUID A; a real route change during refresh does not return `refreshed:true` with UUID B.

Fixes #2026
