### PR TITLE
fix(2024): preserve serialized Manager transport diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_search_nodes keeps serialized browser transport failures classified and diagnosable when ComfyUI-Manager mappings returns no HTTP response (#2024)
+
 ## [0.15.154] - 2026-09-02
 
 ### Fixed

--- a/browser_tests/unit/manager-fetch-failure.test.mjs
+++ b/browser_tests/unit/manager-fetch-failure.test.mjs
@@ -16,6 +16,7 @@ import {
   isTransportFailure,
   managerFetchFailureMessage,
 } from "../../web/js/lib/manager-fetch-failure.js";
+import { managerUnavailableResult } from "../../web/js/lib/manager-install.js";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -111,6 +112,19 @@ test("#1472 transport detection covers the real browser strings", () => {
   }
 });
 
+test("#2024 transport detection survives serialized TypeError and plain error-like objects", () => {
+  for (const value of [
+    "TypeError: Failed to fetch",
+    "Error: NetworkError when attempting to fetch resource",
+    { message: "TypeError: Failed to fetch" },
+  ]) {
+    assert.equal(isTransportFailure(value), true, JSON.stringify(value));
+    const msg = managerFetchFailureMessage("customnode/getmappings?mode=cache", value);
+    assert.match(msg, /TRANSPORT failure/);
+    assert.match(msg, /no HTTP status/);
+  }
+});
+
 test("#1472 a missing message still yields a usable error", () => {
   for (const bad of [undefined, null, new Error("")]) {
     const msg = managerFetchFailureMessage("manager/queue/task", bad);
@@ -187,6 +201,20 @@ test("#2024 isManagerTransportWrap matches the wrap and a bare Failed to fetch",
   assert.equal(isManagerTransportWrap(wrap), true);
   assert.equal(isManagerTransportWrap(new Error("Manager customnode/getmappings: HTTP 500")), false);
   assert.equal(isManagerTransportWrap(new Error("fetch failed for upstream registry")), false);
+});
+
+test("#2024 a serialized transport wrap remains visible to the search result", () => {
+  const wrapped = {
+    message:
+      "Error: ComfyUI-Manager request to /v2/customnode/getmappings?mode=cache did not complete: " +
+      "TypeError: Failed to fetch",
+  };
+  assert.equal(isManagerTransportWrap(wrapped), true);
+  const result = managerUnavailableResult("Spectrum MiniMax H3", wrapped);
+  assert.equal(result.transportFailure, true);
+  assert.equal(result.reason_code, "manager_search_transport");
+  assert.match(result.message, /^ComfyUI-Manager request to \/v2\/customnode\/getmappings\?mode=cache/);
+  assert.match(result.message, /TRANSPORT failure/);
 });
 
 test("#2024 WIRING: managerCall names the ABSOLUTE route, not /v2/", () => {

--- a/browser_tests/unit/manager-search-transport.test.mjs
+++ b/browser_tests/unit/manager-search-transport.test.mjs
@@ -138,6 +138,15 @@ test("#2024 a bare tagged Failed to fetch is reconstructed into the wrap, not le
   assert.match(res.message, /\/v2\/customnode\/getmappings\?mode=cache/);
 });
 
+test("#2024 a bridge-added Error prefix cannot bury the transport wrap", () => {
+  const cause = transportWrap();
+  const prefixed = new Error(`Error: ${cause.message}`);
+  const res = managerUnavailableResult("Spectrum MiniMax H3", prefixed);
+  assert.equal(res.transportFailure, true);
+  assert.match(res.message, /^ComfyUI-Manager request to \/v2\/customnode\/getmappings\?mode=cache/);
+  assert.match(res.message, /TRANSPORT failure/);
+});
+
 test("#2024 v2 transport wrap still uses the absolute legacy getmappings route", async () => {
   const wrap = transportWrap(SEARCH_MAPPINGS_ROUTE);
   assert.equal(isManagerUnreachable(wrap), true);

--- a/web/js/lib/manager-fetch-failure.js
+++ b/web/js/lib/manager-fetch-failure.js
@@ -42,7 +42,7 @@
 
 /** Is this the browser's transport-level failure (no response ever arrived)? */
 export function isTransportFailure(err) {
-  const msg = (err instanceof Error ? err.message : String(err ?? "")).trim();
+  const msg = transportMessage(err);
   // ANCHORED, and deliberately so. Review found the original substring test would
   // reclassify a Manager-ORIGINATED rejection that merely mentions one of these
   // phrases — "Package validation failed: NetworkError in dependency metadata", or
@@ -54,6 +54,26 @@ export function isTransportFailure(err) {
   // them, so anchoring costs nothing real. An unrecognised shape falls through to the
   // caller's own message, which is the honest outcome for an error we cannot classify.
   return TRANSPORT_MESSAGES.some((re) => re.test(msg));
+}
+
+/**
+ * Fetch errors cross the panel/bridge boundary in more than one shape. Keep the
+ * classifier strict about the browser's wording, but tolerate the standard
+ * `TypeError:`/`Error:` decoration added by String(error) or serialization and
+ * plain error-like objects carrying a `message` field. This is still anchored at
+ * the beginning, so Manager-originated sentences that merely mention a transport
+ * word remain rejections, not no-response failures.
+ */
+function transportMessage(err) {
+  let raw = "";
+  try {
+    if (err instanceof Error) raw = err.message;
+    else if (err && typeof err === "object" && typeof err.message === "string") raw = err.message;
+    else raw = String(err ?? "");
+  } catch {
+    return "";
+  }
+  return raw.trim().replace(/^(?:(?:Error|TypeError|DOMException):\s*)+/i, "");
 }
 
 /**
@@ -91,7 +111,14 @@ const TRANSPORT_MESSAGES = [
  * fetch is not labelled as a v2 route (#2024).
  */
 export function managerFetchFailureMessage(route, err, { prefix = "/v2/" } = {}) {
-  const raw = err instanceof Error ? err.message : String(err ?? "");
+  let raw = "";
+  try {
+    if (err instanceof Error) raw = err.message;
+    else if (err && typeof err === "object" && typeof err.message === "string") raw = err.message;
+    else raw = String(err ?? "");
+  } catch {
+    raw = "";
+  }
   const base = String(prefix ?? "/v2/");
   const path = `${base.endsWith("/") ? base : `${base}/`}${String(route ?? "").replace(/^\/+/, "")}`;
   if (!isTransportFailure(err)) {
@@ -124,9 +151,7 @@ export function managerFetchFailureMessage(route, err, { prefix = "/v2/" } = {})
 export function isManagerTransportWrap(err) {
   if (isTransportFailure(err)) return true;
   if (err && typeof err === "object" && isTransportFailure(err.cause)) return true;
-  const msg = (err instanceof Error ? err.message : String(err ?? ""))
-    .trim()
-    .replace(/^(?:Error:\s*)+/i, "");
+  const msg = transportMessage(err);
   const match = /^ComfyUI-Manager request to (\S+) did not complete:\s*([\s\S]+)$/i.exec(msg);
   if (!match) return false;
   return isTransportFailure(match[2]);

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -969,9 +969,23 @@ export function managerUnavailableResult(query, err) {
 /** Keep the #1472 wrap at the FRONT of `message`. MCP #2492 extractText()s that
  *  field and only host-HTTP-falls-back when it starts with the wrap. */
 function managerSearchTransportMessage(reason) {
-  const wrap = /^ComfyUI-Manager request to \S+ did not complete:/i.test(reason)
-    ? reason
+  // A ToolResult/error crossing the bridge may stringify the original Error and
+  // prepend `Error:`. Strip only that standard decoration before preserving the
+  // #1472 wrap; otherwise the host-side fallback sees a non-matching first token
+  // and the useful transport evidence is buried behind a generic re-wrap.
+  const normalizedReason = String(reason ?? "")
+    .trim()
+    .replace(/^(?:Error:\s*)+/i, "");
+  let wrap = /^ComfyUI-Manager request to \S+ did not complete:/i.test(normalizedReason)
+    ? normalizedReason
     : managerFetchFailureMessage(SEARCH_MAPPINGS_ROUTE, reason);
+  // Some bridge serializers retain only the short wrapped message and its
+  // `cause`; the route is preserved but the explanatory suffix is not. The
+  // classification above is still proof this was a no-response failure, so
+  // restore the minimum disclosure before appending the route diagnostics.
+  if (!/TRANSPORT failure/i.test(wrap)) {
+    wrap += " This is a TRANSPORT failure — no usable response reached the browser.";
+  }
   return (
     `${wrap} Both the v2 mappings route (${SEARCH_MAPPINGS_ROUTES[0]}) and the ` +
     `legacy absolute route (${SEARCH_MAPPINGS_ROUTES[1]}) were attempted from this ` +


### PR DESCRIPTION
## Summary

Fixes #2024.

The existing #2080 route fallback remained vulnerable to browser/bridge error-shape changes: serialized `TypeError: Failed to fetch` values and plain `{message}` objects were not classified as transport failures, and a serialized Manager wrap could lose its diagnostic disclosure. The panel now:

- recognizes only anchored browser transport messages, tolerating standard `Error:`/`TypeError:` decoration and error-like objects;
- preserves the mappings route and transport/no-response diagnosis at the front of the structured search result;
- keeps the existing fail-closed route ladder and read-only legacy retry unchanged.

No changes were made to `__init__.py` or `py/apps_routes.py`.

## Verification

- Full unit suite: 8,152 tests, 8,151 passed, 1 todo, 0 failed
- Focused Manager tests: 28 passed, 0 failed
- Typecheck: passed
- JS syntax (`web/js`): passed
- Python compile/compileall: passed
- Scope check: passed
- Changelog check: passed
- Tool vocabulary: passed
- Bandit: no issues
- Registry YARA/network scan: 0 flagged files
- Diff check: passed
