### PR TITLE
fix(panel): reuse fresh schema for add-node drift recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_add_node reuses the freshly fetched node definition when repairing stale registered schemas, so a stale-bundle refusal on a second whole-schema refresh cannot block LoadImage (#2124)
+
 ## [0.15.155] - 2026-09-02
 
 ### Fixed

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -13,12 +13,13 @@
 // caller could perform.
 //
 // THE FIX: the drift branch of `graph_add_node` now RUNS the panel_refresh_nodes
-// recovery itself — `refreshComfyNodeDefs(undefined, { force: true })`, the same
-// forced re-register — then re-reads the registry nodeData and re-checks the
-// drift. A drift the refresh clears is added from the CURRENT definition, with
-// the recovery disclosed on the result; only a drift that SURVIVES a real
-// re-registration is refused, and that refusal says the recovery already ran
-// (and why it did not complete, when the refresh said so).
+// recovery itself — carrying the already-fetched `freshDefs` into the forced
+// re-register — then re-reads the registry nodeData and re-checks the drift. A
+// drift the refresh clears is added from the CURRENT definition, with the recovery
+// disclosed on the result; only a drift that SURVIVES a real re-registration is
+// refused, and that refusal says the recovery already ran (and why it did not
+// complete, when the refresh said so). Carrying the class-scoped payload also keeps
+// a stale-bundle refusal on a second whole-schema fetch from blocking this add (#2124).
 //
 // The re-check reads the REGISTRY, not the refresh's verdict: a refresh that
 // only claims to have run must not be able to wave a stale schema through.
@@ -453,8 +454,9 @@ function realGraphAddNode(comfy, overrides = {}) {
     objectInfoSnapshot: { record: () => true, clear: () => {} },
     backendReconnectEpoch: 0,
     api,
-    // The default is the refresh the reporter ran by hand: forced, whole-schema,
-    // and it re-registers the CURRENT defs — the recovery that clears the drift.
+    // The default is the refresh the reporter ran by hand: forced, and it re-registers
+    // the CURRENT defs — the recovery that clears the drift. The shipped add now carries
+    // the class-scoped payload it already fetched; the override records that contract.
     // Tests that need it to fail or to lie pass their own through overrides.
     refreshComfyNodeDefs: async (defs, opts) => {
       refreshCalls.push({ defs, opts });
@@ -529,8 +531,12 @@ test("#1242: the reporter's add succeeds in one call — the panel refreshes fir
   assert.deepEqual(res.added.widgets, ["image"], "the node is built from the CURRENT definition");
   assert.equal(comfy.graph._nodes.length, 1);
   assert.equal(refreshCalls.length, 1, "exactly one refresh — the recovery, not a retry storm");
-  assert.equal(refreshCalls[0].defs, undefined, "the refresh is the whole-schema forced one");
-  assert.equal(refreshCalls[0].opts.force, true, "the recovery is the forced whole-schema one");
+  assert.deepEqual(
+    refreshCalls[0].defs,
+    { LoadImage: backendObjectInfo().LoadImage },
+    "the recovery reuses the already-fetched current class definition",
+  );
+  assert.equal(refreshCalls[0].opts.force, true, "the recovery remains forced");
   // #1192 — and it is BOUNDED now. This recovery awaits any refresh already in flight before
   // queueing its own; unbounded that wait is the composition defect #1192 is about, arriving
   // at the one await inside this command that named no bound. Asserting the bound EXISTS is
@@ -541,9 +547,35 @@ test("#1242: the reporter's add succeeds in one call — the panel refreshes fir
   );
   assert.deepEqual(
     Object.keys(refreshCalls[0].opts).sort(),
-    ["force", "joinMs"],
-    "…and nothing else is passed",
+    ["force", "joinMs", "preloadedWholeSchema"],
+    "the recovery carries its payload scope as well as its budget",
   );
+  assert.equal(refreshCalls[0].opts.preloadedWholeSchema, false);
+});
+
+test("#2124: a stale-bundle verdict on the discarded whole refresh cannot block LoadImage", async () => {
+  const comfy = makeComfy({ stale: true });
+  const refreshCalls = [];
+  const { graph_add_node } = realGraphAddNode(comfy, {
+    refreshComfyNodeDefs: async (defs, opts) => {
+      refreshCalls.push({ defs, opts });
+      // Model the production stale-bundle guard: a refresh that still needs to
+      // fetch the whole schema is refused, but a payload already fetched for this
+      // class is safe to register in place.
+      if (!defs) return { refreshed: false, reason: "stale_bundle" };
+      await comfy.app.registerNodesFromDefs(defs);
+      return { refreshed: true };
+    },
+  });
+
+  const res = await graph_add_node({ class_type: "LoadImage" });
+
+  assert.equal(res.added.type, "LoadImage");
+  assert.deepEqual(res.added.widgets, ["image"]);
+  assert.equal(refreshCalls.length, 1, "the add performs one payload-carrying recovery");
+  assert.ok(refreshCalls[0].defs?.LoadImage, "the recovery carries LoadImage");
+  assert.equal(refreshCalls[0].opts.preloadedWholeSchema, false);
+  assert.equal(comfy.graph._nodes.length, 1);
 });
 
 test("#1242: the recovery is disclosed on the result, not silent", async () => {

--- a/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
+++ b/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
@@ -106,16 +106,15 @@ test("#1242: the add runs the refresh itself, then re-checks, BEFORE the refusal
   const refusalAt = PANEL.indexOf("added or retyped since this page loaded its node schema");
   assert.ok(checkAt > 0 && refusalAt > checkAt, "the drift check must precede the refusal");
   const between = PANEL.slice(checkAt, refusalAt);
-  // #1192 — the call now spans lines because it carries a bound, so this matches the SHAPE
-  // rather than one spelling of it. STRONGER than the literal it replaces: it pins that the
-  // drift recovery is forced AND that its wait draws from the command budget, which is the
-  // property #1192 needs and the literal could not express.
+  // #1192/#2124 — the call now carries the already-fetched schema payload and a bound, so
+  // this matches the SHAPE rather than one spelling of it. It pins that the drift recovery
+  // is forced, payload-backed, scoped, AND that its wait draws from the command budget.
   const forced = between.match(
-    /refreshComfyNodeDefs\(undefined, \{\s*force: true,\s*joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS,\s*\}\)/,
+    /refreshComfyNodeDefs\(freshDefs, \{\s*force: true,\s*joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS,\s*preloadedWholeSchema: !freshDefsAreSingleClass,\s*\}\)/,
   );
   assert.ok(
     forced,
-    "the drift branch must run the forced refresh itself, bounded by the command budget",
+    "the drift branch must reuse the fresh payload in a forced, scoped refresh bounded by the command budget",
   );
   const refreshAt = forced.index;
   assert.ok(refreshAt > 0, "the drift branch must run the forced refresh itself");

--- a/browser_tests/unit/refresh-stale-bundle.test.mjs
+++ b/browser_tests/unit/refresh-stale-bundle.test.mjs
@@ -343,6 +343,38 @@ test("#2027 SHIPPED: a current bundle still attempts refresh (fail-open on match
   assert.ok(wrapped.beginReplacementCalls > 0, "a current-bundle refresh still fences while it runs");
 });
 
+test("#2124 SHIPPED: a verified preloaded schema bypasses stale-bundle refusal", async () => {
+  const staleVerdict = describeStaleBundleRefresh({ running: "0.15.123", installed: "0.15.124" });
+  let staleProbeCalls = 0;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    objectInfoSnapshot: createObjectInfoSnapshot(),
+    refuseStaleBundleRefresh: async () => {
+      staleProbeCalls += 1;
+      return staleVerdict;
+    },
+    apiValue: {
+      getNodeDefs: async () => {
+        throw new Error("the preloaded path must not fetch again");
+      },
+    },
+  });
+
+  const verdict = await registerComfyNodeDefs(
+    {
+      LoadImage: {
+        name: "LoadImage",
+        input: { required: { image: [["a.png"], {}] } },
+        output: ["IMAGE", "MASK"],
+      },
+    },
+    { preloadedWholeSchema: true },
+  );
+
+  assert.equal(staleProbeCalls, 0, "a supplied authoritative schema needs no bundle-version refusal");
+  assert.notEqual(verdict.reason, "stale_bundle");
+  assert.equal(verdict.refreshed, true, "the supplied schema is registered in place");
+});
+
 test("#2027 SHIPPED refuseStaleBundleRefresh compares PANEL_VERSION to the installed marker", async () => {
   const body = extractFunction("async function refuseStaleBundleRefresh(");
   const factory = new Function(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1853,9 +1853,14 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
   if (replacementMayReplaceWholeSnapshot) {
     // #2027 — a stale browser bundle must not fence or clear last-known schema.
     // Ask before invalidate/beginReplacement so a large-/object_info miss on an
-    // older tab cannot worsen the next widget edit.
-    const staleBundle = await refuseStaleBundleRefresh();
-    if (staleBundle) return staleBundle;
+    // older tab cannot worsen the next widget edit. A caller that already supplied
+    // a verified payload has no refresh fetch to protect: the payload is the
+    // authoritative answer this command just obtained, so do not discard it merely
+    // because the bundle-version probe says a later on-disk bundle exists (#2124).
+    if (preloadedDefs == null) {
+      const staleBundle = await refuseStaleBundleRefresh();
+      if (staleBundle) return staleBundle;
+    }
     // #716 — drop the widget-write burst cache at the START of this run, not after it
     // succeeds (codex). This function runs on exactly the events that change the schema —
     // refresh_nodes, a completed install/download, reconnect — and a refresh that FAILS is
@@ -16303,12 +16308,17 @@ const GRAPH_TOOL_EXECUTORS = {
         // already partly spent, and on the reported scenario (a ComfyUI restart, whose
         // reconnect refresh is still running) it could park here until the relay gave up
         // and the user got the bare "did not reply" this whole change exists to replace.
+        // #2124 — the resolver has already obtained an authoritative definition. Carry
+        // that payload into the recovery instead of throwing it away and starting another
+        // whole-schema fetch; the class-scoped payload is enough to replace this class and
+        // avoids turning a stale-bundle verdict for the second fetch into a false refusal.
         //
         // Same allowance as the resolver's join, and the same reserve held back, so a
         // drift recovery cannot eat the window the widget-registration wait still needs.
-        const verdict = await refreshComfyNodeDefs(undefined, {
+        const verdict = await refreshComfyNodeDefs(freshDefs, {
           force: true,
           joinMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS,
+          preloadedWholeSchema: !freshDefsAreSingleClass,
         });
         if (verdict === REFRESH_JOIN_ABANDONED) {
           // A NAMED reason, not the "unknown" the generic branch below produces for a


### PR DESCRIPTION
Fixes #2124\n\nSummary:\n- Reuse the authoritative object_info payload already fetched by panel_add_node during stale-schema drift recovery.\n- Preserve single-class versus whole-schema refresh scope.\n- Do not let a stale-bundle refusal on a discarded second fetch block LoadImage.\n- Add shipped-path regressions and an Unreleased changelog entry.\n\nValidation:\n- npm.cmd run test:unit\n- npm.cmd run typecheck\n- npm.cmd run check:scope\n- npm.cmd run check:changelog\n- node scripts/check-registry-yara.mjs --help (scan completed: 306 shipped files, 0 findings)\n\nNot merged per request.