### PR TITLE
fix(2030): re-register workflow tab command channel after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- after ComfyUI restart, re-hello the existing workflow tab without reloading unsaved in-memory edits, and panel_set_workflow_target({mode:"current"}) forces that re-register when the server is ready but the tab command channel is stale (#2030)
+
+
 ## [0.15.138] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -46,6 +46,11 @@ import {
   graphMutationReconnectGate,
 } from "../../web/js/lib/reconnect-recovery.js";
 import {
+  shouldReregisterWorkflowTabChannel,
+  watchReconnectTabChannel,
+  ensureWorkflowTabChannel,
+} from "../../web/js/lib/reconnect-tab-channel.js";
+import {
   snapshotGraphState,
   describeInputLink,
   verifyDisconnect,
@@ -107,6 +112,12 @@ test("panel ↔ node-def-refresh.js / canvas-navigation.js / reconnect-recovery.
   assert.equal(typeof workflowOpenReadinessRefusalError, "function");
   assert.equal(typeof readWorkflowOpenReadinessRefusal, "function");
   assert.equal(typeof graphMutationReconnectGate, "function");
+});
+
+test("panel ↔ reconnect-tab-channel.js module edge links (#2030)", () => {
+  assert.equal(typeof shouldReregisterWorkflowTabChannel, "function");
+  assert.equal(typeof watchReconnectTabChannel, "function");
+  assert.equal(typeof ensureWorkflowTabChannel, "function");
 });
 
 test("panel ↔ disconnect-verify.js module edge links (#668)", () => {

--- a/browser_tests/unit/reconnect-tab-channel.test.mjs
+++ b/browser_tests/unit/reconnect-tab-channel.test.mjs
@@ -1,6 +1,6 @@
 // #2030 — after panel_restart_comfyui the backend can be healthy
 // (`server_ready:true`) while this tab's workflow command channel is still the
-// pre-restart mapping (`panel_tab_reconnected:false`). `workflow_list` then
+// pre-restart mapping (`tab_reconnected:false`). `workflow_list` then
 // times out (6000 ms), `panel_set_workflow_target({mode:"current"})` cannot
 // read canvas identity, and mutations stay fenced. Unsaved in-memory edits
 // exist, so the repair must re-register THIS tab — never reload or reopen.

--- a/browser_tests/unit/reconnect-tab-channel.test.mjs
+++ b/browser_tests/unit/reconnect-tab-channel.test.mjs
@@ -1,0 +1,461 @@
+// #2030 — after panel_restart_comfyui the backend can be healthy
+// (`server_ready:true`) while this tab's workflow command channel is still the
+// pre-restart mapping (`panel_tab_reconnected:false`). `workflow_list` then
+// times out (6000 ms), `panel_set_workflow_target({mode:"current"})` cannot
+// read canvas identity, and mutations stay fenced. Unsaved in-memory edits
+// exist, so the repair must re-register THIS tab — never reload or reopen.
+//
+// Distinct from #1999: that restores a Desktop process. This restores the
+// tab command channel of a tab that stayed loaded.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  TAB_CHANNEL_REREGISTER_STEPS_MS,
+  TAB_CHANNEL_WATCH_MAX_ATTEMPTS,
+  shouldReregisterWorkflowTabChannel,
+  watchReconnectTabChannel,
+  ensureWorkflowTabChannel,
+} from "../../web/js/lib/reconnect-tab-channel.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const instantSleep = () => Promise.resolve();
+
+function recordSleep() {
+  const slept = [];
+  return {
+    slept,
+    sleep: async (ms) => {
+      slept.push(ms);
+    },
+  };
+}
+
+function handlerBody(src, sig) {
+  const start = src.indexOf(sig);
+  if (start === -1) return "";
+  const after = start + sig.length;
+  const m = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  return src.slice(start, m ? after + m.index : src.length);
+}
+
+// ---------------------------------------------------------------------------
+// shouldReregisterWorkflowTabChannel
+// ---------------------------------------------------------------------------
+
+test("#2030: server ready + bridge up + stale tab channel → re-register this tab", () => {
+  assert.equal(
+    shouldReregisterWorkflowTabChannel({
+      serverReady: true,
+      bridgeConnected: true,
+      channelReadyForEpoch: false,
+    }),
+    true,
+  );
+});
+
+test("#2030: a channel already ready for this epoch is not re-registered", () => {
+  assert.equal(
+    shouldReregisterWorkflowTabChannel({
+      serverReady: true,
+      bridgeConnected: true,
+      channelReadyForEpoch: true,
+    }),
+    false,
+  );
+});
+
+test("#2030: server not ready → never re-register (the backend cycle is still in flight)", () => {
+  assert.equal(
+    shouldReregisterWorkflowTabChannel({
+      serverReady: false,
+      bridgeConnected: true,
+      channelReadyForEpoch: false,
+    }),
+    false,
+  );
+});
+
+test("#2030: bridge down → never, the socket-open hello owns recovery", () => {
+  assert.equal(
+    shouldReregisterWorkflowTabChannel({
+      serverReady: true,
+      bridgeConnected: false,
+      channelReadyForEpoch: false,
+    }),
+    false,
+  );
+});
+
+test("#2030: an in-flight re-register is one-shot, not a hello storm", () => {
+  assert.equal(
+    shouldReregisterWorkflowTabChannel({
+      serverReady: true,
+      bridgeConnected: true,
+      channelReadyForEpoch: false,
+      alreadyInFlight: true,
+    }),
+    false,
+  );
+});
+
+test("#2030: unreadable inputs fail closed", () => {
+  for (const input of [
+    {},
+    { serverReady: true },
+    { serverReady: "true", bridgeConnected: true },
+    { serverReady: true, bridgeConnected: 1, channelReadyForEpoch: false },
+  ]) {
+    assert.equal(shouldReregisterWorkflowTabChannel(input), false);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// watchReconnectTabChannel — the reconnect watchdog
+// ---------------------------------------------------------------------------
+
+test("#2030 watchdog: a stale channel is re-registered and stops once ready", async () => {
+  let ready = false;
+  let graphLoads = 0;
+  let opens = 0;
+  const reregisters = [];
+  const outcome = await watchReconnectTabChannel({
+    isCurrent: () => true,
+    serverReady: () => true,
+    channelReady: () => ready,
+    reregister: async () => {
+      reregisters.push("hello");
+      ready = true;
+      return true;
+    },
+    loadWorkflow: () => {
+      graphLoads += 1;
+    },
+    openWorkflow: () => {
+      opens += 1;
+    },
+    sleep: instantSleep,
+    firstDelayMs: 0,
+    stepsMs: [0],
+  });
+  assert.equal(outcome, "ready");
+  assert.deepEqual(reregisters, ["hello"]);
+  assert.equal(graphLoads, 0, "unsaved in-memory graph must not be reloaded");
+  assert.equal(opens, 0, "re-register must not reopen the workflow from disk");
+});
+
+test("#2030 watchdog: retries until the hello lands, then stops", async () => {
+  let ready = false;
+  let hellos = 0;
+  const outcome = await watchReconnectTabChannel({
+    isCurrent: () => true,
+    serverReady: () => true,
+    channelReady: () => ready,
+    reregister: async () => {
+      hellos += 1;
+      if (hellos >= 2) ready = true;
+      return hellos >= 2;
+    },
+    sleep: instantSleep,
+    stepsMs: [0, 0, 0],
+  });
+  assert.equal(outcome, "ready");
+  assert.equal(hellos, 2);
+});
+
+test("#2030 watchdog: a throwing re-register is 'not yet', never a graph load", async () => {
+  let ready = false;
+  let hellos = 0;
+  const outcome = await watchReconnectTabChannel({
+    isCurrent: () => true,
+    serverReady: () => true,
+    channelReady: () => ready,
+    reregister: async () => {
+      hellos += 1;
+      if (hellos < 2) throw new Error("hello lease not ready");
+      ready = true;
+      return true;
+    },
+    sleep: instantSleep,
+    stepsMs: [0, 0],
+  });
+  assert.equal(outcome, "ready");
+  assert.equal(hellos, 2);
+});
+
+test("#2030 watchdog: a newer reconnect supersedes the older watch", async () => {
+  let current = true;
+  let hellos = 0;
+  const outcome = await watchReconnectTabChannel({
+    isCurrent: () => current,
+    serverReady: () => true,
+    channelReady: () => false,
+    reregister: async () => {
+      hellos += 1;
+      current = false;
+      return true;
+    },
+    sleep: instantSleep,
+    stepsMs: [0, 0],
+  });
+  assert.equal(outcome, "superseded");
+  assert.equal(hellos, 1, "a superseded watch must not keep greeting");
+});
+
+test("#2030 watchdog: a server that is not ready yet waits without re-registering", async () => {
+  let up = false;
+  let ready = false;
+  let hellos = 0;
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const slept = [];
+  const pending = watchReconnectTabChannel({
+    isCurrent: () => true,
+    serverReady: () => up,
+    channelReady: () => ready,
+    reregister: async () => {
+      hellos += 1;
+      ready = true;
+      return true;
+    },
+    sleep: async (ms) => {
+      slept.push(ms);
+      if (slept.length === 1) await gate;
+    },
+    stepsMs: [5, 7],
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(hellos, 0, "do not hello into a backend that is still down");
+  up = true;
+  release();
+  const outcome = await pending;
+  assert.equal(outcome, "ready");
+  assert.equal(hellos, 1);
+  assert.equal(slept[0], 5);
+});
+
+test("#2030 watchdog: the loop is bounded even if the channel never comes up", async () => {
+  let hellos = 0;
+  const outcome = await watchReconnectTabChannel({
+    isCurrent: () => true,
+    serverReady: () => true,
+    channelReady: () => false,
+    reregister: async () => {
+      hellos += 1;
+      return false;
+    },
+    sleep: instantSleep,
+    stepsMs: [0, 0, 0, 0],
+    maxAttempts: 3,
+  });
+  assert.equal(outcome, "exhausted");
+  assert.equal(hellos, TAB_CHANNEL_WATCH_MAX_ATTEMPTS);
+});
+
+test("#2030 watchdog: cadence matches the shipped reconnect handshake budget", () => {
+  assert.deepEqual([...TAB_CHANNEL_REREGISTER_STEPS_MS], [400, 900, 1600]);
+});
+
+// ---------------------------------------------------------------------------
+// ensureWorkflowTabChannel — panel_set_workflow_target({mode:"current"})
+// ---------------------------------------------------------------------------
+
+test("#2030 ensure: an already-ready channel is a no-op", async () => {
+  let hellos = 0;
+  const outcome = await ensureWorkflowTabChannel({
+    serverReady: true,
+    bridgeConnected: true,
+    channelReady: () => true,
+    reregister: async () => {
+      hellos += 1;
+      return true;
+    },
+  });
+  assert.equal(outcome, "ready");
+  assert.equal(hellos, 0);
+});
+
+test("#2030 ensure: server_ready + stale channel forces one safe re-register", async () => {
+  let ready = false;
+  let hellos = 0;
+  let loads = 0;
+  const outcome = await ensureWorkflowTabChannel({
+    serverReady: true,
+    bridgeConnected: true,
+    channelReady: () => ready,
+    reregister: async () => {
+      hellos += 1;
+      ready = true;
+      return true;
+    },
+    loadWorkflow: () => {
+      loads += 1;
+    },
+    sleep: instantSleep,
+    stepsMs: [0],
+  });
+  assert.equal(outcome, "ready");
+  assert.equal(hellos, 1);
+  assert.equal(loads, 0, "forcing current-target recovery must preserve the in-memory graph");
+});
+
+test("#2030 ensure: a stale channel that never comes up times out without loading disk", async () => {
+  let loads = 0;
+  const { slept, sleep } = recordSleep();
+  const outcome = await ensureWorkflowTabChannel({
+    serverReady: true,
+    bridgeConnected: true,
+    channelReady: () => false,
+    reregister: async () => true,
+    loadWorkflow: () => {
+      loads += 1;
+    },
+    sleep,
+  });
+  assert.equal(outcome, "timeout");
+  assert.deepEqual(slept, [...TAB_CHANNEL_REREGISTER_STEPS_MS]);
+  assert.equal(loads, 0);
+});
+
+test("#2030 ensure: server not ready does not force a hello", async () => {
+  let hellos = 0;
+  const outcome = await ensureWorkflowTabChannel({
+    serverReady: false,
+    bridgeConnected: true,
+    channelReady: () => false,
+    reregister: async () => {
+      hellos += 1;
+      return true;
+    },
+  });
+  assert.equal(outcome, "not-ready");
+  assert.equal(hellos, 0);
+});
+
+test("#2030 ensure: live functions are sampled, not frozen at entry", async () => {
+  let up = false;
+  let connected = false;
+  let ready = false;
+  let hellos = 0;
+  const pending = ensureWorkflowTabChannel({
+    serverReady: () => up,
+    bridgeConnected: () => connected,
+    channelReady: () => ready,
+    reregister: async () => {
+      hellos += 1;
+      ready = true;
+      return true;
+    },
+    sleep: instantSleep,
+    stepsMs: [0],
+  });
+  up = true;
+  connected = true;
+  const outcome = await pending;
+  assert.equal(outcome, "ready");
+  assert.equal(hellos, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Production wiring — the tests above pass against a helper the panel never
+// calls. These fail if the reconnect/re-register hook is deleted.
+// ---------------------------------------------------------------------------
+
+test("#2030 wiring: the panel imports and calls the shipped reconnect/re-register functions", () => {
+  assert.match(
+    SRC,
+    /shouldReregisterWorkflowTabChannel,\s*\n\s*watchReconnectTabChannel,\s*\n\s*ensureWorkflowTabChannel,/,
+    "the panel must import the shipped #2030 helpers by name",
+  );
+  assert.match(SRC, /from "\.\/lib\/reconnect-tab-channel\.js"/);
+  assert.match(SRC, /function kickReconnectTabChannelWatch\(/);
+  assert.match(SRC, /kickReconnectTabChannelWatch\(backendReconnectEpoch\)/);
+  assert.match(SRC, /await ensureWorkflowTabChannel\(\{/);
+});
+
+test("#2030 wiring: the watchdog is kicked from the backend reconnected listener, beside the settle watch", () => {
+  const start = SRC.indexOf('api.addEventListener("reconnected"');
+  assert.notEqual(start, -1);
+  const block = SRC.slice(start, SRC.indexOf("    });", start + 80) + 6);
+  assert.match(block, /kickPostReconnectSettleWatch\(backendReconnectEpoch\)/);
+  assert.match(
+    block,
+    /kickReconnectTabChannelWatch\(backendReconnectEpoch\)/,
+    "the tab-channel watchdog must run on the same reconnect that arms the settle watch",
+  );
+  assert.ok(
+    block.indexOf("kickPostReconnectSettleWatch") < block.indexOf("kickReconnectTabChannelWatch"),
+    "binding settle is independent; tab-channel re-register follows it",
+  );
+  assert.doesNotMatch(
+    block,
+    /openWorkflow\(|loadGraphData\(|workflow_open\(/,
+    "the reconnect listener must not reload the unsaved graph",
+  );
+});
+
+test("#2030 wiring: the watchdog re-registers with rehello, never a workflow load", () => {
+  const start = SRC.indexOf("function kickReconnectTabChannelWatch(");
+  assert.notEqual(start, -1);
+  const next = SRC.indexOf("\nfunction ", start + 1);
+  const body = SRC.slice(start, next > 0 ? next : start + 2500);
+  assert.match(body, /watchReconnectTabChannel\(\{/);
+  assert.match(
+    body,
+    /send: \(\) => liveBridgeClient\?\.rehello\?\.\(\)/,
+    "re-register must be THIS tab's current hello, the same identity sendHello already derives",
+  );
+  assert.doesNotMatch(body, /openWorkflow\(|loadGraphData\(|syncWorkflows\(/);
+  assert.match(
+    body,
+    /ssGet\(REBOOT_KEY\)/,
+    "an agent-triggered panel_restart_comfyui must still re-register when the outage clock missed",
+  );
+  assert.match(body, /shouldReadvertiseAfterComfyRestart\(\{/, "a measured restart-length outage still authorises the watch");
+  assert.match(
+    body,
+    /tabChannelReadyEpoch = epoch/,
+    "a benign blip must keep the existing command channel, not mint a second hello",
+  );
+});
+
+test("#2030 wiring: workflow_list (set_workflow_target current) forces a safe re-register when the channel is stale", () => {
+  const body = handlerBody(SRC, "async workflow_list()");
+  const ensureAt = body.indexOf("await ensureWorkflowTabChannel({");
+  const waitAt = body.indexOf("await waitForReconnectHandshakeBeforeOpen({");
+  const serviceAt = body.indexOf("const s = app?.extensionManager?.workflow;");
+  assert.notEqual(ensureAt, -1, "workflow_list must force tab-channel re-register");
+  assert.notEqual(waitAt, -1, "the #1785 handshake wait stays");
+  assert.notEqual(serviceAt, -1);
+  assert.ok(ensureAt < waitAt, "re-register the command channel before waiting on canvas identity");
+  assert.ok(ensureAt < serviceAt, "do not publish a list before the channel has been asked to re-register");
+  assert.match(
+    body,
+    /send: \(\) => liveBridgeClient\?\.rehello\?\.\(\)/,
+    "current-target recovery must re-hello THIS tab, not open another workflow",
+  );
+  assert.doesNotMatch(body.slice(0, waitAt), /openWorkflow\(|loadGraphData\(/);
+});
+
+test("#2030 wiring: a landed hello stamps this reconnect epoch so the watchdog stops", () => {
+  assert.match(SRC, /tabChannelReadyEpoch = backendReconnectEpoch/);
+  assert.match(
+    SRC,
+    /onHelloLanded:\s*\(ctx\)\s*=>\s*\{[\s\S]*?tabChannelReadyEpoch = backendReconnectEpoch;[\s\S]*?noteDedicatedWorkflowHello\(ctx\)/,
+    "hello-landed must mark the command channel ready for this epoch without dropping the dedicated-workflow ack",
+  );
+});
+
+test("#2030 wiring: #1999 Desktop restore is not this path", () => {
+  const start = SRC.indexOf("function kickReconnectTabChannelWatch(");
+  const next = SRC.indexOf("\nfunction ", start + 1);
+  const body = SRC.slice(start, next > 0 ? next : start + 2500);
+  assert.doesNotMatch(body, /restartCore|restartApp|relaunchApp|Desktop/);
+});

--- a/browser_tests/unit/workflow-list-unsaved-identity.test.mjs
+++ b/browser_tests/unit/workflow-list-unsaved-identity.test.mjs
@@ -114,6 +114,7 @@ function buildWorkflowList({ activeWorkflow, openWorkflows, workflowUuids }) {
     "lateWorkflowSaveReceipts",
     "backendSocketReplyFields",
     "getWorkflowTitle",
+    "ensureWorkflowTabChannel",
     bundle,
   )(
     { extensionManager: { workflow: { openWorkflows } } },
@@ -139,6 +140,7 @@ function buildWorkflowList({ activeWorkflow, openWorkflows, workflowUuids }) {
     () => [],
     () => ({}),
     () => "Unsaved Workflow",
+    async () => {},
   );
 }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -393,6 +393,11 @@ import {
   classifyBackendStatusEvent,
   describeGraphMutationReadiness,
 } from "./lib/reconnect-recovery.js";
+import {
+  shouldReregisterWorkflowTabChannel,
+  watchReconnectTabChannel,
+  ensureWorkflowTabChannel,
+} from "./lib/reconnect-tab-channel.js";
 import { describeHttpFailure } from "./lib/http-failure.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
 import { todoItemGlyph } from "./lib/plan-glyph.js";
@@ -1129,6 +1134,12 @@ let activeWorkflowResyncEpoch = 0;
 let postReconnectBindingProofEpoch = 0;
 // Supersede token for the settle watch — a newer reconnect retires the older watch.
 let postReconnectWatchToken = 0;
+// #2030 — last reconnect epoch whose workflow command channel has a landed hello.
+// Stale while this is behind backendReconnectEpoch: the orchestrator still waits
+// for a newer generation (`panel_tab_reconnected:false`) even though the backend
+// is up. The watchdog re-hellos THIS tab; it never reloads the in-memory graph.
+let tabChannelReadyEpoch = 0;
+let tabChannelWatchToken = 0;
 // #646: ComfyUI's own backend socket is DOWN between its "reconnecting" and
 // "reconnected" events (a null "status" payload is the same lost-connection
 // signal). A graph mutation dispatched in that gap can be applied and then wiped
@@ -2919,6 +2930,11 @@ function setupListeners() {
       // The watch runs only the same safe heals a graph command runs lazily;
       // it never repaints the canvas from serialized state (#604).
       kickPostReconnectSettleWatch(backendReconnectEpoch);
+      // #2030: re-register THIS tab's workflow command channel after the backend
+      // cycle. Distinct from the settle watch: that re-proves canvas binding; this
+      // re-hellos the existing tab so workflow_list answers instead of timing out.
+      // Does not open or load the workflow — unsaved in-memory edits stay.
+      kickReconnectTabChannelWatch(backendReconnectEpoch);
       // #1636: drop the remembered subgraph owner and re-pin viewing/mutation scope.
       clearAutoLayoutScope();
       noteReconnectScopeFence();
@@ -9528,6 +9544,51 @@ function postReconnectBindingSettleWindow() {
 // been observed to pass — never a weaker proxy. The watch performs no canvas
 // repaint and no workflow mutation; when the restore never settles it simply
 // stops, and the binding refusals keep their existing remedies.
+function kickReconnectTabChannelWatch(epoch) {
+  const token = ++tabChannelWatchToken;
+  const restartLength = shouldReadvertiseAfterComfyRestart({
+    bridgeConnected: liveBridgeClient?.isConnected?.() === true,
+    outageMs: comfyBackendOutage.outageMs(),
+    helloLandedSinceOutage: landedHelloCount > comfyBackendOutage.helloBaseline(),
+    alreadyReadvertised: false,
+  });
+  const rebootPending = !!ssGet(REBOOT_KEY);
+  if (!restartLength && !rebootPending) {
+    // Benign WS blip: the existing hello still names this tab. Do not mint a
+    // second one — that is the #1138 false-nudge harm.
+    tabChannelReadyEpoch = epoch;
+    return;
+  }
+  if (
+    !shouldReregisterWorkflowTabChannel({
+      serverReady: !comfyBackendIsDown(),
+      bridgeConnected: liveBridgeClient?.isConnected?.() === true,
+      channelReadyForEpoch: tabChannelReadyEpoch === epoch,
+    })
+  ) {
+    // No live socket: the socket-open hello owns recovery.
+    return;
+  }
+  const outageSeq = comfyBackendOutage.seq();
+  void watchReconnectTabChannel({
+    isCurrent: () => token === tabChannelWatchToken && epoch === backendReconnectEpoch,
+    serverReady: () => !comfyBackendIsDown(),
+    channelReady: () => tabChannelReadyEpoch === epoch,
+    reregister: () =>
+      comfyRestartReadvertise.attempt({
+        outageSeq: outageSeq > 0 ? outageSeq : epoch,
+        reconnectEpoch: epoch,
+        isCurrent: () =>
+          epoch === backendReconnectEpoch &&
+          (outageSeq === 0 || outageSeq === comfyBackendOutage.seq()),
+        send: () => liveBridgeClient?.rehello?.(),
+      }),
+  }).catch(() => {
+    // Best-effort: a failed watch leaves the pre-#2030 behavior (channel stays
+    // stale until a manual refresh).
+  });
+}
+
 function kickPostReconnectSettleWatch(epoch) {
   const token = ++postReconnectWatchToken;
   void watchPostReconnectSettle({
@@ -21095,6 +21156,23 @@ const GRAPH_TOOL_EXECUTORS = {
   // Uses ComfyUI's workflow service. "New workflow" opens a NEW TAB and never
   // touches the current graph (graph_clear is ONLY for clearing the open one).
   async workflow_list() {
+    // #2030 — panel_set_workflow_target({mode:"current"}) uses this read to
+    // recover canvas identity after a ComfyUI restart. If the backend is up but
+    // this tab's command channel is still the pre-restart mapping, force a safe
+    // re-hello of THIS tab first. That does not reload or reopen the workflow,
+    // so unsaved in-memory edits stay on the canvas.
+    await ensureWorkflowTabChannel({
+      serverReady: () => !comfyBackendIsDown(),
+      bridgeConnected: () => liveBridgeClient?.isConnected?.() === true,
+      channelReady: () => tabChannelReadyEpoch === backendReconnectEpoch,
+      reregister: () =>
+        comfyRestartReadvertise.attempt({
+          outageSeq: comfyBackendOutage.seq() || backendReconnectEpoch,
+          reconnectEpoch: backendReconnectEpoch,
+          isCurrent: () => true,
+          send: () => liveBridgeClient?.rehello?.(),
+        }),
+    });
     // #1785 — panel_set_workflow_target({mode:"current"}) uses this read to
     // recover the live tab after a ComfyUI restart. A command can reach the
     // panel before the backend reconnect, node-definition refresh, and restored
@@ -40110,7 +40188,10 @@ function buildPanel() {
       // open credentials card to re-poll oauth_status (see cmcpOpenCredentialsFrame).
       cmcpOauthOnBackendsPush?.();
     },
-    onHelloLanded: noteDedicatedWorkflowHello,
+    onHelloLanded: (ctx) => {
+      tabChannelReadyEpoch = backendReconnectEpoch;
+      noteDedicatedWorkflowHello(ctx);
+    },
     onAck(ack) {
       // In-panel OAuth acks (oauth_begin/oauth_status/oauth_signout) are routed
       // to whichever credentials card is currently open — see

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1136,7 +1136,7 @@ let postReconnectBindingProofEpoch = 0;
 let postReconnectWatchToken = 0;
 // #2030 — last reconnect epoch whose workflow command channel has a landed hello.
 // Stale while this is behind backendReconnectEpoch: the orchestrator still waits
-// for a newer generation (`panel_tab_reconnected:false`) even though the backend
+// for a newer generation (`tab_reconnected:false`) even though the backend
 // is up. The watchdog re-hellos THIS tab; it never reloads the in-memory graph.
 let tabChannelReadyEpoch = 0;
 let tabChannelWatchToken = 0;

--- a/web/js/lib/reconnect-tab-channel.js
+++ b/web/js/lib/reconnect-tab-channel.js
@@ -1,7 +1,7 @@
 // #2030 — after a ComfyUI backend restart the tab can sit on a live bridge
 // socket whose workflow command channel is still the pre-restart mapping.
 // `panel_restart_comfyui` then reports `server_ready:true` /
-// `panel_tab_reconnected:false`, `workflow_list` times out (6000 ms), and
+// `tab_reconnected:false`, `workflow_list` times out (6000 ms), and
 // `panel_set_workflow_target({mode:"current"})` cannot read canvas identity.
 // Mutations stay fenced. Unsaved in-memory edits exist, so the repair is a
 // reconnect watchdog that re-registers THIS tab's current identity — the same
@@ -39,7 +39,7 @@ function readFlag(value) {
  *
  * True only when the backend is up, the bridge socket is live, and this
  * reconnect epoch has not yet landed a hello. That is
- * `server_ready:true` / `panel_tab_reconnected:false`: ComfyUI is healthy, but
+ * `server_ready:true` / `tab_reconnected:false`: ComfyUI is healthy, but
  * this tab's command channel is still the pre-restart mapping.
  *
  * Re-registering means re-hello of THIS tab's current identity. It must not

--- a/web/js/lib/reconnect-tab-channel.js
+++ b/web/js/lib/reconnect-tab-channel.js
@@ -1,0 +1,196 @@
+// #2030 — after a ComfyUI backend restart the tab can sit on a live bridge
+// socket whose workflow command channel is still the pre-restart mapping.
+// `panel_restart_comfyui` then reports `server_ready:true` /
+// `panel_tab_reconnected:false`, `workflow_list` times out (6000 ms), and
+// `panel_set_workflow_target({mode:"current"})` cannot read canvas identity.
+// Mutations stay fenced. Unsaved in-memory edits exist, so the repair is a
+// reconnect watchdog that re-registers THIS tab's current identity — the same
+// hello the panel already sends on a workflow switch — without reloading or
+// reopening the workflow.
+//
+// Distinct from #1999: that restores a Desktop process. This restores the tab
+// command channel of a tab that stayed loaded.
+//
+// Pure + injected I/O so the loop is unit-testable with fakes; the panel wires
+// `client.rehello()` and the live reconnect epoch.
+
+/** Cadence matches the orchestrator's post-open handshake so a caller that
+ *  already waited there is not paying a second, longer budget. */
+export const TAB_CHANNEL_REREGISTER_STEPS_MS = Object.freeze([400, 900, 1600]);
+
+/** Hard bound on watchdog hellos for one reconnect epoch. A wedge must never
+ *  become a hello storm. */
+export const TAB_CHANNEL_WATCH_MAX_ATTEMPTS = 3;
+
+function isTrue(value) {
+  return value === true;
+}
+
+function readFlag(value) {
+  try {
+    return typeof value === "function" ? value() === true : value === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * #2030 — may we re-register THIS tab's existing workflow command channel?
+ *
+ * True only when the backend is up, the bridge socket is live, and this
+ * reconnect epoch has not yet landed a hello. That is
+ * `server_ready:true` / `panel_tab_reconnected:false`: ComfyUI is healthy, but
+ * this tab's command channel is still the pre-restart mapping.
+ *
+ * Re-registering means re-hello of THIS tab's current identity. It must not
+ * reload, reopen, or replace the in-memory graph (unsaved edits).
+ */
+export function shouldReregisterWorkflowTabChannel({
+  serverReady = false,
+  bridgeConnected = false,
+  channelReadyForEpoch = false,
+  alreadyInFlight = false,
+} = {}) {
+  if (!isTrue(serverReady)) return false;
+  if (!isTrue(bridgeConnected)) return false;
+  if (isTrue(channelReadyForEpoch)) return false;
+  if (isTrue(alreadyInFlight)) return false;
+  return true;
+}
+
+/**
+ * After a backend cycle, retry re-registering the existing tab until the
+ * command channel is ready for this epoch, a newer reconnect supersedes the
+ * watch, or the budget is spent.
+ *
+ * `reregister` MUST be a hello of the current identity. Extra `loadWorkflow` /
+ * `openWorkflow` hooks are accepted so tests can prove they are never called;
+ * this function never invokes them.
+ *
+ * @returns {Promise<"ready"|"superseded"|"exhausted">}
+ */
+export async function watchReconnectTabChannel({
+  isCurrent,
+  serverReady,
+  channelReady,
+  reregister,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  firstDelayMs = 0,
+  stepsMs = TAB_CHANNEL_REREGISTER_STEPS_MS,
+  maxAttempts = TAB_CHANNEL_WATCH_MAX_ATTEMPTS,
+} = {}) {
+  const current = () => {
+    try {
+      return typeof isCurrent !== "function" || isCurrent() === true;
+    } catch {
+      return false;
+    }
+  };
+  const ready = () => readFlag(channelReady);
+  const up = () => {
+    try {
+      return typeof serverReady !== "function" || serverReady() === true;
+    } catch {
+      return false;
+    }
+  };
+
+  const steps = Array.isArray(stepsMs) && stepsMs.length ? stepsMs : TAB_CHANNEL_REREGISTER_STEPS_MS;
+  const limit = Number.isFinite(maxAttempts) && maxAttempts > 0 ? maxAttempts : TAB_CHANNEL_WATCH_MAX_ATTEMPTS;
+  let attempts = 0;
+
+  const tick = async () => {
+    if (!current()) return "superseded";
+    if (ready()) return "ready";
+    if (
+      up() &&
+      attempts < limit &&
+      shouldReregisterWorkflowTabChannel({
+        serverReady: true,
+        bridgeConnected: true,
+        channelReadyForEpoch: false,
+        alreadyInFlight: false,
+      })
+    ) {
+      attempts += 1;
+      try {
+        await Promise.resolve(typeof reregister === "function" ? reregister() : false);
+      } catch {
+        // A throwing hello is "not yet", never a reason to load the graph.
+      }
+      if (!current()) return "superseded";
+      if (ready()) return "ready";
+    }
+    return null;
+  };
+
+  const initialDelay = Number(firstDelayMs);
+  if (Number.isFinite(initialDelay) && initialDelay > 0) await sleep(initialDelay);
+  else await Promise.resolve();
+
+  let outcome = await tick();
+  if (outcome) return outcome;
+
+  for (const waitMs of steps) {
+    const ms = Number(waitMs);
+    if (Number.isFinite(ms) && ms > 0) await sleep(ms);
+    else await Promise.resolve();
+    outcome = await tick();
+    if (outcome) return outcome;
+  }
+  if (!current()) return "superseded";
+  return ready() ? "ready" : "exhausted";
+}
+
+/**
+ * `panel_set_workflow_target({mode:"current"})` / `workflow_list` recovery:
+ * if the server is up but this epoch's command channel is stale, force one
+ * safe re-register of the existing tab, then wait until it is ready or the
+ * bounded steps elapse.
+ *
+ * A timeout here is not a graph mutation: nothing was opened, reloaded, or
+ * rebound. Callers decide whether to proceed with the local in-memory list.
+ *
+ * @returns {Promise<"ready"|"timeout"|"not-ready">}
+ */
+export async function ensureWorkflowTabChannel({
+  serverReady,
+  bridgeConnected,
+  channelReady,
+  reregister,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  stepsMs = TAB_CHANNEL_REREGISTER_STEPS_MS,
+} = {}) {
+  // Yield so a caller that arms serverReady/bridgeConnected immediately after
+  // invoking still has those flags sampled live, not frozen at call time.
+  await Promise.resolve();
+
+  const ready = () => readFlag(channelReady);
+  if (ready()) return "ready";
+
+  if (
+    !shouldReregisterWorkflowTabChannel({
+      serverReady: readFlag(serverReady),
+      bridgeConnected: readFlag(bridgeConnected),
+      channelReadyForEpoch: ready(),
+    })
+  ) {
+    return ready() ? "ready" : "not-ready";
+  }
+
+  try {
+    await Promise.resolve(typeof reregister === "function" ? reregister() : false);
+  } catch {
+    // A failed hello is not a reason to skip the wait — the channel may still come up.
+  }
+  if (ready()) return "ready";
+
+  const steps = Array.isArray(stepsMs) && stepsMs.length ? stepsMs : TAB_CHANNEL_REREGISTER_STEPS_MS;
+  for (const waitMs of steps) {
+    const ms = Number(waitMs);
+    if (Number.isFinite(ms) && ms > 0) await sleep(ms);
+    else await Promise.resolve();
+    if (ready()) return "ready";
+  }
+  return ready() ? "ready" : "timeout";
+}


### PR DESCRIPTION
## Problem

After `panel_restart_comfyui` the backend can come back healthy (`server_ready:true`) while this tab's workflow command channel is still the pre-restart mapping (`panel_tab_reconnected:false`). `workflow_list` then times out at 6000 ms, so `panel_set_workflow_target({mode:"current"})` cannot read canvas identity and mutations stay fenced. Unsaved in-memory edits exist, so a reload or `panel_open_workflow` is not a safe recovery.

This is not #1999 (Desktop process restore). The tab stayed loaded; only its command channel is stale.

## Fix

A reconnect watchdog re-registers **this** tab after the backend cycle by re-helloing the current identity — the same hello the panel already sends on a workflow switch. It does not open or load the workflow, so unsaved graph edits stay on the canvas.

`panel_set_workflow_target({mode:"current"})` / `workflow_list` forces that same safe re-register when the server is ready but this reconnect epoch has not yet landed a hello. Benign WS blips keep the existing channel.

## Tests

`browser_tests/unit/reconnect-tab-channel.test.mjs` drives the shipped `shouldReregisterWorkflowTabChannel` / `watchReconnectTabChannel` / `ensureWorkflowTabChannel` functions (24 pass).

Fixes #2030
