### PR TITLE
fix(#2104): advertise connection identity on a bound canvas without Web Locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget no longer refuses promoted subgraph widget writes on a bound live canvas when Web Locks cannot mint an exclusive tab identity: hello still publishes a page-lifetime connection identity, and fail-closed omission is kept only when identity is actually unavailable (#2104)
+
 ## [0.15.146] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/restart-identity-retry.test.mjs
+++ b/browser_tests/unit/restart-identity-retry.test.mjs
@@ -121,22 +121,23 @@ test("#654: concurrent callers share one in-flight resolution", async () => {
   assert.equal(locks.calls, 1, "two concurrent resolves ran ONE lease attempt");
 });
 
-test("#654: with no lock manager at all, resolve fails closed (and stays retryable)", async () => {
+test("#2104: with no lock manager at all, resolve mints a page-lifetime connection identity", async () => {
   let clock = 1000;
   const identity = createRestartTabIdentity({
     storage: fakeStorage("candidate-a"),
     // `{}` — not undefined: undefined would fall back to the DEFAULT
     // (globalThis.navigator?.locks), which Node ≥22 actually provides. A
     // request-less object models the plain-http LAN frontend where the Web
-    // Locks API is absent (secure-context-only).
+    // Locks API is absent (secure-context-only). That origin still binds
+    // graph tools; omitting identity here is the #2104 refusal.
     locks: {},
     randomUUID: () => "rotated",
     now: () => clock,
     retryBackoffMs: 5000,
   });
-  assert.equal(await identity.resolve(), undefined, "no lock manager → no identity claim");
+  assert.equal(await identity.resolve(), "rotated", "no lock manager → page-lifetime identity");
   clock += 5001;
-  assert.equal(await identity.resolve(), undefined, "a retry still fails closed without locks");
+  assert.equal(await identity.resolve(), "rotated", "the page-lifetime identity is cached");
 });
 
 test("#654: a lock manager whose request REJECTS degrades to the same retryable failure, not a cached rejection", async () => {

--- a/browser_tests/unit/restart-tab-identity.test.mjs
+++ b/browser_tests/unit/restart-tab-identity.test.mjs
@@ -97,11 +97,17 @@ test("#709: actual hello sender waits for a definitive delayed lock verdict; no 
   identity.releaseForTests();
 });
 
-test("#709: absent Web Locks omits identity and the sender cannot fabricate restart readiness", async () => {
+test("#2104: absent Web Locks still publishes a page-lifetime connection identity", async () => {
+  // Web Locks is secure-context-only. A bound live canvas on plain-http LAN
+  // (the #2104 reporter: graph_binding bound, panel_query_graph succeeded)
+  // has no lock manager. Omitting tab_session_id made MCP refuse promoted
+  // subgraph widget writes as "the panel connection identity was unavailable"
+  // before graph_set_widget dispatch. A page-lifetime id is not restart-proof
+  // (it does not survive reload), but it is a usable connection identity.
   const identity = createRestartTabIdentity({
     storage: copiedStorage("possibly-copied"),
     locks: null,
-    randomUUID: () => "unused",
+    randomUUID: () => "page-instance-tab",
   });
   const sent = [];
   await sendBridgeHello({
@@ -110,7 +116,55 @@ test("#709: absent Web Locks omits identity and the sender cannot fabricate rest
     resolveTabIdentity: identity.resolve,
     makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
   });
-  assert.equal("tab_session_id" in sent[0], false);
+  await sendBridgeHello({
+    socket: { send: (frame) => sent.push(JSON.parse(frame)) },
+    isCurrent: () => true,
+    resolveTabIdentity: identity.resolve,
+    makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
+  });
+  assert.deepEqual(
+    sent.map((frame) => frame.tab_session_id),
+    ["page-instance-tab", "page-instance-tab"],
+    "a bound canvas without Web Locks must still advertise connection identity",
+  );
+});
+
+test("#2104: a request-less lock object (plain-http LAN) still advertises tab_session_id", async () => {
+  const identity = createRestartTabIdentity({
+    storage: copiedStorage("copied-browser-tab"),
+    // Node ≥22 provides navigator.locks; `{}` models a non-secure origin
+    // where the API is absent rather than contended.
+    locks: {},
+    randomUUID: () => "lan-page-instance",
+  });
+  const sent = [];
+  await sendBridgeHello({
+    socket: { send: (frame) => sent.push(JSON.parse(frame)) },
+    isCurrent: () => true,
+    resolveTabIdentity: identity.resolve,
+    makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
+  });
+  assert.equal(sent[0].tab_session_id, "lan-page-instance");
+});
+
+test("#2104: a present lock manager that refuses every lease still omits tab_session_id", async () => {
+  const identity = createRestartTabIdentity({
+    storage: copiedStorage("copied-browser-tab"),
+    locks: { request: (_name, _options, callback) => Promise.resolve(callback(null)) },
+    randomUUID: () => "unused-rotation",
+  });
+  const sent = [];
+  await sendBridgeHello({
+    socket: { send: (frame) => sent.push(JSON.parse(frame)) },
+    isCurrent: () => true,
+    resolveTabIdentity: identity.resolve,
+    makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
+  });
+  assert.equal(
+    "tab_session_id" in sent[0],
+    false,
+    "fail closed only when identity is actually unavailable (exclusivity unproven)",
+  );
 });
 
 test("#709: a rejected Web Locks request also omits identity instead of hanging or trusting storage", async () => {

--- a/browser_tests/unit/restart-tab-identity.test.mjs
+++ b/browser_tests/unit/restart-tab-identity.test.mjs
@@ -145,6 +145,53 @@ test("#2104: a request-less lock object (plain-http LAN) still advertises tab_se
     makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
   });
   assert.equal(sent[0].tab_session_id, "lan-page-instance");
+  assert.notEqual(
+    sent[0].tab_session_id,
+    "copied-browser-tab",
+    "lockless identity must not be the copyable sessionStorage candidate (#640)",
+  );
+});
+
+test("#2104: a throwing mint with no lock manager still omits identity", async () => {
+  const identity = createRestartTabIdentity({
+    storage: copiedStorage("copied-browser-tab"),
+    locks: null,
+    randomUUID: () => {
+      throw new Error("entropy unavailable");
+    },
+  });
+  const sent = [];
+  await sendBridgeHello({
+    socket: { send: (frame) => sent.push(JSON.parse(frame)) },
+    isCurrent: () => true,
+    resolveTabIdentity: identity.resolve,
+    makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
+  });
+  assert.equal("tab_session_id" in sent[0], false, "fail closed when identity is actually unavailable");
+});
+
+test("#2104: an unreadable lock manager is not 'absent' and still omits identity", async () => {
+  const identity = createRestartTabIdentity({
+    storage: copiedStorage("copied-browser-tab"),
+    locks: {
+      get request() {
+        throw new Error("locks unreadable");
+      },
+    },
+    randomUUID: () => "must-not-mint",
+  });
+  const sent = [];
+  await sendBridgeHello({
+    socket: { send: (frame) => sent.push(JSON.parse(frame)) },
+    isCurrent: () => true,
+    resolveTabIdentity: identity.resolve,
+    makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
+  });
+  assert.equal(
+    "tab_session_id" in sent[0],
+    false,
+    "a present-but-unreadable manager must fail closed, not mint a page-lifetime identity",
+  );
 });
 
 test("#2104: a present lock manager that refuses every lease still omits tab_session_id", async () => {

--- a/web/js/lib/restart-tab-identity.js
+++ b/web/js/lib/restart-tab-identity.js
@@ -12,9 +12,18 @@ function nonBlank(value) {
 /**
  * Resolve an identity suitable for certifying that the browser tab which
  * received a restart is the one which reconnected. A returned ID is backed by
- * an exclusive Web Locks lease held for this page's lifetime. If that cannot be
- * acquired, return undefined so the hello omits the identity and MCP readiness
- * fails closed. There is intentionally no timeout-as-proof fallback.
+ * an exclusive Web Locks lease held for this page's lifetime when that API is
+ * present. If exclusivity cannot be proven because another tab holds the lease,
+ * return undefined so the hello omits the identity and MCP readiness fails
+ * closed. There is intentionally no timeout-as-proof fallback.
+ *
+ * #2104 — Web Locks is secure-context-only. A bound live canvas served over
+ * plain HTTP (LAN ComfyUI) has no lock manager, yet graph reads still succeed
+ * and graph_binding is "bound". Omitting tab_session_id in that case made
+ * panel_set_widget refuse promoted subgraph writes as "the panel connection
+ * identity was unavailable". When the API is absent, mint a page-lifetime
+ * identity instead. Fail closed only when identity is actually unavailable
+ * (locks present, exclusivity unproven).
  *
  * A SUCCESS is cached for the life of the page. A FAILURE is retryable (#654):
  * once `retryBackoffMs` has elapsed, the next resolve() runs a fresh lease
@@ -42,6 +51,15 @@ export function createRestartTabIdentity({
   let lastFailureAt = null;
 
   const fallback = () => (memoryFallback ??= randomUUID());
+  const locksApiPresent = () => {
+    try {
+      return !!(locks && typeof locks.request === "function");
+    } catch {
+      // Unreadable is not "absent". A present-but-unreadable manager must fail
+      // closed rather than mint a connection identity nobody can vouch for.
+      return true;
+    }
+  };
   const read = () => {
     try {
       return nonBlank(storage?.getItem(RESTART_TAB_ID_STORAGE_KEY));
@@ -95,6 +113,18 @@ export function createRestartTabIdentity({
     // browser refresh. Re-attempt at most once per backoff window; inside the
     // window, fail closed with the same undefined the first failure returned.
     if (lastFailureAt != null && now() - lastFailureAt < retryBackoffMs) return undefined;
+    // #2104 — no lock manager is not contention. Graph tools still bind on this
+    // origin (tabRouteIdentity mints a page-instance route), so hello must still
+    // carry a connection identity or MCP refuses promoted subgraph writes.
+    if (!locksApiPresent()) {
+      try {
+        resolved = fallback();
+        return resolved;
+      } catch {
+        lastFailureAt = now();
+        return undefined;
+      }
+    }
     resolving = (async () => {
       let candidate = read() ?? fallback();
       write(candidate);


### PR DESCRIPTION
## Summary

panel_set_widget refused promoted subgraph widget writes with:

> the panel connection identity was unavailable. No graph_set_widget was dispatched

even when panel_set_workflow_target(mode:"current") reported graph_binding:"bound" and panel_query_graph succeeded (FireRed Image Edit 1.1 host, unet_name / lora_name).

MCP treats hello tab_session_id as the panel connection identity. Hello omitted that field whenever Web Locks was absent (plain-http LAN / non-secure origin). Graph routing still bound via the page-instance fallback, so reads worked and writes were refused.

## Fix

- When the Web Locks API is missing, mint a page-lifetime connection identity so a bound canvas can still advertise tab_session_id.
- Keep fail-closed omission only when identity is actually unavailable: locks present and exclusivity unproven, an unreadable lock manager, or a mint that throws.
- Do not mint from copyable sessionStorage.

## Tests

`node --test` on:

- browser_tests/unit/restart-tab-identity.test.mjs
- browser_tests/unit/restart-identity-retry.test.mjs
- browser_tests/unit/session-rebind.test.mjs
- browser_tests/unit/bridge-route.test.mjs

138/138 including session/route siblings.

Fixes #2104
