### PR TITLE
fix(2029): arm KSampler control_after_generate after panel_add_node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 - scoped panel_run keeps the run-to-node target when a queuePrompt wrapper drops the third argument, instead of relying only on request-body repair (#1998)
 - panel_restart_comfyui uses ComfyUI Desktop's restartCore/restartApp to restore the backend after stop, and refuses a Manager reboot when no Desktop relaunch path is available, so a Desktop instance is not left stopped (#1999)
 - panel_run serializes a freshly typed PrimitiveNode STRING widget from the live graph instead of rejecting it as a missing dynamic widget (#2009)
+- KSampler nodes added with panel_add_node keep control_after_generate='randomize' armed, so the ordinary Queue button rolls the seed instead of cache-hitting on 0 until a tab reload (#2029)
 
 ## [0.15.140] - 2026-08-30
 

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -26,6 +26,7 @@ import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-c
 import { fetchSingleNodeInfo } from "../../web/js/lib/single-node-def.js";
 import { reconcileFreshDynamicWidgets } from "../../web/js/lib/dynamic-widget-reconcile.js";
 import { safeRemoveNode } from "../../web/js/lib/safe-remove-node.js";
+import { ensureControlAfterGenerateQueueHooks } from "../../web/js/lib/control-after-generate.js";
 
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -247,6 +248,8 @@ export function addNodeCommandBudgetDeps() {
       `HARNESS STUB refusal for "${classType}" — the shipped wording lives in the panel.`,
     reconcileFreshDynamicWidgets,
     safeRemoveNode,
+    // #2029 — graph_add_node arms inert control_after_generate combos after graph.add.
+    ensureControlAfterGenerateQueueHooks,
   };
 }
 

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -67,6 +67,7 @@ import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
 import { reconcileFreshDynamicWidgets } from "../../web/js/lib/dynamic-widget-reconcile.js";
 import { safeRemoveNode } from "../../web/js/lib/safe-remove-node.js";
+import { ensureControlAfterGenerateQueueHooks } from "../../web/js/lib/control-after-generate.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -402,6 +403,7 @@ function realGraphAddNode({
     sanitizeNodeAuxId,
     reconcileFreshDynamicWidgets,
     safeRemoveNode,
+    ensureControlAfterGenerateQueueHooks,
     OBJECT_INFO_SEED_WAIT_MS: 8000,
     ADD_NODE_COMMAND_BUDGET_MS: budgetMs,
     ADD_NODE_POST_REFRESH_RESERVE_MS: reserveMs,

--- a/browser_tests/unit/control-after-generate.test.mjs
+++ b/browser_tests/unit/control-after-generate.test.mjs
@@ -9,6 +9,8 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import {
   CONTROL_AFTER_GENERATE_MODES,
@@ -17,7 +19,10 @@ import {
   controlAfterGenerateModes,
   controlEntryForWidget,
   controlAfterGenerateWarning,
+  ensureControlAfterGenerateQueueHooks,
 } from "../../web/js/lib/control-after-generate.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 
 // A KSampler-shaped node: seed value widget followed by its control combo, exactly
 // as the ComfyUI frontend builds it (control widget serialize:false/canvasOnly).
@@ -286,4 +291,101 @@ test("a node with no control widget yields no entries", () => {
   const node = { id: 5, type: "CLIPTextEncode", widgets: [{ name: "text", value: "hi" }] };
   assert.deepEqual(controlAfterGenerateModes(node), {});
   assert.deepEqual(controlAfterGenerateEntries(node), []);
+});
+
+// #2029 — panel_add_node materializes the control combo (visible, mode randomize)
+// without afterQueued / linkedWidgets, so the ordinary Queue button never rolls
+// the seed. These tests pin the unfixed node (seed stays 0) and the repair.
+
+function inertSeedNode(mode = "randomize", seedValue = 0) {
+  const seed = { name: "seed", type: "INT", value: seedValue, options: { min: 0, max: 100, step2: 1 } };
+  const control = {
+    name: "control_after_generate",
+    type: "combo",
+    value: mode,
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  return { id: 3, type: "KSampler", widgets: [seed, control], seed, control };
+}
+
+test("#2029 unfixed: an inert control_after_generate combo does not roll the seed", () => {
+  const node = inertSeedNode("randomize", 0);
+  assert.equal(typeof node.control.afterQueued, "undefined");
+  assert.equal(node.seed.linkedWidgets, undefined);
+  node.control.afterQueued?.();
+  assert.equal(node.seed.value, 0, "panel-add default seed must stay 0 when the combo is inert");
+});
+
+test("#2029 ensureControlAfterGenerateQueueHooks arms randomize so a queue rolls the seed", () => {
+  const node = inertSeedNode("randomize", 0);
+  assert.equal(ensureControlAfterGenerateQueueHooks(node), 1);
+  assert.equal(typeof node.control.afterQueued, "function");
+  assert.equal(node.seed.linkedWidgets[0], node.control);
+
+  const orig = Math.random;
+  Math.random = () => 0.5;
+  try {
+    node.control.afterQueued();
+  } finally {
+    Math.random = orig;
+  }
+  assert.equal(node.seed.value, 50);
+});
+
+test("#2029 increment/decrement actually step the governed seed", () => {
+  const inc = inertSeedNode("increment", 10);
+  ensureControlAfterGenerateQueueHooks(inc);
+  inc.control.afterQueued();
+  assert.equal(inc.seed.value, 11);
+
+  const dec = inertSeedNode("decrement", 10);
+  ensureControlAfterGenerateQueueHooks(dec);
+  dec.control.afterQueued();
+  assert.equal(dec.seed.value, 9);
+});
+
+test("#2029 a live frontend hook is left alone; linkedWidgets is still filled", () => {
+  const node = inertSeedNode("randomize", 0);
+  let calls = 0;
+  const existing = () => {
+    calls += 1;
+  };
+  node.control.afterQueued = existing;
+  assert.equal(ensureControlAfterGenerateQueueHooks(node), 0);
+  assert.equal(node.control.afterQueued, existing);
+  assert.equal(node.seed.linkedWidgets[0], node.control);
+  node.control.afterQueued();
+  assert.equal(calls, 1);
+  assert.equal(node.seed.value, 0, "our repair must not wrap and double-apply a live hook");
+});
+
+test("#2029 WidgetControlMode 'before' rolls on the second beforeQueued, not afterQueued", () => {
+  const node = inertSeedNode("increment", 0);
+  ensureControlAfterGenerateQueueHooks(node, { getControlMode: () => "before" });
+  node.control.afterQueued();
+  assert.equal(node.seed.value, 0);
+  node.control.beforeQueued();
+  assert.equal(node.seed.value, 0, "first beforeQueued is the frontend skip");
+  node.control.beforeQueued();
+  assert.equal(node.seed.value, 1);
+});
+
+test("#2029 a linked (converted-to-input) seed is not rolled", () => {
+  const node = inertSeedNode("randomize", 7);
+  node.inputs = [{ name: "seed", link: 99, widget: { name: "seed" } }];
+  ensureControlAfterGenerateQueueHooks(node);
+  node.control.afterQueued();
+  assert.equal(node.seed.value, 7);
+});
+
+test("#2029 graph_add_node arms control_after_generate after the node is on the graph", () => {
+  const panel = readFileSync(PANEL_JS, "utf8");
+  const addAt = panel.indexOf("async graph_add_node(");
+  const removeAt = panel.indexOf("graph_remove_node(", addAt);
+  assert.ok(addAt > 0 && removeAt > addAt, "graph_add_node must exist");
+  const body = panel.slice(addAt, removeAt);
+  const graphAddAt = body.indexOf("graph.add(node)");
+  const ensureAt = body.indexOf("ensureControlAfterGenerateQueueHooks(node");
+  assert.ok(graphAddAt > 0, "the node must be added to the graph");
+  assert.ok(ensureAt > graphAddAt, "queue-hook repair must run AFTER graph.add(node)");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -588,6 +588,7 @@ import {
 import {
   controlAfterGenerateModes,
   controlAfterGenerateEntries,
+  ensureControlAfterGenerateQueueHooks,
 } from "./lib/control-after-generate.js";
 import { autoMatchSlots, slotDiagnostic, loopbackRefusalReason } from "./lib/connect-match.js";
 import {
@@ -16262,6 +16263,18 @@ const GRAPH_TOOL_EXECUTORS = {
     } finally {
       graph.afterChange();
     }
+    // #2029 — LG.createNode can leave a control_after_generate combo showing
+    // "randomize" without afterQueued/linkedWidgets, so the ordinary Queue button
+    // never rolls the seed until a tab reload rebuilds the node.
+    ensureControlAfterGenerateQueueHooks(node, {
+      getControlMode: () => {
+        try {
+          return comfyApp?.ui?.settings?.getSettingValue?.("Comfy.WidgetControlMode");
+        } catch {
+          return undefined;
+        }
+      },
+    });
     // #1709 — only a node that reached the live graph earns reuse. The definition is already
     // detached by snapshotBackendDef, and the epoch/context fence prevents it crossing a
     // reconnect or workflow/graph switch.

--- a/web/js/lib/control-after-generate.js
+++ b/web/js/lib/control-after-generate.js
@@ -199,3 +199,115 @@ export function controlAfterGenerateWarning(node, widgetName, scope = {}) {
     `${controlAfterGenerateRemedy(entry, node, scope)}`
   );
 }
+
+// #2029 — panel_add_node can leave the control combo visible (mode "randomize")
+// without the queue hooks app.queuePrompt actually fires. ComfyUI_frontend
+// widgets.ts hangs beforeQueued/afterQueued on the combo and points the value
+// widget's linkedWidgets at it; without that, ordinary Queue-button runs cache-hit
+// on seed 0 until a tab reload rebuilds the node through the frontend pipeline.
+const ADVANCING_CONTROL_MODES = new Set(["randomize", "increment", "decrement", "increment-wrap"]);
+const SAFE_INTEGER_MAX = 1125899906842624;
+const SAFE_INTEGER_MIN = -1125899906842624;
+const controlHasQueued = new WeakSet();
+
+function targetInputIsConnected(node, target) {
+  const name = target?.name;
+  if (typeof name !== "string") return false;
+  const inputs = Array.isArray(node?.inputs) ? node.inputs : [];
+  for (const input of inputs) {
+    if (!input || input.link == null) continue;
+    if (input.widget?.name === name || input.name === name) return true;
+  }
+  return false;
+}
+
+function nextControlledValue(target, mode) {
+  if (!ADVANCING_CONTROL_MODES.has(mode)) return undefined;
+  const values = target?.options?.values;
+  if (Array.isArray(values) && values.length) {
+    const asString = values.map((v) => String(v));
+    let index = asString.indexOf(String(target.value));
+    const length = values.length;
+    if (mode === "randomize") index = Math.floor(Math.random() * length);
+    else if (mode === "decrement") index -= 1;
+    else index += 1;
+    if (mode === "increment-wrap" && index >= length) index = 0;
+    index = Math.max(0, Math.min(length - 1, index));
+    return values[index];
+  }
+  if (typeof target?.value !== "number" || !Number.isFinite(target.value)) return undefined;
+  const opts = target.options && typeof target.options === "object" ? target.options : {};
+  const step2 = Number(opts.step2) || (Number(opts.step) > 0 ? Number(opts.step) / 10 : 1) || 1;
+  const rawMin = Number(opts.min);
+  const rawMax = Number(opts.max);
+  const min = Number.isFinite(rawMin) ? Math.max(SAFE_INTEGER_MIN, rawMin) : 0;
+  const max = Number.isFinite(rawMax) ? Math.min(SAFE_INTEGER_MAX, rawMax) : min;
+  let next = target.value;
+  if (mode === "decrement") next -= step2;
+  else if (mode === "increment" || mode === "increment-wrap") next += step2;
+  else {
+    const range = (max - min) / step2;
+    next = Math.floor(Math.random() * range) * step2 + min;
+  }
+  return Math.min(Math.max(next, min), max);
+}
+
+function linkControlToTarget(target, control) {
+  if (!target || target === control) return;
+  if (!Array.isArray(target.linkedWidgets)) target.linkedWidgets = [];
+  if (!target.linkedWidgets.includes(control)) target.linkedWidgets.push(control);
+}
+
+function applyControlToTarget(node, target, control) {
+  if (targetInputIsConnected(node, target)) return;
+  const mode = typeof control?.value === "string" ? control.value : String(control?.value ?? "");
+  const next = nextControlledValue(target, mode);
+  if (next === undefined) return;
+  target.value = next;
+  if (typeof target.callback === "function") target.callback(next);
+}
+
+/**
+ * Make an already-materialized control_after_generate combo actually roll its
+ * governed widget on app.queuePrompt, matching the frontend seed-widget pipeline.
+ *
+ * No-op when the combo already carries beforeQueued/afterQueued (a UI-created or
+ * reload-rebuilt node). Never invents a control widget that is not already there.
+ * Returns how many inert combos were armed.
+ */
+export function ensureControlAfterGenerateQueueHooks(node, { getControlMode } = {}) {
+  const entries = controlAfterGenerateEntries(node);
+  if (!entries.length) return 0;
+  const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+  let armed = 0;
+  const runsBefore = () => {
+    try {
+      return getControlMode?.() === "before";
+    } catch {
+      return false;
+    }
+  };
+  for (const entry of entries) {
+    if (!entry || entry.widget === entry.control) continue;
+    const control = widgets.find((w) => w && w.name === entry.control);
+    const target = widgets.find((w) => w && w.name === entry.widget);
+    if (!control || !target || control === target) continue;
+    try {
+      linkControlToTarget(target, control);
+    } catch {
+      /* a non-writable linkedWidgets still gets the queue hooks below */
+    }
+    if (typeof control.beforeQueued === "function" || typeof control.afterQueued === "function") {
+      continue;
+    }
+    control.beforeQueued = () => {
+      if (runsBefore() && controlHasQueued.has(control)) applyControlToTarget(node, target, control);
+      controlHasQueued.add(control);
+    };
+    control.afterQueued = () => {
+      if (!runsBefore()) applyControlToTarget(node, target, control);
+    };
+    armed += 1;
+  }
+  return armed;
+}


### PR DESCRIPTION
KSampler nodes created with panel_add_node showed control_after_generate='randomize' but the ordinary Queue button never rolled the seed (consecutive runs cache-hit on seed 0) until a tab reload rebuilt the node.

graph_add_node now arms inert control combos with the frontend afterQueued/linkedWidgets pipeline so randomize/increment/decrement actually fire.

Fixes #2029