### PR TITLE
fix(#2028): explain unresolved wildcard-to-wildcard connect refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- a wildcard-to-wildcard connect refusal is reported as unbound * ports needing a concrete typed producer, not a false type mismatch (#2028)
+
+
 ## [0.15.148] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/connect-dynamic-prefix.test.mjs
+++ b/browser_tests/unit/connect-dynamic-prefix.test.mjs
@@ -106,6 +106,8 @@ const resolveRail = () => null;
 const isEmptyRailSlotRef = (ref) => ref == null || ref === "";
 const slotDiagnostic = () => "slot diagnostic";
 const loopbackRefusalReason = () => "loopback";
+const unresolvedWildcardPairReason = () => "wildcard pair";
+const isWildcardSlotType = () => false;
 const findSubgraphHostNode = () => null;
 const uniqueSubgraphOutputName = (_g, base) => base;
 const uniqueSubgraphInputName = (_g, base) => base;
@@ -128,6 +130,8 @@ function buildConnect(graph, overrides = {}) {
     }),
     slotDiagnostic,
     loopbackRefusalReason,
+    unresolvedWildcardPairReason,
+    isWildcardSlotType,
     uniqueSubgraphOutputName,
     uniqueSubgraphInputName,
     isLinkPersisted,

--- a/browser_tests/unit/connect-match.test.mjs
+++ b/browser_tests/unit/connect-match.test.mjs
@@ -13,7 +13,8 @@
  *          input when no free wildcard slot exists yet; an explicit to_input
  *          still replaces deliberately.
  * Plus the invariant that genuinely incompatible types stay refused (#204),
- * and the same-node loopback refusal diagnostic (#1266).
+ * the same-node loopback refusal diagnostic (#1266), and the unresolved
+ * wildcard-to-wildcard refusal diagnostic (#2028).
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -26,6 +27,7 @@ import {
   isWildcardSlotType,
   slotDiagnostic,
   loopbackRefusalReason,
+  unresolvedWildcardPairReason,
 } from "../../web/js/lib/connect-match.js";
 
 // VHS_LoadVideo-shaped origin: IMAGE output at index 0, plus non-IMAGE outputs.
@@ -451,4 +453,58 @@ test("#1266: a genuinely incompatible same-node pair is not CALLED compatible �
   const reason = loopbackRefusalReason(node, 0, 3);
   assert.match(reason, /refuses before any type check runs/);
   assert.doesNotMatch(reason, /ARE type-compatible/);
+});
+
+// ---- #2028: unresolved wildcard-to-wildcard is not a type mismatch ---------
+//
+// Reported: connecting PrimitiveNode output 0 (type *) to ComfySwitchNode
+// input "on_false" (type *) was refused with "No input on node 790 accepts
+// type *" — while the diagnostic's own slot listing showed [0] "on_false"
+// (*). LiteGraph's connect() needs a concrete type to bind; neither port
+// supplies one, so connect() returns null. The computed slotDiagnostic tail
+// was reading that as a type incompatibility. Keep the refusal; name the
+// unbound pair and tell the caller to land a concrete typed producer first.
+
+function primitiveNode791() {
+  return {
+    id: 791,
+    type: "PrimitiveNode",
+    outputs: [{ name: "connect to widget input", type: "*" }],
+  };
+}
+function comfySwitchNode790() {
+  return {
+    id: 790,
+    type: "ComfySwitchNode",
+    inputs: [
+      { name: "on_false", type: "*", link: null },
+      { name: "on_true", type: "*", link: null },
+      { name: "switch", type: "BOOLEAN", widget: true, link: null },
+    ],
+  };
+}
+
+test("#2028: the unresolved-wildcard reason names the pair and tells the caller to bind a concrete type first", () => {
+  const reason = unresolvedWildcardPairReason(primitiveNode791(), comfySwitchNode790(), 0, 0);
+  assert.match(reason, /unresolved wildcard-to-wildcard/);
+  assert.match(reason, /output "connect to widget input" \(\*\)/);
+  assert.match(reason, /input "on_false" \(\*\)/);
+  assert.match(reason, /concrete typed producer/);
+  assert.match(reason, /INTConstant/);
+});
+
+test("#2028: with the reason override the diagnostic KEEPS the slot listing but drops the false type tail", () => {
+  const origin = primitiveNode791();
+  const target = comfySwitchNode790();
+  const msg = slotDiagnostic(origin, target, {
+    from_output: 0,
+    to_input: "on_false",
+    reason: unresolvedWildcardPairReason(origin, target, 0, 0),
+  });
+  // The full slot listing is preserved — it was the reporter's evidence.
+  assert.match(msg, /\[0\] "on_false" \(\*\)/);
+  // The false "no input accepts type *" claim is gone.
+  assert.doesNotMatch(msg, /No input on node 790 accepts type/);
+  assert.match(msg, /unresolved wildcard-to-wildcard/);
+  assert.match(msg, /INTConstant/);
 });

--- a/browser_tests/unit/connect-raw-rail-refuse.test.mjs
+++ b/browser_tests/unit/connect-raw-rail-refuse.test.mjs
@@ -123,6 +123,8 @@ const isEmptyRailSlotRef = (ref) =>
   ref == null || ref === "" || (typeof ref === "string" && ["new", "empty", "+"].includes(ref.trim().toLowerCase()));
 const slotDiagnostic = () => "slot diagnostic";
 const loopbackRefusalReason = () => "loopback";
+const unresolvedWildcardPairReason = () => "wildcard pair";
+const isWildcardSlotType = () => false;
 const findSubgraphHostNode = () => null;
 const uniqueSubgraphOutputName = (_g, base) => base;
 const uniqueSubgraphInputName = (_g, base) => base;
@@ -240,6 +242,8 @@ function buildConnect(graph, exposeCalls) {
     autoMatchSlots,
     slotDiagnostic,
     loopbackRefusalReason,
+    unresolvedWildcardPairReason,
+    isWildcardSlotType,
     uniqueSubgraphOutputName,
     uniqueSubgraphInputName,
     isLinkPersisted,

--- a/browser_tests/unit/connect-slot-rename.test.mjs
+++ b/browser_tests/unit/connect-slot-rename.test.mjs
@@ -121,6 +121,8 @@ const resolveRail = () => null;
 const isEmptyRailSlotRef = (ref) => ref == null || ref === "";
 const slotDiagnostic = () => "slot diagnostic";
 const loopbackRefusalReason = () => "loopback";
+const unresolvedWildcardPairReason = () => "wildcard pair";
+const isWildcardSlotType = () => false;
 const findSubgraphHostNode = () => null;
 const uniqueSubgraphOutputName = (_g, base) => base;
 const uniqueSubgraphInputName = (_g, base) => base;
@@ -154,6 +156,8 @@ function buildConnect(graph, overrides = {}) {
     autoMatchSlots,
     slotDiagnostic,
     loopbackRefusalReason,
+    unresolvedWildcardPairReason,
+    isWildcardSlotType,
     uniqueSubgraphOutputName,
     uniqueSubgraphInputName,
     isLinkPersisted,

--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -132,6 +132,8 @@ function autoMatchSlots(origin, target, from_output, to_input) {
 
 const slotDiagnostic = () => "slot diagnostic";
 const loopbackRefusalReason = () => "loopback";
+const unresolvedWildcardPairReason = () => "wildcard pair";
+const isWildcardSlotType = () => false;
 const findSubgraphHostNode = () => null;
 const uniqueSubgraphOutputName = (_g, base) => base;
 const uniqueSubgraphInputName = (_g, base) => base;
@@ -150,6 +152,8 @@ function buildExecutors(graph, canvas = {}) {
     "autoMatchSlots",
     "slotDiagnostic",
     "loopbackRefusalReason",
+    "unresolvedWildcardPairReason",
+    "isWildcardSlotType",
     "uniqueSubgraphOutputName",
     "uniqueSubgraphInputName",
     "isLinkPersisted",
@@ -198,6 +202,8 @@ return GRAPH_TOOL_EXECUTORS;`,
     autoMatchSlots,
     slotDiagnostic,
     loopbackRefusalReason,
+    unresolvedWildcardPairReason,
+    isWildcardSlotType,
     uniqueSubgraphOutputName,
     uniqueSubgraphInputName,
     isLinkPersisted,

--- a/browser_tests/unit/connect-title-rewrite.test.mjs
+++ b/browser_tests/unit/connect-title-rewrite.test.mjs
@@ -136,6 +136,8 @@ const resolveRail = () => null;
 const isEmptyRailSlotRef = (ref) => ref == null || ref === "";
 const slotDiagnostic = () => "slot diagnostic";
 const loopbackRefusalReason = () => "loopback";
+const unresolvedWildcardPairReason = () => "wildcard pair";
+const isWildcardSlotType = () => false;
 const findSubgraphHostNode = () => null;
 const uniqueSubgraphOutputName = (_g, base) => base;
 const uniqueSubgraphInputName = (_g, base) => base;
@@ -170,6 +172,8 @@ function buildConnect(graph, titleDeps = {}) {
     autoMatchSlots,
     slotDiagnostic,
     loopbackRefusalReason,
+    unresolvedWildcardPairReason,
+    isWildcardSlotType,
     uniqueSubgraphOutputName,
     uniqueSubgraphInputName,
     isLinkPersisted,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -595,7 +595,13 @@ import {
   controlAfterGenerateEntries,
   ensureControlAfterGenerateQueueHooks,
 } from "./lib/control-after-generate.js";
-import { autoMatchSlots, slotDiagnostic, loopbackRefusalReason } from "./lib/connect-match.js";
+import {
+  autoMatchSlots,
+  slotDiagnostic,
+  loopbackRefusalReason,
+  unresolvedWildcardPairReason,
+  isWildcardSlotType,
+} from "./lib/connect-match.js";
 import {
   snapshotInputSlotLinks,
   snapshotInputSlotNames,
@@ -17391,11 +17397,22 @@ const GRAPH_TOOL_EXECUTORS = {
       // ("No input on node N accepts type X") is a FALSE type mismatch: the
       // refusal says nothing about the slots' types. Keep the full slot listing
       // but override the tail with the actual restriction.
+      // #2028: the same false tail fires when BOTH selected ports are still
+      // unresolved wildcards (`*`): LiteGraph has no concrete type to bind, so
+      // connect() returns null even though the listing shows `*` inputs. Keep
+      // the refusal; say the ports are unbound and a typed producer must land
+      // first. Loopback wins when both apply — connect() never reached types.
+      const outType = origin.outputs?.[outIdx]?.type;
+      const inType = target.inputs?.[inIdx]?.type;
       throw new Error(
         slotDiagnostic(origin, target, {
           from_output,
           to_input,
-          ...(origin === target ? { reason: loopbackRefusalReason(origin, outIdx, inIdx) } : {}),
+          ...(origin === target
+            ? { reason: loopbackRefusalReason(origin, outIdx, inIdx) }
+            : isWildcardSlotType(outType) && isWildcardSlotType(inType)
+              ? { reason: unresolvedWildcardPairReason(origin, target, outIdx, inIdx) }
+              : {}),
         }),
       );
     }

--- a/web/js/lib/connect-match.js
+++ b/web/js/lib/connect-match.js
@@ -15,6 +15,11 @@
 //   #1266 — a LiteGraph refusal on a SAME-NODE (loopback) connect is not a
 //          type mismatch: loopbackRefusalReason replaces the computed
 //          "no input accepts type X" tail that falsely blamed the slots' types.
+//   #2028 — a LiteGraph refusal on two UNRESOLVED wildcards (`*` → `*`) is
+//          not a type mismatch either: the listing already showed `*` inputs.
+//          unresolvedWildcardPairReason replaces the computed
+//          "no input accepts type *" tail and tells the caller to land a
+//          concrete typed producer first.
 
 export const SLOT_RANK_EXACT = 2;
 export const SLOT_RANK_WILD = 1;
@@ -209,6 +214,29 @@ export function loopbackRefusalReason(node, outIdx, inIdx) {
   return (
     `LiteGraph refuses a connection from a node to ITSELF (${pair}): ${verdict}. ` +
     `Route through a Reroute node to wire the node's own output back to its input.`
+  );
+}
+
+/** #2028 — the honest failure tail when LiteGraph refused a connection whose
+ *  SELECTED output AND input are both still unresolved wildcards (`*`).
+ *  connect() needs a concrete type to bind; a PrimitiveNode output (`*`) into
+ *  a ComfySwitchNode on_false (`*`) supplies none, so the link is null. The
+ *  computed slotDiagnostic tail ("no input accepts type *") is a FALSE type
+ *  mismatch here: the listing already showed `*` inputs. Names the resolved
+ *  slot pair, states that neither port is bound, and points at connecting a
+ *  concrete typed producer first (INTConstant is the workaround the reporter
+ *  verified). Only a reason string; the caller passes it as slotDiagnostic's
+ *  `reason` override so the full slot listing is kept. */
+export function unresolvedWildcardPairReason(origin, target, outIdx, inIdx) {
+  const out = origin.outputs?.[outIdx];
+  const inp = target.inputs?.[inIdx];
+  const pair =
+    `output "${out?.name ?? outIdx}" (${renderSlotType(out?.type)}) → ` +
+    `input "${inp?.name ?? inIdx}" (${renderSlotType(inp?.type)})`;
+  return (
+    `LiteGraph refuses an unresolved wildcard-to-wildcard pair (${pair}): ` +
+    `neither port supplies a concrete type to bind. ` +
+    `Connect a concrete typed producer first (for example INTConstant), then retry this connection.`
   );
 }
 


### PR DESCRIPTION
Fixes #2028

`graph_connect` from a PrimitiveNode `*` output to a ComfySwitchNode `on_false` `*` input kept refusing, but the diagnostic said "No input on node N accepts type *" even though the listing showed `*` inputs. LiteGraph returned null because neither port supplies a concrete type to bind.

## Fix

Keep the refusal. After `connect()` returns null, if both selected ports are unresolved wildcards, override the diagnostic tail with `unresolvedWildcardPairReason()` so the caller is told to land a concrete typed producer first (for example INTConstant). Same-node loopback still wins when both apply.

This is the diagnostic message, not a silent success. MCP #2542 retries wildcard-to-wildcard from the orchestrator.

## Tests

`npm run test:unit`: 7836 pass, 1 todo.

`browser_tests/unit/connect-match.test.mjs`: 35 tests, including two new #2028 pins for the reason string and the slot listing / false-tail override.
