### PR TITLE
fix(#1533): retain VHS dimensions across format updates

### DIFF
--- a/browser_tests/unit/set-widget-vhs-dimensions.test.mjs
+++ b/browser_tests/unit/set-widget-vhs-dimensions.test.mjs
@@ -1,0 +1,148 @@
+/**
+ * #1533 — VHS_LoadVideo's custom dimensions are VHSINT widgets whose format
+ * callback replaces their options and invokes the callback again. These tests
+ * keep that production lifecycle, including serialized widget read-back, while
+ * driving the same runSetWidget path used by graph_set_widget.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+
+const TYPE = "VHS_LoadVideo";
+const REGISTRY = { [TYPE]: {} };
+const FRESH = { [TYPE]: {} };
+
+function vhsIntCallback(value) {
+  if (this.options.max && value > this.options.max) value = this.options.max;
+  if (this.options.min && value < this.options.min) value = this.options.min;
+  if (value === 0) return;
+  const step = this.options.step;
+  const mod = this.options.mod ?? 0;
+  this.value = Math.round((value - mod) / step) * step + mod;
+}
+
+function makeDimension(name, value = 0, options = {}) {
+  return {
+    name,
+    type: "VHS.ANNOTATED",
+    value,
+    options: { default: 0, min: 0, max: 8192, disable: 0, ...options },
+    config: ["VHSINT", options],
+    callback: vhsIntCallback,
+  };
+}
+
+function makeVhsNode({ width = 0, height = 0 } = {}) {
+  const baseOptions = { default: 0, min: 0, max: 8192, disable: 0 };
+  const formats = {
+    None: {},
+    AnimateDiff: {
+      custom_width: { step: 8, mod: 0, reset: 512 },
+      custom_height: { step: 8, mod: 0, reset: 512 },
+    },
+  };
+  const node = { id: 1533, type: TYPE, widgets: [] };
+  const format = {
+    name: "format",
+    type: "combo",
+    value: "AnimateDiff",
+    options: { values: Object.keys(formats) },
+  };
+  const widthWidget = makeDimension("custom_width", width, baseOptions);
+  const heightWidget = makeDimension("custom_height", height, baseOptions);
+  node.widgets.push(format, widthWidget, heightWidget);
+
+  // Mirrors VideoHelperSuite's initializeLoadFormat: it keeps the original
+  // options, installs a format-specific clone, then replays each widget callback.
+  const base = {
+    custom_width: widthWidget.options,
+    custom_height: heightWidget.options,
+  };
+  format.callback = function (value) {
+    const selected = formats[value];
+    if (!selected) return;
+    for (const widget of [widthWidget, heightWidget]) {
+      const wasDefault = widget.options?.reset == widget.value;
+      widget.options = Object.assign({}, base[widget.name], selected[widget.name]);
+      if (wasDefault && widget.options.reset !== undefined) widget.value = widget.options.reset;
+      widget.callback(widget.value);
+    }
+  };
+  format.callback("AnimateDiff");
+
+  // Mirrors VideoHelperSuite's useKVState serializer: the live widget values,
+  // not a separate panel-side cache, are the persisted/read-back state.
+  node.onSerialize = (info) => {
+    info.widgets_values = {};
+    for (const widget of node.widgets) info.widgets_values[widget.name] = widget.value;
+  };
+  return { node, format, widthWidget, heightWidget };
+}
+
+const oracle = {
+  registry: REGISTRY,
+  getFreshObjectInfo: async () => FRESH,
+};
+
+test("#1533 non-zero custom dimensions survive VHS format callback and serialization", async () => {
+  const { node, format, widthWidget, heightWidget } = makeVhsNode();
+
+  await runSetWidget(node, "custom_width", 1280, oracle);
+  await runSetWidget(node, "custom_height", 720, oracle);
+  assert.equal(widthWidget.value, 1280);
+  assert.equal(heightWidget.value, 720);
+
+  // Switching to None removes the dim step in VHS and immediately replays the
+  // VHSINT callbacks. This is the recurrence: without the production fix both
+  // non-zero values become NaN and serialize as null.
+  format.value = "None";
+  format.callback("None");
+
+  assert.equal(widthWidget.value, 1280);
+  assert.equal(heightWidget.value, 720);
+  const serialized = {};
+  node.onSerialize(serialized);
+  assert.deepEqual(serialized.widgets_values, {
+    format: "None",
+    custom_width: 1280,
+    custom_height: 720,
+  });
+});
+
+test("#1533 a panel format update preserves loaded non-zero dimensions", async () => {
+  const { node } = makeVhsNode({ width: 1280, height: 720 });
+
+  const result = await runSetWidget(node, "format", "None", oracle);
+  assert.equal(result.set.value, "None");
+  const serialized = {};
+  node.onSerialize(serialized);
+  assert.equal(serialized.widgets_values.custom_width, 1280);
+  assert.equal(serialized.widgets_values.custom_height, 720);
+});
+
+test("#1533 rebuilt VHS rows are rewritten through the retained receipt", async () => {
+  const first = makeVhsNode();
+  let flushes = 0;
+  const flushAfterRebuild = async () => {
+    if (flushes++ !== 0) return;
+    const replacement = makeVhsNode();
+    first.node.widgets = replacement.node.widgets;
+    first.format = replacement.format;
+    first.widthWidget = replacement.widthWidget;
+    first.heightWidget = replacement.heightWidget;
+    // The frontend rebuild replays the current format after replacing rows.
+    first.format.callback("None");
+  };
+
+  const result = await runSetWidget(first.node, "custom_width", 1280, {
+    ...oracle,
+    awaitFrontendWidgetFlush: flushAfterRebuild,
+  });
+
+  assert.equal(result.set.value, 1280);
+  assert.equal(first.node.widgets.find((widget) => widget.name === "custom_width").value, 1280);
+  const serialized = {};
+  first.node.onSerialize(serialized);
+  assert.equal(serialized.widgets_values.custom_width, 1280);
+});

--- a/browser_tests/unit/set-widget-vhs-dimensions.test.mjs
+++ b/browser_tests/unit/set-widget-vhs-dimensions.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { applyWidgetWrite } from "../../web/js/lib/widget-write.js";
 
 const TYPE = "VHS_LoadVideo";
 const REGISTRY = { [TYPE]: {} };
@@ -84,6 +85,46 @@ const oracle = {
   registry: REGISTRY,
   getFreshObjectInfo: async () => FRESH,
 };
+
+test("#1533 a throwing VHS callback accessor cannot block the assignment", () => {
+  const { node, widthWidget } = makeVhsNode();
+  let reads = 0;
+  Object.defineProperty(widthWidget, "callback", {
+    configurable: true,
+    get() {
+      reads += 1;
+      throw new Error("VHS callback accessor boom");
+    },
+  });
+
+  const result = applyWidgetWrite(node, "custom_width", 832, {});
+
+  assert.equal(widthWidget.value, 832);
+  assert.equal(result.value, 832);
+  assert.equal(reads, 1);
+  assert.match(result.write_warning ?? "", /VHS callback accessor boom/);
+  assert.equal(result.write_warning_source, undefined);
+});
+
+test("#1533 does not wrap same-shaped dimensions on unrelated nodes", () => {
+  const widthWidget = makeDimension("custom_width");
+  let runs = 0;
+  const callback = function () {
+    runs += 1;
+    this.value = NaN;
+  };
+  widthWidget.callback = callback;
+  const unrelatedNode = { id: 1534, type: "UnrelatedNode", widgets: [widthWidget] };
+
+  const result = applyWidgetWrite(unrelatedNode, "custom_width", 832, {});
+
+  assert.equal(result.value, 832);
+  assert.equal(runs, 1);
+  assert.equal(widthWidget.callback, callback);
+  widthWidget.callback(999);
+  assert.equal(runs, 2);
+  assert.ok(Number.isNaN(widthWidget.value));
+});
 
 test("#1533 non-zero custom dimensions survive VHS format callback and serialization", async () => {
   const { node, format, widthWidget, heightWidget } = makeVhsNode();

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -298,6 +298,91 @@ function restoreFiniteNumberIfUnstored(widget, expected) {
   }
 }
 
+// #1533 — VHS_LoadVideo replaces custom_width/custom_height.options when its format
+// changes, then replays the same VHSINT callback. Keep the finite value across that
+// later replay too; the one-shot restore below this write cannot protect future callbacks.
+const guardedVhsDimensionCallbacks = new WeakSet();
+
+function guardVhsDimensionCallback(widget) {
+  let type;
+  let name;
+  try {
+    type = String(widget?.type ?? "").toLowerCase();
+    name = widget?.name;
+  } catch {
+    return { matched: false };
+  }
+  if (type !== "vhs.annotated" || (name !== "custom_width" && name !== "custom_height")) {
+    return { matched: false };
+  }
+
+  const callback = widget.callback;
+  if (typeof callback !== "function" || guardedVhsDimensionCallbacks.has(callback)) {
+    return { matched: true, callback };
+  }
+
+  const guarded = function (...args) {
+    let previous;
+    try {
+      previous = this?.value;
+    } catch {
+      previous = undefined;
+    }
+    try {
+      return reflectApply(callback, this, args);
+    } finally {
+      try {
+        restoreFiniteNumberIfUnstored(this, previous);
+      } catch {
+        /* the enclosing write's verification remains authoritative */
+      }
+    }
+  };
+  guardedVhsDimensionCallbacks.add(guarded);
+  try {
+    widget.callback = guarded;
+    return { matched: true, callback: guarded };
+  } catch {
+    return { matched: true, callback };
+  }
+}
+
+function guardVhsDimensionCallbacksOnNode(node, skipWidget = null) {
+  let nodeType;
+  let triggerType;
+  let triggerName;
+  try {
+    nodeType = String(node?.type ?? "").toLowerCase();
+    triggerType = String(skipWidget?.type ?? "").toLowerCase();
+    triggerName = skipWidget?.name;
+  } catch {
+    return;
+  }
+  const triggerIsDimension =
+    triggerType === "vhs.annotated" && (triggerName === "custom_width" || triggerName === "custom_height");
+  if (nodeType !== "vhs_loadvideo" || (triggerName !== "format" && !triggerIsDimension)) return;
+
+  let widgets;
+  try {
+    widgets = node?.widgets;
+  } catch {
+    return;
+  }
+  try {
+    if (!Array.isArray(widgets)) return;
+    for (const widget of widgets) {
+      if (widget === skipWidget) continue;
+      try {
+        guardVhsDimensionCallback(widget);
+      } catch {
+        /* the normal callback path remains authoritative for unreadable widgets */
+      }
+    }
+  } catch {
+    /* the normal callback path remains authoritative for an unreadable widget list */
+  }
+}
+
 /**
  * Does `node.widgets` have a STABLE IDENTITY — is it one array the node keeps, so that
  * comparing the array OBJECT says something and re-pointing it restores something — or
@@ -3185,8 +3270,18 @@ export function applyWidgetWrite(
   // Captured at lookup so the disclosure can describe it WITHOUT reading `w.callback`
   // a second time (it may be an accessor with side effects, or a throwing one).
   let widgetCallback = null;
+  let guardedDimensionCallback = null;
+  let guardedDimensionCallbackMatched = false;
   safeBefore();
   try {
+    if (!fastBypasserAction && !liveCustomTextWrite) {
+      // Install before assignment because a frontend value setter may invoke the
+      // callback as part of the assignment itself.
+      guardVhsDimensionCallbacksOnNode(targetNode, valueWidget);
+      const guarded = guardVhsDimensionCallback(valueWidget);
+      guardedDimensionCallbackMatched = guarded.matched;
+      guardedDimensionCallback = guarded.callback;
+    }
     // Assign BOTH values first — EXCEPT on an instance-scoped promoted write, where
     // the inner widget is not a second copy of this value but the SHARED SUBGRAPH
     // DEFINITION every sibling instance reads (comfyui-mcp#1707). There the rail IS
@@ -3286,7 +3381,7 @@ export function applyWidgetWrite(
     // editor + options.setValue path above is what serializes; read-back
     // still decides whether the write stuck.
     if (!fastBypasserAction && !liveCustomTextWrite) {
-      widgetCallback = valueWidget.callback;
+      widgetCallback = guardedDimensionCallbackMatched ? guardedDimensionCallback : valueWidget.callback;
       if (widgetCallback !== null && widgetCallback !== undefined) {
         const callbackArgs = [coerced, canvas, valueNode, valueNode.pos, undefined];
         threwFromCallback = true;

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -303,16 +303,26 @@ function restoreFiniteNumberIfUnstored(widget, expected) {
 // later replay too; the one-shot restore below this write cannot protect future callbacks.
 const guardedVhsDimensionCallbacks = new WeakSet();
 
-function guardVhsDimensionCallback(widget) {
+function guardVhsDimensionCallback(node, widget) {
   let type;
   let name;
+  let widgets;
   try {
+    if (String(node?.type ?? "").toLowerCase() !== "vhs_loadvideo") {
+      return { matched: false };
+    }
     type = String(widget?.type ?? "").toLowerCase();
     name = widget?.name;
+    widgets = node?.widgets;
   } catch {
     return { matched: false };
   }
-  if (type !== "vhs.annotated" || (name !== "custom_width" && name !== "custom_height")) {
+  if (
+    !Array.isArray(widgets) ||
+    !widgets.includes(widget) ||
+    type !== "vhs.annotated" ||
+    (name !== "custom_width" && name !== "custom_height")
+  ) {
     return { matched: false };
   }
 
@@ -373,7 +383,7 @@ function guardVhsDimensionCallbacksOnNode(node, skipWidget = null) {
     for (const widget of widgets) {
       if (widget === skipWidget) continue;
       try {
-        guardVhsDimensionCallback(widget);
+        guardVhsDimensionCallback(node, widget);
       } catch {
         /* the normal callback path remains authoritative for unreadable widgets */
       }
