### PR TITLE
fix(panel): route workflow template reads through live panel

### DIFF
--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -73,7 +73,7 @@ async function rejection(promise, code) {
   });
 }
 
-test("#2283: the allowed operations use only their fixed same-origin routes", async () => {
+test("#2196/#2283: the allowed operations use only their fixed same-origin routes", async () => {
   const apiURLCalls = [];
   const fileURLCalls = [];
   const apiCalls = [];
@@ -83,6 +83,7 @@ test("#2283: the allowed operations use only their fixed same-origin routes", as
     system_stats: '{"system":{"os":"windows"},"devices":[]}',
     logs: "ERROR: render failed\n",
     object_info: '{"KSampler":{"input":{"required":{}}}}',
+    workflow_templates: '{"templates":[]}',
   };
   for (const operation of Object.keys(bodies)) {
     const result = await fetchComfyUIReadForMcp(
@@ -118,9 +119,9 @@ test("#2283: the allowed operations use only their fixed same-origin routes", as
     });
   }
 
-  assert.deepEqual(apiURLCalls, ["/history", "/system_stats", "/object_info"]);
+  assert.deepEqual(apiURLCalls, ["/history", "/system_stats", "/object_info", "/workflow_templates"]);
   assert.deepEqual(fileURLCalls, ["/internal/logs/raw"]);
-  assert.deepEqual(apiCalls.map(({ path }) => path), ["/history", "/system_stats", "/object_info"]);
+  assert.deepEqual(apiCalls.map(({ path }) => path), ["/history", "/system_stats", "/object_info", "/workflow_templates"]);
   assert.deepEqual(rawCalls.map(({ url }) => url), ["https://panel.test/comfy/internal/logs/raw"]);
   for (const { init } of [...apiCalls, ...rawCalls]) {
     assert.equal(init.method, "GET");

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -14,6 +14,7 @@ const READ_OPERATIONS = new Map([
   ["system_stats", "/system_stats"],
   ["logs", "/internal/logs"],
   ["object_info", "/object_info"],
+  ["workflow_templates", "/workflow_templates"],
 ]);
 const LOGS_TRANSPORT_PATH = "/internal/logs/raw";
 
@@ -73,7 +74,7 @@ export function validateFetchComfyUIReadArgs(args) {
     throw invalidInput("operation is required");
   }
   if (typeof args.operation !== "string" || !READ_OPERATIONS.has(args.operation)) {
-    throw invalidInput("operation must be one of history, system_stats, logs, object_info");
+    throw invalidInput("operation must be one of history, system_stats, logs, object_info, workflow_templates");
   }
   return { operation: args.operation, path: READ_OPERATIONS.get(args.operation) };
 }


### PR DESCRIPTION
Companion for artokun/comfyui-mcp#2196.

MCP already dispatches `fetch_comfyui_read(operation: workflow_templates)` for `list_packs(action: list_templates)`. Panel 0.15.153 rejected that operation in `web/js/lib/fetch-comfyui-read.js`, causing the connected-panel path to fall back to `NO_PANEL_ORIGIN`/headless loopback when COMFYUI_URL was unreachable.

This PR adds the smallest safe Panel companion: a fixed `workflow_templates` allowlist entry using `/workflow_templates`, which the existing authenticated `apiURL` helper resolves to same-origin `/api/workflow_templates`, and extends the route regression coverage.

Preserved:
- fixed operation validation and fail-closed unexpected-field/origin/redirect/body-size behavior
- authenticated `api.fetchApi` transport and normal credentials
- MCP loopback fallback and generation fences (MCP files are untouched)
- no network operations in `init.py` or `apps_routes.py`

Refs artokun/comfyui-mcp#2196

Validation:
- focused relay test: 9 passed
- full `npm.cmd run test:unit`: 8,147 passed, 1 existing todo, 0 failed
- `npm.cmd run typecheck`: passed
- JS syntax check: 260 files passed
- scope check: passed
- Python compile/parity checks: passed
- Bandit (`bandit -r . -s B101,B112,B311`): passed
- registry YARA/network scan (`node scripts/check-registry-yara.mjs --allow 0`): passed
- changelog/docs guard: passed
- pack contents and version metadata checks: passed
- `npm.cmd run build`: unavailable; package.json has no build script

Do not merge automatically; this is the paired Panel PR for the MCP issue.