### PR TITLE
docs(#2150): a missing completion receipt is not only an old orchestrator

### DIFF
--- a/browser_tests/unit/run-completion-redelivery-storm.test.mjs
+++ b/browser_tests/unit/run-completion-redelivery-storm.test.mjs
@@ -22,6 +22,14 @@
  * v0.52.122 (`8282e05`), so no receipt could arrive and every replay minted a
  * fresh agent turn.
  *
+ * #2150 — that version is an EXAMPLE of a peer that never answers, not the only
+ * one, and reading it as the only one is what sent a 0.52.146 report here
+ * instead of upstream. A current orchestrator withholds the receipt whenever the
+ * completion cannot be tied to a live run ticket (evicted, `reused`, a changed
+ * tab/conversation, or a re-minted key) — see comfyui-mcp#2700 and the note in
+ * run-completion.js. These pins are therefore about a peer that does not answer
+ * for ANY reason; they deliberately do not model why.
+ *
  * WHAT IS COUNTED is deliberately "frames the transport ACCEPTED for this run
  * and no receipt has retired", not "reconcile passes": a refusal gives its own
  * slot back but must never reset the count, or a flapping transport mints one

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -488,6 +488,23 @@ export function createRunCompletionTracker({
   // depends on a peer capability it cannot observe must be bounded, or a peer
   // that never answers turns it into an infinite loop.
   //
+  // #2150 — AND AN OLD ORCHESTRATOR IS NOT THE ONLY WAY TO GET NO RECEIPT. That
+  // is the reading the paragraph above invites, and a reporter took it: they saw
+  // this budget spent in full on comfyui-mcp 0.52.146, read "before v0.52.122",
+  // concluded the ack path must be present-but-blocked, and filed a panel bug for
+  // an orchestrator one. On a CURRENT orchestrator the ack is gated on
+  // `acceptsCompletionReceipt()`, which needs a live ticket for the prompt id
+  // that is not `reused`, passes `ownsRun()`, and carries THIS completion key.
+  // A completion can be journaled, delivered to the agent, and still fail every
+  // one of those — the ticket was evicted (mcp caps at 64), the tab id or
+  // conversation churned across a reconnect, or a remount re-minted the key.
+  // The same check drives the agent-facing "its origin is UNDETERMINED" banner,
+  // so that banner and a spent budget are one condition, not two symptoms.
+  // Tracked upstream as comfyui-mcp#2700, which is where the fix belongs: the
+  // panel cannot tell a declined receipt from a frame lost in transit, because
+  // both look like silence, and recovering the lost one is what this replay is
+  // FOR. So the bound stays, and it stays at three.
+  //
   // So: the replay stays, and what is counted is the only thing that can
   // actually reach the agent — a completion frame the TRANSPORT ACCEPTED for
   // this run which no receipt has retired. Past the budget the panel stops


### PR DESCRIPTION
## What this is

**Comment-only.** No behaviour change. Two files, +25 lines, all of it prose.

## Why

`web/js/lib/run-completion.js` explains the `#1842` replay bound by describing the
orchestrator its reporters ran:

> comfyui-mcp did not send `ack {kind:"completion"}` at all before v0.52.122, so no
> receipt could ever arrive and every replay minted a fresh agent turn.

That is true, and it reads as *the* way to get no receipt. A reporter read it that way:
on comfyui-mcp **0.52.146** they saw one workflow's completion storyboard delivered three
times — exactly `maxUnackedDeliveries` — concluded the ack path must be present-but-blocked
by something about the payload (a `CompareFrames` node emitting 769 temp outputs), and filed
**#2150** against this repo for an orchestrator defect. Their own note flags the payload link
as UNVERIFIED; it is not the cause.

## What is actually true

The receipt is gated on `acceptsCompletionReceipt()`
(`comfyui-mcp/src/orchestrator/run-completion-journal.ts:1674`), which needs a live ticket
for the prompt id that is `!reused`, passes `ownsRun()`, and carries **this** completion key.
A completion can be journaled, delivered to the agent, and still fail every one of those.

I drove the real journal on mcp `main` @ `1200628` rather than reasoning about it —
**7/7 pass**:

| case | condition | `correlate` | ack sent? |
|---|---|---|---|
| baseline | live, owned, keyed ticket | `matched` | yes |
| A | open ticket **evicted** (`MAX_TICKETS = 64`) | `foreign` | **no** |
| B | ticket opened with **no** completion key | `matched` | yes — hypothesis **disproven**, `record()` adopts a late key |
| C | different **conversation** | `foreign` | **no** |
| E | frame key ≠ ticket key (remount re-mints) | `foreign` | **no** |
| F | tab id churned across reconnect | `foreign` | **no** |

`correlate()` refuses `matched` on the same conditions, and `foreign` is what renders the
agent-facing `"its origin is UNDETERMINED"` banner (`panel-agent.ts:105`). So the two signals
the reporter listed as separate correlated observations are **one condition**. Written up with
the evidence test as **comfyui-mcp#2700**.

## Why nothing changes here

The panel cannot act on this. A declined receipt and a frame lost in transit are both
*silence* — `sendFrame` returning true only proves the browser wrote to the socket, and the
orchestrator sends nothing back when it declines. Recovering the lost one is what the replay
exists to do (`CONTROL #1739` / `CONTROL #370` in the storm test), so the bound stays, and it
stays at three. The fix belongs upstream: send a negative receipt when the frame was journaled
but could not be tied to a ticket. That is comfyui-mcp#2700's job, not this PR's.

## Where to look hardest

- **The claim I am correcting was not false, only incomplete**, so the risk is over-correcting
  into a different wrong statement. The added note asserts five things about *mcp* code from
  another repo. A/C/E/F are executed, not read; B is the one I got wrong on the first pass and
  the table records it as disproven rather than dropping it.
- **`comfyui-mcp#2700` is referenced from a source comment**, which makes it a cited fact for
  every later reader of this file. If that issue is closed as not-a-bug, this comment becomes
  the stale thing it is trying to prevent.
- The storm test's header note claims those pins "deliberately do not model why" a peer does
  not answer. Worth checking that is still accurate of all 7 cases and not just the two `#1842`
  ones.

## Verification

- `npm run test:unit` — **exit 0** on `6f53eb33`.
- `browser_tests/unit/run-completion-redelivery-storm.test.mjs` — 7/7, unchanged.
- No mutation test: there is nothing to mutate. A comment cannot fail a test, and I am not
  going to invent an assertion over prose to manufacture one.
- **Browser gate NOT run.** Nothing here is panel-visible — no rendered string, no DOM, no
  locale key — so a Playwright run would prove nothing about this diff. Saying so explicitly
  rather than implying coverage I do not have.

Context for #2150 (that issue is being closed separately, as upstream — this PR does not
resolve it).
