### PR TITLE
fix(2025): flush set-widget ack after the value lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget no longer reports outcome-unknown after the value has landed: the handler ack is flushed once graph_set_widget resolves, and a timeout after delivery returns applied and verified from an idempotent readback (#2025)
+
+
 ## [0.15.135] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/set-widget-timeout-ack.test.mjs
+++ b/browser_tests/unit/set-widget-timeout-ack.test.mjs
@@ -1,0 +1,208 @@
+/**
+ * #2025 — a live-canvas panel_set_widget mutation that already landed must not
+ * be reported as outcome-unknown when the command relay times out.
+ *
+ * The shipped graph_set_widget path budgets 80s; the outer relay reports 90s.
+ * After the write lands, the handler result/ack must be flushed and correlated
+ * once runSetWidget resolves. Defence-in-depth: when that wait times out after
+ * delivery, an idempotent readback of the targeted widget returns
+ * "applied and verified" when it equals the requested value.
+ *
+ * These drive the SHIPPED awaitSetWidgetAck / widgetWriteTimeoutReadback
+ * functions (and runSetWidget through them) — not a mock of the unit under test.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { runSetWidget, awaitSetWidgetAck } from "../../web/js/lib/set-widget.js";
+import {
+  honestWidgetAck,
+  widgetWriteTimeoutReadback,
+  APPLIED_AND_VERIFIED_NOTE,
+} from "../../web/js/lib/delivery-ack.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+const SET_WIDGET_SRC = readFileSync(join(HERE, "../../web/js/lib/set-widget.js"), "utf8");
+
+const REGISTRY = { LoraLoader: {} };
+const FRESH = { LoraLoader: {} };
+const freshOracle = { getFreshObjectInfo: async () => FRESH };
+
+function makeLoraLoader(strength = 0.9) {
+  const widget = { name: "strength_model", type: "number", value: strength };
+  const node = { id: 12, type: "LoraLoader", widgets: [widget] };
+  return { node, widget };
+}
+
+function fireableTimers() {
+  const timers = [];
+  return {
+    timers,
+    setTimer: (fn) => {
+      timers.push(fn);
+      return timers.length;
+    },
+    clearTimer: () => {},
+    fire: () => {
+      assert.equal(timers.length, 1, "the outer wait must arm a timeout");
+      timers[0]();
+    },
+  };
+}
+
+test("#2025 readback: a landed widget equals the request is applied and verified", () => {
+  const out = widgetWriteTimeoutReadback({
+    requested: 0.35,
+    actual: 0.35,
+    found: true,
+    node_id: 12,
+    widget: "strength_model",
+    delivered: true,
+  });
+  assert.equal(out.applied, true);
+  assert.equal(out.verified, true);
+  assert.equal(out.set.value, 0.35);
+  assert.equal(out.set.node_id, 12);
+  assert.equal(out.set.widget, "strength_model");
+  assert.equal(out.error, undefined);
+  assert.equal(out.ack_note, APPLIED_AND_VERIFIED_NOTE);
+  assert.match(String(out.ack_note), /applied and verified/i);
+});
+
+test("#2025 readback: a mismatch after delivery stays unknown, not applied", () => {
+  const out = widgetWriteTimeoutReadback({
+    requested: 0.35,
+    actual: 0.9,
+    found: true,
+    node_id: 12,
+    widget: "strength_model",
+    delivered: true,
+  });
+  assert.equal(out.applied, false);
+  assert.notEqual(out.verified, true);
+  assert.match(String(out.error), /receipt|unknown|retry/i);
+  assert.doesNotMatch(String(out.ack_note ?? ""), /applied and verified/i);
+});
+
+test("#2025 readback: an undelivered command never claims applied even if values match", () => {
+  const out = widgetWriteTimeoutReadback({
+    requested: 0.35,
+    actual: 0.35,
+    found: true,
+    node_id: 12,
+    widget: "strength_model",
+    delivered: false,
+  });
+  assert.equal(out.applied, false);
+  assert.notEqual(out.verified, true);
+});
+
+test("#2025 timeout after delivery: hanging handler + matching live widget is applied and verified", async () => {
+  const { node } = makeLoraLoader(0.35);
+  const never = new Promise(() => {});
+  const clock = fireableTimers();
+  const pending = awaitSetWidgetAck(never, {
+    node,
+    widget: "strength_model",
+    requested: 0.35,
+    timeoutMs: 80,
+    delivered: true,
+    timers: { setTimer: clock.setTimer, clearTimer: clock.clearTimer },
+  });
+  clock.fire();
+  const out = await pending;
+  assert.equal(out.applied, true, "a landed write is not outcome-unknown");
+  assert.equal(out.verified, true);
+  assert.equal(out.set.value, 0.35);
+  assert.equal(out.set.node_id, 12);
+  assert.equal(out.error, undefined);
+  assert.match(String(out.ack_note), /applied and verified/i);
+});
+
+test("#2025 timeout after delivery: a mismatch keeps the inner refusal instead of inventing unknown", async () => {
+  const { node } = makeLoraLoader(0.9);
+  let rejectWrite;
+  const hung = new Promise((_, reject) => {
+    rejectWrite = reject;
+  });
+  const clock = fireableTimers();
+  const pending = awaitSetWidgetAck(hung, {
+    node,
+    widget: "strength_model",
+    requested: 0.35,
+    timeoutMs: 80,
+    delivered: true,
+    timers: { setTimer: clock.setTimer, clearTimer: clock.clearTimer },
+  });
+  clock.fire();
+  const early = await Promise.race([
+    pending.then(() => "answered", () => "answered"),
+    new Promise((resolve) => setTimeout(() => resolve("still waiting"), 20)),
+  ]);
+  assert.equal(early, "still waiting", "an unlanded write must not be rewritten as a timeout ack");
+  rejectWrite(new Error("the value is not a valid option"));
+  await assert.rejects(() => pending, /not a valid option/);
+});
+
+test("#2025 once runSetWidget resolves, the handler ack is flushed and correlated", async () => {
+  const { node, widget } = makeLoraLoader(0.9);
+  const res = await awaitSetWidgetAck(
+    runSetWidget(node, "strength_model", 0.35, {
+      registry: REGISTRY,
+      ...freshOracle,
+    }),
+    {
+      node,
+      widget: "strength_model",
+      requested: 0.35,
+      timeoutMs: 1000,
+    },
+  );
+  assert.equal(widget.value, 0.35, "the production write path must land the value");
+  assert.equal(res.applied, true, "a resolved write must flush applied:true");
+  assert.equal(res.set.value, 0.35);
+  assert.equal(res.set.node_id, 12);
+  assert.equal(res.set.widget, "strength_model");
+  assert.equal(res.error, undefined);
+});
+
+test("#2025 a resolved receipt is flushed even without a live node readback", async () => {
+  const set = { node_id: 12, widget: "strength_model", value: 0.35 };
+  const out = await awaitSetWidgetAck(Promise.resolve({ set }), {
+    timeoutMs: 50,
+  });
+  assert.equal(out.applied, true);
+  assert.equal(out.set.value, 0.35);
+  assert.equal(out.error, undefined);
+  assert.deepEqual(honestWidgetAck({ set }).set, set);
+});
+
+test("#2025 a refused write is still a refusal, not a verified apply", async () => {
+  await assert.rejects(
+    () =>
+      awaitSetWidgetAck(Promise.reject(new Error("strength_model is not a valid option")), {
+        node: makeLoraLoader(0.9).node,
+        widget: "strength_model",
+        requested: 0.35,
+        timeoutMs: 50,
+      }),
+    /not a valid option/,
+  );
+});
+
+test("#2025 wiring: graph_set_widget threads the command budget into awaitSetWidgetAck", () => {
+  const start = PANEL_SRC.indexOf("async graph_set_widget({");
+  const end = PANEL_SRC.indexOf("\n  // artokun/comfyui-mcp#938", start);
+  assert.ok(start >= 0, "graph_set_widget handler not found");
+  assert.ok(end > start, "graph_set_widget handler boundary not found");
+  const handler = PANEL_SRC.slice(start, end);
+  assert.match(handler, /await runSetWidget\(node, widget, value, setWidgetOpts\)/);
+  assert.match(handler, /timeoutMs:\s*budget\.bounded\(\)/);
+  assert.match(SET_WIDGET_SRC, /return awaitSetWidgetAck\(/);
+  assert.match(SET_WIDGET_SRC, /widgetWriteTimeoutReadback/);
+  assert.match(SET_WIDGET_SRC, /from "\.\/delivery-ack\.js"/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18360,6 +18360,10 @@ const GRAPH_TOOL_EXECUTORS = {
           return false;
         }
       },
+      // #2025 — the remaining command budget bounds the write+ack. On timeout after
+      // delivery, awaitSetWidgetAck readbacks the live widget instead of hanging
+      // until the 90s relay reports outcome-unknown.
+      timeoutMs: budget.bounded(),
     };
     // The creation and its rollback both live inside this call now, at the synchronous write
     // boundary — see `prepareWriteTarget` above. There is nothing to undo out here.

--- a/web/js/lib/delivery-ack.js
+++ b/web/js/lib/delivery-ack.js
@@ -12,6 +12,10 @@
  * callback returned. Neither may be rewritten as "rejected" or as a timeout
  * that names no receipt.
  *
+ * #2025 — when the outer wait ends after delivery and there is no `set`
+ * receipt, an idempotent live-widget readback that equals the request is
+ * itself the receipt ("applied and verified"), never outcome-unknown.
+ *
  * Dependency-free. Unit-testable with plain values.
  */
 
@@ -110,4 +114,56 @@ export function honestWidgetAck(result, { timeout = false } = {}) {
   }
 
   return result;
+}
+
+/** Named in the #2025 timeout-readback receipt when the live widget equals the request. */
+export const APPLIED_AND_VERIFIED_NOTE = "applied and verified";
+
+function widgetValuesEqual(expected, actual) {
+  if (
+    (expected !== null && typeof expected === "object") ||
+    (actual !== null && typeof actual === "object")
+  ) {
+    try {
+      return JSON.stringify(expected) === JSON.stringify(actual);
+    } catch {
+      return false;
+    }
+  }
+  return Object.is(expected, actual);
+}
+
+/**
+ * #2025 — defence-in-depth when the outer wait ends after the command was
+ * delivered. Idempotent readback of the targeted widget: if the live value
+ * equals the request, the mutation already landed and must not be reported
+ * as outcome-unknown.
+ *
+ * @param {{
+ *   requested?: any,
+ *   actual?: any,
+ *   found?: boolean,
+ *   node_id?: any,
+ *   widget?: any,
+ *   delivered?: boolean,
+ * }} [input]
+ */
+export function widgetWriteTimeoutReadback({
+  requested,
+  actual,
+  found = false,
+  node_id,
+  widget,
+  delivered = true,
+} = {}) {
+  if (!delivered) return honestWidgetAck({}, { timeout: true });
+  if (found && widgetValuesEqual(requested, actual)) {
+    return {
+      applied: true,
+      verified: true,
+      set: { node_id, widget, value: actual },
+      ack_note: APPLIED_AND_VERIFIED_NOTE,
+    };
+  }
+  return honestWidgetAck({}, { timeout: true });
 }

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -57,7 +57,7 @@ import {
   serverDeclaresRemoteComboOptions,
 } from "./input-asset.js";
 import { withTimeout } from "./bounded-step.js";
