### PR TITLE
fix(#2158): classify and MEASURE a failed workflow switch instead of asserting it

### DIFF
--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -774,6 +774,67 @@ test("#2158 production workflow_open MEASURES a transport failure instead of ass
   assert.equal(journal.at(-1)?.resolved?.path, target.path);
 });
 
+test("#2158 production workflow_open still REJECTS when its own diagnosis throws", async () => {
+  // The hazard the extraction harness surfaced. Diagnosis runs inside a catch block, and
+  // a throw raised there lands in this executor's OUTER handler — which reads it as a
+  // disk-read warning, leaves `openFailed` null, and lets the open continue down its
+  // SUCCESS path. A workflow switch that threw would be reported as one that worked.
+  const previous = { path: "workflows/previous.json" };
+  const target = { path: "workflows/target.json", filename: "target.json", isModified: false };
+  const nativeError = new Error("NetworkError when attempting to fetch resource.");
+  const journal = [];
+  const panel = productionExecutor("workflow_open", {
+    backendReconnectEpoch: 4,
+    activeWorkflowResyncEpoch: 4,
+    postReconnectBindingProofEpoch: 4,
+    app: {
+      canvas: {},
+      extensionManager: {
+        workflow: {
+          openWorkflows: [target],
+          workflows: [],
+          getWorkflowByPath: () => target,
+          openWorkflow: async () => {
+            throw nativeError;
+          },
+        },
+      },
+    },
+    activeWorkflowRef: () => previous,
+    sameWorkflowObject,
+    // The diagnosis itself is broken. Whatever else happens, the FAILURE must survive.
+    openSwitchFailureMessage: () => {
+      throw new TypeError("openSwitchFailureMessage is not a function");
+    },
+    workflowTabId: (workflow) => `wf:${workflow.path}`,
+    workflowStableUuid: () => "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95",
+    noteOpenAttempt: (entry) => {
+      journal.push(entry);
+      return { seq: journal.length };
+    },
+    coerceMessageText: (value) => String(value),
+    getWorkflowTitle: () => "Previous",
+    waitForReconnectHandshakeBeforeOpen: async () => {},
+    comfyBackendIsDown: () => false,
+    postReconnectBindingSettleWindow: () => false,
+    nodeDefRefreshInFlight: null,
+    flushSourceCanvasBeforeSwitch: async () => {},
+    claimActiveWorkflowMove: () => {},
+    acquireCanvasInteractionLock: () => ({ token: 1 }),
+    releaseCanvasInteractionLock: () => {},
+    MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+  });
+
+  const failure = await panel.method({ path: target.path, rid: "diagnosis-throws" }).then(
+    (ok) => assert.fail(`a failed switch must never resolve as success: ${JSON.stringify(ok)}`),
+    (err) => err,
+  );
+  // The raw failure is kept rather than lost — degraded, but never silently successful.
+  assert.equal(failure, nativeError);
+  assert.match(journal.at(-1)?.error ?? "", /NetworkError/);
+  assert.equal(panel.guard(), null, "and the reload guard is still released");
+});
+
 test("#2158 production workflow_open refuses the clean negative when the pointer DID move", async () => {
   // The hazard the hardcoded `false` was hiding. `openWorkflow` assigns
   // `activeWorkflow.value` and only THEN writes `comfyApp.canvas.bg_tint`, so a throw

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -29,6 +29,10 @@ import {
   graphRootWorkflowUuidMatches,
   graphRootWorkflowUuidMismatches,
 } from "../../web/js/lib/graph-binding.js";
+import {
+  classifyOpenSwitchFailure,
+  openSwitchFailureMessage,
+} from "../../web/js/lib/open-switch-failure.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
@@ -151,6 +155,12 @@ function productionExecutor(methodName, environment) {
     POINTER_WATCH_UNAVAILABLE_NOTICE,
     workflowOpenReadinessRefusalError,
     readWorkflowOpenReadinessRefusal,
+    // #2158 — the shipped switch-failure classifier. A `new Function` scope has no module
+    // bindings, so an import the executor body now references is an undefined identifier
+    // here; without these the native-failure path throws a TypeError out of its own catch
+    // and the open walks on down the success path.
+    classifyOpenSwitchFailure,
+    openSwitchFailureMessage,
     graphRootMatchesState,
     graphRootWorkflowUuidMatches,
     graphRootWorkflowUuidMismatches,
@@ -632,6 +642,10 @@ test("#887 production workflow_open native failure retires proof before its nega
       },
     },
     activeWorkflowRef: () => previous,
+    // #2158 — the executor now MEASURES the pointer in its native-failure catch, so this
+    // scenario needs a real comparator. Without one the measurement degrades to
+    // "not observable" and the clean negative this test exists to pin is unreachable.
+    sameWorkflowObject,
     workflowTabId: (workflow) => `wf:${workflow.path}`,
     workflowStableUuid: () => "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95",
     noteOpenAttempt: (entry) => {
@@ -651,14 +665,175 @@ test("#887 production workflow_open native failure retires proof before its nega
     MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
   });
 
-  await assert.rejects(panel.method({ path: target.path, rid: "native-failure" }), nativeError);
+  // #2158 — the rejection now CARRIES the original rather than BEING it. The raw browser
+  // string was what the report could not act on, so the thrown error is the classified
+  // one and the cause chain keeps the original for anyone who wants it verbatim.
+  const failure = await panel.method({ path: target.path, rid: "native-failure" }).then(
+    () => assert.fail("a native switch failure must reject"),
+    (err) => err,
+  );
+  assert.equal(failure.cause, nativeError, "the original error is preserved as the cause");
+  assert.match(failure.message, /native switch rejected after partial work/, "and quoted verbatim");
   assert.deepEqual(panel.proofs(), {
     active: 3,
     post: 3,
   });
   assert.equal(panel.guard(), null, "native failure must release the production reload guard");
+  // The pointer never left `previous` in this scenario, and the executor MEASURED that,
+  // so the clean negative this test exists to pin still holds — it is now earned rather
+  // than asserted.
   assert.equal(journal.at(-1)?.applied, false, "the native failure remains a clean negative reply");
   assert.match(journal.at(-1)?.error ?? "", /native switch rejected/);
+  // #2158 — and the receipt now names WHICH workflow it is about. The orchestrator's
+  // correlator rejects a receipt whose resolved path does not match the request before it
+  // reads `applied` at all, so a null here made the verdict above unreachable.
+  assert.equal(journal.at(-1)?.resolved?.path, target.path);
+  assert.equal(journal.at(-1)?.resolved?.routing_key, `wf:${target.path}`);
+});
+
+test("#2158 production workflow_open MEASURES a transport failure instead of asserting a negative", async () => {
+  // The reported failure, executed: switching between two saved workflows when the
+  // frontend's `/userdata` read throws the browser's transport error.
+  const previous = { path: "workflows/VR180 Restoration - 1s Trim Proof.json" };
+  const target = {
+    path: "workflows/VR180 SeedVR2 Benchmark Runner.json",
+    filename: "VR180 SeedVR2 Benchmark Runner.json",
+    isModified: false,
+  };
+  // Firefox's wording, which is what the reporter saw.
+  const nativeError = new Error("NetworkError when attempting to fetch resource.");
+  const journal = [];
+  // The store pushes the path into its open-tab list BEFORE the read that throws, so the
+  // tab really is listed afterwards. That is the residue the old message denied.
+  const openWorkflows = [];
+  const panel = productionExecutor("workflow_open", {
+    backendReconnectEpoch: 4,
+    activeWorkflowResyncEpoch: 4,
+    postReconnectBindingProofEpoch: 4,
+    app: {
+      canvas: {},
+      extensionManager: {
+        workflow: {
+          openWorkflows,
+          workflows: [target],
+          getWorkflowByPath: () => target,
+          openWorkflow: async () => {
+            openWorkflows.push(target); // the store's pre-read mutation
+            throw nativeError; // ...and then the fetch fails
+          },
+        },
+      },
+    },
+    activeWorkflowRef: () => previous, // the pointer never moves
+    sameWorkflowObject,
+    workflowTabId: (workflow) => `wf:${workflow.path}`,
+    workflowStableUuid: () => "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95",
+    noteOpenAttempt: (entry) => {
+      journal.push(entry);
+      return { seq: journal.length };
+    },
+    coerceMessageText: (value) => String(value),
+    getWorkflowTitle: () => "Proof",
+    waitForReconnectHandshakeBeforeOpen: async () => {},
+    comfyBackendIsDown: () => false,
+    postReconnectBindingSettleWindow: () => false,
+    nodeDefRefreshInFlight: null,
+    flushSourceCanvasBeforeSwitch: async () => {},
+    claimActiveWorkflowMove: () => {},
+    acquireCanvasInteractionLock: () => ({ token: 1 }),
+    releaseCanvasInteractionLock: () => {},
+    MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+  });
+
+  const failure = await panel.method({ path: target.path, rid: "transport-failure" }).then(
+    () => assert.fail("a transport failure must reject"),
+    (err) => err,
+  );
+
+  // 1. The symptom: the bare browser string now arrives classified and routed.
+  assert.match(failure.message, /NetworkError when attempting to fetch resource/, "verbatim");
+  assert.match(failure.message, /TRANSPORT failure/);
+  assert.match(failure.message, /GET \/userdata/);
+  assert.match(failure.message, /no HTTP status or response body to report/);
+  assert.match(failure.message, /VR180 SeedVR2 Benchmark Runner\.json/);
+
+  // 2. The measurement, which is the part that used to be an assertion.
+  assert.match(failure.message, /MEASURED, NOT ASSUMED/);
+  assert.match(failure.message, /the switch did not happen/);
+  assert.match(failure.message, /VR180 Restoration - 1s Trim Proof\.json/, "names the workflow still active");
+  assert.match(failure.message, /re-issuing panel_open_workflow is safe/);
+
+  // 3. The residue the old "nothing was applied" denied — OBSERVED here, because the
+  //    fake store performs the same pre-read push the real one does.
+  assert.ok(openWorkflows.includes(target), "the store really did list the tab before throwing");
+  assert.match(failure.message, /now listed among the open workflow tabs/);
+
+  // 4. The receipt keeps the accurate clean negative, so the orchestrator still tells the
+  //    caller it is safe to retry — earned from the pointer read, not hardcoded.
+  assert.equal(journal.at(-1)?.applied, false);
+  assert.equal(journal.at(-1)?.resolved?.path, target.path);
+});
+
+test("#2158 production workflow_open refuses the clean negative when the pointer DID move", async () => {
+  // The hazard the hardcoded `false` was hiding. `openWorkflow` assigns
+  // `activeWorkflow.value` and only THEN writes `comfyApp.canvas.bg_tint`, so a throw
+  // after the pointer moved is reachable — and "confirmed not applied, safe to retry" is
+  // then a claim about a canvas that has already become the target's.
+  const previous = { path: "workflows/previous.json" };
+  const target = { path: "workflows/target.json", filename: "target.json", isModified: false };
+  const nativeError = new Error("Cannot set properties of null (setting 'bg_tint')");
+  const journal = [];
+  let active = previous;
+  const panel = productionExecutor("workflow_open", {
+    backendReconnectEpoch: 4,
+    activeWorkflowResyncEpoch: 4,
+    postReconnectBindingProofEpoch: 4,
+    app: {
+      canvas: {},
+      extensionManager: {
+        workflow: {
+          openWorkflows: [target],
+          workflows: [],
+          getWorkflowByPath: () => target,
+          openWorkflow: async () => {
+            active = target; // the pointer moved...
+            throw nativeError; // ...and the very next line threw
+          },
+        },
+      },
+    },
+    activeWorkflowRef: () => active,
+    sameWorkflowObject,
+    workflowTabId: (workflow) => `wf:${workflow.path}`,
+    workflowStableUuid: () => "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95",
+    noteOpenAttempt: (entry) => {
+      journal.push(entry);
+      return { seq: journal.length };
+    },
+    coerceMessageText: (value) => String(value),
+    getWorkflowTitle: () => "Previous",
+    waitForReconnectHandshakeBeforeOpen: async () => {},
+    comfyBackendIsDown: () => false,
+    postReconnectBindingSettleWindow: () => false,
+    nodeDefRefreshInFlight: null,
+    flushSourceCanvasBeforeSwitch: async () => {},
+    claimActiveWorkflowMove: () => {},
+    acquireCanvasInteractionLock: () => ({ token: 1 }),
+    releaseCanvasInteractionLock: () => {},
+    MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+  });
+
+  const failure = await panel.method({ path: target.path, rid: "moved-pointer" }).then(
+    () => assert.fail("the failure must still reject"),
+    (err) => err,
+  );
+
+  // The verdict degrades, so the orchestrator says "inspect before retrying" instead of
+  // "confirmed not applied".
+  assert.equal(journal.at(-1)?.applied, "unknown", "a moved pointer is never a clean negative");
+  assert.match(failure.message, /the active workflow IS now "workflows\/target\.json"/);
+  assert.match(failure.message, /Re-read the graph/);
+  assert.doesNotMatch(failure.message, /the switch did not happen/);
 });
 
 test("#1898 production workflow_open accepts a settled readable outline after normalization races", async () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -461,8 +461,24 @@ test("#402 wiring: workflow_open BOUNDS the post-open disk read and never claims
 test("#402/#721 wiring: workflow_open journals clean negatives and partial rebind outcomes", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const body = handlerBody(src, "async workflow_open({");
-  assert.match(body, /const failOpen = \(err\) => \{/, "there must be a single negative-journal helper");
-  assert.match(body, /applied: false/, "the failure path must journal applied:false");
+  // Still ONE negative-journal helper. #2158 gave it an options bag so the native-switch
+  // catch can journal what it MEASURED, but the default is pinned to the clean negative:
+  // every pre-switch caller keeps journaling `applied:false` without saying so.
+  assert.match(
+    body,
+    /const failOpen = \(err, \{ applied = false, resolved = null \} = \{\}\) => \{/,
+    "there must be a single negative-journal helper, defaulting to the clean negative",
+  );
+  // Exactly ONE `failOpen` call may override the default, and it is the native-switch
+  // throw. Every other one is a genuine "nothing started" and must keep the clean
+  // negative — an override creeping onto those would silently turn real negatives into
+  // "undetermined" and cost the caller the "safe to retry" answer.
+  const code = stripComments(body);
+  const calls = [...code.matchAll(/throw failOpen\(([\s\S]{0,400}?)\);/g)].map((m) => m[1]);
+  const overriding = calls.filter((c) => /,\s*\{/.test(c));
+  assert.equal(overriding.length, 1, "exactly one failOpen call passes a measured verdict");
+  assert.match(overriding[0], /^openFailed\s*,/, "and it is the native-switch failure");
+  assert.ok(calls.length > overriding.length, "the pre-switch throws still use the bare default");
   assert.match(body, /noteOpenAttempt\(\{[\s\S]*?cmd: "workflow_open",[\s\S]*?applied: true,/, "the success path must journal a receipt");
   // A failed post-switch repaint is not a clean negative: the active workflow may
   // already have changed. It must be journaled UNKNOWN, while every other throw

--- a/browser_tests/unit/open-switch-failure.test.mjs
+++ b/browser_tests/unit/open-switch-failure.test.mjs
@@ -254,3 +254,18 @@ test("#2158 WIRED: the classifier is SHARED with #1472, not a second copy of the
   assert.match(lib, /import \{ isTransportFailure \} from "\.\/manager-fetch-failure\.js";/);
   assert.doesNotMatch(lib, /networkerror when attempting to fetch resource/i, "no second copy of the table");
 });
+
+test("#2158 the raw message is not double-punctuated", () => {
+  // Firefox's string already ends in a full stop and Chrome's does not, so a bare
+  // `${raw}.` produced "…fetch resource.." for the exact browser this was reported from.
+  const ff = openSwitchFailureMessage({ path: "a.json", err: FIREFOX, activeIsSource: true });
+  assert.doesNotMatch(ff, /\.\./, "no doubled full stop");
+  assert.match(ff, /fetch resource\. This is a TRANSPORT failure/);
+  // Chrome's has no trailing stop and must still get one.
+  const cr = openSwitchFailureMessage({ path: "a.json", err: CHROME, activeIsSource: true });
+  assert.match(cr, /Failed to fetch\. This is a TRANSPORT failure/);
+  // Same on the non-transport branch, where the server's own text is kept.
+  const ans = openSwitchFailureMessage({ path: "a.json", err: ANSWERED, activeIsSource: true });
+  assert.match(ans, /404 Not Found\. MEASURED/);
+  assert.doesNotMatch(ans, /\.\./);
+});

--- a/browser_tests/unit/open-switch-failure.test.mjs
+++ b/browser_tests/unit/open-switch-failure.test.mjs
@@ -1,0 +1,256 @@
+/**
+ * #2158 — `panel_open_workflow` failed with a bare `NetworkError when attempting to fetch
+ * resource.` while switching between two saved workflows.
+ *
+ * Two things were wrong and they are tested separately, because only one of them is the
+ * symptom that got reported:
+ *
+ *   1. The message. The raw browser string was rethrown with no route and no
+ *      classification, even though the panel already owned a classifier for exactly this
+ *      failure class (`manager-fetch-failure.js`, comfyui-mcp#1472).
+ *   2. The receipt. The executor journaled `applied: false` — "confirmed not applied, safe
+ *      to retry" in the orchestrator's vocabulary — from an ASSERTION, on a path where the
+ *      store had already been mutated and where the active pointer can have moved.
+ *
+ * The second is the one that could hurt someone, so most of what follows is about it.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  WORKFLOW_CONTENT_ROUTE,
+  classifyOpenSwitchFailure,
+  openSwitchFailureMessage,
+} from "../../web/js/lib/open-switch-failure.js";
+
+const PANEL_JS = new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url);
+
+/** The exact string Firefox produced in the report. */
+const FIREFOX = new Error("NetworkError when attempting to fetch resource.");
+/** The reporter was on Firefox; the other engines must classify identically. */
+const CHROME = new Error("Failed to fetch");
+const SAFARI = new Error("Load failed");
+/** What `UserFile.load()` throws when the server ANSWERED and said no. */
+const ANSWERED = new Error("Failed to load file 'workflows/a.json': 404 Not Found");
+
+// --- classification -------------------------------------------------------
+
+test("#2158 the reported Firefox string is recognised as a transport failure", () => {
+  for (const err of [FIREFOX, CHROME, SAFARI]) {
+    assert.equal(classifyOpenSwitchFailure({ err }).transport, true, err.message);
+  }
+});
+
+test("#2158 an ANSWERED failure is NOT relabelled as transport", () => {
+  // The dangerous direction. A 404/403 means the server considered the request and said
+  // no; calling that "no usable response reached the browser" would send the caller after
+  // their network when the file is simply not there.
+  const v = classifyOpenSwitchFailure({ err: ANSWERED });
+  assert.equal(v.transport, false);
+  const text = openSwitchFailureMessage({ path: "workflows/a.json", err: ANSWERED, activeIsSource: true });
+  assert.match(text, /404 Not Found/, "the real message survives");
+  assert.doesNotMatch(text, /TRANSPORT failure/);
+  // And it must NOT inherit the "safe to retry" sentence, which is only earned by
+  // knowing the failed call was a read that never reached the server.
+  assert.doesNotMatch(text, /safe/i);
+});
+
+test("#2158 a transport phrase MID-SENTENCE is not a transport failure", () => {
+  // Inherited from #1472's anchoring, and re-pinned here because this module is a new
+  // consumer of it: a workflow whose own content mentions the phrase must not flip the
+  // classification of an error the server actually produced.
+  const err = new Error("Workflow validation failed: NetworkError in a saved node property");
+  assert.equal(classifyOpenSwitchFailure({ err }).transport, false);
+});
+
+// --- the verdict, which is the load-bearing half --------------------------
+
+test("#2158 `false` is returned ONLY when the pointer is PROVEN to be on the source", () => {
+  const v = classifyOpenSwitchFailure({
+    err: FIREFOX,
+    activeIsTarget: false,
+    activeIsSource: true,
+    tabAppeared: true,
+    contentLoaded: false,
+  });
+  assert.equal(v.applied, false);
+  // The tab residue is REPORTED but must not downgrade the verdict: downgrading would
+  // replace "safe to retry" with "inspect first" on exactly the case this issue is
+  // about, which is the caller's situation getting worse.
+  assert.deepEqual(v.residue, ["tab_listed_without_content"]);
+});
+
+test("#2158 a pointer that MOVED TO THE TARGET can never be reported as not-applied", () => {
+  // The wrong-graph hazard. `openWorkflow` assigns `activeWorkflow.value` and only THEN
+  // writes `comfyApp.canvas.bg_tint`, so a throw after the pointer moved is reachable.
+  // Saying "confirmed not applied" there tells the caller the canvas is still the
+  // previous workflow's while it is not.
+  const v = classifyOpenSwitchFailure({
+    err: new Error("Cannot set properties of null (setting 'bg_tint')"),
+    activeIsTarget: true,
+    activeIsSource: false,
+    tabAppeared: false,
+    contentLoaded: true,
+  });
+  assert.equal(v.applied, "unknown");
+  assert.ok(v.residue.includes("active_pointer_moved_to_target"));
+  assert.ok(v.residue.includes("workflow_content_loaded"));
+});
+
+test("#2158 an UNOBSERVABLE pointer degrades to unknown, never to a negative", () => {
+  // The whole bug in one line: an unmeasured negative is not a negative. Every one of
+  // these must refuse to claim the clean negative.
+  for (const obs of [
+    {},
+    { activeIsSource: null, activeIsTarget: null },
+    { activeIsSource: false, activeIsTarget: false }, // active is some THIRD workflow
+    { activeIsSource: undefined },
+  ]) {
+    assert.equal(classifyOpenSwitchFailure({ err: FIREFOX, ...obs }).applied, "unknown", JSON.stringify(obs));
+  }
+});
+
+test("#2158 `false` from sameWorkflowObject is 'not proven', not 'proven different'", () => {
+  // sameWorkflowObject never proves difference — it returns false for "cannot prove".
+  // So a false on activeIsTarget must not, on its own, license the clean negative.
+  assert.equal(
+    classifyOpenSwitchFailure({ err: FIREFOX, activeIsTarget: false, activeIsSource: false }).applied,
+    "unknown",
+  );
+});
+
+// --- the message ----------------------------------------------------------
+
+test("#2158 the transport message names the ROUTE and refuses to invent a status", () => {
+  const text = openSwitchFailureMessage({
+    path: "workflows/VR180 SeedVR2 Benchmark Runner.json",
+    err: FIREFOX,
+    activeIsTarget: false,
+    activeIsSource: true,
+    tabAppeared: true,
+    contentLoaded: false,
+    sourceLabel: "workflows/VR180 Restoration - 1s Trim Proof.json",
+  });
+  // The workflow the reporter asked for, and the one they were on.
+  assert.match(text, /VR180 SeedVR2 Benchmark Runner\.json/);
+  assert.match(text, /VR180 Restoration - 1s Trim Proof\.json/);
+  // The route — the single thing the bare error was missing.
+  assert.match(text, /GET \/userdata/);
+  assert.equal(WORKFLOW_CONTENT_ROUTE, "/userdata/<workflow path>");
+  // The raw browser text is preserved, not replaced.
+  assert.match(text, /NetworkError when attempting to fetch resource/);
+  // No status or body is promised, because none exists.
+  assert.match(text, /no HTTP status or response body to report/);
+  // The measurement is labelled as such, so it reads differently from the assertion it
+  // replaced.
+  assert.match(text, /MEASURED, NOT ASSUMED/);
+  assert.match(text, /the switch did not happen/);
+  // The actionable recovery, earned by the failed call being a read.
+  assert.match(text, /re-issuing panel_open_workflow is safe/);
+  // And the residue the old message denied.
+  assert.match(text, /now listed among the open workflow tabs/);
+});
+
+test("#2158 when the pointer moved, the message says so INSTEAD of claiming a clean miss", () => {
+  const text = openSwitchFailureMessage({
+    path: "workflows/b.json",
+    err: new Error("Cannot set properties of null (setting 'bg_tint')"),
+    activeIsTarget: true,
+    activeIsSource: false,
+  });
+  assert.match(text, /the active workflow IS now "workflows\/b\.json"/);
+  assert.match(text, /Re-read the graph/);
+  assert.doesNotMatch(text, /the switch did not happen/);
+  assert.doesNotMatch(text, /safe/i, "a moved pointer must never carry the retry-is-safe sentence");
+});
+
+test("#2158 an unobservable pointer says it cannot tell, and asks for a read", () => {
+  const text = openSwitchFailureMessage({ path: "workflows/b.json", err: FIREFOX });
+  assert.match(text, /could NOT observe which workflow is active/);
+  assert.match(text, /Read the active workflow before deciding whether to retry/);
+  assert.doesNotMatch(text, /the switch did not happen/);
+});
+
+test("#2158 a tab that was ALREADY listed is not reported as new residue", () => {
+  // `tabAppeared:false` is what the executor passes when its BEFORE snapshot already saw
+  // the tab. Reporting it anyway would blame this failure for a tab the user opened.
+  const text = openSwitchFailureMessage({
+    path: "workflows/b.json",
+    err: FIREFOX,
+    activeIsSource: true,
+    tabAppeared: false,
+  });
+  assert.doesNotMatch(text, /now listed among the open workflow tabs/);
+});
+
+// --- wiring: a module nothing calls is inert ------------------------------
+
+test("#2158 WIRED: the native-switch catch MEASURES instead of asserting", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+
+  // The assertion this issue is about is GONE. It is the sentence, not the mechanism,
+  // that encoded the wrong belief.
+  assert.doesNotMatch(
+    src,
+    /The native switch itself failed — nothing was applied/,
+    "the unmeasured claim must not survive",
+  );
+
+  // The catch reads the pointer and feeds the classifier.
+  const at = src.indexOf("openSwitchObservations = {");
+  assert.ok(at > 0, "the catch records its observations");
+  // Compared LOCALLY rather than by whole-file index — several of these identifiers
+  // appear elsewhere in a 2.5MB file and a global index comparison passes for the wrong
+  // reason.
+  const near = src.slice(at - 1500, at + 1200);
+  assert.match(near, /activeNow = activeWorkflowRef\(\)/, "the pointer is actually read");
+  assert.match(near, /activeIsTarget:/);
+  assert.match(near, /activeIsSource:/);
+  assert.match(near, /tabAppeared:/);
+  assert.match(near, /openSwitchFailureMessage\(\{/, "the classified message replaces the raw one");
+
+  // Each observation is GUARDED — an unreadable store must yield null, not false. That
+  // is the property the whole fix rests on.
+  assert.match(near, /activeReadable \? provenSame\(activeNow, target\) : null/);
+  assert.match(near, /activeReadable \? provenSame\(activeNow, activeBefore\) : null/);
+});
+
+test("#2158 WIRED: the receipt carries the measured verdict AND the resolved identity", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf('let applied = "unknown";');
+  assert.ok(at > 0, "the throw site classifies");
+  const near = src.slice(at, at + 1100);
+  assert.match(near, /applied = classifyOpenSwitchFailure\(\{/, "the journal takes the MEASURED verdict");
+  assert.match(near, /throw failOpen\(openFailed, \{\s*\n?\s*applied,/);
+  // The default is the HONEST side. If the classifier is ever unusable the verdict must
+  // land on "unknown" — a fabricated `false` is read by the orchestrator as "confirmed
+  // not applied, safe to retry", which is the wrong-graph edit this whole change avoids.
+  assert.ok(
+    src.slice(at, src.indexOf("classifyOpenSwitchFailure({", at)).includes('"unknown"'),
+    "the pre-classification default is unknown, not false",
+  );
+  // Without a resolved path the orchestrator's correlator rejects the receipt before it
+  // ever reads `applied`, which would make the measurement unreachable.
+  assert.match(near, /resolved: \{[\s\S]{0,200}?path: target\.path/);
+  assert.match(near, /routing_key: workflowTabId\(target\)/);
+});
+
+test("#2158 WIRED: the tab-list snapshot is taken BEFORE the switch, or it proves nothing", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const snapshot = src.indexOf("const targetWasListedOpen = targetIsListedOpen();");
+  const switchAt = src.indexOf("await s.openWorkflow(target);");
+  assert.ok(snapshot > 0, "the before-snapshot exists");
+  assert.ok(switchAt > 0, "the native switch is still here");
+  assert.ok(snapshot < switchAt, "the snapshot must precede the mutation it is a baseline for");
+  // And it is a DIFFERENT question from wasOpen, which asks about loaded content.
+  assert.match(src, /const wasOpen = !!target\.changeTracker;/);
+});
+
+test("#2158 WIRED: the classifier is SHARED with #1472, not a second copy of the table", () => {
+  // A duplicated table drifts: a browser wording added to one would be unknown to the
+  // other, and this module would silently stop recognising a real transport failure.
+  const lib = readFileSync(new URL("../../web/js/lib/open-switch-failure.js", import.meta.url), "utf8");
+  assert.match(lib, /import \{ isTransportFailure \} from "\.\/manager-fetch-failure\.js";/);
+  assert.doesNotMatch(lib, /networkerror when attempting to fetch resource/i, "no second copy of the table");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -544,6 +544,10 @@ import {
   openWorkflowNotFoundMessage,
 } from "./lib/open-workflow-not-found.js";
 import { classifyDiskProbe } from "./lib/workflow-disk-probe.js";
+import {
+  classifyOpenSwitchFailure,
+  openSwitchFailureMessage,
+} from "./lib/open-switch-failure.js";
 /** #1448 — wall-clock bound on the refusal-path /userdata probe. Generous: it only
  *  ever runs when the open is already failing, and a slow answer still beats none. */
 const WORKFLOW_DISK_PROBE_MS = 4000;
@@ -22145,13 +22149,22 @@ const GRAPH_TOOL_EXECUTORS = {
     // did NOT apply" fact, and a caller whose reply was lost mid-command needs that
     // negative just as much as the positive: without it the only remaining evidence is
     // the post-reconnect `active` pointer, which proves nothing (#433).
-    const failOpen = (err) => {
+    // #2158 — `applied` and `resolved` are PARAMETERS, not constants.
+    //
+    // Every caller below this line that leaves them at their defaults is a throw from
+    // BEFORE the native switch — no workflow resolved, nothing touched — where `false`
+    // is a measured fact about a mutation that provably never started.
+    //
+    // The native-switch catch is NOT one of those, and hardcoding them here is what let
+    // it journal "nothing was applied" about a store that had already been mutated. It
+    // passes what it measured instead; see the throw site at the end of this executor.
+    const failOpen = (err, { applied = false, resolved = null } = {}) => {
       noteOpenAttempt({
         cmd: "workflow_open",
         rid,
         requested: path,
-        resolved: null,
-        applied: false,
+        resolved,
+        applied,
         error: coerceMessageText(err?.message ?? err),
       });
       return err;
@@ -22462,6 +22475,28 @@ const GRAPH_TOOL_EXECUTORS = {
     // reads it fresh from disk. openWorkflow does NOT mutate originalContent for an
     // already-open tab (its load() early-returns), so the baseline stays valid.
     const wasOpen = !!target.changeTracker;
+    // #2158 — is the target listed among the OPEN TABS? Deliberately a different question
+    // from `wasOpen`, which asks whether its CONTENT is loaded.
+    //
+    // The store pushes the path into `openWorkflowPaths` BEFORE it reads the file, and
+    // `openWorkflows` is a computed over that array — so a switch whose read then fails
+    // leaves the target listed as an open tab with nothing behind it. That residue is the
+    // fact the failure path used to deny ("nothing was applied"), and denying it needs a
+    // BEFORE reading: the target may perfectly well have been listed already.
+    //
+    // `null` means the store did not expose a readable list — never "no".
+    const targetIsListedOpen = () => {
+      try {
+        const list = s?.openWorkflows;
+        if (!Array.isArray(list)) return null;
+        return list.some(
+          (w) => w && (sameWorkflowObject(w, target) === true || (w.path && w.path === target.path)),
+        );
+      } catch {
+        return null;
+      }
+    };
+    const targetWasListedOpen = targetIsListedOpen();
     // #442 / codex — SNAPSHOT the tab's unsaved-edit state BEFORE the mutating
     // awaits (`openWorkflow`, the freeze, the re-baseline). The #1641 handshake
     // wait above is not one of those: it does not touch `isModified`. The flag
@@ -22517,6 +22552,10 @@ const GRAPH_TOOL_EXECUTORS = {
     let reloaded = false;
     let reloadError = null;
     let openFailed = null;
+    // #2158 — what the panel MEASURED about the store after the native switch threw.
+    // Null while no switch failure has happened; the throw site at the end of this
+    // executor turns it into the receipt's `applied` verdict.
+    let openSwitchObservations = null;
     let rebindFailed = null;
     // #1001 — the per-node geometry the frontend rewrote while reproducing this load
     // faithfully. Non-null means the content proof passed WITHOUT being byte-identical,
@@ -22610,11 +22649,68 @@ const GRAPH_TOOL_EXECUTORS = {
               sameWorkflowObject(nativeOpenHistory[0], target) === true);
         activePointerEpochAtOpen = activePointerEpoch;
       } catch (err) {
-        // The native switch itself failed — nothing was applied. Recorded, then rethrown
-        // through failOpen below (outside the freeze) so the negative is journaled.
-        openFailed = err instanceof Error ? err : new Error(coerceMessageText(err));
-        // #968 r2 — the claim was staked before the switch; the switch did not happen, so
-        // release it rather than let a later move inherit this command's name.
+        // #2158 — the native switch threw. MEASURE what it left behind; do not assert it.
+        //
+        // This used to read "nothing was applied", and journal `applied: false` to match.
+        // Both halves were wrong. The store mutates its open-tab list BEFORE the read that
+        // throws, and the throw can also come from AFTER the active pointer moved (the
+        // `bg_tint` write on a null canvas is the reachable one) — in which case "confirmed
+        // not applied" is asserted about a canvas that HAS become the target's.
+        //
+        // Read the pointer here, while the failure is fresh, and let the classifier decide
+        // the verdict from what was actually seen. Every read is guarded: an observation
+        // that throws is `null` ("not observable"), never `false`.
+        const thrown = err instanceof Error ? err : new Error(coerceMessageText(err));
+        // RECORD THE FAILURE FIRST, then enrich it. Everything below is diagnosis, and
+        // diagnosis must never be able to lose the diagnosis's subject: a throw raised
+        // inside a catch block lands in this executor's OUTER handler, which reads it as
+        // a disk-read warning, leaves `openFailed` null, and lets the open walk on down
+        // its SUCCESS path — reporting a workflow switch that threw as one that worked.
+        openFailed = thrown;
+        try {
+          let activeNow = null;
+          let activeReadable = true;
+          try {
+            activeNow = activeWorkflowRef();
+          } catch {
+            activeReadable = false;
+          }
+          const provenSame = (a, b) => {
+            try {
+              return sameWorkflowObject(a, b) === true;
+            } catch {
+              return null;
+            }
+          };
+          const listedNow = targetIsListedOpen();
+          openSwitchObservations = {
+            // `sameWorkflowObject` proves sameness and never proves difference, so only a
+            // `true` is acted on downstream — a `false` here is "not proven", which the
+            // classifier treats as unknown rather than as a negative.
+            activeIsTarget: activeReadable ? provenSame(activeNow, target) : null,
+            activeIsSource: activeReadable ? provenSame(activeNow, activeBefore) : null,
+            // A residue only if it was NOT already listed before the switch.
+            tabAppeared: targetWasListedOpen === false ? listedNow : false,
+            contentLoaded: wasOpen === false ? !!target.changeTracker : false,
+          };
+          openFailed = new Error(
+            openSwitchFailureMessage({
+              path,
+              err: thrown,
+              ...openSwitchObservations,
+              sourceLabel: workflowTabId(activeBefore) || activeBefore?.path || null,
+            }),
+            { cause: thrown },
+          );
+        } catch (diagnosisFailed) {
+          // Keep the raw failure and say the diagnosis is missing, rather than silently
+          // presenting an unclassified error as though it had been examined.
+          console.warn("[comfyui-mcp-panel] workflow_open switch-failure diagnosis failed:", diagnosisFailed);
+        }
+        // #968 r2 — the claim was staked before the switch; release it rather than let a
+        // later move inherit this command's name. Unconditional, exactly as before: the
+        // claim is about who OWNS the next observed move, and this command is no longer a
+        // candidate whether or not the pointer turned out to have moved.
         claimActiveWorkflowMove(null, null);
       } finally {
         endWorkflowReloadStep(reloadGuardToken);
@@ -23847,7 +23943,40 @@ const GRAPH_TOOL_EXECUTORS = {
     // inside the freeze, before re-baseline, so they cannot fail the open and
     // cannot dirty a tab that was just marked clean. Skip here if that ran, or
     // if the disk re-read already applied the on-disk graph.
-    if (openFailed) throw failOpen(openFailed);
+    if (openFailed) {
+      // #2158 — journal the MEASURED verdict, not a hardcoded `false`.
+      //
+      // `applied` is the #402 field the orchestrator turns into advice: `false` becomes
+      // "confirmed not applied … It is safe to retry", `"unknown"` becomes "inspect the
+      // current workflow before deciding whether to retry". The reported transport
+      // failure keeps `false` — the pointer is measurably still on the source and the
+      // call that threw is a GET, so retrying really is safe — while a switch that moved
+      // the pointer before throwing, or one the panel could not observe, now degrades to
+      // `"unknown"` instead of claiming a negative it never checked.
+      //
+      // `resolved` is passed for the same reason: a receipt that reports a verdict while
+      // withholding WHICH workflow it is about cannot be acted on. The orchestrator's
+      // correlator requires the resolved path to match the request before it will read
+      // `applied` at all, so a null here made the measurement unreachable.
+      let applied = "unknown";
+      try {
+        applied = classifyOpenSwitchFailure({
+          err: openFailed?.cause ?? openFailed,
+          ...(openSwitchObservations ?? {}),
+        }).applied;
+      } catch {
+        // Fail to the honest side. "unknown" costs the caller an extra look at the
+        // active workflow; a fabricated `false` costs them a wrong-graph edit.
+      }
+      throw failOpen(openFailed, {
+        applied,
+        resolved: {
+          path: target.path,
+          filename: target.filename,
+          routing_key: workflowTabId(target),
+        },
+      });
+    }
     if (rebindFailed) {
       // #1089 follow-up — the foreign-source finding rides the FAILURE too.
       //

--- a/web/js/lib/open-switch-failure.js
+++ b/web/js/lib/open-switch-failure.js
@@ -75,6 +75,13 @@ function messageOf(err) {
   return (err instanceof Error ? err.message : String(err ?? "")).trim();
 }
 
+/** The raw text as a sentence, without doubling a full stop it already carries. Firefox's
+ *  string ends in one and Chrome's does not, so a bare `${raw}.` reads as "…resource.."
+ *  for the exact browser this issue was reported from. */
+function asSentence(raw) {
+  return /[.!?]$/.test(raw) ? raw : `${raw}.`;
+}
+
 /** A tri-state observation: `true`, `false`, or `null` when it could not be observed. */
 function triState(v) {
   return v === true ? true : v === false ? false : null;
@@ -147,7 +154,7 @@ export function openSwitchFailureMessage({
   if (verdict.transport) {
     parts.push(
       `panel_open_workflow could not switch to ${want}: the frontend's read of the workflow ` +
-        `file did not complete. ${raw}. This is a TRANSPORT failure on the workflow-content ` +
+        `file did not complete. ${asSentence(raw)} This is a TRANSPORT failure on the workflow-content ` +
         `route (GET ${WORKFLOW_CONTENT_ROUTE}) — no usable response reached the browser, so ` +
         `there is no HTTP status or response body to report (#2158). Likely causes are ComfyUI ` +
         `having stopped or restarted, the tab having lost its connection, or a proxy in front ` +
@@ -158,7 +165,7 @@ export function openSwitchFailureMessage({
     // what it actually said, and add only the route it was attempted against.
     parts.push(
       `panel_open_workflow could not switch to ${want}: the native workflow switch failed ` +
-        `while reading the workflow file (GET ${WORKFLOW_CONTENT_ROUTE}). ${raw}.`,
+        `while reading the workflow file (GET ${WORKFLOW_CONTENT_ROUTE}). ${asSentence(raw)}`,
     );
   }
 

--- a/web/js/lib/open-switch-failure.js
+++ b/web/js/lib/open-switch-failure.js
@@ -1,0 +1,204 @@
+/**
+ * #2158 — `panel_open_workflow` failed with a bare `NetworkError when attempting to
+ * fetch resource.` and nothing else. No route, no classification, no statement of what
+ * the failed switch left behind.
+ *
+ * ## What actually threw, read out of the frontend rather than guessed
+ *
+ * The panel's open executor calls the workflow STORE's `openWorkflow(target)`:
+ *
+ *     openWorkflow = async (workflow) => {
+ *       if (isActive(workflow)) return workflow
+ *       if (!openWorkflowPaths.value.includes(workflow.path))
+ *         openWorkflowPaths.value.push(workflow.path)   // <-- store mutated HERE
+ *       const loadedWorkflow = await workflow.load()    // <-- throws HERE
+ *       activeWorkflow.value = loadedWorkflow           // <-- not reached
+ *       comfyApp.canvas.bg_tint = loadedWorkflow.tintCanvasBg
+ *       ...
+ *     }
+ *
+ * `workflow.load()` bottoms out in `UserFile.load()`, which sets `isLoading = true` and
+ * then `await api.getUserData(this.path)` — a plain `GET /userdata/<encoded path>`. On a
+ * transport failure that fetch THROWS rather than returning a non-200, so the browser's
+ * own string is what propagates: Firefox says `NetworkError when attempting to fetch
+ * resource.`, Chrome `Failed to fetch`, Safari `Load failed`.
+ *
+ * Confirmed against BOTH the 1.47.2 source and the shipped 1.51.9 minified bundle, which
+ * bracket the 1.49.6 the report came from.
+ *
+ * ## The two things the executor was getting wrong
+ *
+ * 1. It rethrew the browser's message verbatim. The panel already owns a classifier for
+ *    exactly this failure class — `manager-fetch-failure.js`, built for comfyui-mcp#1472
+ *    when `panel_install_node` failed the same bare way, whose table already carries
+ *    Firefox's wording. It was simply never wired to the open path. This module reuses
+ *    that classifier rather than growing a second copy of the table, so a browser whose
+ *    wording is added there is understood here too.
+ *
+ * 2. It journaled `applied: false` and commented "nothing was applied". That is an
+ *    ASSERTION, not a measurement, and `applied` is the load-bearing #402 field: the
+ *    orchestrator turns `false` into "confirmed not applied by the panel's
+ *    request-id-correlated receipt. It is safe to retry."
+ *
+ *    For the REPORTED failure that advice happens to be right — the call that threw is a
+ *    GET, so nothing was written server-side and a retry is genuinely safe. But it is
+ *    right by accident. The same catch also covers a throw from AFTER the pointer moved
+ *    (`activeWorkflow.value` is assigned, then `comfyApp.canvas.bg_tint` is written, and
+ *    a null canvas there throws). In that configuration the panel would tell the caller
+ *    "confirmed not applied" while the active workflow HAS become the target — the
+ *    wrong-graph hazard #968/#1111 exist to prevent, wearing the strongest phrasing in
+ *    the vocabulary.
+ *
+ * So the verdict here is MEASURED. Where the panel can see that the active workflow is
+ * still the one it started on, `false` stays `false` and the caller keeps the accurate
+ * "safe to retry". Where the pointer moved, or where the panel could not observe it at
+ * all, the answer degrades to `"unknown"` and the orchestrator tells the caller to
+ * inspect before retrying. Both directions are strictly better than asserting.
+ *
+ * ## Why the tab residue is reported but does NOT change the verdict
+ *
+ * The push into `openWorkflowPaths` happens before the read, so a failed switch leaves
+ * the target listed among the open tabs with no content behind it (`openWorkflows` is a
+ * computed over that same array). That is a real, user-visible side effect and the
+ * caller should be told about it — but it is not a reason to downgrade `applied`.
+ * Downgrading would replace "safe to retry" with "inspect first" on the exact case this
+ * issue is about, which is the caller's situation getting worse, not better. It belongs
+ * in the prose, and that is where it goes.
+ */
+
+import { isTransportFailure } from "./manager-fetch-failure.js";
+
+/** The route the frontend reads a saved workflow's bytes from. */
+export const WORKFLOW_CONTENT_ROUTE = "/userdata/<workflow path>";
+
+function messageOf(err) {
+  return (err instanceof Error ? err.message : String(err ?? "")).trim();
+}
+
+/** A tri-state observation: `true`, `false`, or `null` when it could not be observed. */
+function triState(v) {
+  return v === true ? true : v === false ? false : null;
+}
+
+/**
+ * Classify a throw out of the store's `openWorkflow`, from what the panel MEASURED.
+ *
+ * Every observation is tri-state, and `null` means "not observable" — never "no". The
+ * whole point of this module is that an unmeasured negative is what shipped the bug.
+ *
+ *   `activeIsTarget`  the active workflow IS the requested one now.
+ *   `activeIsSource`  the active workflow is still the one active when the open started.
+ *   `tabAppeared`     the target is listed among the open tabs and was not before.
+ *   `contentLoaded`   the target's content is loaded now and was not before.
+ */
+export function classifyOpenSwitchFailure({
+  err = null,
+  activeIsTarget = null,
+  activeIsSource = null,
+  tabAppeared = null,
+  contentLoaded = null,
+} = {}) {
+  const transport =
+    isTransportFailure(err) ||
+    (err && typeof err === "object" ? isTransportFailure(err.cause) : false);
+
+  const target = triState(activeIsTarget);
+  const source = triState(activeIsSource);
+
+  const residue = [];
+  if (target === true) residue.push("active_pointer_moved_to_target");
+  if (triState(contentLoaded) === true) residue.push("workflow_content_loaded");
+  if (triState(tabAppeared) === true) residue.push("tab_listed_without_content");
+
+  // ONLY a positive observation that the pointer never left the source licenses the
+  // hard negative. Anything else — it moved, it moved somewhere third, or it could not
+  // be read — is `"unknown"`.
+  const applied = target !== true && source === true ? false : "unknown";
+
+  return { transport, applied, residue, activeIsTarget: target, activeIsSource: source };
+}
+
+/**
+ * What to say when the native workflow switch threw.
+ *
+ * `path` is the selector the caller asked for. `sourceLabel` names the workflow that was
+ * active when the open started, when the panel knows it.
+ */
+export function openSwitchFailureMessage({
+  path = null,
+  err = null,
+  activeIsTarget = null,
+  activeIsSource = null,
+  tabAppeared = null,
+  contentLoaded = null,
+  sourceLabel = null,
+} = {}) {
+  const verdict = classifyOpenSwitchFailure({
+    err,
+    activeIsTarget,
+    activeIsSource,
+    tabAppeared,
+    contentLoaded,
+  });
+  const raw = messageOf(err) || "no message";
+  const want = path ? `"${path}"` : "the requested workflow";
+  const parts = [];
+
+  if (verdict.transport) {
+    parts.push(
+      `panel_open_workflow could not switch to ${want}: the frontend's read of the workflow ` +
+        `file did not complete. ${raw}. This is a TRANSPORT failure on the workflow-content ` +
+        `route (GET ${WORKFLOW_CONTENT_ROUTE}) — no usable response reached the browser, so ` +
+        `there is no HTTP status or response body to report (#2158). Likely causes are ComfyUI ` +
+        `having stopped or restarted, the tab having lost its connection, or a proxy in front ` +
+        `of /userdata.`,
+    );
+  } else {
+    // Never relabel an error whose shape is not recognised — same rule as #1472. Keep
+    // what it actually said, and add only the route it was attempted against.
+    parts.push(
+      `panel_open_workflow could not switch to ${want}: the native workflow switch failed ` +
+        `while reading the workflow file (GET ${WORKFLOW_CONTENT_ROUTE}). ${raw}.`,
+    );
+  }
+
+  // The measured half. Stated as an observation with its own provenance, so a reader can
+  // tell it apart from the inference that used to stand here.
+  if (verdict.activeIsTarget === true) {
+    parts.push(
+      `MEASURED, NOT ASSUMED: the active workflow IS now ${want} even though the switch ` +
+        `reported failure — the store moved the pointer and then threw. Do NOT treat the ` +
+        `canvas as the previous workflow's. Re-read the graph before issuing any further ` +
+        `command, because commands are answered against whatever is active now.`,
+    );
+  } else if (verdict.activeIsSource === true) {
+    parts.push(
+      `MEASURED, NOT ASSUMED: the active workflow is still ` +
+        `${sourceLabel ? `"${sourceLabel}"` : "the one that was active before this command"} — ` +
+        `the switch did not happen.` +
+        (verdict.transport
+          ? ` The call that failed is a READ of the workflow file and writes nothing on the ` +
+            `server, so re-issuing panel_open_workflow is safe once ComfyUI is reachable again.`
+          : ""),
+    );
+  } else {
+    parts.push(
+      `The panel could NOT observe which workflow is active after the failure, so it does not ` +
+        `claim the switch did or did not happen. Read the active workflow before deciding ` +
+        `whether to retry.`,
+    );
+  }
+
+  if (verdict.residue.includes("tab_listed_without_content")) {
+    parts.push(
+      `SIDE EFFECT the store applied before it threw: ${want} is now listed among the open ` +
+        `workflow tabs even though its content never loaded — the store appends the path to ` +
+        `its open-tab list BEFORE it reads the file. This does not have to be cleaned up ` +
+        `first: the panel decides "was this tab already open" from loaded content, not from ` +
+        `tab membership, so the next open reads the file normally. Close the tab if you do ` +
+        `not want it.`,
+    );
+  }
+
+  return parts.join(" ");
+}


### PR DESCRIPTION
Fixes #2158.

`panel_open_workflow` failed with a bare `Error: NetworkError when attempting to fetch resource.` — no route, no classification, and no statement of what the failed switch left behind.

## Root cause, read out of the frontend rather than inferred

The panel's open executor calls the workflow store's `openWorkflow(target)`:

```js
openWorkflow = async (workflow) => {
  if (isActive(workflow)) return workflow
  if (!openWorkflowPaths.value.includes(workflow.path))
    openWorkflowPaths.value.push(workflow.path)   // <-- store MUTATED here
  const loadedWorkflow = await workflow.load()    // <-- throws here
  activeWorkflow.value = loadedWorkflow           // <-- not reached
  comfyApp.canvas.bg_tint = loadedWorkflow.tintCanvasBg
  ...
}
```

`workflow.load()` bottoms out in `UserFile.load()`, which sets `isLoading = true` then `await api.getUserData(this.path)` — a plain `GET /userdata/<encodeURIComponent(path)>`. On a transport failure that fetch **throws** rather than returning a non-200, so the browser's own string is what propagates. `NetworkError when attempting to fetch resource.` is Firefox's wording.

Verified against **both** the 1.47.2 source and the shipped **1.51.9** minified bundle, which bracket the reporter's 1.49.6:

```js
openWorkflow=async n=>{if(isActive(n))return n;i.value.includes(n.path)||i.value.push(n.path);let r=await n.load();t.value=r,Q.canvas.bg_tint=r.tintCanvasBg;...}
```

## What changed

**1. The message** (the reported symptom). The panel already owned a classifier for exactly this failure class — `web/js/lib/manager-fetch-failure.js`, built for comfyui-mcp#1472 when `panel_install_node` failed the same bare way, whose table already carries Firefox's wording. It was never wired to the open path. The new `open-switch-failure.js` **imports** that classifier rather than growing a second copy of the table, then names the route, keeps the raw text verbatim, and refuses to promise a status or body that cannot exist.

**2. The receipt** — the more serious half, and the part most worth your attention. The catch asserted "nothing was applied" and journaled `applied: false`. That is the load-bearing #402 field: `mcp/src/orchestrator/panel-tools.ts:7168` turns `false` into *"confirmed not applied by the panel's request-id-correlated receipt. It is safe to retry."*

For the reported transport failure that advice is right — but only by accident. The same catch also covers a throw from **after** the pointer moved (`activeWorkflow.value` is assigned, then `comfyApp.canvas.bg_tint` is written, and a null canvas there throws). There, "confirmed not applied" is a claim about a canvas that has already become the target's — the wrong-graph hazard #968/#1111 exist to prevent, wearing the strongest phrasing in the vocabulary.

So the verdict is now **measured**: proven still on the source keeps `false` (the reported case keeps its accurate "safe to retry"); a moved or unobservable pointer degrades to `"unknown"`.

## Where the load-bearing claims are — please push on these

- **`resolved` is now passed on the failure path.** This is the widest part of the diff. Previously `resolved: null` made `resolvedOpenPathMatches` return false, so the orchestrator's correlator reported `"unknown"` before ever reading `applied` — the measurement would have been unreachable without it. The newly-reachable branch is only `not_applied`, gated on the measured `false`; `applied: true` is never emitted on this path, so the `"applied"` branch stays unreachable.
- **The tab residue is reported in prose but deliberately does NOT downgrade `applied`.** Downgrading would swap "safe to retry" for "inspect first" on exactly the case this issue is about. I think that trade is right; it is a judgement call, not a fact.
- **`sameWorkflowObject` proves sameness and never proves difference.** Only a `true` is acted on; a `false` is treated as unknown. If that reading is wrong, the verdict logic is wrong.
- **The tab-list check uses path equality**, unlike `sameWorkflowObject`, because the store's own tab list is keyed by path (`openWorkflows` is a computed over `openWorkflowPaths`). Asking "is this path listed" is the store's own question.
- **`claimActiveWorkflowMove(null, null)` stays unconditional** even when the pointer did move. #968's UNKNOWN fallback explicitly disclaims exonerating the panel, so this fails safe — but it does mean a genuinely-moved pointer goes unattributed.

Also hardens the catch so diagnosis cannot lose its own subject: a throw raised inside a catch block lands in the executor's **outer** handler, which reads it as a disk-read warning, leaves `openFailed` null, and lets the open walk on down its **success** path. That was surfaced by the extraction harness, not by inspection.

## Verification

- `npm run test:unit` — **8121 pass, 0 fail** (baseline before the change: 8102). `typecheck` and `check:scope` clean.
- **Mutation-verified, 7 mutations, each producing a named red test** (restored from a copy, never `git checkout`):

| mutation | red test |
|---|---|
| hardcode `applied: false` again | `#2158 ...refuses the clean negative when the pointer DID move` |
| rethrow the raw error (pre-fix message) | 3 tests incl. `#887 ...native failure retires proof` |
| drop `resolved` from the receipt | `#2158 ...MEASURES a transport failure`, `#887 ...` |
| let an unobserved pointer yield `false` | `#2158 an UNOBSERVABLE pointer degrades to unknown` |
| classify every failure as transport | `#2158 an ANSWERED failure is NOT relabelled` |
| take the tab baseline after the switch | `#2158 WIRED: the tab-list snapshot is taken BEFORE` |
| remove the record-first hardening | `#2158 ...still REJECTS when its own diagnosis throws` |

- **Three tests drive the real executor body** through the existing `productionExecutor` harness (not the helper in isolation): the reported transport failure, the moved-pointer hazard, and the broken-diagnosis case.
- **Real Chromium**: loaded the shipped module graph over a local static server and drove it with the reporter's exact string — module resolves, no page errors, `transport:true` for Firefox's wording and `false` for an answered 404, and the three verdicts match node. This caught a real cosmetic defect the unit tests missed (`...fetch resource..`, a doubled full stop), now fixed and pinned.

## What I did NOT do

- **The Playwright e2e suite was not run against this branch, and I am not implying coverage I do not have.** The only live ComfyUI (pid 30964, port 8188) is the owner's Desktop instance, and its `custom_nodes/comfyui-mcp-panel` junction points at the main checkout — which is sitting on `feat/benjidirector-module`, not this branch. A green run there would have exercised that branch's code, not mine. Repointing the junction would mutate an instance that had live connections at the time. No isolated slot was allocated for this run. The Chromium check above is the browser evidence I could take safely; `check:scope` (`tsc --allowJs --checkJs` across the import graph) covers module resolution statically.
- **No auto-retry.** The report also asked to "preserve/retry the saved-workflow switch reliably". That is a feature and stays unbuilt under the freeze — and on the merits it is the wrong remedy, for the reason `manager-fetch-failure.js` already documents: a transport failure does not establish the server never acted. A *caller-driven* retry is already safe, which I checked rather than assumed: `wasOpen` keys on `target.changeTracker`, which a failed load leaves null, so the next open takes the correct first-open path rather than the already-open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
