### PR TITLE
fix(panel): rehydrate loaded node defs before run

### DIFF
--- a/browser_tests/unit/loaded-node-def-refresh-2180.test.mjs
+++ b/browser_tests/unit/loaded-node-def-refresh-2180.test.mjs
@@ -7,6 +7,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
+import {
+  describeUnrunnable,
+  graphToPromptFailureRefusal,
+  graphToPromptUnusable,
+  missingNodeRunRefusal,
+  unresolvedNodeTypes,
+  unserializableGraphRefusal,
+  unrunnableNodeIdsInScope,
+} from "../../web/js/lib/missing-node-preflight.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const SOURCE = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
@@ -47,4 +58,77 @@ test("#2180 leaves the fail-closed refusal when rehydration does not repair the 
   assert.match(recovery, /built = retryBuild\.value;/);
   assert.match(source, /const badIds = unrunnableNodeIdsInScope\(built, partialTargets\);/);
   assert.match(source, /throw new Error\(\s*missingNodeRunRefusal\(/);
+});
+
+test("#2180 blocks queueing when the recovery serialization is malformed", async () => {
+  const marker = SOURCE.indexOf("// Inspect the SERIALIZED prompt");
+  assert.ok(marker > 0, "could not locate the graph_run preflight");
+  const start = SOURCE.lastIndexOf("try {", marker);
+  const endMark = SOURCE.indexOf("if (err instanceof Error && /^NOT queued:/.test(err.message)) throw err;", start);
+  assert.ok(endMark > start, "could not locate the graph_run preflight catch");
+  const body = SOURCE.slice(start, SOURCE.indexOf("\n", endMark)) + "\n    }";
+
+  let serializations = 0;
+  let refreshes = 0;
+  let queueCalls = 0;
+  const preflight = new Function(
+    "app",
+    "graph",
+    "unrunnableNodeIdsInScope",
+    "partialTargets",
+    "describeUnrunnable",
+    "missingNodeRunRefusal",
+    "graphToPromptUnusable",
+    "graphToPromptFailureRefusal",
+    "unserializableGraphRefusal",
+    "rootGraph",
+    "unresolvedNodeTypes",
+    "window",
+    "withTimeout",
+    "budget",
+    "RUN_SERIALIZE_TIMEOUT_MS",
+    "refreshComfyNodeDefs",
+    `return async function preflight() {\n${body}\n};`,
+  )(
+    {
+      graphToPrompt() {
+        serializations += 1;
+        return serializations === 1
+          ? { output: { 1: { class_type: undefined, inputs: {} } }, workflow: {} }
+          : {};
+      },
+    },
+    { _nodes: [{ id: 1, type: "StaleCustomNode" }] },
+    unrunnableNodeIdsInScope,
+    undefined,
+    describeUnrunnable,
+    missingNodeRunRefusal,
+    graphToPromptUnusable,
+    graphToPromptFailureRefusal,
+    unserializableGraphRefusal,
+    { _nodes: [{ id: 1, type: "StaleCustomNode" }] },
+    unresolvedNodeTypes,
+    { LiteGraph: { registered_node_types: {} } },
+    withTimeout,
+    makeCommandBudget(30000),
+    8000,
+    async (_payload, options) => {
+      refreshes += 1;
+      assert.equal(options.force, true);
+    },
+  );
+
+  let refusal;
+  try {
+    await preflight();
+    queueCalls += 1;
+  } catch (error) {
+    refusal = error instanceof Error ? error.message : String(error);
+  }
+
+  assert.equal(serializations, 2, "the malformed value must come from the recovery retry");
+  assert.equal(refreshes, 1, "the loaded-node recovery must run once");
+  assert.equal(queueCalls, 0, "a malformed retry prompt must not reach queueing");
+  assert.match(refusal, /^NOT queued:/);
+  assert.match(refusal, /graphToPrompt/);
 });

--- a/browser_tests/unit/loaded-node-def-refresh-2180.test.mjs
+++ b/browser_tests/unit/loaded-node-def-refresh-2180.test.mjs
@@ -1,0 +1,50 @@
+// panel#2180 — a programmatic graph load can leave backend nodes present on the
+// canvas while their frontend classes are absent from this tab's registry. The
+// run preflight must give the authoritative refresh one chance to rehydrate them
+// before refusing a prompt with missing class_type values.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SOURCE = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function graphRunSource() {
+  const start = SOURCE.indexOf("  async graph_run({ batch_count, to_node_id }) {");
+  const end = SOURCE.indexOf("\n\n  graph_", start + 1);
+  assert.ok(start >= 0, "could not locate graph_run executor");
+  assert.ok(end > start, "could not locate graph_run executor boundary");
+  return SOURCE.slice(start, end);
+}
+
+test("#2180 retries serialization after refreshing definitions for loaded nodes", () => {
+  const source = graphRunSource();
+  const firstBuild = source.indexOf("const preflightBuild = await withTimeout(");
+  const refresh = source.indexOf("await refreshComfyNodeDefs(undefined", firstBuild);
+  const secondBuild = source.indexOf("const retryBuild = await withTimeout(", refresh);
+  const refusal = source.indexOf("missingNodeRunRefusal(", secondBuild);
+
+  assert.ok(firstBuild >= 0, "panel_run must build a preflight prompt");
+  assert.ok(refresh > firstBuild, "the recovery refresh must follow the first serialization");
+  assert.ok(secondBuild > refresh, "panel_run must retry serialization after the refresh");
+  assert.ok(refusal > secondBuild, "the existing refusal must remain after the retry");
+
+  const recovery = source.slice(refresh, secondBuild);
+  assert.match(recovery, /force: true/, "the recovery must fetch current definitions");
+  assert.match(recovery, /joinMs: refreshBudget/, "the recovery must share the run budget");
+  assert.match(recovery, /runBudgetMs: refreshBudget/, "the refresh run must be bounded");
+  assert.match(recovery, /skipDuplicateComboRefresh: true/, "the loaded graph must not pay for a duplicate schema fetch");
+});
+
+test("#2180 leaves the fail-closed refusal when rehydration does not repair the prompt", () => {
+  const source = graphRunSource();
+  const recovery = source.slice(
+    source.indexOf("if (unrunnableNodeIdsInScope(built, partialTargets).length)"),
+    source.indexOf("const badIds = unrunnableNodeIdsInScope(built, partialTargets);"),
+  );
+  assert.match(recovery, /built = retryBuild\.value;/);
+  assert.match(source, /const badIds = unrunnableNodeIdsInScope\(built, partialTargets\);/);
+  assert.match(source, /throw new Error\(\s*missingNodeRunRefusal\(/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20129,8 +20129,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // graph or replace it with a less useful queue-time error.
         throw new Error(graphToPromptFailureRefusal(preflightBuild.error));
       }
-      const built = preflightBuild.value;
-      preflightPrompt = built;
+      let built = preflightBuild.value;
       // comfyui-mcp#1582 — SERIALIZATION ITSELF CAN FAIL, and this is where that has to
       // be caught. `unrunnableNodeIds(undefined)` answers `[]` — correctly, since a
       // result that does not exist has no unrunnable entries in it — and the check below
@@ -20158,6 +20157,44 @@ const GRAPH_TOOL_EXECUTORS = {
           ),
         );
       }
+      // #2180 — graph_load is shared by panel_load_workflow and panel_flatten_workflow.
+      // A programmatic load can leave real custom-node instances on the canvas before
+      // this tab has their classes in LiteGraph.registered_node_types. The first prompt
+      // then carries missing class_type values even though the backend's /object_info can
+      // repair the registry. Refresh and reserialize once; if either operation cannot
+      // prove recovery, the existing refusal below remains the fail-closed outcome.
+      if (unrunnableNodeIdsInScope(built, partialTargets).length) {
+        // Keep 5s for the queue/receipt path after this recovery refresh.
+        const refreshBudget = budget.bounded(5000);
+        try {
+          await refreshComfyNodeDefs(undefined, {
+            force: true,
+            joinMs: refreshBudget,
+            runBudgetMs: refreshBudget,
+            // The refresh's own reapply sweep already has the fetched definitions and
+            // repairs the loaded instances; avoid paying for a second /object_info read.
+            skipDuplicateComboRefresh: true,
+          });
+        } catch {
+          // The retry below is deliberately still made: a late single-flight refresh may
+          // have completed its registration, and a failed refresh must not become a new
+          // panel_run failure mode.
+        }
+        const retryBuild = await withTimeout(
+          Promise.resolve(app.graphToPrompt()).then(
+            (value) => ({ value }),
+            (error) => ({ error }),
+          ),
+          budget.bounded(RUN_SERIALIZE_TIMEOUT_MS),
+          () => null,
+        );
+        if (retryBuild == null) throw new Error("graph_run recovery pre-flight: graphToPrompt did not answer in time");
+        if ("error" in retryBuild) {
+          throw new Error(graphToPromptFailureRefusal(retryBuild.error));
+        }
+        built = retryBuild.value;
+      }
+      preflightPrompt = built;
       // comfyui-mcp#1871 — SCOPED to the requested branch. The refusal's own premise ("a
       // run carrying an unregistered type cannot succeed") holds for a full run and stopped
       // holding for a run-to-node once #1511 let ComfyUI's refusal of an excluded branch be

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20193,6 +20193,19 @@ const GRAPH_TOOL_EXECUTORS = {
           throw new Error(graphToPromptFailureRefusal(retryBuild.error));
         }
         built = retryBuild.value;
+        // The recovery serializer is independently untrusted: a refresh can repair the
+        // registry while the second graphToPrompt still returns no usable prompt. Keep the
+        // same fail-closed refusal before this recovered value can reach queuePrompt.
+        if (graphToPromptUnusable(built)) {
+          throw new Error(
+            unserializableGraphRefusal(
+              unresolvedNodeTypes(
+                rootGraph ?? graph,
+                (window.LiteGraph ?? globalThis.LiteGraph)?.registered_node_types ?? {},
+              ),
+            ),
+          );
+        }
       }
       preflightPrompt = built;
       // comfyui-mcp#1871 — SCOPED to the requested branch. The refusal's own premise ("a


### PR DESCRIPTION
Rehydrate live node instances from authoritative /object_info when the initial panel_run serialization has missing class_type values, retry serialization once within the run budget, and preserve the existing fail-closed refusal if recovery does not repair the prompt. Adds #2180 regression coverage. Validation: npm.cmd run test:unit; npm.cmd run typecheck; npm.cmd run check:scope; python -m bandit -r . -s B101,B112,B311; node scripts/check-registry-yara.mjs --allow 0. Addresses #2180. Not merged or released.