-import { honestWidgetAck } from "./delivery-ack.js";
+import { honestWidgetAck, widgetWriteTimeoutReadback } from "./delivery-ack.js";
 
 /**
  * Fire an undo-history hook that can never escape.
@@ -136,6 +136,84 @@ export function awaitFrontendWidgetFlush(timers) {
     });
   });
   return withTimeout(flush, FRONTEND_WIDGET_FLUSH_MS, () => undefined, timers);
+}
+
+const SET_WIDGET_ACK_TIMEOUT = Symbol("set-widget-ack-timeout");
+
+/**
+ * #2025 — never-throwing live read of one named widget. Used by the timeout
+ * readback so a missing node or a hostile getter cannot replace the ack.
+ */
+export function readLiveWidgetValue(node, widgetName) {
+  try {
+    const live = node?.widgets?.find((candidate) => candidate?.name === widgetName);
+    if (!live) return { found: false, value: undefined };
+    return { found: true, value: live.value };
+  } catch {
+    return { found: false, value: undefined };
+  }
+}
+
+/**
+ * #2025 — flush and correlate a graph_set_widget result once the write
+ * resolves, and fall back to an idempotent live-widget readback when the
+ * outer wait ends after delivery.
+ *
+ * `writePromise` is the SAME runSetWidget call the handler awaits. A refusal
+ * still throws. A resolved receipt is passed through honestWidgetAck so an
+ * applied write is never a hard timeout with no receipt. A timeout after
+ * delivery reads the targeted widget and returns "applied and verified"
+ * when it equals the requested value.
+ *
+ * The original write is not cancelled: withTimeout never cancels, and a
+ * rejection handler is attached immediately so an abandoned late throw
+ * cannot become an unhandled rejection.
+ *
+ * @param {Promise<any>|any} writePromise
+ * @param {{
+ *   node?: any,
+ *   widget?: any,
+ *   requested?: any,
+ *   timeoutMs?: number,
+ *   timers?: { setTimer?: Function, clearTimer?: Function },
+ *   delivered?: boolean,
+ * }} [opts]
+ */
+export async function awaitSetWidgetAck(writePromise, {
+  node,
+  widget,
+  requested,
+  timeoutMs,
+  timers,
+  delivered = true,
+} = {}) {
+  const tracked = Promise.resolve(writePromise);
+  tracked.then(() => {}, () => {});
+  const captured = tracked.then(
+    (result) => ({ ok: true, result }),
+    (error) => ({ ok: false, error }),
+  );
+  const raced = await withTimeout(captured, timeoutMs, () => SET_WIDGET_ACK_TIMEOUT, timers);
+  if (raced !== SET_WIDGET_ACK_TIMEOUT) {
+    if (raced?.ok) return honestWidgetAck(raced.result);
+    throw raced.error;
+  }
+  const live = readLiveWidgetValue(node, widget);
+  const verified = widgetWriteTimeoutReadback({
+    requested,
+    actual: live.value,
+    found: live.found,
+    node_id: node?.id,
+    widget,
+    delivered,
+  });
+  // Only short-circuit when the live widget already equals the request. A
+  // timeout before the write must still surface the inner worded refusal
+  // (stale combo, hung /view probe) rather than inventing outcome-unknown.
+  if (verified.applied && verified.verified) return verified;
+  const settled = await captured;
+  if (settled?.ok) return honestWidgetAck(settled.result);
+  throw settled.error;
 }
 
 function widgetValuesMatch(expected, actual) {
@@ -237,7 +315,26 @@ export function scopedAuthorizationTypes(node, promotedResolution, isResolvedPro
   return types;
 }
 
-export async function runSetWidget(
+const ACK_WRAPPED = Symbol("set-widget-ack-wrapped");
+
+export async function runSetWidget(node, widgetName, value, opts = {}) {
+  if (!opts[ACK_WRAPPED]) {
+    return awaitSetWidgetAck(
+      runSetWidgetBody(node, widgetName, value, { ...opts, [ACK_WRAPPED]: true }),
+      {
+        node,
+        widget: widgetName,
+        requested: value,
+        timeoutMs: opts.timeoutMs,
+        timers: opts.ackTimers,
+        delivered: opts.delivered !== false,
+      },
+    );
+  }
+  return runSetWidgetBody(node, widgetName, value, opts);
+}
+
+async function runSetWidgetBody(
   node,
   widgetName,
   value,


### PR DESCRIPTION
## Summary
- After a live-canvas `panel_set_widget` mutation lands, flush and correlate the `graph_set_widget` handler receipt instead of leaving the relay at outcome-unknown.
- When the remaining command budget ends after delivery, idempotent readback of the targeted widget returns **applied and verified** if it already equals the requested value (core LoraLoader `strength_model` 0.9 → 0.35).
- A timeout before the write still surfaces the inner worded refusal (stale combo, hung `/view` probe) rather than inventing unknown.

Fixes #2025

## Test plan
- `node --test browser_tests/unit/set-widget-timeout-ack.test.mjs` (9 passing)
- `node --test browser_tests/unit/set-widget-stale-combo-budget.test.mjs` (hung `/view` probe still refuses in words)
- `node scripts/check-changelog.mjs`

Not in scope: #2032 / #2035.
