### PR TITLE
fix: redact combo option values from refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- omit private combo option values from panel_set_widget refusal diagnostics while preserving the invalid-value verdict and option count (#2547)
+
 ## [0.15.136] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -672,6 +672,36 @@ test("combo: an invalid value is REJECTED, not coerced to another enum", () => {
   assert.equal(node.widgets[0].value, "pose-1.safetensors", "must not have mutated on reject");
 });
 
+test("#2547: an invalid combo refusal keeps the verdict/count but never discloses option values", () => {
+  const privateOptions = [
+    "private-project/input/portrait-01.png",
+    "private-project/input/portrait-02.png",
+    "private-project/input/client-reference.png",
+  ];
+  const node = {
+    id: 278,
+    type: "LoadImage",
+    widgets: [{ name: "image", options: { values: privateOptions }, value: privateOptions[0] }],
+  };
+
+  let refusal;
+  try {
+    applyWidgetWrite(node, "image", "", HOOKS);
+  } catch (err) {
+    refusal = err;
+  }
+
+  assert.ok(refusal instanceof WidgetWriteError);
+  assert.match(refusal.message, /not a valid option for combo widget "image"/);
+  assert.match(refusal.message, /holds 3 options/);
+  assert.match(refusal.message, /rejected VALUE, not an unreadable list/);
+  assert.match(refusal.message, /intentionally omitted/);
+  for (const privateValue of privateOptions) {
+    assert.equal(refusal.message.includes(privateValue), false, `must not disclose ${privateValue}`);
+  }
+  assert.equal(node.widgets[0].value, privateOptions[0], "must not mutate on reject");
+});
+
 test("combo: a numeric index is NOT reinterpreted as a dropdown position", () => {
   const node = { id: 1, type: "N", widgets: [{ name: "c", options: { values: ["alpha", "beta", "gamma"] }, value: "alpha" }] };
   assert.throws(() => applyWidgetWrite(node, "c", 1, HOOKS), WidgetWriteError);

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1146,13 +1146,14 @@ export function coerceWidgetValue(
     // installed is caught here instead of failing 40 seconds into a run. The message says
     // which of the two happened, so an agent can tell "your value is wrong" apart from
     // "the panel could not look" and stop treating them as the same failure.
-    const preview = options.slice(0, 40).map((o) => JSON.stringify(o)).join(", ");
     throw new WidgetWriteError(
       `Value ${JSON.stringify(value)} is not a valid option for combo widget ` +
         `"${name}". Its option list WAS read successfully and holds ${options.length} ` +
         `option${options.length === 1 ? "" : "s"}, none of them this value — so this is a ` +
-        `rejected VALUE, not an unreadable list. Valid options (${options.length}): ${preview}` +
-        (options.length > 40 ? ", …" : ""),
+        `rejected VALUE, not an unreadable list. The valid option values are intentionally ` +
+        `omitted from this diagnostic because combo values may contain private filenames ` +
+        `or paths. Choose a value from the widget's current dropdown (refreshing its ` +
+        `options first if needed) and retry.`,
       { combo: true },
     );
   }


### PR DESCRIPTION
## Summary
- keep invalid-combo refusals actionable by preserving the verdict, option count, and refresh/retry guidance
- omit all combo option values from diagnostics because file-backed lists can contain private filenames and paths
- add a production-path widget-write regression for the LoadImage-style failure in #2547

## Validation
- npm.cmd run test:unit (7609 passed, 1 todo)
- npm.cmd run check:scope
- npm.cmd run typecheck
- npm.cmd run i18n:check
- git diff --check

Closes paired report artokun/comfyui-mcp#2547