### PR TITLE
fix(2125): an absent active workflow is not a tab switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_add_node no longer refuses with "the active workflow or graph view changed" on a frontend that exposes no active workflow: absent-at-both-ends is unchanged, not a tab switch, so the mutation runs on the same canvas the reads already succeeded on (#2125)
+
 ## [0.15.149] - 2026-08-30
 
 ### Fixed

--- a/browser_tests/unit/graph-mutation-context-absent-workflow.test.mjs
+++ b/browser_tests/unit/graph-mutation-context-absent-workflow.test.mjs
@@ -1,0 +1,225 @@
+// #2125 — panel_add_node refused on a canvas nothing had touched.
+//
+// The reporter read `panel_graph_outline` on an empty unsaved workflow, then
+// called `panel_add_node` and got "The active workflow or graph view changed
+// while this node was preparing; nothing was added. Retry on the intended tab."
+// No tab switch and no graph edit happened between the two calls, the graph
+// stayed empty, and every retry refused identically.
+//
+// That asymmetry — read succeeds, mutation refuses — is the fingerprint.
+// `revalidateGraphMutationContext` is the ONLY gate on the mutation path that
+// compares a before/after workflow reference, and `activeWorkflowRef()` returns
+// null whenever the frontend exposes no active workflow. The comparator it
+// delegates to, `sameWorkflowObject`, answers false for any pair containing a
+// null (correct for an identity question: no shared carrier, nothing proven),
+// so absent-then-absent read as "the tab changed".
+//
+// The rest of the panel treats an absent workflow as supported, not as a
+// refusal: `graphEmptyBindingUnproven` returns false on it ("no workflow
+// service — legacy availability") and the binding bar that runs immediately
+// AFTER this gate therefore returns no verdict at all. This gate was the one
+// place that disagreed.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { sameGraphMutationContext } from "../../web/js/lib/graph-mutation-context.js";
+import { sameWorkflowObject } from "../../web/js/lib/workflow-chat-identity.js";
+import { resolveGraphBindingVerdict } from "../../web/js/lib/graph-binding.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+// STABLE across every ctx() in this file: a fresh object per call would make the
+// app/graph/canvas slots differ too, and then every "still refused" assertion
+// below would pass for a reason that has nothing to do with the workflow slot.
+const APP = {};
+const ROOT_GRAPH = { _nodes: [] };
+const CANVAS = {};
+
+function ctx(overrides = {}) {
+  return { app: APP, graph: ROOT_GRAPH, rootGraph: ROOT_GRAPH, canvas: CANVAS, workflow: null, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// The comparator
+// ---------------------------------------------------------------------------
+
+test("#2125: a workflow absent at BOTH ends is unchanged — the context did not move", () => {
+  const before = ctx();
+  // The strongest possible statement of the defect: the SAME object, compared
+  // with itself, through the comparator production actually passes in.
+  assert.equal(
+    sameGraphMutationContext(before, before, sameWorkflowObject),
+    true,
+    "an identical context object cannot be a tab switch",
+  );
+  // And a re-read that produced an equal-but-distinct record, as the real
+  // capture/revalidate pair does.
+  assert.equal(sameGraphMutationContext(before, { ...before }, sameWorkflowObject), true);
+});
+
+test("#2125: absence APPEARING or DISAPPEARING is still a change", () => {
+  const absent = ctx();
+  const wfA = { changeTracker: {} };
+  const wfB = { changeTracker: {} };
+  // A workflow that seats itself mid-preflight: the node would land on a tab the
+  // caller never named. Still refused.
+  assert.equal(sameGraphMutationContext(absent, ctx({ workflow: wfA }), sameWorkflowObject), false);
+  // A workflow that vanishes mid-preflight. Still refused.
+  assert.equal(sameGraphMutationContext(ctx({ workflow: wfA }), absent, sameWorkflowObject), false);
+  // And the case the guard exists for, untouched: two different workflows.
+  assert.equal(
+    sameGraphMutationContext(ctx({ workflow: wfA }), ctx({ workflow: wfB }), sameWorkflowObject),
+    false,
+    "the tab-switch guard this whole gate exists for must not be weakened",
+  );
+  // A proxy/raw pair of the SAME workflow stays same (the reason the comparator
+  // is injected at all).
+  assert.equal(
+    sameGraphMutationContext(
+      ctx({ workflow: wfA }),
+      ctx({ workflow: { __v_raw: wfA } }),
+      sameWorkflowObject,
+    ),
+    true,
+  );
+});
+
+test("#2125: the non-workflow slots still decide the verdict when the workflow is absent", () => {
+  // Admitting absent→absent must not admit a graph/canvas move underneath it.
+  const before = ctx();
+  for (const slot of ["app", "graph", "rootGraph", "canvas"]) {
+    assert.equal(
+      sameGraphMutationContext(before, { ...before, [slot]: {} }, sameWorkflowObject),
+      false,
+      `a changed ${slot} must still refuse even with no workflow to compare`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Why admitting it is safe: the gate that runs NEXT already permits this state
+// ---------------------------------------------------------------------------
+
+test("#2125: the binding bar that follows this gate returns no verdict on an absent workflow", () => {
+  // This is the load-bearing safety claim. If the binding assert refused an
+  // absent workflow, admitting it here would only move the refusal one line
+  // down and the fix would be cosmetic. It does not: every predicate degrades
+  // to no-refusal, which is the "legacy availability" contract stated in
+  // graphEmptyBindingUnproven.
+  const rootGraph = { _nodes: [] };
+  const verdict = resolveGraphBindingVerdict({
+    graph: rootGraph,
+    rootGraph,
+    activeWorkflow: null,
+    activeWorkflowUuid: null,
+    liveNodeCount: 0,
+    inSubgraph: false,
+    rootUuidMismatch: false,
+    includeBaselineReadGuard: true,
+    requireDirtyMutationBinding: true, // the MUTATION bar, not the read bar
+    postReconnectWindow: false,
+    graphLoading: false,
+  });
+  assert.equal(verdict, null, "an absent workflow is permitted by the binding bar — so the add proceeds");
+});
+
+// ---------------------------------------------------------------------------
+// The call site: the REAL revalidateGraphMutationContext source, executed
+// ---------------------------------------------------------------------------
+
+/** Build the panel's real capture/revalidate pair over injected dependencies.
+ *  Source-sliced rather than re-implemented: a fix that lives only in the lib
+ *  while the call site passes its own comparator would pass every test above
+ *  and still ship the refusal. */
+function buildMutationContextPair(deps) {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const start = src.indexOf("function captureGraphMutationContext()");
+  assert.notEqual(start, -1, "captureGraphMutationContext must exist");
+  const endNeedle = "  return current;\n}";
+  const end = src.indexOf(endNeedle, start);
+  assert.notEqual(end, -1, "revalidateGraphMutationContext must still end by returning the context");
+  const body = src.slice(start, end + endNeedle.length);
+  assert.match(body, /function revalidateGraphMutationContext\(captured\)/, "both halves are in the slice");
+  const names = Object.keys(deps);
+  const make = new Function(
+    ...names,
+    `${body}\nreturn { captureGraphMutationContext, revalidateGraphMutationContext };`,
+  );
+  return make(...names.map((n) => deps[n]));
+}
+
+function harness({ workflow = null, bindingVerdict = null } = {}) {
+  const rootGraph = { _nodes: [] };
+  const app = {};
+  const canvas = {};
+  const calls = { asserted: 0 };
+  return {
+    rootGraph,
+    calls,
+    ...buildMutationContextPair({
+      // The real comparators — this is the whole point of the harness.
+      sameGraphMutationContext,
+      sameWorkflowObject,
+      getGraphCtx: () => ({ app, graph: rootGraph, rootGraph, canvas, LG: {} }),
+      activeWorkflowRef: () => workflow,
+      // The #646 reconnect gate is not what this test is about; it must stay
+      // wired (reconnect-recovery.test.mjs pins that) but answer "no refusal".
+      graphMutationReconnectGate: () => null,
+      comfyBackendIsDown: () => false,
+      postReconnectBindingSettleWindow: () => false,
+      reconnectRefusalError: (gate) => new Error(`reconnect-refusal:${gate}`),
+      assertGraphBoundToActiveWorkflow: () => {
+        calls.asserted += 1;
+        if (bindingVerdict) throw new Error(bindingVerdict);
+      },
+      MUTATION_BINDING_BAR: { requireDirtyMutationBinding: true },
+    }),
+  };
+}
+
+test("#2125 call site: graph_add_node's revalidation admits a canvas whose workflow is absent", () => {
+  const h = harness({ workflow: null });
+  const captured = h.captureGraphMutationContext();
+  assert.equal(captured.workflow, null, "the reporter's state: no active workflow to read");
+
+  // The await window of the real command happens here. Nothing touches the tab.
+  const current = h.revalidateGraphMutationContext(captured);
+
+  assert.equal(current.rootGraph, h.rootGraph, "the node is committed to the canvas that was captured");
+  assert.equal(h.calls.asserted, 1, "and the binding bar still ran — the gate was admitted, not skipped");
+});
+
+test("#2125 call site: a genuine tab switch during the preflight is still refused", () => {
+  // The guard's reason for existing, exercised through the same real source: the
+  // capture sees workflow A, the revalidate sees workflow B.
+  // Every non-workflow slot is a STABLE object across both reads, so the only
+  // thing that can decide this test is the workflow slot.
+  const app = {};
+  const canvas = {};
+  const rootGraph = { _nodes: [] };
+  let workflow = { changeTracker: {} };
+  const pair = buildMutationContextPair({
+    sameGraphMutationContext,
+    sameWorkflowObject,
+    getGraphCtx: () => ({ app, graph: rootGraph, rootGraph, canvas, LG: {} }),
+    activeWorkflowRef: () => workflow,
+    graphMutationReconnectGate: () => null,
+    comfyBackendIsDown: () => false,
+    postReconnectBindingSettleWindow: () => false,
+    reconnectRefusalError: (gate) => new Error(`reconnect-refusal:${gate}`),
+    assertGraphBoundToActiveWorkflow: () => {},
+    MUTATION_BINDING_BAR: {},
+  });
+  const captured = pair.captureGraphMutationContext();
+  // Sanity: with the workflow held FIXED this same pair admits the context, so a
+  // refusal below can only be the switch.
+  pair.revalidateGraphMutationContext(captured);
+  const switched = { changeTracker: {} };
+  workflow = switched;
+  assert.throws(
+    () => pair.revalidateGraphMutationContext(captured),
+    /active workflow or graph view changed/,
+    "a real switch must still refuse — #2125 must not become a hole in the #646/#349 fence",
+  );
+});

--- a/browser_tests/unit/graph-mutation-context-absent-workflow.test.mjs
+++ b/browser_tests/unit/graph-mutation-context-absent-workflow.test.mjs
@@ -36,8 +36,18 @@ const APP = {};
 const ROOT_GRAPH = { _nodes: [] };
 const CANVAS = {};
 
+// `workflowReadable: true` = the probe RAN and found no active workflow. A context
+// that omits it (or sets it false) is an UNREADABLE probe and must stay refused.
 function ctx(overrides = {}) {
-  return { app: APP, graph: ROOT_GRAPH, rootGraph: ROOT_GRAPH, canvas: CANVAS, workflow: null, ...overrides };
+  return {
+    app: APP,
+    graph: ROOT_GRAPH,
+    rootGraph: ROOT_GRAPH,
+    canvas: CANVAS,
+    workflow: null,
+    workflowReadable: true,
+    ...overrides,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -82,6 +92,41 @@ test("#2125: absence APPEARING or DISAPPEARING is still a change", () => {
       sameWorkflowObject,
     ),
     true,
+  );
+});
+
+test("#2125 gate r1: an UNREADABLE probe is not proven absence — it stays refused", () => {
+  // `activeWorkflowRef()` answers null both when there is no active workflow and
+  // when the lookup THREW. Only the first is evidence the tab did not move; the
+  // second is "I did not find out", and two of them must not witness each other.
+  const unreadable = ctx({ workflowReadable: false });
+  const proven = ctx();
+  assert.equal(
+    sameGraphMutationContext(unreadable, unreadable, sameWorkflowObject),
+    false,
+    "two failed reads must not pass as absent-then-absent — the workflow may have changed under them",
+  );
+  assert.equal(sameGraphMutationContext(proven, unreadable, sameWorkflowObject), false);
+  assert.equal(sameGraphMutationContext(unreadable, proven, sameWorkflowObject), false);
+  // Fail-closed for any caller that does not carry the flag at all: the relaxation
+  // is opt-in by evidence, never by default.
+  const silent = { ...proven };
+  delete silent.workflowReadable;
+  assert.equal(
+    sameGraphMutationContext(silent, silent, sameWorkflowObject),
+    false,
+    "a context that never stated readability gets the pre-fix behaviour",
+  );
+  // …and readability is irrelevant once a workflow is actually present.
+  const wf = { changeTracker: {} };
+  assert.equal(
+    sameGraphMutationContext(
+      { ...ctx({ workflow: wf }), workflowReadable: false },
+      { ...ctx({ workflow: wf }), workflowReadable: false },
+      sameWorkflowObject,
+    ),
+    true,
+    "a probe that returned an object plainly ran, whatever the flag says",
   );
 });
 
@@ -149,7 +194,7 @@ function buildMutationContextPair(deps) {
   return make(...names.map((n) => deps[n]));
 }
 
-function harness({ workflow = null, bindingVerdict = null } = {}) {
+function harness({ workflow = null, readable = true, bindingVerdict = null } = {}) {
   const rootGraph = { _nodes: [] };
   const app = {};
   const canvas = {};
@@ -162,6 +207,7 @@ function harness({ workflow = null, bindingVerdict = null } = {}) {
       sameGraphMutationContext,
       sameWorkflowObject,
       getGraphCtx: () => ({ app, graph: rootGraph, rootGraph, canvas, LG: {} }),
+      probeActiveWorkflow: () => ({ workflow, readable }),
       activeWorkflowRef: () => workflow,
       // The #646 reconnect gate is not what this test is about; it must stay
       // wired (reconnect-recovery.test.mjs pins that) but answer "no refusal".
@@ -190,6 +236,55 @@ test("#2125 call site: graph_add_node's revalidation admits a canvas whose workf
   assert.equal(h.calls.asserted, 1, "and the binding bar still ran — the gate was admitted, not skipped");
 });
 
+test("#2125 call site r1: a probe that THREW at both ends is still refused", () => {
+  // The gate's P1. If the panel reported this as an ordinary absence, a workflow
+  // that moved during the preflight while the lookup happened to be throwing
+  // would be written to unverified.
+  const h = harness({ workflow: null, readable: false });
+  const captured = h.captureGraphMutationContext();
+  assert.equal(captured.workflow, null);
+  assert.equal(captured.workflowReadable, false, "the capture must record that the probe did not run");
+  assert.throws(
+    () => h.revalidateGraphMutationContext(captured),
+    /active workflow or graph view changed/,
+    "unreadable is 'I did not find out', never 'nothing changed'",
+  );
+  assert.equal(h.calls.asserted, 0, "and nothing reached the binding assert or the graph");
+});
+
+test("#2125 call site r1: the panel's own probe reports readable:false when the lookup throws", () => {
+  // Not a stub: the REAL probeActiveWorkflow source, driven with a getter that
+  // throws — the shape that makes activeWorkflowRef() return a bare null today.
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const start = src.indexOf("function probeActiveWorkflow()");
+  assert.notEqual(start, -1, "probeActiveWorkflow must exist");
+  const endNeedle = "\n}";
+  const body = src.slice(start, src.indexOf(endNeedle, start) + endNeedle.length);
+  const probe = new Function("window", "app", `${body}\nreturn probeActiveWorkflow;`);
+
+  const exploding = {};
+  Object.defineProperty(exploding, "activeWorkflow", {
+    get() { throw new Error("extensionManager surface is unavailable"); },
+  });
+  assert.deepEqual(
+    probe({}, { extensionManager: { workflow: exploding } })(),
+    { workflow: null, readable: false },
+    "a throwing lookup must be reported as unreadable, not as an absent workflow",
+  );
+
+  // And the two states it must still distinguish.
+  assert.deepEqual(
+    probe({}, { extensionManager: { workflow: { activeWorkflow: null } } })(),
+    { workflow: null, readable: true },
+    "a lookup that ran and found nothing is PROVEN absence",
+  );
+  const wf = { changeTracker: {} };
+  assert.deepEqual(
+    probe({}, { extensionManager: { workflow: { activeWorkflow: wf } } })(),
+    { workflow: wf, readable: true },
+  );
+});
+
 test("#2125 call site: a genuine tab switch during the preflight is still refused", () => {
   // The guard's reason for existing, exercised through the same real source: the
   // capture sees workflow A, the revalidate sees workflow B.
@@ -203,6 +298,7 @@ test("#2125 call site: a genuine tab switch during the preflight is still refuse
     sameGraphMutationContext,
     sameWorkflowObject,
     getGraphCtx: () => ({ app, graph: rootGraph, rootGraph, canvas, LG: {} }),
+    probeActiveWorkflow: () => ({ workflow, readable: true }),
     activeWorkflowRef: () => workflow,
     graphMutationReconnectGate: () => null,
     comfyBackendIsDown: () => false,

--- a/browser_tests/unit/graph-mutation-context-absent-workflow.test.mjs
+++ b/browser_tests/unit/graph-mutation-context-absent-workflow.test.mjs
@@ -198,7 +198,7 @@ function harness({ workflow = null, readable = true, bindingVerdict = null } = {
   const rootGraph = { _nodes: [] };
   const app = {};
   const canvas = {};
-  const calls = { asserted: 0 };
+  const calls = { asserted: 0, assertOpts: null, freshReads: 0 };
   return {
     rootGraph,
     calls,
@@ -208,15 +208,21 @@ function harness({ workflow = null, readable = true, bindingVerdict = null } = {
       sameWorkflowObject,
       getGraphCtx: () => ({ app, graph: rootGraph, rootGraph, canvas, LG: {} }),
       probeActiveWorkflow: () => ({ workflow, readable }),
-      activeWorkflowRef: () => workflow,
+      // Any read taken OUTSIDE the two probes is a fresh sample of the same
+      // surface — the gate r2 P1. Counted so a test can assert there are none.
+      activeWorkflowRef: () => {
+        calls.freshReads += 1;
+        return workflow;
+      },
       // The #646 reconnect gate is not what this test is about; it must stay
       // wired (reconnect-recovery.test.mjs pins that) but answer "no refusal".
       graphMutationReconnectGate: () => null,
       comfyBackendIsDown: () => false,
       postReconnectBindingSettleWindow: () => false,
       reconnectRefusalError: (gate) => new Error(`reconnect-refusal:${gate}`),
-      assertGraphBoundToActiveWorkflow: () => {
+      assertGraphBoundToActiveWorkflow: (_graph, _rootGraph, opts) => {
         calls.asserted += 1;
+        calls.assertOpts = opts;
         if (bindingVerdict) throw new Error(bindingVerdict);
       },
       MUTATION_BINDING_BAR: { requireDirtyMutationBinding: true },
@@ -234,6 +240,47 @@ test("#2125 call site: graph_add_node's revalidation admits a canvas whose workf
 
   assert.equal(current.rootGraph, h.rootGraph, "the node is committed to the canvas that was captured");
   assert.equal(h.calls.asserted, 1, "and the binding bar still ran — the gate was admitted, not skipped");
+});
+
+test("#2125 gate r2: the binding assert decides on the probe, not a third fresh read", () => {
+  // The gate's r2 P1. Admitting a PROVEN absence at the comparison is only safe if
+  // the binding bar decides about that same observation. Left to take its own
+  // `activeWorkflowRef()` sample, a throw there returns null, and every predicate in
+  // resolveGraphBindingVerdict reads null as "no workflow service — legacy
+  // availability" — so the write would be permitted on an UNREADABLE surface, which
+  // is precisely the conflation this whole fix removes one line above.
+  const h = harness({ workflow: null, readable: true });
+  const captured = h.captureGraphMutationContext();
+  h.revalidateGraphMutationContext(captured);
+
+  assert.equal(h.calls.asserted, 1, "the binding bar still runs");
+  assert.ok(h.calls.assertOpts, "…and it is given options");
+  assert.deepEqual(
+    h.calls.assertOpts.workflowProbe,
+    { workflow: null, readable: true },
+    "the binding bar is handed the observation the comparison just validated",
+  );
+  assert.equal(
+    h.calls.freshReads,
+    0,
+    "nothing on this path takes a fresh activeWorkflowRef() sample — one observation, one decision",
+  );
+});
+
+test("#2125 gate r2: the binding assert PREFERS the supplied probe over its own read", () => {
+  // The consuming half, pinned on the real source. The assert is far too entangled
+  // to execute here, so this asserts the exact expression that decides it — a revert
+  // to a bare `activeWorkflowRef()` fails.
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const start = src.indexOf("function assertGraphBoundToActiveWorkflow(");
+  assert.notEqual(start, -1, "assertGraphBoundToActiveWorkflow must exist");
+  const body = src.slice(start, src.indexOf("\n}\n", start));
+  assert.match(
+    body,
+    /const activeWorkflow = workflowProbe \? workflowProbe\.workflow : activeWorkflowRef\(\);/,
+    "a caller-supplied observation wins; only a caller that made none re-reads",
+  );
+  assert.match(body, /workflowProbe = null,/, "and the option defaults off, so every other caller is unchanged");
 });
 
 test("#2125 call site r1: a probe that THREW at both ends is still refused", () => {

--- a/browser_tests/unit/reconnect-recovery.test.mjs
+++ b/browser_tests/unit/reconnect-recovery.test.mjs
@@ -708,20 +708,36 @@ test("#618 regression: the binding verdict still receives the #433 settle window
 test("#646 wiring: the async write boundary re-checks the gate (a dispatch can span a backend drop)", () => {
   const start = SRC.indexOf("function revalidateGraphMutationContext(");
   assert.notEqual(start, -1);
-  const body = SRC.slice(start, start + 1400);
+  // The WHOLE function, not a fixed byte window. A `start + N` slice silently
+  // stops asserting the moment a comment pushes a needle past N: `indexOf`
+  // returns -1, and -1 compares LESS THAN every real offset, so an ordering
+  // assertion written this way flips from "proven" to "vacuously true" (or, as
+  // in #2125, fails for a reason that has nothing to do with the ordering).
+  // Slice to the function's own end and require each needle to actually exist.
+  const end = SRC.indexOf("\n}", SRC.indexOf("  return current;", start));
+  assert.ok(end > start, "revalidateGraphMutationContext must still end by returning the context");
+  const body = SRC.slice(start, end);
   assert.match(
     body,
     /graphMutationReconnectGate\(\{[\s\S]*?backendDown: comfyBackendIsDown\(\),[\s\S]*?bindingSettleWindow: postReconnectBindingSettleWindow\(\)/,
     "the pre-write revalidation consults the same live signals",
   );
+  const at = (needle) => {
+    const i = body.indexOf(needle);
+    assert.notEqual(i, -1, `${needle} must be present in revalidateGraphMutationContext`);
+    return i;
+  };
   assert.ok(
-    body.indexOf("graphMutationReconnectGate({") < body.indexOf("getGraphCtx()"),
+    at("graphMutationReconnectGate({") < at("getGraphCtx()"),
     "the gate fires BEFORE getGraphCtx — the probe can change the canvas (the rebind heal), which would falsify 'nothing changed' (codex r7)",
   );
   assert.ok(
-    body.indexOf("graphMutationReconnectGate({") < body.indexOf("assertGraphBoundToActiveWorkflow("),
+    at("graphMutationReconnectGate({") < at("assertGraphBoundToActiveWorkflow("),
     "the gate fires BEFORE the write-boundary binding assert",
   );
+  // #2125 — the workflow probe is part of the "nothing changed" evidence, so it
+  // must be read AFTER the canvas-changing getGraphCtx, exactly as the capture does.
+  assert.ok(at("getGraphCtx()") < at("probeActiveWorkflow()"), "the workflow probe follows getGraphCtx");
 });
 
 test("#1325 wiring: a null status only arms the flag when the live socket is not OPEN", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4017,16 +4017,28 @@ function captureWasSuppressed(tracker) {
   }
 }
 
-function activeWorkflowRef() {
+// #2125 — the ONE read of the active workflow, tagged with whether it actually
+// RAN. `activeWorkflowRef()` collapses "the frontend exposes no active workflow"
+// and "the lookup threw" into the same `null`, which is fine for every caller
+// that only wants the object, and NOT fine for a caller asking whether anything
+// changed: two throws would otherwise witness "absent, then absent" for a tab
+// that moved underneath them. `readable:false` means "I did not find out".
+function probeActiveWorkflow() {
   try {
-    return (
-      window.comfyAPI?.app?.app?.extensionManager?.workflow?.activeWorkflow ||
-      (typeof app !== "undefined" && app?.extensionManager?.workflow?.activeWorkflow) ||
-      null
-    );
+    return {
+      workflow:
+        window.comfyAPI?.app?.app?.extensionManager?.workflow?.activeWorkflow ||
+        (typeof app !== "undefined" && app?.extensionManager?.workflow?.activeWorkflow) ||
+        null,
+      readable: true,
+    };
   } catch {
-    return null;
+    return { workflow: null, readable: false };
   }
+}
+
+function activeWorkflowRef() {
+  return probeActiveWorkflow().workflow;
 }
 
 function savedWorkflowPath(wf = activeWorkflowRef()) {
@@ -13659,7 +13671,13 @@ async function awaitRequiredCustomWidgetRegistration(
 
 function captureGraphMutationContext() {
   const context = getGraphCtx();
-  return { ...context, workflow: activeWorkflowRef() };
+  // #2125 — carry the READABILITY of the workflow probe alongside its result. The
+  // comparison below admits an absent workflow, and it may only do so when both
+  // ends PROVED the absence; a probe that threw returns the same `null` and
+  // proves nothing. One probe call per capture, so the flag cannot disagree with
+  // the value it describes.
+  const probe = probeActiveWorkflow();
+  return { ...context, workflow: probe.workflow, workflowReadable: probe.readable };
 }
 
 function revalidateGraphMutationContext(captured) {
@@ -13676,7 +13694,11 @@ function revalidateGraphMutationContext(captured) {
     bindingSettleWindow: postReconnectBindingSettleWindow(),
   });
   if (reconnectGate) throw reconnectRefusalError(reconnectGate);
-  const current = { ...getGraphCtx(), workflow: activeWorkflowRef() };
+  // getGraphCtx FIRST, then the workflow probe — the same order as the capture, so
+  // the two contexts are built from the same sequence of reads (#2125).
+  const currentGraphCtx = getGraphCtx();
+  const currentProbe = probeActiveWorkflow(); // #2125 — see captureGraphMutationContext
+  const current = { ...currentGraphCtx, workflow: currentProbe.workflow, workflowReadable: currentProbe.readable };
   if (!sameGraphMutationContext(captured, current, sameWorkflowObject)) {
     throw new Error(
       "The active workflow or graph view changed while this node was preparing; nothing was added. Retry on the intended tab.",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9686,11 +9686,27 @@ function assertGraphBoundToActiveWorkflow(
     // `graphCommandBindingBar`. Gating the stale-tag bypass on the absence of the
     // mutation flag would be default-permit (codex).
     staleTagReadBypass = false,
+    // #2125 (gate r2 P1) — the caller's OWN observation of the active workflow, when
+    // it already made one as part of proving nothing changed. See below.
+    workflowProbe = null,
   } = {},
 ) {
   const liveNodeCount = rootGraph?._nodes?.length ?? 0;
   const inSubgraph = !!rootGraph && graph !== rootGraph;
-  const activeWorkflow = activeWorkflowRef();
+  // #2125 (gate r2 P1) — DECIDE ON THE CALLER'S OBSERVATION, not a fresh one.
+  //
+  // `revalidateGraphMutationContext` admits an absent workflow only when its probe
+  // PROVED the absence (it ran and found nothing), never when the probe threw. A
+  // bare re-read here would be a third, independent sample of the same surface, and
+  // `activeWorkflowRef()` reports a throw as `null` — which every predicate below
+  // reads as "no workflow service — legacy availability". So the gate could admit on
+  // a proven absence and this layer could then permit the write on an UNREADABLE one,
+  // re-introducing one line down exactly the conflation the gate exists to prevent.
+  //
+  // One observation, one decision. Callers that did not probe (every read path, and
+  // the direct mutation paths that have no preflight to straddle) pass nothing and
+  // get the original read, unchanged.
+  const activeWorkflow = workflowProbe ? workflowProbe.workflow : activeWorkflowRef();
   // Every caller, including direct CivitAI graph_load and local snapshot restore,
   // must establish the active object identity before relying on a dirty-tab
   // relaxation. workflowStableUuid is root-blind when this object has no cache:
@@ -13706,6 +13722,11 @@ function revalidateGraphMutationContext(captured) {
   }
   assertGraphBoundToActiveWorkflow(current.graph, current.rootGraph, {
     ...MUTATION_BINDING_BAR,
+    // #2125 (gate r2 P1) — the binding decision must be about the workflow this
+    // function just PROVED unchanged, not about a third sample of the same surface
+    // taken microseconds later. Without this the comparison above and the binding
+    // bar below can disagree about whether the workflow was readable at all.
+    workflowProbe: currentProbe,
   });
   return current;
 }

--- a/web/js/lib/graph-mutation-context.js
+++ b/web/js/lib/graph-mutation-context.js
@@ -3,11 +3,48 @@
  * switch. The caller supplies the workflow comparator because ComfyUI can
  * expose the same workflow through a Vue proxy and its raw object.
  */
+
+/**
+ * #2125 — the workflow slot answers a CHANGE question, not an IDENTITY one, and
+ * the two disagree about absence.
+ *
+ * `activeWorkflowRef()` returns null whenever the frontend exposes no active
+ * workflow — an `extensionManager.workflow` surface that is missing, still
+ * seating, or throwing. The caller's comparator (`sameWorkflowObject`) answers
+ * false for ANY pair containing a null, and that is the right answer to the
+ * question it is asked: two references sharing no identity carrier can never be
+ * PROVEN the same. But absent-then-absent is not two references, it is no
+ * reference twice, and nothing moved between them.
+ *
+ * Delegating the null pair to that comparator therefore refused every graph
+ * mutation on such a frontend, claiming "the active workflow or graph view
+ * changed" about a tab that never changed and telling the caller to "retry on
+ * the intended tab" — advice no retry can satisfy, because the next capture
+ * reads null again and refuses identically. The rest of the panel treats this
+ * state as supported: `graphEmptyBindingUnproven` returns false on a null
+ * workflow ("no workflow service — legacy availability"), and every other
+ * predicate in `resolveGraphBindingVerdict` degrades to no-refusal, so the
+ * binding bar that runs immediately after this gate lets the mutation through.
+ * This gate was the only one that did not, and it runs on the MUTATION path
+ * alone — which is why the reporter's `panel_graph_outline` read succeeded
+ * against the very canvas the following `panel_add_node` was refused on.
+ *
+ * Absence appearing or disappearing is still a change: a workflow that arrives
+ * mid-preflight, or one that vanishes, both stay refused. Only absent→absent is
+ * admitted, and it is admitted because it is not evidence of anything.
+ */
+function sameWorkflowSlot(before, after, sameWorkflow) {
+  const beforeAbsent = before == null;
+  const afterAbsent = after == null;
+  if (beforeAbsent || afterAbsent) return beforeAbsent && afterAbsent;
+  return sameWorkflow(before, after);
+}
+
 export function sameGraphMutationContext(before, after, sameWorkflow = (a, b) => a === b) {
   return !!before && !!after &&
     before.app === after.app &&
     before.graph === after.graph &&
     before.rootGraph === after.rootGraph &&
     before.canvas === after.canvas &&
-    sameWorkflow(before.workflow, after.workflow);
+    sameWorkflowSlot(before.workflow, after.workflow, sameWorkflow);
 }

--- a/web/js/lib/graph-mutation-context.js
+++ b/web/js/lib/graph-mutation-context.js
@@ -32,12 +32,26 @@
  * Absence appearing or disappearing is still a change: a workflow that arrives
  * mid-preflight, or one that vanishes, both stay refused. Only absent→absent is
  * admitted, and it is admitted because it is not evidence of anything.
+ *
+ * ABSENT IS NOT THE SAME AS UNREADABLE (gate r1 P1), and the whole safety of the
+ * paragraph above rests on the distinction. `activeWorkflowRef()` also answers
+ * `null` when its lookup THREW, and two throws would otherwise witness
+ * "absent, then absent" across a preflight the workflow genuinely moved during —
+ * admitting a write onto a canvas nothing verified. So the caller reports whether
+ * the probe RAN (`workflowReadable`), and a null is only unchanged when BOTH ends
+ * proved there was nothing to see. Unreadable, or unstated, fails closed exactly
+ * as before this fix: a context that does not carry the flag is refused on a null
+ * workflow, so no other caller can opt into the relaxation by accident.
  */
+function absenceProven(context) {
+  return context.workflow == null && context.workflowReadable === true;
+}
+
 function sameWorkflowSlot(before, after, sameWorkflow) {
-  const beforeAbsent = before == null;
-  const afterAbsent = after == null;
-  if (beforeAbsent || afterAbsent) return beforeAbsent && afterAbsent;
-  return sameWorkflow(before, after);
+  if (before.workflow == null || after.workflow == null) {
+    return absenceProven(before) && absenceProven(after);
+  }
+  return sameWorkflow(before.workflow, after.workflow);
 }
 
 export function sameGraphMutationContext(before, after, sameWorkflow = (a, b) => a === b) {
@@ -46,5 +60,5 @@ export function sameGraphMutationContext(before, after, sameWorkflow = (a, b) =>
     before.graph === after.graph &&
     before.rootGraph === after.rootGraph &&
     before.canvas === after.canvas &&
-    sameWorkflowSlot(before.workflow, after.workflow, sameWorkflow);
+    sameWorkflowSlot(before, after, sameWorkflow);
 }


### PR DESCRIPTION
Fixes #2125.

## What the reporter saw

On an empty unsaved workflow: `panel_graph_outline` **succeeded**, then `panel_add_node`
was refused with

> The active workflow or graph view changed while this node was preparing; nothing was
> added. Retry on the intended tab.

No tab switch, no graph edit, graph left empty, every retry identical.

## Root cause

That read-succeeds / mutation-refuses asymmetry is the fingerprint.
`revalidateGraphMutationContext` is the **only** gate on the mutation path that compares a
before/after workflow reference, and `activeWorkflowRef()` returns `null` whenever the
frontend exposes no active workflow (`extensionManager.workflow` missing, still seating, or
throwing). The comparator it delegates to, `sameWorkflowObject`, answers `false` for **any**
pair containing a null — which is the correct answer to the question it is asked (two
references sharing no identity carrier can never be *proven* the same), and the wrong answer
to the question the gate is asking (did anything *change*?).

So absent-then-absent read as "the tab changed". Verified by execution against `origin/main`
before touching anything — the gate refuses when handed the **literally identical context
object**:

```
sameWorkflowObject(null, null)          = false
sameGraphMutationContext(ctx, ctx, swo) = false   <- same object, nothing moved
```

The rest of the panel treats an absent workflow as *supported*, not as a refusal:
`graphEmptyBindingUnproven` returns false on it (`// no workflow service — legacy
availability`) and every other predicate in `resolveGraphBindingVerdict` degrades to
no-refusal. Confirmed by execution on the **mutation** bar:

```
resolveGraphBindingVerdict(activeWorkflow: null, empty root, requireDirtyMutationBinding) = null
```

The binding assert that runs on the very next line already lets this through. This gate was
the one place that did not — and it sits on the mutation path only, which is exactly why the
outline read worked on the same canvas.

Corroborating detail from the report: the environment line says *"ComfyUI frontend version
unavailable"*. The panel reads that from `app.extensionManager.frontendVersion` — the same
`extensionManager` surface `activeWorkflowRef()` probes for `.workflow.activeWorkflow`.

## The fix

One predicate, at the mutation-context boundary: absence at **both** ends is unchanged.
Absence appearing or disappearing stays refused.

Deliberately **not** fixed in `sameWorkflowObject` — it has ~12 other call sites (openWorkflows
enumeration loops, owner-record comparisons) where a null pair must keep answering false. This
is a change question, not an identity question, so it belongs in the context comparator.

## Please look hardest at these

- **The safety claim that makes this a fix and not a cosmetic message change** is that the
  binding bar permits a null workflow. If that were wrong, I would only be moving the refusal
  one line down. It is asserted by execution in the test, not by reading.
- **Is admitting `null → null` a hole in the #646/#349 wrong-canvas fence?** My argument: no,
  because a null workflow carries no canvas claim at all, the `app`/`graph`/`rootGraph`/`canvas`
  identity checks are untouched and still decide, and the binding assert still runs. Tests pin
  the three transitions that must stay refused (null→wf, wf→null, A→B) and that a changed
  graph/canvas still refuses even with no workflow present.
- **`== null` vs falsy.** `activeWorkflowRef()` ends in `|| null`, so it yields `null`, but the
  slot is compared with `== null` (null *and* undefined) rather than truthiness, so a workflow
  object is never treated as absent.

## Correction to the issue thread

The follow-up comment says updating 0.15.102 → 0.15.149 restored this. I extracted the function
bodies of `revalidateGraphMutationContext`, `captureGraphMutationContext`, `getGraphCtx` and
`activeWorkflowRef` at both tags and diffed them: **all four are byte-identical**, as are
`graph-mutation-context.js` and `sameWorkflowObject`. The version bump does not explain the
recovery — the ComfyUI restart (re-seating the workflow store, so `activeWorkflow` became
non-null) does, and that is consistent with this root cause. The refusal path was still fully
live on `origin/main` @ `b6847f6b` (v0.15.149).

## Evidence

- New: `browser_tests/unit/graph-mutation-context-absent-workflow.test.mjs` — 6 tests.
  Two run the **real** `captureGraphMutationContext` / `revalidateGraphMutationContext` source
  sliced out of `comfyui-mcp-panel.js` and executed over injected deps, so a fix that lived only
  in the lib while the call site passed its own comparator would not pass.
- **Mutation-verified.** Reverting the predicate to `return false` turns the lib test *and* the
  call-site test red (4 pass / 2 fail); the other four stay green, which is the point — they pin
  behaviour that must not change.
- Full unit suite: **7857 pass / 0 fail / 1 todo**.
- `check:changelog`, `check-panel-scope`, `i18n-check` all clean.

## Browser coverage — what I do NOT have

I could not run the Playwright suite: it needs a live ComfyUI and no instance was allocated to
this run. So this change is **not** covered by a browser test, and I am not implying it is. The
call-site test executes the real production source of the gate, which is the strongest coverage
available without a rig, but it is not the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
