### PR TITLE
fix(#2010): already-empty combo clear is a no-op success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_set_widget clear of an already-empty combo (VHS_LoadVideo video="") succeeds even when the dropdown has no empty option (#2010)
 - a wildcard-to-wildcard connect refusal is reported as unbound * ports needing a concrete typed producer, not a false type mismatch (#2028)
 
 

--- a/browser_tests/unit/set-widget-refresh.test.mjs
+++ b/browser_tests/unit/set-widget-refresh.test.mjs
@@ -161,3 +161,38 @@ test("a valid value on the FIRST try does not call refresh at all", async () => 
   assert.equal(res.refreshed, undefined);
   assert.equal(refreshCalls, 0);
 });
+
+test("#2010: already-empty combo + clear:true is a no-op success without refreshing", async () => {
+  const files = ["clip_a.mp4", "clip_b.webm", "clip_c.mp4", "clip_d.mov"];
+  const widget = { name: "video", type: "combo", options: { values: files }, value: "" };
+  const node = { id: 165, type: "VHS_LoadVideo", widgets: [widget] };
+  let refreshCalls = 0;
+  const res = await runSetWidget(node, "video", undefined, {
+    registry: { VHS_LoadVideo: {} },
+    getFreshObjectInfo: async () => ({ VHS_LoadVideo: {} }),
+    clear: true,
+    refreshCombos: async () => {
+      refreshCalls += 1;
+    },
+  });
+  assert.equal(res.set.value, "");
+  assert.equal(widget.value, "");
+  assert.equal(res.refreshed, undefined);
+  assert.equal(refreshCalls, 0, "already-empty clear must not enter stale-combo recovery");
+});
+
+test("#2010: clear:true on a populated combo still refuses when \"\" is not an option", async () => {
+  const files = ["clip_a.mp4", "clip_b.webm", "clip_c.mp4", "clip_d.mov"];
+  const widget = { name: "video", type: "combo", options: { values: files }, value: files[0] };
+  const node = { id: 174, type: "VHS_LoadVideo", widgets: [widget] };
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "video", undefined, {
+        registry: { VHS_LoadVideo: {} },
+        getFreshObjectInfo: async () => ({ VHS_LoadVideo: {} }),
+        clear: true,
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(widget.value, files[0], "must not mutate on refuse");
+});

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -60,6 +60,43 @@ test("#347: clearing to '' does NOT weaken combo/numeric strictness (#240)", () 
   assert.throws(() => coerceWidgetValue(num, ""), /not a number/);
 });
 
+// #2010: VHS_LoadVideo's `video` combo lists filenames and no empty option, yet the
+// live widget is already "". An idempotent clear of that already-empty value must
+// succeed as a no-op; a populated combo still refuses "" when it is not an option.
+const VHS_VIDEO_FILES = ["clip_a.mp4", "clip_b.webm", "clip_c.mp4", "clip_d.mov"];
+
+test("#2010: clearing an already-empty VHS_LoadVideo combo succeeds even without an empty option", () => {
+  const widget = {
+    name: "video",
+    type: "combo",
+    options: { values: [...VHS_VIDEO_FILES] },
+    value: "",
+  };
+  const node = { id: 165, type: "VHS_LoadVideo", widgets: [widget] };
+
+  assert.equal(coerceWidgetValue(widget, ""), "");
+  const set = applyWidgetWrite(node, "video", "", HOOKS);
+  assert.equal(set.value, "");
+  assert.equal(widget.value, "");
+});
+
+test("#2010: clearing a populated combo still refuses when \"\" is not an option", () => {
+  const widget = {
+    name: "video",
+    type: "combo",
+    options: { values: [...VHS_VIDEO_FILES] },
+    value: VHS_VIDEO_FILES[0],
+  };
+  const node = { id: 174, type: "VHS_LoadVideo", widgets: [widget] };
+
+  assert.throws(() => coerceWidgetValue(widget, ""), WidgetWriteError);
+  assert.throws(
+    () => applyWidgetWrite(node, "video", "", HOOKS),
+    (err) => err instanceof WidgetWriteError && /not a valid option/.test(err.message),
+  );
+  assert.equal(widget.value, VHS_VIDEO_FILES[0], "must not mutate on refuse");
+});
+
 test("#524: exact case wins when two widgets differ only by case", () => {
   const backgroundToggle = { name: "Background", type: "BOOLEAN", value: false };
   const backgroundMode = { name: "background", type: "COMBO", options: { values: ["Alpha", "Color"] }, value: "Alpha" };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17784,7 +17784,16 @@ const GRAPH_TOOL_EXECUTORS = {
       arguments[0] && typeof arguments[0] === "object" ? arguments[0].expected_scope : undefined;
     const expected_node_identity =
       arguments[0] && typeof arguments[0] === "object" ? arguments[0].expected_node_identity : undefined;
-    const { defer_until_idle, expected_value, defer_replay } = arguments[0] ?? {};
+    const { defer_until_idle, expected_value, defer_replay, clear } = arguments[0] ?? {};
+    if (clear !== undefined && clear !== true && clear !== false) {
+      throw new Error("graph_set_widget clear must be a boolean");
+    }
+    if (clear === true) {
+      if (value !== undefined && value !== null && value !== "") {
+        throw new Error("graph_set_widget cannot combine clear:true with a non-empty value");
+      }
+      value = "";
+    }
     if (
       expected_node_identity !== undefined &&
       (typeof expected_node_identity !== "string" ||
@@ -17868,6 +17877,7 @@ const GRAPH_TOOL_EXECUTORS = {
           ...(expected_node_identity !== undefined ? { expected_node_identity } : {}),
           expected_value,
           defer_replay: true,
+          ...(clear !== undefined ? { clear } : {}),
         });
       }
       const deferredGraph = graph;
@@ -17911,6 +17921,7 @@ const GRAPH_TOOL_EXECUTORS = {
             ...(expected_node_identity !== undefined ? { expected_node_identity } : {}),
             expected_value,
             defer_replay: true,
+            ...(clear !== undefined ? { clear } : {}),
           }),
       });
     }
