### PR TITLE
fix(366): write the parent promoted CLIPTextEncode rail, not the inner clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget on a subgraph host's promoted CLIPTextEncode.text writes the parent rail, not only the inner converted-to-input widget, so queue serialization uses the new value (#366)
+
 ## [0.15.139] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -650,6 +650,69 @@ test("#366 recurrence: stale inner _widget is rematerialized into the host-keyed
   assert.equal(set.promoted_from.value_scope, "instance");
 });
 
+test("#366 recurrence: promoted CLIPTextEncode.text writes the host rail, not the inner converted-to-input clone", async () => {
+  const reg = loadedRegistry();
+  const innerWidget = { name: "text", type: "STRING", value: "old instructional prompt" };
+  const inner = {
+    id: 11,
+    type: "CLIPTextEncode",
+    widgets: [innerWidget],
+    inputs: [{ name: "text", widget: { name: "text" }, type: "STRING", link: 1 }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const subgraph = {
+    _nodes: [inner],
+    inputs: [{ name: "text", linkIds: [1] }],
+    inputNode: { id: -10 },
+    links: { 1: { id: 1, origin_id: -10, origin_slot: 0, target_id: 11, target_slot: 0 } },
+    getNodeById: (id) => (String(id) === "11" ? inner : null),
+  };
+  const innerClone = { name: "text", type: "STRING", value: "old instructional prompt" };
+  const store = { value: "old instructional prompt" };
+  const hostInput = {
+    name: "text",
+    widgetId: "root:22:text",
+    widget: { name: "text" },
+    _widget: innerClone,
+    _subgraphSlot: { name: "text" },
+  };
+  const parent = {
+    id: 22,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [hostInput],
+    get widgets() {
+      if (!hostInput._widget && hostInput.widgetId) {
+        const rail = {
+          name: "text",
+          widgetId: hostInput.widgetId,
+          type: "STRING",
+          get value() {
+            return store.value;
+          },
+          set value(next) {
+            store.value = next;
+          },
+        };
+        hostInput._widget = rail;
+      }
+      return hostInput._widget ? [hostInput._widget] : [];
+    },
+  };
+  const resolveSource = (_node, input) =>
+    input?.name === "text" ? { sourceNodeId: "11", sourceWidgetName: "text" } : null;
+
+  const { set } = await setViaHandler(reg, parent, "text", "new vertical prompt", resolveSource);
+
+  assert.equal(store.value, "new vertical prompt", "the host-keyed rail store must receive the write");
+  assert.notEqual(hostInput._widget, innerClone);
+  assert.equal(innerWidget.value, "old instructional prompt");
+  assert.equal(innerClone.value, "old instructional prompt");
+  assert.equal(set.node_id, 22);
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+  assert.equal(set.promoted_from.value_scope, "instance");
+});
+
 test("set_widget e2e: unreachable ⇒ REFUSE even for a would-be-core type, no mutation", async () => {
   const reg = unreachableRegistry();
   const node = { id: 1, type: "CheckpointLoaderSimple", widgets: [{ name: "ckpt_name", type: "text", value: "" }] };

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2069,6 +2069,93 @@ test("#366: a promoted COMBO lora_name rail is synced when _widget still points 
   assert.equal(set.promoted_from.parent_widget_synced, true);
 });
 
+/**
+ * #366 CLIPTextEncode recurrence (frontend 1.48.7): promoting `text` converts the
+ * inner widget to an input fed from rail -10. Unlike Primitive, host `_widget` is
+ * a CLONE of that inner widget (different object), so the MiniMax `=== innerWidget`
+ * rematerialize never ran. SubgraphNode.widgets still returns the clone first and
+ * never builds the host-keyed store projection queue compilation reads.
+ */
+function makeConvertedClipTextEncodeFixture({
+  innerId = 11,
+  parentId = 22,
+  oldValue = "old instructional prompt",
+} = {}) {
+  const innerWidget = { name: "text", type: "STRING", value: oldValue };
+  const inner = {
+    id: innerId,
+    type: "CLIPTextEncode",
+    widgets: [innerWidget],
+    inputs: [{ name: "text", widget: { name: "text" }, type: "STRING", link: 1 }],
+  };
+  const links = {
+    1: { id: 1, origin_id: -10, origin_slot: 0, target_id: innerId, target_slot: 0 },
+  };
+  const subgraph = {
+    _nodes: [inner],
+    inputs: [{ name: "text", linkIds: [1] }],
+    inputNode: { id: -10 },
+    links,
+    getNodeById: (id) => (String(id) === String(innerId) ? inner : null),
+    getLink: (id) => links[id] ?? null,
+  };
+  const innerClone = { name: "text", type: "STRING", value: oldValue };
+  const store = { value: oldValue };
+  const hostInput = {
+    name: "text",
+    widgetId: `root:${parentId}:text`,
+    widget: { name: "text" },
+    _widget: innerClone,
+    _subgraphSlot: { name: "text" },
+  };
+  const parent = {
+    id: parentId,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [hostInput],
+    get widgets() {
+      if (!hostInput._widget && hostInput.widgetId) {
+        const rail = {
+          name: "text",
+          widgetId: hostInput.widgetId,
+          type: "STRING",
+          get value() {
+            return store.value;
+          },
+          set value(next) {
+            store.value = next;
+          },
+        };
+        hostInput._widget = rail;
+      }
+      return hostInput._widget ? [hostInput._widget] : [];
+    },
+  };
+  const resolveSource = (_node, subgraphInput) =>
+    subgraphInput?.name === "text" ? { sourceNodeId: String(innerId), sourceWidgetName: "text" } : null;
+  return { parent, inner, innerWidget, innerClone, hostInput, store, resolveSource };
+}
+
+test("#366: a promoted CLIPTextEncode.text write syncs the host-keyed rail, not the inner converted-to-input clone", () => {
+  const { parent, innerWidget, innerClone, hostInput, store, resolveSource } =
+    makeConvertedClipTextEncodeFixture();
+
+  const set = applyWidgetWrite(parent, "text", "new vertical prompt", { resolveSource });
+
+  assert.equal(store.value, "new vertical prompt", "the serializing parent rail store must receive the write");
+  assert.notEqual(hostInput._widget, innerClone, "the converted-to-input clone must not remain the rail handle");
+  assert.notEqual(hostInput._widget, innerWidget);
+  assert.equal(innerWidget.value, "old instructional prompt", "the shared inner CLIPTextEncode is not the serializing rail");
+  assert.equal(innerClone.value, "old instructional prompt", "writing the clone would not update the store");
+  assert.equal(set.value, "new vertical prompt");
+  assert.equal(set.node_id, 22);
+  assert.equal(set.widget, "text");
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+  assert.equal(set.promoted_from.value_scope, "instance");
+  assert.equal(set.promoted_from.subgraph_node_id, 22);
+  assert.equal(set.promoted_from.inner_node_id, 11);
+});
+
 test("#366: options.setValue on the parent rail is driven so the serializing store updates", () => {
   const store = { value: 5 };
   const inner = { id: 136, type: "PrimitiveFloat", widgets: [{ name: "value", type: "number", value: 5 }] };

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1309,32 +1309,15 @@ export function resolveHostPromotedWidgets(subgraphNode, hostInput) {
   // binding. A stale `_widget` can still be a live member of node.widgets while
   // belonging to the link-driven inner projection, so object identity alone is
   // insufficient to decide which identity-linked member is the parent rail.
-  let hostWidgetId = null;
-  try {
-    const id = hostInput.widgetId;
-    if (typeof id === "string" && id.length > 0) hostWidgetId = id;
-  } catch {
-    // Keep the legacy identity path below; an unreadable optional key is not a
-    // reason to replace a directly linked, otherwise valid projection.
-  }
+  const hostWidgetId = readHostWidgetId(hostInput);
   if (!hostWidgetId) return out;
 
-  const readWidgetId = (widget) => {
-    let id = null;
-    try {
-      const candidateId = widget.widgetId;
-      if (typeof candidateId === "string" && candidateId.length > 0) id = candidateId;
-    } catch {
-      // Treat a projection with an unreadable optional key as legacy-unkeyed.
-    }
-    return id;
-  };
-  const described = out.map((widget) => ({ widget, id: readWidgetId(widget) }));
+  const described = out.map((widget) => ({ widget, id: readProjectionWidgetId(widget) }));
   // The projection list can be rebuilt independently of the host input object.
   // Include a newly materialized member by its exact host-owned key so a stale
   // `_widget` cannot win just because it is still one of the input's references.
   const keyedLive = inWidgets
-    .map((widget) => ({ widget, id: readWidgetId(widget) }))
+    .map((widget) => ({ widget, id: readProjectionWidgetId(widget) }))
     .filter((entry) => entry.id === hostWidgetId);
   const keyed = keyedLive;
   if (keyed.length > 1) return [];
@@ -1368,16 +1351,31 @@ function readHostWidgetId(hostInput) {
   }
 }
 
+function readProjectionWidgetId(widget) {
+  try {
+    const id = widget?.widgetId;
+    return typeof id === "string" && id.length > 0 ? id : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * ComfyUI's SubgraphNode.widgets getter returns `_widget` first and never builds
- * the host-keyed store projection while that handle still points at the INNER
- * Primitive widget. Dropping that stale handle and re-reading widgets lets the
- * getter materialize the rail queue compilation actually reads (#366).
+ * the host-keyed store projection while that handle still points at an INNER
+ * converted-to-input widget. That handle is the Primitive object itself, or a
+ * CLIPTextEncode.text clone that is a different object with the same name/value.
+ * Dropping the stale handle and re-reading widgets lets the getter materialize
+ * the rail queue compilation actually reads (#366).
  */
 function rematerializeHostPromotedWidgets(subgraphNode, hostInput, innerWidget) {
   if (!subgraphNode || !hostInput || !innerWidget) return [];
-  if (hostInput._widget !== innerWidget) return [];
-  if (!readHostWidgetId(hostInput)) return [];
+  const hostId = readHostWidgetId(hostInput);
+  if (!hostId) return [];
+  const current = hostInput._widget;
+  if (!current) return [];
+  // Already the host-keyed rail — do not drop a live serializing projection.
+  if (current !== innerWidget && readProjectionWidgetId(current) === hostId) return [];
   const saved = hostInput._widget;
   try {
     hostInput._widget = undefined;
@@ -1398,10 +1396,23 @@ function liveHostPromotedWidgets(subgraphNode, hostInput, innerWidget) {
   const current = resolveHostPromotedWidgets(subgraphNode, hostInput).filter(
     (widget) => widget && widget !== innerWidget,
   );
-  if (current.length) return current;
+  const hostId = readHostWidgetId(hostInput);
+  const keyed = hostId ? current.filter((widget) => readProjectionWidgetId(widget) === hostId) : [];
+  if (keyed.length) {
+    const displays = current.filter(
+      (widget) => widget !== keyed[0] && readProjectionWidgetId(widget) == null,
+    );
+    return [keyed[0], ...displays];
+  }
+  // No host key: unkeyed identity-linked projections are the rail. A host key
+  // with only an unkeyed clone must rematerialize first — returning the clone
+  // here is the CLIPTextEncode.text recurrence (inner written, parent store stale).
+  if (!hostId && current.length) return current;
   const rematerialized = rematerializeHostPromotedWidgets(subgraphNode, hostInput, innerWidget);
   if (rematerialized.length) return rematerialized;
-  return recoverHostPromotedWidgetsAfterLoad(subgraphNode, hostInput, innerWidget);
+  const recovered = recoverHostPromotedWidgetsAfterLoad(subgraphNode, hostInput, innerWidget);
+  if (recovered.length) return recovered;
+  return current;
 }
 
 /**


### PR DESCRIPTION
Fixes #366.

Exact recurrence after the v0.15.126 MiniMax Primitive rematerialize: `panel_set_widget` on a subgraph host's promoted `CLIPTextEncode.text` writes/verifies the inner converted-to-input widget (or a clone of it) while the parent rail store stays stale. Queue compilation reads `store.get(input.widgetId)`, so the render uses the old value.

The previous rematerialize only dropped `_widget` when it was the inner Primitive object itself (`=== innerWidget`). CLIPTextEncode promotions leave a **different** object with the same name/value; `SubgraphNode.widgets` still returns that clone first and never builds the host-keyed store projection.

This change:
- Treats any non-host-keyed `_widget` as stale (inner Primitive **or** converted-to-input clone)
- Drops it and rematerializes the host-keyed rail before writing
- Leaves unkeyed identity rails without a host `widgetId` on the legacy path

Tests drive shipped `applyWidgetWrite` / `runSetWidget`:
- `browser_tests/unit/widget-write.test.mjs` — CLIPTextEncode.text clone vs host-keyed store
- `browser_tests/unit/node-resolve.test.mjs` — same shape through production `runSetWidget`

PANEL_VERSION remains 0.15.139. Do not merge from this PR.