@@ -3270,18 +3280,8 @@ export function applyWidgetWrite(
   // Captured at lookup so the disclosure can describe it WITHOUT reading `w.callback`
   // a second time (it may be an accessor with side effects, or a throwing one).
   let widgetCallback = null;
-  let guardedDimensionCallback = null;
-  let guardedDimensionCallbackMatched = false;
   safeBefore();
   try {
-    if (!fastBypasserAction && !liveCustomTextWrite) {
-      // Install before assignment because a frontend value setter may invoke the
-      // callback as part of the assignment itself.
-      guardVhsDimensionCallbacksOnNode(targetNode, valueWidget);
-      const guarded = guardVhsDimensionCallback(valueWidget);
-      guardedDimensionCallbackMatched = guarded.matched;
-      guardedDimensionCallback = guarded.callback;
-    }
     // Assign BOTH values first — EXCEPT on an instance-scoped promoted write, where
     // the inner widget is not a second copy of this value but the SHARED SUBGRAPH
     // DEFINITION every sibling instance reads (comfyui-mcp#1707). There the rail IS
@@ -3381,7 +3381,13 @@ export function applyWidgetWrite(
     // editor + options.setValue path above is what serializes; read-back
     // still decides whether the write stuck.
     if (!fastBypasserAction && !liveCustomTextWrite) {
-      widgetCallback = guardedDimensionCallbackMatched ? guardedDimensionCallback : valueWidget.callback;
+      // #1533 — callback observation and VHS callback guarding happen only AFTER all
+      // value assignments. A callback accessor is widget code, not a preflight gate:
+      // if it throws, the established post-assignment verification/warning path owns
+      // the receipt and the requested value is not undone merely because it was read.
+      guardVhsDimensionCallbacksOnNode(targetNode, valueWidget);
+      const guarded = guardVhsDimensionCallback(targetNode, valueWidget);
+      widgetCallback = guarded.matched ? guarded.callback : valueWidget.callback;
       if (widgetCallback !== null && widgetCallback !== undefined) {
         const callbackArgs = [coerced, canvas, valueNode, valueNode.pos, undefined];
         threwFromCallback = true;


### PR DESCRIPTION
## Summary

- Guard the exact VHS_LoadVideo `custom_width`/`custom_height` VHSINT callback after target authorization.
- Preserve finite dimensions when VHS replaces widget options and replays callbacks during format updates.
- Add production-shaped `runSetWidget` regressions for serialized read-back and rebuilt widget receipts.

## Validation

- `npm.cmd run test:unit` — 8,134 passed, 1 TODO
- `npm.cmd run typecheck`
- `npm.cmd run check:changelog`
- `node scripts/check-tool-vocabulary.mjs`
- `node scripts/check-registry-yara.mjs --allow 0`
- protected runtime-pack checks

Fixes #1533