### PR TITLE
fix(#389): refuse empty graph reads with missing-node state

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -513,6 +513,7 @@ test("missingNodeStateReportsNodes: only positive, shaped missing-node state is 
   assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 2 }), true);
   assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 0, missingNodesError: ["MissingType"] }), true);
   assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 0, missingNodesError: { types: ["MissingType"] } }), true);
+  assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 0, missingNodesError: { types: [] } }), false);
   assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 0, missingNodesError: [] }), false);
 });
 
@@ -555,6 +556,33 @@ test("#389 production wiring: both graph read executors pass the live missing-no
   const errorsBlock = src.slice(errors, errors + 6500);
   assert.match(errorsBlock, /const missingNodeState = getPiniaStore\("missingNodesError"\);/);
   assert.match(errorsBlock, /missingNodeState,\s*\n\s*\}\);/);
+});
+
+test("#389 production fence: the executable helper forwards missing-node evidence into the resolver", () => {
+  // This extracts and runs the production assertGraphBoundToActiveWorkflow helper
+  // with the same dependency injection used by the surrounding fence tests. If
+  // the option is removed from either the destructuring or the resolver call,
+  // this genuinely-empty/tagged root no longer refuses and the test fails.
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-A-1",
+    foreignClaim: "none",
+    rootNodeCount: 0,
+    activeModified: false,
+    activeTracker: { activeState: { nodes: [], links: [], groups: [] } },
+    rootSerializer: () => ({ nodes: [], links: [], groups: [] }),
+  });
+  assert.throws(
+    () =>
+      h.assertBound(h.rootB, h.rootB, {
+        includeBaselineReadGuard: true,
+        missingNodeState: {
+          hasMissingNodes: true,
+          missingNodeCount: 1,
+          missingNodesError: ["MissingNode"],
+        },
+      }),
+    /\[empty-graph-missing-nodes\]/,
+  );
 });
 
 test("graphRootMismatchesActiveWorkflow: TRUE - a nonempty prior tab remains on the canvas (#349)", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -21,6 +21,7 @@ import {
   activeWorkflowProvenEmpty,
   graphEmptyBindingUnproven,
   graphReadDesynced,
+  missingNodeStateReportsNodes,
   graphRootMidPopulation,
   graphRootMismatchesActiveWorkflow,
   graphRootContentDriftOnBoundCanvas,
@@ -504,6 +505,56 @@ test("graphReadDesynced: FALSE — descended into an empty subgraph (legitimatel
 test("graphReadDesynced: defensive — missing args never throw, default to not-desynced", () => {
   assert.equal(graphReadDesynced(), false);
   assert.equal(graphReadDesynced({}), false);
+});
+
+test("missingNodeStateReportsNodes: only positive, shaped missing-node state is evidence", () => {
+  assert.equal(missingNodeStateReportsNodes(null), false);
+  assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: false, missingNodeCount: 4 }), false);
+  assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 2 }), true);
+  assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 0, missingNodesError: ["MissingType"] }), true);
+  assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 0, missingNodesError: { types: ["MissingType"] } }), true);
+  assert.equal(missingNodeStateReportsNodes({ hasMissingNodes: true, missingNodeCount: 0, missingNodesError: [] }), false);
+});
+
+test("#389 recurrence: a bound empty root is still refused when the session reports missing nodes", () => {
+  const root = {
+    _nodes: [],
+    extra: { comfyui_mcp: { workflow_uuid: "workflow-A" } },
+    serialize: () => ({ nodes: [], links: [], groups: [] }),
+  };
+  const activeWorkflow = {
+    isModified: false,
+    changeTracker: { activeState: { nodes: [], links: [], groups: [] } },
+  };
+  const verdict = resolveGraphBindingVerdict({
+    graph: root,
+    rootGraph: root,
+    activeWorkflow,
+    activeWorkflowUuid: "workflow-A",
+    liveNodeCount: 0,
+    missingNodeState: {
+      hasMissingNodes: true,
+      missingNodeCount: 2,
+      missingNodesError: ["MissingNodeA", "MissingNodeB"],
+    },
+  });
+  assert.equal(verdict?.reason, "empty-graph-missing-nodes");
+  assert.equal(verdict?.live, 0);
+  assert.match(graphBindingRefusalMessage(verdict), /NOT applied/);
+  assert.match(graphBindingRefusalMessage(verdict), /missing node state/);
+});
+
+test("#389 production wiring: both graph read executors pass the live missing-node store to the fence", () => {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const outline = src.indexOf("graph_outline({ max_chars }");
+  const errors = src.indexOf("async graph_get_errors()");
+  assert.ok(outline >= 0 && errors > outline, "read executors are present in production panel");
+  const outlineBlock = src.slice(outline, errors);
+  assert.match(outlineBlock, /const missingNodeState = getPiniaStore\("missingNodesError"\);/);
+  assert.match(outlineBlock, /missingNodeState,\s*\n\s*\}\);/);
+  const errorsBlock = src.slice(errors, errors + 6500);
+  assert.match(errorsBlock, /const missingNodeState = getPiniaStore\("missingNodesError"\);/);
+  assert.match(errorsBlock, /missingNodeState,\s*\n\s*\}\);/);
 });
 
 test("graphRootMismatchesActiveWorkflow: TRUE - a nonempty prior tab remains on the canvas (#349)", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9760,6 +9760,10 @@ function assertGraphBoundToActiveWorkflow(
     // #2125 (gate r2 P1) — the caller's OWN observation of the active workflow, when
     // it already made one as part of proving nothing changed. See below.
     workflowProbe = null,
+    // #389 — the read caller's same-tick observation of ComfyUI's load-time
+    // missing-node store. Keep it with the rest of this call's evidence so the
+    // resolver can refuse an empty root instead of dropping the observation.
+    missingNodeState = null,
   } = {},
 ) {
   const liveNodeCount = rootGraph?._nodes?.length ?? 0;
@@ -9990,6 +9994,7 @@ function assertGraphBoundToActiveWorkflow(
     requireDirtyMutationBinding,
     postReconnectWindow: postReconnectSettleWindow(),
     graphLoading,
+    missingNodeState,
   });
   if (verdict) throw new Error(graphBindingRefusalMessage(verdict));
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14542,6 +14542,7 @@ const GRAPH_TOOL_EXECUTORS = {
   // raw node dump makes you reconstruct). Read-only.
   graph_outline({ max_chars } = {}) {
     const { graph, rootGraph } = getGraphCtx();
+    const missingNodeState = getPiniaStore("missingNodesError");
     // panel#389: refuse a false-clean empty read when the live graph is desynced
     // from the active workflow (empty canvas graph while the workflow reports nodes).
     // panel#1233: re-assert on this command's OWN read bar, not bare defaults. The
@@ -14554,6 +14555,7 @@ const GRAPH_TOOL_EXECUTORS = {
     assertGraphBoundToActiveWorkflow(graph, rootGraph, {
       ...graphCommandBindingBar("graph_outline"),
       includeBaselineReadGuard: true,
+      missingNodeState,
     });
     // #429: geometric group membership is tested boundingRect-first, so resync every
     // node's cached rect to its live pos/size BEFORE computing membership — a node
@@ -21077,6 +21079,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // asset+validation state, fabricating and omitting per-node errors (codex round-9 P1).
     // Reading it here binds every downstream surface to ONE consistent post-await graph.
     const { app: comfy, graph, rootGraph } = getGraphCtx();
+    const missingNodeState = getPiniaStore("missingNodesError");
     // panel#389: refuse a false-clean empty read when the live graph is desynced
     // from the active workflow (empty canvas graph while the workflow reports nodes)
     // — otherwise get_errors reports "no errors" for a workflow whose red nodes the
@@ -21087,6 +21090,7 @@ const GRAPH_TOOL_EXECUTORS = {
     assertGraphBoundToActiveWorkflow(graph, rootGraph, {
       ...graphCommandBindingBar("graph_get_errors"),
       includeBaselineReadGuard: true,
+      missingNodeState,
     });
     const nodes = graph._nodes ?? [];
     const byId = new Map(nodes.map((n) => [String(n.id), n]));

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -101,10 +101,14 @@ export function missingNodeStateReportsNodes(missingNodeState) {
     if (!missingNodeState?.hasMissingNodes) return false;
     if (Number(missingNodeState.missingNodeCount) > 0) return true;
     const raw = missingNodeState.missingNodesError;
-    if (Array.isArray(raw)) return raw.length > 0;
-    if (raw && typeof raw === "object") {
-      return Object.keys(raw).length > 0 || Object.values(raw).some((value) => Array.isArray(value) && value.length > 0);
-    }
+    // Match collectMissingAssets' parser exactly: an object whose selected
+    // record array is present but empty is absence, not positive evidence.
+    const records = Array.isArray(raw)
+      ? raw
+      : raw && typeof raw === "object"
+        ? (Object.values(raw).find(Array.isArray) ?? Object.keys(raw))
+        : [];
+    return records.length > 0;
   } catch {
     // An unreadable optional store cannot prove a mismatch.
   }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -88,6 +88,30 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
 }
 
 /**
+ * True when ComfyUI's load-time missing-node store positively reports missing
+ * nodes. The store is independent from both LiteGraph's live graph and the
+ * workflow ChangeTracker, so it is useful evidence specifically in the
+ * recurrence where those two other surfaces both look empty. A malformed
+ * store is not evidence: preserve the existing fail-open behavior unless the
+ * frontend explicitly says it has missing nodes and carries either a count or
+ * a record we can observe.
+ */
+export function missingNodeStateReportsNodes(missingNodeState) {
+  try {
+    if (!missingNodeState?.hasMissingNodes) return false;
+    if (Number(missingNodeState.missingNodeCount) > 0) return true;
+    const raw = missingNodeState.missingNodesError;
+    if (Array.isArray(raw)) return raw.length > 0;
+    if (raw && typeof raw === "object") {
+      return Object.keys(raw).length > 0 || Object.values(raw).some((value) => Array.isArray(value) && value.length > 0);
+    }
+  } catch {
+    // An unreadable optional store cannot prove a mismatch.
+  }
+  return false;
+}
+
+/**
  * The active workflow's OWN current-state node count, or `null` when that state
  * is absent/malformed. Unlike activeWorkflowNodeCount this NEVER falls back to
  * the load/save baseline (`initialState`): a baseline legitimately differs from
@@ -186,11 +210,18 @@ export function graphEmptyBindingUnproven({
   activeWorkflow,
   activeWorkflowUuid,
   graphLoading = false,
+  missingNodeState = null,
 } = {}) {
   if (!!rootGraph && graph && graph !== rootGraph) return false; // subgraph scope
   const live = rootGraph?._nodes;
   if (!Array.isArray(live) || live.length !== 0) return false; // populated or unobservable
   if (!activeWorkflow) return false; // no workflow service — legacy availability
+  // A positive load-time missing-node report is independent evidence that the
+  // empty canvas is not a clean, authoritative read. This must run before the
+  // identity-tag/proven-empty relaxations: a reused root can still carry the
+  // active tag while the loaded workflow's missing-node state names content the
+  // live graph does not contain (#389 recurrence).
+  if (missingNodeStateReportsNodes(missingNodeState)) return true;
   if (activeWorkflowProvenEmpty(activeWorkflow)) return false; // PROVEN empty — truthful 0
   if (graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid })) return false; // positively bound
   // #833 — both sides provably content-free. The clause above cannot fire on a blank
@@ -2998,6 +3029,7 @@ export function resolveGraphBindingVerdict({
   requireDirtyMutationBinding = false,
   postReconnectWindow = false,
   graphLoading = false,
+  missingNodeState = null,
 } = {}) {
   const nodeCount = Number.isFinite(Number(liveNodeCount))
     ? Number(liveNodeCount)
@@ -3092,7 +3124,14 @@ export function resolveGraphBindingVerdict({
       ...(reason === "root-shape-mismatch" ? { structureMatches: structureMatches === true } : {}),
     };
   }
-  if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid, graphLoading })) {
+  if (missingNodeStateReportsNodes(missingNodeState) && !inSubgraph && nodeCount === 0) {
+    return {
+      reason: "empty-graph-missing-nodes",
+      expected: activeWorkflowNodeCount(activeWorkflow),
+      live: nodeCount,
+    };
+  }
+  if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid, graphLoading, missingNodeState })) {
     return { reason: "empty-binding-unproven", expected: activeWorkflowNodeCount(activeWorkflow) };
   }
   return null;
@@ -3131,6 +3170,14 @@ export function graphBindingRefusalMessage(verdict) {
       `reconnect, or a failed open, and node_count 0 could be a FALSE-EMPTY reading, so this ` +
       `command was NOT applied as authoritative. Retry in a moment once the tab settles; if it ` +
       `persists, re-open the workflow tab (panel_open_workflow) or reload the panel.`
+    );
+  }
+  if (verdict.reason === "empty-graph-missing-nodes") {
+    return (
+      `[empty-graph-missing-nodes] The live root canvas reads EMPTY while the active session reports ` +
+      `missing node state, so node_count 0 is not a trustworthy clean graph read. This command ` +
+      `was NOT applied as authoritative. Re-open the active workflow tab (panel_open_workflow) ` +
+      `or reload the panel, then retry once the loaded graph and missing-node state agree.`
     );
   }
   // #606 — name the firing predicate honestly, and order the remedies by which


### PR DESCRIPTION
## Summary

Fixes #389.

A loaded workflow can leave the live root graph empty while the independent ComfyUI `missingNodesError` session store still reports missing nodes. The existing empty-root relaxation accepted the root identity tag as sufficient and let `panel_graph_outline` / `panel_get_errors` return a false-clean `node_count: 0`.

This change captures that store immediately before each read's binding assertion and returns a fail-closed `empty-graph-missing-nodes` refusal for root-scope zero-node reads with positive missing-node evidence. Subgraph reads and absent/malformed/negative store evidence retain the prior behavior. No network operations were added to `init.py` or `apps_routes.py`.

## Validation

- `npm.cmd run test:unit` — 8134 passed, 1 todo
- `npm.cmd run typecheck` — passed
- `npm.cmd run check:scope` — passed
- `node scripts/check-tool-vocabulary.mjs` — passed
- `node scripts/check-registry-yara.mjs` — 0 flagged files

Exact implementation head: `29d3639636b2ade945d9e083e3420ea496244464`