### PR TITLE
fix(2027): refuse stale-bundle refresh instead of clearing schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_refresh_nodes refuses a stale browser bundle with a Ctrl+Shift+R remedy instead of clearing last-known schema (#2027)
 - panel_refresh_nodes publishes the workflow UUID of the canvas it refreshed, and refuses a retryable route-registration miss if the active route moves, instead of returning refreshed:true with another UUID (#2026)
 - panel_set_widget no longer reports outcome-unknown after the value has landed: the handler ack is flushed once graph_set_widget resolves, and a timeout after delivery returns applied and verified from an idempotent readback (#2025)
 

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -238,6 +238,7 @@ function realRegisterComfyNodeDefs({ app, api, objectInfoCache, objectInfoSnapsh
     "initialBackendReconnectEpoch",
     "comfyBackendSocketDown",
     "TRANSPORT_OUTCOME",
+    "refuseStaleBundleRefresh",
   ];
   const values = {
     app,
@@ -265,6 +266,7 @@ function realRegisterComfyNodeDefs({ app, api, objectInfoCache, objectInfoSnapsh
     initialBackendReconnectEpoch: epoch,
     comfyBackendSocketDown: false,
     TRANSPORT_OUTCOME,
+    refuseStaleBundleRefresh: async () => null,
   };
   const factory = new Function(
     ...names,

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -36,7 +36,7 @@ import { commandIsCanvasIndependent } from "../../web/js/lib/workflow-chat-ident
 import { sealProvenRootBinding } from "../../web/js/lib/graph-binding.js";
 import { composeShowMediaReply } from "../../web/js/lib/media-preview.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
-import { describeNodeDefRefresh } from "../../web/js/lib/node-def-refresh.js";
+import { describeNodeDefRefresh, describeStaleBundleRefresh } from "../../web/js/lib/node-def-refresh.js";
 import { confirmCanvasNavigation } from "../../web/js/lib/canvas-navigation.js";
 import {
   watchPostReconnectSettle,
@@ -100,6 +100,7 @@ test("panel ↔ media-preview.js / run-completion-frame.js ↔ bounded-step.js e
 
 test("panel ↔ node-def-refresh.js / canvas-navigation.js / reconnect-recovery.js edges link (#635/#619/#663/#646/#1641/#1914)", () => {
   assert.equal(typeof describeNodeDefRefresh, "function");
+  assert.equal(typeof describeStaleBundleRefresh, "function");
   assert.equal(typeof confirmCanvasNavigation, "function");
   assert.equal(typeof watchPostReconnectSettle, "function");
   assert.equal(typeof waitForReconnectHandshakeBeforeOpen, "function");

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -486,6 +486,7 @@ function buildRegisterComfyNodeDefs({
     // ending from the TAG rather than from its sentence (#1223), so the extracted body
     // throws ReferenceError without it.
     "TRANSPORT_OUTCOME",
+    "refuseStaleBundleRefresh",
     `// #1180 — defined HERE, from the api this scope already has, so each factory site
      // gets its own stub without threading a helper through every call.
      const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
@@ -548,6 +549,7 @@ function buildRegisterComfyNodeDefs({
     7,
     socketDown,
     TRANSPORT_OUTCOME,
+    async () => null,
   );
 }
 

--- a/browser_tests/unit/refresh-graph-guard.test.mjs
+++ b/browser_tests/unit/refresh-graph-guard.test.mjs
@@ -258,6 +258,7 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     "nodeInventoryLabel",
     "describeRefreshGraphLoss",
     "restoredLiveNodesNote",
+    "refuseStaleBundleRefresh",
     `const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
        if (typeof api?.getNodeDefs !== "function") return null;
        const settled = await withTimeout(
@@ -306,6 +307,7 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     nodeInventoryLabel,
     describeRefreshGraphLoss,
     restoredLiveNodesNote,
+    async () => null,
   );
 }
 

--- a/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-reapply-budget.test.mjs
@@ -72,6 +72,7 @@ function buildRun({
     "NODE_DEFS_RETRY_DELAYS_MS", "objectInfoCache", "objectInfoSnapshot", "verifiedNodeDefCache", "backendReconnectEpoch",
     "comfyBackendSocketDown",
     "TRANSPORT_OUTCOME",
+    "refuseStaleBundleRefresh",
   ];
   const vals = {
     app: appValue, api: apiValue,
@@ -95,6 +96,7 @@ function buildRun({
     backendReconnectEpoch: 7,
     comfyBackendSocketDown: false,
     TRANSPORT_OUTCOME,
+    refuseStaleBundleRefresh: async () => null,
   };
   const factory = new Function(...names, `
     const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {

--- a/browser_tests/unit/refresh-stale-bundle.test.mjs
+++ b/browser_tests/unit/refresh-stale-bundle.test.mjs
@@ -1,0 +1,420 @@
+/**
+ * #2027 — panel_refresh_nodes must not clear last-known schema on a stale bundle.
+ *
+ * Reported: the live tab ran panel 0.15.123 while the installed pack was 0.15.124.
+ * On a large custom-node install, panel_refresh_nodes returned object_info_fetch_failed
+ * and cleared the last-known schema. The next panel_set_widget saw /models/checkpoints
+ * listing the new file while the stale /object_info combo still exposed only four old
+ * options. The on-disk pack already had the large-refresh budget; the open tab did not.
+ *
+ * These tests drive the SHIPPED registerComfyNodeDefs (the function that retires schema)
+ * and the shipped refresh_nodes executor. Unfixed: a version mismatch still attempts
+ * the refresh and fences/clears the snapshot, answering refreshed:false without
+ * stale_bundle. Fixed: stale_bundle + Ctrl+Shift+R, schema left untouched.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  describeStaleBundleRefresh,
+  NODE_DEF_REFRESH_REASONS,
+  describeNodeDefRefresh,
+} from "../../web/js/lib/node-def-refresh.js";
+import { comboRebuildCovered } from "../../web/js/lib/asset-staleness.js";
+import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { fetchWholeObjectInfo, TRANSPORT_OUTCOME } from "../../web/js/lib/object-info-oracle.js";
+import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
+import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
+import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
+import {
+  COMBO_NO_ANSWER,
+  COMBO_OK,
+  NODE_DEFS_FETCH_SHARE,
+  NODE_DEFS_FETCH_TIMEOUT_MS,
+  NODE_DEFS_NO_ANSWER,
+  NODE_DEFS_RUN_BUDGET_MS,
+  REFRESH_NODES_EXECUTOR_DEPS,
+  monotonicNow,
+  nodeDefsBudgetLeft,
+} from "./_panel-constants.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+
+const SCHEMA = { CheckpointLoaderSimple: { input: { required: { ckpt_name: ["COMBO", { options: ["old.safetensors"] }] } } } };
+const SILENCE = [
+  { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+  { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+];
+const EPOCH = 7;
+
+function stored(snap, defs = SCHEMA, epoch = EPOCH, generation = 0) {
+  return snap.record(defs, {
+    observedAtEpoch: epoch,
+    currentEpoch: epoch,
+    observedAtGeneration: generation,
+    currentGeneration: generation,
+    whole: true,
+  });
+}
+
+function extractFunction(marker) {
+  const start = SRC.indexOf(marker);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = SRC.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") {
+      i = SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && SRC[i + 1] === "*") {
+      i = SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < SRC.length; i += 1) {
+        if (SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function: ${marker}`);
+}
+
+function buildRegisterComfyNodeDefs({
+  apiValue,
+  objectInfoSnapshot,
+  verifiedNodeDefCache = createVerifiedNodeDefCache(),
+  objectInfoCache = createObjectInfoCache(),
+  refuseStaleBundleRefresh = async () => null,
+} = {}) {
+  const body = extractFunction("async function registerComfyNodeDefs(");
+  const factory = new Function(
+    "app",
+    "api",
+    "recordObjectInfoTypes",
+    "reapplyDefsToLiveNodes",
+    "comboRebuildCovered",
+    "describeNodeDefRefresh",
+    "NODE_DEF_REFRESH_REASONS",
+    "fetchNodeDefsWithRetry",
+    "withTimeout",
+    "NODE_DEFS_NO_ANSWER",
+    "COMBO_OK",
+    "COMBO_NO_ANSWER",
+    "NODE_DEFS_FETCH_TIMEOUT_MS",
+    "NODE_DEFS_RUN_BUDGET_MS",
+    "NODE_DEFS_FETCH_SHARE",
+    "fetchWholeObjectInfo",
+    "nodeDefsBudgetLeft",
+    "monotonicNow",
+    "NODE_DEFS_RETRY_DELAYS_MS",
+    "objectInfoCache",
+    "objectInfoSnapshot",
+    "verifiedNodeDefCache",
+    "initialBackendReconnectEpoch",
+    "comfyBackendSocketDown",
+    "TRANSPORT_OUTCOME",
+    "refuseStaleBundleRefresh",
+    `const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
+       if (typeof api?.getNodeDefs !== "function") return null;
+       const settled = await withTimeout(
+         Promise.resolve().then(() => api.getNodeDefs()).then((value) => ({ value }), (err) => ({ err })),
+         ms,
+         () => NODE_DEFS_NO_ANSWER,
+       );
+       if (settled === NODE_DEFS_NO_ANSWER) return NODE_DEFS_NO_ANSWER;
+       if ("err" in settled) throw settled.err;
+       return settled.value;
+     };
+     let backendReconnectEpoch = initialBackendReconnectEpoch;
+     let nodeDefsRefreshConfirmed = false;
+     ${body}
+     return { registerComfyNodeDefs };`,
+  );
+  return factory(
+    { graph: null, registerNodesFromDefs: async () => {}, refreshComboInNodes: async () => {} },
+    apiValue,
+    () => ({}),
+    () => {},
+    comboRebuildCovered,
+    describeNodeDefRefresh,
+    NODE_DEF_REFRESH_REASONS,
+    (getDefs, opts) => fetchNodeDefsWithRetry(getDefs, { ...opts, sleep: async () => {} }),
+    withTimeout,
+    NODE_DEFS_NO_ANSWER,
+    COMBO_OK,
+    COMBO_NO_ANSWER,
+    NODE_DEFS_FETCH_TIMEOUT_MS,
+    NODE_DEFS_RUN_BUDGET_MS,
+    NODE_DEFS_FETCH_SHARE,
+    fetchWholeObjectInfo,
+    nodeDefsBudgetLeft,
+    monotonicNow,
+    OBJECT_INFO_RETRY_DELAYS_MS,
+    objectInfoCache,
+    objectInfoSnapshot,
+    verifiedNodeDefCache,
+    EPOCH,
+    false,
+    TRANSPORT_OUTCOME,
+    refuseStaleBundleRefresh,
+  );
+}
+
+function buildRefreshNodes(refreshImpl, extra = {}) {
+  const start = SRC.indexOf("async refresh_nodes()");
+  assert.notEqual(start, -1, "refresh_nodes executor not found");
+  const open = SRC.indexOf("{", start);
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") {
+      i = SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && SRC[i + 1] === "*") {
+      i = SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < SRC.length; i += 1) {
+        if (SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) {
+      end = i;
+      break;
+    }
+  }
+  assert.notEqual(end, -1, "could not bound the refresh_nodes executor body");
+  const body = SRC.slice(start, end + 1);
+  const deps = { ...REFRESH_NODES_EXECUTOR_DEPS, ...extra };
+  const extraEntries = Object.entries(deps);
+  const factory = new Function(
+    "refreshComfyNodeDefs",
+    ...extraEntries.map(([name]) => name),
+    `return (${body.replace(/^async refresh_nodes\(\)/, "async function refresh_nodes()")});`,
+  );
+  return factory(refreshImpl, ...extraEntries.map(([, value]) => value));
+}
+
+function wrapSnapshot(snapshot) {
+  let beginReplacementCalls = 0;
+  let clearCalls = 0;
+  const originalBegin = snapshot.beginReplacement.bind(snapshot);
+  const originalClear = snapshot.clear.bind(snapshot);
+  snapshot.beginReplacement = () => {
+    beginReplacementCalls += 1;
+    return originalBegin();
+  };
+  snapshot.clear = () => {
+    clearCalls += 1;
+    return originalClear();
+  };
+  return {
+    snapshot,
+    get beginReplacementCalls() {
+      return beginReplacementCalls;
+    },
+    get clearCalls() {
+      return clearCalls;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure verdict
+// ---------------------------------------------------------------------------
+
+test("#2027 equal versions are not a stale-bundle refusal", () => {
+  assert.equal(describeStaleBundleRefresh({ running: "0.15.124", installed: "0.15.124" }), null);
+});
+
+test("#2027 a missing probe is unknown — fail open, never invent stale_bundle", () => {
+  assert.equal(describeStaleBundleRefresh({ running: "0.15.123", installed: null }), null);
+  assert.equal(describeStaleBundleRefresh({ running: "0.15.123", installed: "" }), null);
+  assert.equal(describeStaleBundleRefresh({ running: "", installed: "0.15.124" }), null);
+  assert.equal(describeStaleBundleRefresh({}), null);
+});
+
+test("#2027 a version mismatch is stale_bundle with a Ctrl+Shift+R remedy", () => {
+  const v = describeStaleBundleRefresh({ running: "0.15.123", installed: "0.15.124" });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.STALE_BUNDLE);
+  assert.equal(v.reason, "stale_bundle");
+  assert.equal(v.running, "0.15.123");
+  assert.equal(v.installed, "0.15.124");
+  assert.match(v.remedy, /Ctrl\+Shift\+R/);
+  assert.match(v.remedy, /0\.15\.123/);
+  assert.match(v.remedy, /0\.15\.124/);
+  assert.match(v.remedy, /last-known schema was left unchanged/i);
+});
+
+// ---------------------------------------------------------------------------
+// SHIPPED registerComfyNodeDefs — the function that would otherwise clear schema
+// ---------------------------------------------------------------------------
+
+test("#2027 SHIPPED: a stale bundle returns stale_bundle and preserves last-known schema", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const verifiedNodeDefCache = createVerifiedNodeDefCache();
+  assert.equal(stored(snapshot), true);
+  const wrapped = wrapSnapshot(snapshot);
+  const generationBefore = verifiedNodeDefCache.generation();
+  let fetchCalls = 0;
+  const staleVerdict = describeStaleBundleRefresh({ running: "0.15.123", installed: "0.15.124" });
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    objectInfoSnapshot: snapshot,
+    verifiedNodeDefCache,
+    refuseStaleBundleRefresh: async () => staleVerdict,
+    apiValue: {
+      getNodeDefs: async () => {
+        fetchCalls += 1;
+        throw new Error("Failed to fetch");
+      },
+    },
+  });
+
+  const verdict = await registerComfyNodeDefs(undefined);
+
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "stale_bundle", "must not report object_info_fetch_failed over a stale tab");
+  assert.match(verdict.remedy, /Ctrl\+Shift\+R/);
+  assert.equal(fetchCalls, 0, "must not attempt the large /object_info refresh");
+  assert.equal(wrapped.beginReplacementCalls, 0, "must not fence the last-known schema");
+  assert.equal(wrapped.clearCalls, 0, "must not clear the last-known schema");
+  assert.equal(verifiedNodeDefCache.generation(), generationBefore, "must not retire per-class proof");
+  const fallback = snapshot.authorize({
+    epoch: EPOCH,
+    generation: generationBefore,
+    socketDown: false,
+    outcomes: SILENCE,
+  });
+  assert.ok(fallback.defs?.CheckpointLoaderSimple, "the last-known schema remains usable for the next widget write");
+});
+
+test("#2027 SHIPPED: a current bundle still attempts refresh (fail-open on match)", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  stored(snapshot);
+  const wrapped = wrapSnapshot(snapshot);
+  let fetchCalls = 0;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    objectInfoSnapshot: snapshot,
+    refuseStaleBundleRefresh: async () => null,
+    apiValue: {
+      getNodeDefs: async () => {
+        fetchCalls += 1;
+        throw new Error("Failed to fetch");
+      },
+    },
+  });
+
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(fetchCalls > 0, true, "a current bundle still fetches");
+  assert.notEqual(verdict.reason, "stale_bundle");
+  assert.equal(verdict.refreshed, false);
+  assert.ok(wrapped.beginReplacementCalls > 0, "a current-bundle refresh still fences while it runs");
+});
+
+test("#2027 SHIPPED refuseStaleBundleRefresh compares PANEL_VERSION to the installed marker", async () => {
+  const body = extractFunction("async function refuseStaleBundleRefresh(");
+  const factory = new Function(
+    "api",
+    "PANEL_VERSION",
+    "describeStaleBundleRefresh",
+    `${body}; return refuseStaleBundleRefresh;`,
+  );
+  let versionRoute = 0;
+  const probe = factory(
+    {
+      fetchApi: async (route, init) => {
+        versionRoute += 1;
+        assert.equal(route, "/comfyui_mcp_panel/version");
+        assert.equal(init?.cache, "no-store");
+        return { ok: true, json: async () => ({ version: "0.15.124" }) };
+      },
+    },
+    "0.15.123",
+    describeStaleBundleRefresh,
+  );
+  const stale = await probe();
+  assert.equal(versionRoute, 1);
+  assert.equal(stale.reason, "stale_bundle");
+  assert.equal(stale.running, "0.15.123");
+  assert.equal(stale.installed, "0.15.124");
+  assert.match(stale.remedy, /Ctrl\+Shift\+R/);
+
+  const current = await factory(
+    { fetchApi: async () => ({ ok: true, json: async () => ({ version: "0.15.124" }) }) },
+    "0.15.124",
+    describeStaleBundleRefresh,
+  )();
+  assert.equal(current, null, "equal versions fail open into the refresh");
+
+  const unknown = await factory(
+    { fetchApi: async () => ({ ok: false }) },
+    "0.15.123",
+    describeStaleBundleRefresh,
+  )();
+  assert.equal(unknown, null, "an unreadable probe must not invent stale_bundle");
+});
+
+test("#2027 wiring: registerComfyNodeDefs asks the stale-bundle gate before beginReplacement", () => {
+  const body = extractFunction("async function registerComfyNodeDefs(");
+  const gateAt = body.indexOf("refuseStaleBundleRefresh");
+  const fenceAt = body.indexOf("objectInfoSnapshot.beginReplacement");
+  assert.notEqual(gateAt, -1, "the shipped refresh must consult refuseStaleBundleRefresh");
+  assert.notEqual(fenceAt, -1, "the schema fence is still the start-of-run effect");
+  assert.ok(gateAt < fenceAt, "stale-bundle detection must run before the last-known schema is fenced");
+});
+
+// ---------------------------------------------------------------------------
+// SHIPPED refresh_nodes — the command reply the agent actually reads
+// ---------------------------------------------------------------------------
+
+test("#2027 SHIPPED: refresh_nodes forwards stale_bundle instead of object_info_fetch_failed", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  stored(snapshot);
+  const wrapped = wrapSnapshot(snapshot);
+  const refresh_nodes = buildRefreshNodes(async () =>
+    describeStaleBundleRefresh({ running: "0.15.123", installed: "0.15.124" }),
+  );
+
+  const reply = await refresh_nodes();
+  assert.equal(reply.ok, true);
+  assert.equal(reply.refreshed, false);
+  assert.equal(reply.reason, "stale_bundle");
+  assert.match(reply.remedy, /Ctrl\+Shift\+R/);
+  assert.equal(wrapped.clearCalls, 0, "forwarding the verdict must not clear last-known schema");
+  assert.ok(
+    snapshot.authorize({ epoch: EPOCH, generation: 0, socketDown: false, outcomes: SILENCE }).defs
+      ?.CheckpointLoaderSimple,
+  );
+});

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -502,6 +502,7 @@ function realPreloadedRefresh({ app, api, objectInfoCache, objectInfoSnapshot, v
     "initialBackendReconnectEpoch",
     "comfyBackendSocketDown",
     "TRANSPORT_OUTCOME",
+    "refuseStaleBundleRefresh",
   ];
   const values = {
     app,
@@ -529,6 +530,7 @@ function realPreloadedRefresh({ app, api, objectInfoCache, objectInfoSnapshot, v
     initialBackendReconnectEpoch: 0,
     comfyBackendSocketDown: false,
     TRANSPORT_OUTCOME,
+    refuseStaleBundleRefresh: async () => null,
   };
   const factory = new Function(
     ...names,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1776,6 +1776,7 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     Number.isFinite(runOpts?.runBudgetMs) && runOpts.runBudgetMs > 0
       ? runOpts.runBudgetMs
       : NODE_DEFS_RUN_BUDGET_MS;
+  let runDeadline = monotonicNow() + runBudgetMs;
   // Whole-schema start-of-run effects. A one-class payload from graph_add_node is not a
   // type-set replacement (#2050): fencing the last-observed snapshot and then running
   // refreshComboInNodes() would re-fetch the same dump that just missed its budget, and
@@ -1783,14 +1784,10 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // proof it just verified.
   if (replacementMayReplaceWholeSnapshot) {
     // #2027 — a stale browser bundle must not fence or clear last-known schema.
-    // Ask before the run deadline is armed so a slow version probe cannot steal
-    // fetch budget, and before invalidate/beginReplacement so a large-/object_info
-    // miss on an older tab cannot worsen the next widget edit.
+    // Ask before invalidate/beginReplacement so a large-/object_info miss on an
+    // older tab cannot worsen the next widget edit.
     const staleBundle = await refuseStaleBundleRefresh();
     if (staleBundle) return staleBundle;
-  }
-  let runDeadline = monotonicNow() + runBudgetMs;
-  if (replacementMayReplaceWholeSnapshot) {
     // #716 — drop the widget-write burst cache at the START of this run, not after it
     // succeeds (codex). This function runs on exactly the events that change the schema —
     // refresh_nodes, a completed install/download, reconnect — and a refresh that FAILS is

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -323,6 +323,7 @@ import { refreshMissingAssetTrust } from "./lib/missing-asset-refresh.js";
 import {
   NODE_DEF_REFRESH_REASONS,
   describeNodeDefRefresh,
+  describeStaleBundleRefresh,
   describeRefreshGraphLoss,
   restoredLiveNodesNote,
 } from "./lib/node-def-refresh.js";
@@ -1671,6 +1672,41 @@ const OBJECT_INFO_SEED_WAIT_MS = 8000;
 const awaitObjectInfoHistorySeed = (waitMs = OBJECT_INFO_SEED_WAIT_MS) =>
   awaitHistoryBaseline(objectInfoHistory, objectInfoHistorySeed, waitMs);
 
+/**
+ * #2027 — compare the running PANEL_VERSION to the installed pack marker.
+ * A stale tab must not attempt the whole-schema refresh: the on-disk pack may
+ * already have the large-/object_info budget this cached bundle lacks, and a
+ * miss used to retire last-known combo lists the next widget write still needed.
+ * Fail-open on an unreadable probe (same rule as the startup heal).
+ */
+async function refuseStaleBundleRefresh() {
+  try {
+    let installed = null;
+    if (typeof api?.fetchApi === "function") {
+      let timer = null;
+      const probe = (async () => {
+        const res = await api.fetchApi("/comfyui_mcp_panel/version", { cache: "no-store" });
+        if (!res || !res.ok) return null;
+        const body = await res.json().catch(() => null);
+        return typeof body?.version === "string" ? body.version : null;
+      })();
+      try {
+        installed = await Promise.race([
+          probe,
+          new Promise((resolve) => {
+            timer = setTimeout(() => resolve(null), 2000);
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    }
+    return describeStaleBundleRefresh({ running: PANEL_VERSION, installed });
+  } catch {
+    return null;
+  }
+}
+
 async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   // Trust the live combos for suppressing missing-asset candidates ONLY once they have
   // ACTUALLY BEEN REBUILT from an authoritative payload this run obtained. Two things can
@@ -1740,12 +1776,20 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
     Number.isFinite(runOpts?.runBudgetMs) && runOpts.runBudgetMs > 0
       ? runOpts.runBudgetMs
       : NODE_DEFS_RUN_BUDGET_MS;
-  let runDeadline = monotonicNow() + runBudgetMs;
   // Whole-schema start-of-run effects. A one-class payload from graph_add_node is not a
   // type-set replacement (#2050): fencing the last-observed snapshot and then running
   // refreshComboInNodes() would re-fetch the same dump that just missed its budget, and
   // beginReplacement would bump the generation so the add could not file the per-class
   // proof it just verified.
+  if (replacementMayReplaceWholeSnapshot) {
+    // #2027 — a stale browser bundle must not fence or clear last-known schema.
+    // Ask before the run deadline is armed so a slow version probe cannot steal
+    // fetch budget, and before invalidate/beginReplacement so a large-/object_info
+    // miss on an older tab cannot worsen the next widget edit.
+    const staleBundle = await refuseStaleBundleRefresh();
+    if (staleBundle) return staleBundle;
+  }
+  let runDeadline = monotonicNow() + runBudgetMs;
   if (replacementMayReplaceWholeSnapshot) {
     // #716 — drop the widget-write burst cache at the START of this run, not after it
     // succeeds (codex). This function runs on exactly the events that change the schema —

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -14,6 +14,7 @@
 //
 // Pure: every input is observed by the caller and passed in.
 
+import { resolveBundleStaleness } from "./bundle-version.js";
 import { nodeInventoryLabel } from "./graph-node-inventory.js";
 // #608 — the ONE renderer for "what each route did", shared with the two other refusals
 // that already print it (`graph_get_object_info` and the set_widget fence). It caps the
@@ -34,19 +35,50 @@ export const NODE_DEF_REFRESH_REASONS = Object.freeze({
   // be restored. A data-loss verdict: it overrides even a real phase failure,
   // because the lost nodes are the fact the caller must act on first.
   GRAPH_NODES_LOST: "graph_nodes_lost",
-  // #1404 — the ONE token in this map that `describeNodeDefRefresh` never produces,
-  // because it does not describe a run at all: the caller's command budget ran out
-  // WAITING for a refresh (someone else's, then its own), and the run it stopped
-  // waiting for is still going. It lives here anyway, and deliberately: `reason` is a
-  // single vocabulary as far as its reader is concerned, and a value that could only be
-  // found by reading the executor is a value nobody will handle. Distinct from every
-  // token above by the fact that matters to a caller — nothing failed, so a retry is
-  // expected to succeed rather than hoped to.
+  // #1404 — a token `describeNodeDefRefresh` never produces, because it does not
+  // describe a run at all: the caller's command budget ran out WAITING for a refresh
+  // (someone else's, then its own), and the run it stopped waiting for is still going.
+  // It lives here anyway, and deliberately: `reason` is a single vocabulary as far as
+  // its reader is concerned, and a value that could only be found by reading the
+  // executor is a value nobody will handle. Distinct from every token above by the
+  // fact that matters to a caller — nothing failed, so a retry is expected to succeed
+  // rather than hoped to.
   REFRESH_STILL_RUNNING: "refresh_still_running",
   // #1695 — a run that crossed a backend reconnect cannot certify the replacement
   // connection's node registry or combo lists.
   REFRESH_SUPERSEDED: "refresh_superseded",
+  // #2027 — also never produced by describeNodeDefRefresh: the refresh was not
+  // attempted because this tab is running a different panel bundle than the pack
+  // on disk. The comparison happens before any phase starts, so a stale tab cannot
+  // retire last-known schema on a large-/object_info miss the installed pack already
+  // fixed.
+  STALE_BUNDLE: "stale_bundle",
 });
+
+/**
+ * #2027 — refuse a node-def refresh when the running browser bundle is STALE.
+ *
+ * Fail-open: only a well-formed mismatch is evidence. A missing/malformed probe
+ * is the same "unknown" resolveBundleStaleness already uses for the startup heal,
+ * and must not invent a stale_bundle verdict that would skip a legitimate refresh.
+ *
+ * @returns {null|{refreshed:false, reason:string, running:string, installed:string, remedy:string}}
+ */
+export function describeStaleBundleRefresh({ running, installed } = {}) {
+  if (resolveBundleStaleness({ running, installed }) !== "stale") return null;
+  const run = String(running).trim();
+  const inst = String(installed).trim();
+  return {
+    refreshed: false,
+    reason: NODE_DEF_REFRESH_REASONS.STALE_BUNDLE,
+    running: run,
+    installed: inst,
+    remedy:
+      `This tab is running panel ${run} while the installed pack is ${inst}. ` +
+      `Hard-refresh this tab (Ctrl+Shift+R) to load panel ${inst} before refreshing node definitions. ` +
+      `Nothing was refreshed, and the last-known schema was left unchanged.`,
+  };
+}
 
 function detailSuffix(thrown) {
   const text = String(thrown?.message ?? thrown ?? "").trim();


### PR DESCRIPTION
Fixes #2027

A live tab running an older `PANEL_VERSION` than the installed pack could call `panel_refresh_nodes`, miss a large `/object_info` fetch, and retire last-known combo lists. The next `panel_set_widget` then saw the new checkpoint on `/models/checkpoints` while the stale `/object_info` combo still listed only the old options.

Before fencing the last-known schema, compare the running bundle to `GET /comfyui_mcp_panel/version`. A proven mismatch returns `stale_bundle` with a Ctrl+Shift+R remedy and leaves the snapshot untouched. An unreadable probe fails open so a current tab still refreshes.

## Tests
`node --test browser_tests/unit/refresh-stale-bundle.test.mjs` — 8 pass
