### PR TITLE
fix(panel#1668): prevent ImpactSwitch restore callback crash

### DIFF
--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -358,6 +358,112 @@ test("#1668 records the narrow link-disconnect crash and verifies a linked-widge
   assert.deepEqual(verifyNodeRestore(node, info).linkDrivenWidgetDifferences, ["select"]);
 });
 
+test("#1668 skips an ImpactSwitch callback before a missing endpoint API and verifies the completed node", async () => {
+  class LGraphNode {
+    constructor(id) {
+      this.id = id;
+      this.type = "ImpactSwitch";
+      this.widgets = [{ name: "select" }, { name: "input1" }];
+      this.inputs = [];
+      this.outputs = [];
+    }
+
+    onConnectionsChange() {
+      throw new Error("the missing endpoint API was called");
+    }
+
+    configure(info) {
+      this.inputs = info.inputs;
+      this.widgets_values = info.widgets_values;
+      this.onConnectionsChange(1, 1, true, this.graph._links.get(901), this.inputs[1]);
+    }
+
+    serialize() {
+      return {
+        id: this.id,
+        type: this.type,
+        inputs: this.inputs,
+        widgets_values: this.widgets_values,
+      };
+    }
+  }
+  const LG = { LGraphNode };
+  const node = new LGraphNode(122);
+  const farNode = {
+    id: 321,
+    connectCalls: 0,
+    connect() {
+      this.connectCalls += 1;
+      return this.findInputSlot("input1");
+    },
+  };
+  const graph = {
+    _links: new Map([[901, { id: 901, origin_id: 321, target_id: 122 }]]),
+    getNodeById: (id) => (id === 122 ? node : id === 321 ? farNode : null),
+  };
+  node.graph = graph;
+  const info = {
+    id: 122,
+    type: "ImpactSwitch",
+    inputs: [
+      { name: "select", link: null, widget: { name: "select" } },
+      { name: "input1", link: 901, widget: { name: "input1" } },
+    ],
+    widgets_values: ["saved-selection", "saved-input"],
+  };
+  const isolation = installNodeConfigureIsolation(LG, graph);
+  try {
+    assert.doesNotThrow(() => node.configure(info), "only the proven link callback failure is contained");
+  } finally {
+    isolation.restore();
+  }
+  assert.equal(isolation.failures.length, 1);
+  assert.equal(isolation.failures[0].callbackContained, true);
+  assert.equal(isolation.failures[0].linkDisconnectEvidence, true);
+  assert.match(isolation.failures[0].error, /findInputSlot/);
+  assert.equal(farNode.connectCalls, 0, "the missing endpoint API was never reached");
+  assert.equal(graph._links.has(901), true, "the serialized link record remains intact");
+  assert.equal(node.inputs[1].link, 901, "the serialized input link remains intact");
+
+  let configureCalls = 0;
+  const originalConfigure = node.configure;
+  node.configure = (...args) => {
+    configureCalls += 1;
+    return originalConfigure.apply(node, args);
+  };
+  const result = await retryNodeRestores(graph, isolation.failures);
+  assert.equal(configureCalls, 0, "the known-bad callback is not invoked a second time");
+  assert.deepEqual(result.restored, [{ id: 122, type: "ImpactSwitch" }]);
+  assert.deepEqual(result.failed, []);
+  assert.deepEqual(result.recovered, [{
+    id: 122,
+    type: "ImpactSwitch",
+    ownerGraphToken: isolation.failures[0].ownerGraphToken,
+    linkDrivenWidgetDifferences: [],
+  }]);
+});
+
+test("#1668 keeps callback containment fail-closed when the graph endpoint API is absent", () => {
+  class LGraphNode {
+    onConnectionsChange() {
+      throw new TypeError("t.findInputSlot is not a function");
+    }
+
+    configure() {
+      this.onConnectionsChange(1, 0, true, null, null);
+    }
+  }
+  const isolation = installNodeConfigureIsolation({ LGraphNode });
+  try {
+    new LGraphNode().configure({ id: 122, type: "ImpactSwitch" });
+  } finally {
+    isolation.restore();
+  }
+  assert.equal(isolation.failures.length, 1);
+  assert.equal(isolation.failures[0].callbackContained, undefined);
+  assert.equal(isolation.failures[0].linkDisconnectEvidence, false);
+});
+
 test("#1668 records mirror-write evidence when the far node is valid but its referenced slot is missing", () => {
   const LG = makeLiteGraph();
   const base = LG.LGraphNode.prototype.configure;

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -392,6 +392,9 @@ test("#1668 skips an ImpactSwitch callback before a missing endpoint API and ver
   const farNode = {
     id: 321,
     connectCalls: 0,
+    findOutputSlot() {
+      return 0;
+    },
     connect() {
       this.connectCalls += 1;
       return this.findInputSlot("input1");
@@ -441,6 +444,55 @@ test("#1668 skips an ImpactSwitch callback before a missing endpoint API and ver
     ownerGraphToken: isolation.failures[0].ownerGraphToken,
     linkDrivenWidgetDifferences: [],
   }]);
+});
+
+test("#1668 preflight is directional when the unrelated endpoint API is absent", () => {
+  for (const { direction, link, presentMethod } of [
+    { direction: 1, link: { id: 903, origin_id: 321, target_id: 122 }, presentMethod: "findInputSlot" },
+    { direction: 2, link: { id: 904, origin_id: 122, target_id: 321 }, presentMethod: "findOutputSlot" },
+  ]) {
+    let callbackCalls = 0;
+    let endpointCalls = 0;
+    class LGraphNode {
+      constructor(id) {
+        this.id = id;
+        this.type = "ImpactSwitch";
+        this.inputs = [];
+        this.outputs = [];
+      }
+
+      onConnectionsChange(type, index, connected, linkInfo) {
+        callbackCalls += 1;
+        const far = this.graph.getNodeById(linkInfo.origin_id === this.id ? linkInfo.target_id : linkInfo.origin_id);
+        far[presentMethod]();
+      }
+
+      configure() {
+        this.onConnectionsChange(direction, 0, true, this.graph._links.get(link.id));
+      }
+    }
+    const node = new LGraphNode(122);
+    const farNode = {
+      id: 321,
+      [presentMethod]() {
+        endpointCalls += 1;
+      },
+    };
+    const graph = {
+      _links: new Map([[link.id, link]]),
+      getNodeById: (id) => (id === 122 ? node : id === 321 ? farNode : null),
+    };
+    node.graph = graph;
+    const isolation = installNodeConfigureIsolation({ LGraphNode }, graph);
+    try {
+      assert.doesNotThrow(() => node.configure(), `direction ${direction} callback is allowed to run`);
+    } finally {
+      isolation.restore();
+    }
+    assert.deepEqual(isolation.failures, [], `direction ${direction} is not suppressed by the unrelated missing API`);
+    assert.equal(callbackCalls, 1);
+    assert.equal(endpointCalls, 1);
+  }
 });
 
 test("#1668 keeps callback containment fail-closed when the graph endpoint API is absent", () => {

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -70,7 +70,11 @@ function graphLinkEntries(graph) {
   return [];
 }
 
-function missingLinkEndpointSlotMethod(graph, node, link) {
+function missingLinkEndpointSlotMethod(graph, node, link, direction, serializedType) {
+  const isImpactSwitch =
+    node?.type === "ImpactSwitch" || node?.comfyClass === "ImpactSwitch" || serializedType === "ImpactSwitch";
+  const requiredMethod = direction === 2 ? "findOutputSlot" : direction === 1 ? "findInputSlot" : null;
+  if (!isImpactSwitch || !requiredMethod) return null;
   const nodeId = node?.id;
   if (nodeId == null || !link || typeof graph?.getNodeById !== "function") return null;
   const nodeIsOrigin = sameNodeId(link.origin_id, nodeId);
@@ -80,9 +84,7 @@ function missingLinkEndpointSlotMethod(graph, node, link) {
   try {
     const far = graph.getNodeById(farId);
     if (far == null) return null;
-    for (const method of ["findInputSlot", "findOutputSlot"]) {
-      if (typeof far[method] !== "function") return method;
-    }
+    if (typeof far[requiredMethod] !== "function") return requiredMethod;
   } catch {
     // A graph or endpoint that cannot be inspected is not evidence. The
     // callback is allowed to run and any resulting throw is handled below.
@@ -268,7 +270,13 @@ export function installNodeConfigureIsolation(LG, graph = null) {
     let callbackWrapper = null;
     if (typeof callback === "function") {
       callbackWrapper = function (...args) {
-        const missingSlotMethod = missingLinkEndpointSlotMethod(this?.graph ?? graph, this, args?.[3]);
+        const missingSlotMethod = missingLinkEndpointSlotMethod(
+          this?.graph ?? graph,
+          this,
+          args?.[3],
+          args?.[0],
+          info?.type,
+        );
         if (missingSlotMethod) {
           // ImpactSwitch's restore callback can call a string-slot connect on a
           // plain/stale far endpoint. That call would invoke a missing

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -70,6 +70,26 @@ function graphLinkEntries(graph) {
   return [];
 }
 
+function missingLinkEndpointSlotMethod(graph, node, link) {
+  const nodeId = node?.id;
+  if (nodeId == null || !link || typeof graph?.getNodeById !== "function") return null;
+  const nodeIsOrigin = sameNodeId(link.origin_id, nodeId);
+  const nodeIsTarget = sameNodeId(link.target_id, nodeId);
+  const farId = nodeIsOrigin ? link.target_id : nodeIsTarget ? link.origin_id : null;
+  if (farId == null) return null;
+  try {
+    const far = graph.getNodeById(farId);
+    if (far == null) return null;
+    for (const method of ["findInputSlot", "findOutputSlot"]) {
+      if (typeof far[method] !== "function") return method;
+    }
+  } catch {
+    // A graph or endpoint that cannot be inspected is not evidence. The
+    // callback is allowed to run and any resulting throw is handled below.
+  }
+  return null;
+}
+
 function hasBrokenLinkEndpoint(graph, node, err) {
   const nodeId = node?.id;
   if (nodeId == null || typeof graph?.getNodeById !== "function") return false;
@@ -240,8 +260,67 @@ export function installNodeConfigureIsolation(LG, graph = null) {
       // An uncloneable payload cannot be safely verified after a throw.
       serializedSnapshot = null;
     }
+    const callback = this?.onConnectionsChange;
+    const hasOwnCallback = Object.prototype.hasOwnProperty.call(this ?? {}, "onConnectionsChange");
+    const ownCallback = hasOwnCallback ? this.onConnectionsChange : undefined;
+    let containedCallbackFailure = null;
+    let containedCallbackEvidence = false;
+    let callbackWrapper = null;
+    if (typeof callback === "function") {
+      callbackWrapper = function (...args) {
+        const missingSlotMethod = missingLinkEndpointSlotMethod(this?.graph ?? graph, this, args?.[3]);
+        if (missingSlotMethod) {
+          // ImpactSwitch's restore callback can call a string-slot connect on a
+          // plain/stale far endpoint. That call would invoke a missing
+          // findInputSlot/findOutputSlot API. Leave the serialized link records
+          // untouched and verify the completed node instead of making the call.
+          containedCallbackFailure ??= new TypeError(
+            `link restore callback skipped: far endpoint lacks ${missingSlotMethod}`,
+          );
+          containedCallbackEvidence = true;
+          return undefined;
+        }
+        try {
+          return callback.apply(this, args);
+        } catch (err) {
+          // Impact Pack's dynamic-slot hook can call a LiteGraph slot lookup on
+          // a stale/plain far endpoint while configure is restoring links. Only
+          // contain the exact crash when the live graph proves that endpoint is
+          // broken; absent graph APIs remain fail-closed and propagate into the
+          // normal configure-failure record below.
+          if (!isLinkDisconnectCrash(err) || !hasBrokenLinkEndpoint(this?.graph ?? graph, this, err)) {
+            throw err;
+          }
+          containedCallbackFailure ??= err;
+          containedCallbackEvidence = true;
+          return undefined;
+        }
+      };
+      try {
+        this.onConnectionsChange = callbackWrapper;
+      } catch {
+        callbackWrapper = null;
+      }
+    }
     try {
-      return original.call(this, info);
+      const result = original.call(this, info);
+      if (containedCallbackFailure) {
+        const ownerGraph = this?.graph ?? null;
+        const evidenceGraph = this?.graph ?? graph ?? null;
+        failures.push({
+          id: info?.id ?? this?.id ?? null,
+          type: info?.type ?? this?.type ?? null,
+          error: errorText(containedCallbackFailure),
+          linkDisconnectCrash: true,
+          linkDisconnectEvidence:
+            containedCallbackEvidence || hasBrokenLinkEndpoint(evidenceGraph, this, containedCallbackFailure),
+          callbackContained: true,
+          ownerGraph,
+          ownerGraphToken: graphIdentityToken(ownerGraph),
+          info: serializedSnapshot,
+        });
+      }
+      return result;
     } catch (err) {
       const ownerGraph = this?.graph ?? null;
       const evidenceGraph = this?.graph ?? graph ?? null;
@@ -261,6 +340,16 @@ export function installNodeConfigureIsolation(LG, graph = null) {
         info: serializedSnapshot,
       });
       return undefined;
+    } finally {
+      if (callbackWrapper && this.onConnectionsChange === callbackWrapper) {
+        try {
+          if (hasOwnCallback) this.onConnectionsChange = ownCallback;
+          else delete this.onConnectionsChange;
+        } catch {
+          // A frontend-defined non-configurable callback remains installed; it
+          // is safer to leave that state than to replace somebody else's hook.
+        }
+      }
     }
   };
   proto.configure = wrapped;
@@ -375,6 +464,33 @@ export async function retryNodeRestores(graph, failures, options = {}) {
         type: failure.type,
         error: "active workflow changed during restore retry",
         retry: "workflow-switched",
+      });
+      continue;
+    }
+    if (linkDisconnectCrash && failure.callbackContained === true) {
+      // The node configure completed; only its link callback was contained.
+      // Do not invoke that callback again after isolation has been removed. A
+      // strict snapshot check is the only safe way to accept this path.
+      const verification = verifyNodeRestore(node, failure.info);
+      if (verification.verified) {
+        restored.push({ id: failure.id, type: failure.type });
+        const ownerGraphToken = failure.ownerGraphToken ?? graphIdentityToken(failure.ownerGraph);
+        recovered.push({
+          id: failure.id,
+          type: failure.type,
+          ...(ownerGraphToken != null ? { ownerGraphToken } : {}),
+          linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences,
+        });
+        continue;
+      }
+      failed.push({
+        id: failure.id,
+        type: failure.type,
+        error: failure.error ?? "link-disconnect restore failure",
+        ...(verification.differences.length ? { widgetDifferences: verification.differences } : {}),
+        ...(verification.linkDrivenWidgetDifferences.length
+          ? { linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences }
+          : {}),
       });
       continue;
     }


### PR DESCRIPTION
Fixes #1668

The workflow restore isolation now preflights linked endpoints before an onConnectionsChange callback can invoke a missing findInputSlot/findOutputSlot API. It preserves serialized link state, verifies the completed node, and does not re-run the dangerous callback on retry.

Validation: focused restore harness, full unit suite, typecheck, scope, changelog/docs, YARA, and Bandit passed. No live ComfyUI was used. No build script exists in v0.15.152.