### PR TITLE
fix(2099): fall back to installed nodes when Manager search times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_search_nodes answers from installed /object_info when Manager search times out, and a timeout miss is a retryable named reason instead of an empty 15s hang (#2099)
 - panel_set_widget on a subgraph host's promoted CLIPTextEncode.text writes the parent rail, not only the inner converted-to-input widget, so queue serialization uses the new value (#366)
 
 ## [0.15.139] - 2026-08-30

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -32,6 +32,8 @@ const {
   parseObjectInfoSearch,
   objectInfoSearchFallback,
   SEARCH_LIMIT_CAP,
+  MANAGER_SEARCH_TIMEOUT,
+  MANAGER_SEARCH_UNREACHABLE,
 } = ManagerInstall;
 
 test("looksLikeGitUrl recognizes every git protocol, plus author/repo shorthand (#301)", () => {
@@ -1670,9 +1672,9 @@ test("#1908 the production nodes_search handler answers a stalled Manager inside
     budgetMs: 25,
     managerGet,
     managerCall,
-    fetchObjectInfo: async () => {
-      throw new Error("object_info fallback must not run after the search budget aborts");
-    },
+    // #2099 — a Manager budget abort still tries /object_info. An empty map is
+    // a miss, so the result stays the retryable timeout rather than hanging.
+    fetchObjectInfo: async () => ({}),
   });
 
   const started = Date.now();
@@ -1680,10 +1682,12 @@ test("#1908 the production nodes_search handler answers a stalled Manager inside
   const elapsed = Date.now() - started;
 
   assert.ok(elapsed < 1000, `stalled search must settle promptly, took ${elapsed} ms`);
-  assert.equal(managerCallUsed, false, "an exhausted search budget must not start another route");
+  assert.equal(managerCallUsed, false, "an exhausted search budget must not start another Manager route");
   assert.equal(result.supported, false);
   assert.equal(result.managerReachable, false);
   assert.equal(result.query, "MiniMaxH3UnifiedToVideo");
+  assert.equal(result.retryable, true);
+  assert.equal(result.reason_code, MANAGER_SEARCH_TIMEOUT);
   assert.match(result.reason, /timed out/i);
   assert.match(result.message, /No canvas workflow was changed/i);
   assert.match(result.message, /Retry/i);
@@ -1894,6 +1898,8 @@ test("managerUnavailableResult is a safe, actionable structured payload", () => 
   assert.equal(r.supported, false);
   assert.equal(r.query, "");
   assert.equal(r.reason, UNREACHABLE.message);
+  assert.equal(r.retryable, true);
+  assert.equal(r.reason_code, MANAGER_SEARCH_UNREACHABLE);
 });
 
 // ---- #426: /object_info installed-node fallback when Manager is unreachable ---

--- a/browser_tests/unit/nodes-search-timeout-fallback.test.mjs
+++ b/browser_tests/unit/nodes-search-timeout-fallback.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * #2099 — panel_search_nodes query "DaSiWa" waited out the 15s Manager budget
+ * and returned supported:false / managerReachable:false / count:0, even when
+ * DaSiWa_SeedControl was already loaded in /object_info.
+ *
+ * The shipped behaviour:
+ *   1. A Manager command-budget abort still searches installed nodes via the
+ *      injected /object_info map, with a signal that is NOT the aborted budget.
+ *   2. A local hit is returned as installed-only (source: object_info). It is
+ *      never dressed as a Manager catalogue row.
+ *   3. A timeout miss is a retryable named reason, not an empty hang.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  searchNodesVia,
+  parseObjectInfoSearch,
+  MANAGER_SEARCH_TIMEOUT,
+  OBJECT_INFO_SEARCH_FALLBACK_MS,
+} from "../../web/js/lib/manager-install.js";
+
+const PANEL = readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
+
+const UNREACHABLE = new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+
+/** The reporter's missing class, plus a neighbour from the same pack. */
+const DASIVA_OBJECT_INFO = {
+  DaSiWa_SeedControl: {
+    display_name: "DaSiWa Seed Control",
+    category: "DaSiWa",
+    description: "Seed control from ComfyUI-DaSiWa-Nodes",
+    python_module: "custom_nodes.ComfyUI-DaSiWa-Nodes",
+  },
+  DaSiWa_NodeStatusSwitch: {
+    display_name: "DaSiWa Node Status Switch",
+    category: "DaSiWa",
+    description: "",
+    python_module: "custom_nodes.ComfyUI-DaSiWa-Nodes",
+  },
+  KSampler: { display_name: "KSampler", category: "sampling", description: "" },
+};
+
+function abortError(message = "Manager request aborted") {
+  return Object.assign(new Error(message), { name: "AbortError" });
+}
+
+function hangingManagerGet() {
+  return async (_route, { signal } = {}) =>
+    new Promise((_, reject) => {
+      let fallbackTimer;
+      const abort = () => {
+        clearTimeout(fallbackTimer);
+        reject(abortError());
+      };
+      if (signal?.aborted) return abort();
+      signal?.addEventListener("abort", abort, { once: true });
+      fallbackTimer = setTimeout(
+        () => reject(new Error("test fallback fired before the internal budget")),
+        250,
+      );
+    });
+}
+
+test("#2099 parseObjectInfoSearch locates DaSiWa_SeedControl for query DaSiWa", () => {
+  const r = parseObjectInfoSearch(DASIVA_OBJECT_INFO, "DaSiWa", 15);
+  assert.equal(r.count, 2);
+  assert.equal(
+    r.results.some((row) => row.id === "DaSiWa_SeedControl"),
+    true,
+  );
+  assert.equal(r.results.every((row) => row.installed === true), true);
+});
+
+test("#2099 a Manager timeout still returns the installed DaSiWa_SeedControl hit", async () => {
+  const budget = AbortSignal.timeout(25);
+  let objectInfoCalls = 0;
+  let objectInfoSignalAbortedAtCall = null;
+  const managerCall = async () => {
+    throw new Error("legacy fallback must not run after the search budget aborts");
+  };
+  const res = await searchNodesVia(hangingManagerGet(), managerCall, {
+    query: "DaSiWa",
+    objectInfoGet: async ({ signal } = {}) => {
+      objectInfoCalls += 1;
+      objectInfoSignalAbortedAtCall = signal?.aborted === true;
+      return DASIVA_OBJECT_INFO;
+    },
+    budgetSignal: budget,
+    timeoutMs: 25,
+  });
+
+  assert.equal(objectInfoCalls, 1, "timeout must still consult /object_info");
+  assert.equal(
+    objectInfoSignalAbortedAtCall,
+    false,
+    "the installed-node fallback must not inherit the aborted Manager budget",
+  );
+  assert.equal(res.supported, true);
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.source, "object_info");
+  assert.equal(res.installedOnly, true);
+  assert.equal(res.managerTimedOut, true);
+  assert.equal(res.catalogue_size, undefined, "must not invent a Manager catalogue");
+  assert.equal(res.requested_mode, undefined);
+  assert.ok(res.results.some((row) => row.id === "DaSiWa_SeedControl"));
+  assert.equal(
+    res.results.some((row) => row.id === "https://github.com/darksidewalker/ComfyUI-DaSiWa-Nodes"),
+    false,
+    "must not invent a Manager pack URL",
+  );
+  assert.match(res.message, /INSTALLED/i);
+  assert.match(res.message, /not a Manager/i);
+});
+
+test("#2099 a Manager timeout with no installed match is a retryable named reason", async () => {
+  const budget = AbortSignal.timeout(25);
+  const managerCall = async () => {
+    throw new Error("legacy fallback must not run after the search budget aborts");
+  };
+  const started = Date.now();
+  const res = await searchNodesVia(hangingManagerGet(), managerCall, {
+    query: "DaSiWa",
+    objectInfoGet: async () => ({ KSampler: { display_name: "KSampler" } }),
+    budgetSignal: budget,
+    timeoutMs: 25,
+  });
+  const elapsed = Date.now() - started;
+
+  assert.ok(elapsed < 1000, `timeout miss must settle promptly, took ${elapsed} ms`);
+  assert.equal(res.supported, false);
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.count, 0);
+  assert.deepEqual(res.results, []);
+  assert.equal(res.retryable, true);
+  assert.equal(res.reason_code, MANAGER_SEARCH_TIMEOUT);
+  assert.match(res.reason, /timed out after 25 ms/);
+  assert.match(res.message, /Retry/i);
+  assert.equal(res.source, undefined, "a miss must not claim an object_info hit");
+});
+
+test("#2099 an unreachable Manager still locates DaSiWa_SeedControl locally", async () => {
+  const boom = async () => {
+    throw UNREACHABLE;
+  };
+  const res = await searchNodesVia(boom, boom, {
+    query: "DaSiWa",
+    objectInfoGet: async () => DASIVA_OBJECT_INFO,
+  });
+  assert.equal(res.supported, true);
+  assert.equal(res.source, "object_info");
+  assert.equal(res.installedOnly, true);
+  assert.ok(res.results.some((row) => row.id === "DaSiWa_SeedControl"));
+  assert.equal(res.managerTimedOut, undefined);
+  assert.equal(res.catalogue_size, undefined);
+});
+
+test("#2099 OBJECT_INFO_SEARCH_FALLBACK_MS fits the remaining bridge slack", () => {
+  // 15s Manager budget + this window must stay under the 20s read reply.
+  assert.ok(OBJECT_INFO_SEARCH_FALLBACK_MS > 0);
+  assert.ok(OBJECT_INFO_SEARCH_FALLBACK_MS <= 5000);
+});
+
+test("#2099 WIRING: nodes_search still goes through searchNodesVia with fetchObjectInfo", () => {
+  const fnMatch = PANEL.match(/async nodes_search\(\{ query, limit \}\) \{[\s\S]*?\n  \},/);
+  assert.ok(fnMatch, "could not locate the production nodes_search handler");
+  assert.match(fnMatch[0], /return searchNodesVia\(managerGet, managerCall,/);
+  assert.match(fnMatch[0], /objectInfoGet: fetchObjectInfo/);
+  assert.match(fnMatch[0], /budgetSignal/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -26395,11 +26395,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // (no-/v2) legacy route on an unreachable/404 signal (a legacy-UI pip build
     // or real 3.x Manager can serve /customnode/getmappings while the /v2 route
     // 404s — or detectManagerDialect's /v2 probe fails). When BOTH are
-    // unreachable it falls back to an INSTALLED-node search over the connected
-    // ComfyUI's /object_info (#426) so a legacy/disabled Manager still returns
-    // usable, already-installed matches; on a miss it returns the structured
-    // {supported:false,…} capability result. A browser-origin transport wrap
-    // (#2024) is kept as the message so it is not a bare Failed to fetch.
+    // unreachable OR the command budget expires (#2099) it falls back to an
+    // INSTALLED-node search over the connected ComfyUI's /object_info (#426) so
+    // a stalled/legacy/disabled Manager still returns usable already-installed
+    // matches (DaSiWa_SeedControl); a timeout miss is a retryable named reason
+    // rather than an empty hang, and local hits are never dressed as Manager
+    // catalogue rows. A browser-origin transport wrap (#2024) is kept as the
+    // message so it is not a bare Failed to fetch.
     const budgetSignal = AbortSignal.timeout(NODES_SEARCH_COMMAND_BUDGET_MS);
     return searchNodesVia(managerGet, managerCall, {
       query,

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -704,6 +704,19 @@ export function matchesAllTerms(hay, terms) {
  */
 export const SEARCH_LIMIT_CAP = 40;
 
+/**
+ * #2099 — after the Manager command budget expires, /object_info still gets a
+ * short dedicated window so a stalled registry does not skip an installed-node
+ * hit (DaSiWa_SeedControl). Sized to fit inside the bridge's remaining slack
+ * after NODES_SEARCH_COMMAND_BUDGET_MS (15s of a 20s read window).
+ */
+export const OBJECT_INFO_SEARCH_FALLBACK_MS = 2500;
+
+/** Named reasons for a Manager-search miss that is safe to retry. */
+export const MANAGER_SEARCH_TIMEOUT = "manager_search_timeout";
+export const MANAGER_SEARCH_UNREACHABLE = "manager_unreachable";
+export const MANAGER_SEARCH_TRANSPORT = "manager_search_transport";
+
 /** Route tail `managerGet`/`managerCall` prefix; v2 adds `/v2/`, legacy adds `/`. */
 export const SEARCH_MAPPINGS_ROUTE = "customnode/getmappings?mode=cache";
 
@@ -821,12 +834,16 @@ export function parseObjectInfoSearch(objectInfo, query, limit) {
 }
 
 /**
- * #426 — when BOTH Manager registry routes are unreachable, try the installed-node
- * `/object_info` search before giving up. On a hit, return a supported result the
- * agent can act on (installed-only); otherwise fall through to the structured
- * "Manager unavailable" capability result. `objectInfoGet` is dependency-injected
- * (the panel wires the live /object_info fetch) so this stays unit-testable, and
- * NEVER throws — any /object_info failure degrades to managerUnavailableResult.
+ * #426/#2099 — when Manager registry search is unreachable OR times out, try the
+ * installed-node `/object_info` search before giving up. On a hit, return a
+ * supported result the agent can act on (installed-only, never a fabricated
+ * Manager catalogue row); otherwise fall through to the structured miss.
+ * `objectInfoGet` is dependency-injected so this stays unit-testable, and NEVER
+ * throws — any /object_info failure degrades to managerUnavailableResult.
+ *
+ * A Manager command-budget abort is NOT caller cancellation: /object_info is a
+ * local ComfyUI read and must not inherit that abort, or an installed class
+ * like DaSiWa_SeedControl is skipped after a 15s empty hang.
  */
 export async function objectInfoSearchFallback(
   objectInfoGet,
@@ -840,22 +857,32 @@ export async function objectInfoSearchFallback(
 ) {
   const effectiveCallerSignal = callerSignal ?? (budgetSignal ? undefined : requestSignal);
   throwIfManagerSearchCallerAborted(effectiveCallerSignal);
-  if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
-  if (isAbortLikeError(err)) throw err;
-  if (typeof objectInfoGet !== "function") return managerUnavailableResult(query, err);
+  const timedOut = budgetSignal?.aborted === true || err?.managerSearchTimedOut === true;
+  // #2099 — Manager timeout is the case we still want /object_info for. Caller
+  // abort remains an AbortError. A non-timeout AbortError from Manager itself
+  // (no budget tag) is still cancellation.
+  if (!timedOut && isAbortLikeError(err)) throw err;
+  if (typeof objectInfoGet !== "function") {
+    return timedOut ? managerSearchTimedOutResult(query, timeoutMs) : managerUnavailableResult(query, err);
+  }
+  const fallbackOptions = objectInfoFallbackRequestOptions(
+    effectiveCallerSignal,
+    timedOut,
+    requestSignal,
+  );
   let info;
   try {
-    info = await objectInfoGet(requestSignal ? { signal: requestSignal } : undefined);
+    info = await objectInfoGet(fallbackOptions);
   } catch (fallbackErr) {
     throwIfManagerSearchCallerAborted(effectiveCallerSignal);
-    if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
-    if (isAbortLikeError(fallbackErr)) throw fallbackErr;
-    return managerUnavailableResult(query, err);
+    if (!timedOut && isAbortLikeError(fallbackErr)) throw fallbackErr;
+    return timedOut ? managerSearchTimedOutResult(query, timeoutMs) : managerUnavailableResult(query, err);
   }
   throwIfManagerSearchCallerAborted(effectiveCallerSignal);
-  if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
   const parsed = parseObjectInfoSearch(info, query, limit);
-  if (!parsed.count) return managerUnavailableResult(query, err);
+  if (!parsed.count) {
+    return timedOut ? managerSearchTimedOutResult(query, timeoutMs) : managerUnavailableResult(query, err);
+  }
   const result = {
     supported: true,
     managerReachable: false,
@@ -864,16 +891,32 @@ export async function objectInfoSearchFallback(
     count: parsed.count,
     results: parsed.results,
     query: query == null ? "" : String(query),
-    message:
-      "ComfyUI-Manager's registry search is unavailable (the built-in Manager is " +
-      "disabled, or a legacy/partial build without the search endpoint), so these are " +
-      "INSTALLED nodes matching your query from the connected ComfyUI's /object_info — " +
-      "already available to use directly (add with panel_add_node). Searching/installing " +
-      "NEW packs from the registry needs the built-in Manager (v4+) enabled.",
+    message: timedOut
+      ? "ComfyUI-Manager's registry search timed out, so these are INSTALLED nodes " +
+        "matching your query from the connected ComfyUI's /object_info — already " +
+        "available to use directly (add with panel_add_node). This is not a Manager " +
+        "catalogue result. Retry the registry search if you need installable packs."
+      : "ComfyUI-Manager's registry search is unavailable (the built-in Manager is " +
+        "disabled, or a legacy/partial build without the search endpoint), so these are " +
+        "INSTALLED nodes matching your query from the connected ComfyUI's /object_info — " +
+        "already available to use directly (add with panel_add_node). Searching/installing " +
+        "NEW packs from the registry needs the built-in Manager (v4+) enabled.",
   };
+  if (timedOut) result.managerTimedOut = true;
   // #1287 — the clamp disclosure must survive the fallback re-wrap too.
   if (parsed.limit_cap) result.limit_cap = parsed.limit_cap;
   return result;
+}
+
+/** After a Manager budget abort, /object_info must not see that aborted signal. */
+function objectInfoFallbackRequestOptions(callerSignal, timedOut, requestSignal) {
+  if (!timedOut) return requestSignal ? { signal: requestSignal } : undefined;
+  const fallbackBudget =
+    typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+      ? AbortSignal.timeout(OBJECT_INFO_SEARCH_FALLBACK_MS)
+      : undefined;
+  const signal = managerSearchRequestSignal(callerSignal, fallbackBudget);
+  return signal ? { signal } : undefined;
 }
 
 /**
@@ -888,6 +931,11 @@ export function managerUnavailableResult(query, err) {
   const timedOut = err?.managerSearchTimedOut === true;
   const reason = String(err?.message ?? err ?? "ComfyUI-Manager not reachable");
   const transport = !timedOut && isManagerTransportWrap(err);
+  const reason_code = timedOut
+    ? MANAGER_SEARCH_TIMEOUT
+    : transport
+      ? MANAGER_SEARCH_TRANSPORT
+      : MANAGER_SEARCH_UNREACHABLE;
   const result = {
     supported: false,
     managerReachable: false,
@@ -895,6 +943,8 @@ export function managerUnavailableResult(query, err) {
     results: [],
     query: query == null ? "" : String(query),
     reason,
+    reason_code,
+    retryable: true,
     message: timedOut
       ? "Node-registry search timed out before ComfyUI-Manager replied. No canvas " +
         "workflow was changed. Retry the search; if the Manager remains slow or " +
@@ -938,12 +988,37 @@ function managerSearchTransportMessage(reason) {
  * budget is converted into a bounded, actionable result. Caller cancellation
  * remains an AbortError so callers can stop the operation without it looking like
  * a successful, structured Manager timeout. */
-function managerSearchTimedOutResult(query, timeoutMs) {
+function managerSearchTimeoutError(timeoutMs) {
   const err = new Error(
     `ComfyUI-Manager node search timed out after ${timeoutMs ?? 15000} ms; no reply arrived.`,
   );
   err.managerSearchTimedOut = true;
-  return managerUnavailableResult(query, err);
+  return err;
+}
+
+function managerSearchTimedOutResult(query, timeoutMs) {
+  return managerUnavailableResult(query, managerSearchTimeoutError(timeoutMs));
+}
+
+function managerSearchTimeoutFallback(
+  objectInfoGet,
+  query,
+  limit,
+  timeoutMs,
+  requestSignal,
+  budgetSignal,
+  callerSignal,
+) {
+  return objectInfoSearchFallback(
+    objectInfoGet,
+    query,
+    limit,
+    managerSearchTimeoutError(timeoutMs),
+    requestSignal,
+    timeoutMs,
+    budgetSignal,
+    callerSignal,
+  );
 }
 
 function isAbortLikeError(err) {
@@ -1105,10 +1180,12 @@ export function emptyCatalogueResult(query) {
  *   2. on an unreachable/404 signal, retry the ABSOLUTE legacy route (a legacy-
  *      UI pip build or real 3.x Manager can serve /customnode/getmappings while
  *      the /v2 route 404s, or detectManagerDialect's /v2 probe fails);
- *   3. if the absolute route is ALSO unreachable, try the installed-node
- *      /object_info search (#426) via the injected `objectInfoGet`; on a miss,
- *      return the structured {supported:false,…} capability result instead of
- *      throwing. A browser-origin transport wrap (#2024, "Failed to fetch" with
+ *   3. if the absolute route is ALSO unreachable, OR the command budget expires
+ *      before either route replies (#2099), try the installed-node /object_info
+ *      search (#426) via the injected `objectInfoGet`. A timeout miss is a
+ *      retryable named reason, not an empty hang; a local hit (DaSiWa_SeedControl)
+ *      is returned as installed-only and is never dressed as a Manager catalogue
+ *      row. A browser-origin transport wrap (#2024, "Failed to fetch" with
  *      no HTTP response) stays at the front of `message` so it is not a bare
  *      fetch failure and MCP host-HTTP fallback can still see it.
  * Any non-"unreachable" error still propagates.
@@ -1127,14 +1204,34 @@ export async function searchNodesVia(
     data = await managerGet(route, requestOptions);
   } catch (err) {
     throwIfManagerSearchCallerAborted(signal);
-    if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
+    if (budgetSignal?.aborted) {
+      return managerSearchTimeoutFallback(
+        objectInfoGet,
+        query,
+        limit,
+        timeoutMs,
+        requestSignal,
+        budgetSignal,
+        signal,
+      );
+    }
     if (isAbortLikeError(err)) throw err;
     if (!isManagerUnreachable(err)) throw err;
     try {
       data = await managerCall(route, requestOptions);
     } catch (err2) {
       throwIfManagerSearchCallerAborted(signal);
-      if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
+      if (budgetSignal?.aborted) {
+        return managerSearchTimeoutFallback(
+          objectInfoGet,
+          query,
+          limit,
+          timeoutMs,
+          requestSignal,
+          budgetSignal,
+          signal,
+        );
+      }
       if (isAbortLikeError(err2)) throw err2;
       if (isManagerUnreachable(err2))
         return objectInfoSearchFallback(
@@ -1151,7 +1248,6 @@ export async function searchNodesVia(
     }
   }
   throwIfManagerSearchCallerAborted(signal);
-  if (budgetSignal?.aborted) return managerSearchTimedOutResult(query, timeoutMs);
   const parsed = parseNodeMappings(data, query, limit);
   // #808 — an EMPTY catalogue is not a no-match, and only this branch can tell the
   // caller so. Checked on `catalogue_size` (packs the payload carried) rather than


### PR DESCRIPTION
## Problem

`panel_search_nodes` query `"DaSiWa"` waited out the 15s Manager budget and returned `supported:false` / `managerReachable:false` / `count:0`, even when `DaSiWa_SeedControl` was already loaded in `/object_info`. The timeout path skipped the installed-node fallback that unreachable Manager already uses.

## Fix

When Manager search times out (or is unreachable), still search the connected ComfyUI's `/object_info` on a short dedicated signal that does **not** inherit the aborted Manager budget.

- A local hit such as `DaSiWa_SeedControl` is returned as `source: "object_info"` / `installedOnly: true`. It is never dressed as a Manager catalogue row.
- A timeout miss is a retryable named reason (`reason_code: "manager_search_timeout"`, `retryable: true`) instead of an empty hang.

## Tests

`browser_tests/unit/nodes-search-timeout-fallback.test.mjs` plus the existing `#1908` / `#426` Manager-search tests (162 pass).

Fixes #2099
