### PR TITLE
fix(2035): make dynamic widget timeout outcome explicit

### DIFF
--- a/browser_tests/unit/set-widget-2035-dynamic-ack.test.mjs
+++ b/browser_tests/unit/set-widget-2035-dynamic-ack.test.mjs
@@ -1,0 +1,164 @@
+/**
+ * #2035 — a dynamic/custom widget write can outlive the panel acknowledgement wait.
+ *
+ * These drive runSetWidget(), the same production body used by graph_set_widget. The
+ * fixture follows ComfyUI's COMFY_DYNAMICCOMBO_V3 shape: assigning the root combo updates
+ * the live value synchronously and rebuilds its dotted child widgets synchronously.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+
+const NODE_TYPE = "TextGenerate";
+const FRESH = { [NODE_TYPE]: {} };
+const REGISTRY = { [NODE_TYPE]: {} };
+
+function fireableTimers() {
+  const timers = [];
+  return {
+    setTimer: (fn) => {
+      timers.push(fn);
+      return timers.length;
+    },
+    clearTimer: () => {},
+    fire: () => {
+      assert.equal(timers.length, 1, "the runSetWidget acknowledgement wait must arm one timeout");
+      timers[0]();
+    },
+  };
+}
+
+function makeDynamicTextGenerate(initial = "on") {
+  let current = initial;
+  let setterCalls = 0;
+  const root = {
+    name: "sampling_mode",
+    type: "combo",
+    options: { values: ["on", "off"] },
+  };
+  const node = {
+    id: 2035,
+    type: NODE_TYPE,
+    widgets: [root],
+  };
+
+  const rebuild = () => {
+    node.widgets = [root, { name: `sampling_mode.${current}`, type: "text", value: "" }];
+  };
+  Object.defineProperty(root, "value", {
+    configurable: true,
+    get: () => current,
+    set: (next) => {
+      setterCalls += 1;
+      current = next;
+      rebuild();
+    },
+  });
+  rebuild();
+
+  return {
+    node,
+    root,
+    forceValue(next) {
+      current = next;
+      rebuild();
+    },
+    get setterCalls() {
+      return setterCalls;
+    },
+  };
+}
+
+function widgetOpts(extra = {}) {
+  return {
+    registry: REGISTRY,
+    getFreshObjectInfo: async () => FRESH,
+    ...extra,
+  };
+}
+
+test("#2035 current behavior: a dynamic V3 root write lands and rebuilds its children", async () => {
+  const dynamic = makeDynamicTextGenerate();
+  const result = await runSetWidget(dynamic.node, "sampling_mode", "off", widgetOpts());
+
+  assert.equal(result.applied, true);
+  assert.equal(result.set.value, "off");
+  assert.equal(dynamic.root.value, "off");
+  assert.equal(dynamic.setterCalls, 1);
+  assert.deepEqual(
+    dynamic.node.widgets.map((widget) => widget.name),
+    ["sampling_mode", "sampling_mode.off"],
+  );
+});
+
+test("#2035 timeout: unknown is returned promptly and a late dynamic body cannot mutate or retry", async () => {
+  const dynamic = makeDynamicTextGenerate();
+  const clock = fireableTimers();
+  let releaseFresh;
+  const freshPending = new Promise((resolve) => {
+    releaseFresh = () => resolve(FRESH);
+  });
+  const pending = runSetWidget(
+    dynamic.node,
+    "sampling_mode",
+    "off",
+    widgetOpts({
+      getFreshObjectInfo: () => freshPending,
+      timeoutMs: 80,
+      ackTimers: { setTimer: clock.setTimer, clearTimer: clock.clearTimer },
+    }),
+  );
+
+  clock.fire();
+  await assert.rejects(pending, /outcome is UNKNOWN.*NOT retried.*panel_query_graph/i);
+  assert.equal(dynamic.root.value, "on", "the delayed body must not have written before preflight completed");
+  assert.equal(dynamic.setterCalls, 0);
+
+  // The transport wait is over, but the original object-info operation is not cancellable.
+  // Releasing it exercises the late continuation and proves the cooperative write fence
+  // prevents the mutation that would otherwise be reported after the unknown reply.
+  releaseFresh();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(dynamic.root.value, "on");
+  assert.equal(dynamic.setterCalls, 0, "an unknown timeout must not trigger a late write or duplicate retry");
+  assert.deepEqual(dynamic.node.widgets.map((widget) => widget.name), ["sampling_mode", "sampling_mode.on"]);
+});
+
+test("#2035 timeout after a transient dynamic write does not invoke the post-flush rewrite", async () => {
+  const dynamic = makeDynamicTextGenerate();
+  const clock = fireableTimers();
+  let releaseFlush;
+  let flushStarted;
+  const flushReady = new Promise((resolve) => {
+    flushStarted = resolve;
+  });
+  const flushPending = new Promise((resolve) => {
+    releaseFlush = resolve;
+  });
+  const pending = runSetWidget(
+    dynamic.node,
+    "sampling_mode",
+    "off",
+    widgetOpts({
+      timeoutMs: 80,
+      ackTimers: { setTimer: clock.setTimer, clearTimer: clock.clearTimer },
+      awaitFrontendWidgetFlush: () => {
+        flushStarted();
+        return flushPending;
+      },
+    }),
+  );
+
+  await flushReady;
+  assert.equal(dynamic.root.value, "off");
+  assert.equal(dynamic.setterCalls, 1, "the first synchronous dynamic write must have landed");
+  dynamic.forceValue("on");
+
+  clock.fire();
+  await assert.rejects(pending, /outcome is UNKNOWN.*NOT retried/i);
+  releaseFlush();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(dynamic.root.value, "on");
+  assert.equal(dynamic.setterCalls, 1, "the timeout must suppress the existing post-flush rewrite");
+});

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -140,6 +140,42 @@ export function awaitFrontendWidgetFlush(timers) {
 
 const SET_WIDGET_ACK_TIMEOUT = Symbol("set-widget-ack-timeout");
 
+function widgetWriteOutcomeUnknownError() {
+  return new Error(
+    `panel_set_widget outcome is UNKNOWN after delivery: the requested widget value was ` +
+      `not observed in a live readback before the acknowledgement wait ended. The original ` +
+      `write was NOT retried. Call panel_query_graph to check the current value before ` +
+      `issuing this mutation again (#2035).`,
+  );
+}
+
+// #2035 — native dynamic-combo roots and custom widgets expose their live mutation through
+// a value setter, while an ordinary LiteGraph widget owns a plain data property. This is a
+// structural capability check, not a node-name allowlist: only a widget whose setter can
+// rebuild/customize the live canvas gets the early-unknown contract below.
+function hasValueSetter(widget) {
+  try {
+    let proto = widget;
+    while (proto && proto !== Object.prototype) {
+      const descriptor = Object.getOwnPropertyDescriptor(proto, "value");
+      if (descriptor) return typeof descriptor.set === "function";
+      proto = Object.getPrototypeOf(proto);
+    }
+  } catch {
+    /* an unreadable widget stays on the existing receipt/refusal path */
+  }
+  return false;
+}
+
+function shouldAbandonSetWidgetOnTimeout(node, widgetName) {
+  try {
+    const widget = node?.widgets?.find((candidate) => candidate?.name === widgetName);
+    return widget?.type === "custom" || hasValueSetter(widget);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * #2025 — never-throwing live read of one named widget. Used by the timeout
  * readback so a missing node or a hostile getter cannot replace the ack.
@@ -177,6 +213,8 @@ export function readLiveWidgetValue(node, widgetName) {
  *   timeoutMs?: number,
  *   timers?: { setTimer?: Function, clearTimer?: Function },
  *   delivered?: boolean,
+ *   abandonOnTimeout?: boolean,
+ *   onTimeout?: () => void,
  * }} [opts]
  */
 export async function awaitSetWidgetAck(writePromise, {
@@ -186,6 +224,8 @@ export async function awaitSetWidgetAck(writePromise, {
   timeoutMs,
   timers,
   delivered = true,
+  abandonOnTimeout = false,
+  onTimeout,
 } = {}) {
   const tracked = Promise.resolve(writePromise);
   tracked.then(() => {}, () => {});
@@ -211,6 +251,19 @@ export async function awaitSetWidgetAck(writePromise, {
   // timeout before the write must still surface the inner worded refusal
   // (stale combo, hung /view probe) rather than inventing outcome-unknown.
   if (verified.applied && verified.verified) return verified;
+  // #2035 — the production wrapper can safely stop waiting here only if the original
+  // body also has a cooperative write fence. Without that fence, returning an unknown
+  // reply would let the still-running body reach applyWidgetWrite later and a caller's
+  // state read/retry could race a delayed mutation. The direct helper keeps its older
+  // refusal-preserving default for callers that do not provide that fence.
+  if (abandonOnTimeout && delivered) {
+    try {
+      onTimeout?.();
+    } catch {
+      /* abandonment is a safety latch; a diagnostic hook must not reopen the wait */
+    }
+    throw widgetWriteOutcomeUnknownError();
+  }
   const settled = await captured;
   if (settled?.ok) return honestWidgetAck(settled.result);
   throw settled.error;
@@ -316,11 +369,18 @@ export function scopedAuthorizationTypes(node, promotedResolution, isResolvedPro
 }
 
 const ACK_WRAPPED = Symbol("set-widget-ack-wrapped");
+const ACK_STATE = Symbol("set-widget-ack-state");
 
 export async function runSetWidget(node, widgetName, value, opts = {}) {
   if (!opts[ACK_WRAPPED]) {
+    const ackState = { abandoned: false };
+    const abandonOnTimeout = shouldAbandonSetWidgetOnTimeout(node, widgetName);
     return awaitSetWidgetAck(
-      runSetWidgetBody(node, widgetName, value, { ...opts, [ACK_WRAPPED]: true }),
+      runSetWidgetBody(node, widgetName, value, {
+        ...opts,
+        [ACK_WRAPPED]: true,
+        [ACK_STATE]: ackState,
+      }),
       {
         node,
         widget: widgetName,
@@ -328,6 +388,14 @@ export async function runSetWidget(node, widgetName, value, opts = {}) {
         timeoutMs: opts.timeoutMs,
         timers: opts.ackTimers,
         delivered: opts.delivered !== false,
+        abandonOnTimeout,
+        ...(abandonOnTimeout
+          ? {
+              onTimeout: () => {
+                ackState.abandoned = true;
+              },
+            }
+          : {}),
       },
     );
   }
@@ -441,8 +509,13 @@ async function runSetWidgetBody(
     // treating a verified write as retained. Production uses awaitFrontendWidgetFlush;
     // unit tests inject a flush that reproduces the later empty overwrite.
     awaitFrontendWidgetFlush: awaitFrontendWidgetFlushInjected,
+    [ACK_STATE]: ackState,
   } = {},
 ) {
+  const assertNotAbandoned = () => {
+    if (ackState?.abandoned) throw widgetWriteOutcomeUnknownError();
+  };
+
   // Never re-derived, and never cached: the oracle may not have run yet when this closure is
   // built, and a caller that answers differently per call is answering about a different
   // fetch. A non-function is the unwired default ("live", see above); a THROWING one, or one
@@ -872,6 +945,7 @@ async function runSetWidgetBody(
   // (2) Repair positional UNKNOWN/UNKNOWN_n widget names against the live def so
   //     the caller's real widget name resolves (#199) — resolved direct node only.
   if (reconcile) {
+    assertNotAbandoned();
     assertTargetStillCurrentNow();
     reconcileUnknownWidgetNames(node);
   }
@@ -910,6 +984,7 @@ async function runSetWidgetBody(
     // synchronous. A workflow switch while the fresh-object-info fetch was in
     // flight therefore refuses before touching either canvas; retry and upload
     // recovery use this same boundary too.
+    assertNotAbandoned();
     assertTargetStillCurrentNow();
     // #757 — CREATE A MISSING TARGET HERE, INSIDE THE SAME SYNCHRONOUS STRETCH.
     //
@@ -1125,10 +1200,13 @@ async function runSetWidgetBody(
    */
   async function retainVerifiedWrite(set, rewrite) {
     await flushFrontendWidgets();
+    assertNotAbandoned();
     assertTargetStillCurrentNow();
     if (widgetStillHolds(set)) return set;
+    assertNotAbandoned();
     const retried = rewrite();
     await flushFrontendWidgets();
+    assertNotAbandoned();
     assertTargetStillCurrentNow();
     if (widgetStillHolds(retried)) return retried;
     const live = readLiveWritten(retried);


### PR DESCRIPTION
## Summary

Fixes #2035 for the production dynamic/custom `panel_set_widget` path.

- Detects native dynamic/custom widget behavior structurally through the live value setter.
- When the delivered command times out without a matching readback, returns explicit outcome-unknown and latches the still-running body before reconciliation, writing, or the existing post-flush rewrite.
- Preserves verified readback success and existing ordinary-widget/stale-combo refusal behavior; no mutation is retried.

## Verification

- Focused: 19 passed (`set-widget-2035-dynamic-ack`, `set-widget-timeout-ack`, `primitive-widget-retain`).
- Full unit: 7,594 tests, 7,593 passed, 0 failed, 1 existing todo.
- `npm.cmd run typecheck` passed.
- `npm.cmd run check:scope` passed.
- `npm.cmd run check:changelog` passed; no changelog/version change required.

Base: `main` at `545284afc494eacc2258c4de77bd7b52b4f9d354`
Head: `fix/2035-widget-ack` at `03a86c1e8646aeff785567839b3d368374dad5bd`