@@ -18215,6 +18226,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // past the end of a very long argument.
     const setWidgetOpts = {
       registry: LG?.registered_node_types ?? {},
+      ...(clear !== undefined ? { clear } : {}),
       // Fresh-backend type authorization (#458 set_widget gap): the go/no-go for the
       // resolved target node's TYPE is decided against the CURRENT /object_info — NOT
       // the stale LiteGraph registry, which keeps a positive for an uninstalled pack

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -539,11 +539,23 @@ async function runSetWidgetBody(
     // unit tests inject a flush that reproduces the later empty overwrite.
     awaitFrontendWidgetFlush: awaitFrontendWidgetFlushInjected,
     [ACK_STATE]: ackState,
+    clear,
   } = {},
 ) {
   const assertNotAbandoned = () => {
     if (ackState?.abandoned) throw widgetWriteOutcomeUnknownError();
   };
+  if (clear !== undefined && clear !== true && clear !== false) {
+    throw new Error("panel_set_widget clear must be a boolean");
+  }
+  if (clear === true) {
+    if (value !== undefined && value !== null && value !== "") {
+      throw new Error(
+        `panel_set_widget cannot combine clear:true with a non-empty value on widget "${widgetName}"`,
+      );
+    }
+    value = "";
+  }
 
   // Never re-derived, and never cached: the oracle may not have run yet when this closure is
   // built, and a caller that answers differently per call is answering about a different

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1128,6 +1128,16 @@ export function coerceWidgetValue(
     }
     // STRICT typed membership first: an exact-typed option is always writable.
     if (options.includes(value)) return value;
+    // #2010: an already-empty combo is already the requested clear. VHS_LoadVideo's
+    // video dropdown lists filenames and no "", yet the live widget is video="".
+    // That no-op must succeed; a populated combo still refuses "" below.
+    if (value === "") {
+      try {
+        if (widget.value === "") return value;
+      } catch {
+        /* unreadable current value stays an off-list refusal */
+      }
+    }
     // #667: NUMERIC-LABELLED options (VHS ProRes profile ["lt",…,"4444",…], ffv1
     // level ["0","1","3"]). The tool's `value` param is string|number|boolean, so a
     // numeric-looking label can arrive as the NUMBER 4444 after upstream JSON


### PR DESCRIPTION
Fixes #2010

`panel_set_widget` with `clear:true` on VHS_LoadVideo `video=""` was refused because the combo listed filenames and no empty option, even though the live widget was already empty. Idempotent cleanup was impossible.

## Fix

- Combo coercion treats already-empty + `""` as a no-op success when `""` is not in the option list.
- `clear:true` maps to that empty write. A populated combo still refuses an empty value that is not an option.

## Tests

`npm run test:unit`: 7838 pass, 1 todo.

- `browser_tests/unit/widget-write.test.mjs`: already-empty VHS_LoadVideo combo clear succeeds; populated combo still refuses.
- `browser_tests/unit/set-widget-refresh.test.mjs`: `clear:true` on an already-empty combo succeeds without stale-combo refresh.