### PR TITLE
fix(2192): panel_get_errors drops validation errors the live graph contradicts

### DIFF
--- a/browser_tests/unit/_graph-get-errors-harness.mjs
+++ b/browser_tests/unit/_graph-get-errors-harness.mjs
@@ -6,7 +6,7 @@ import {
   combineNodeErrorMaps,
   findNodeByScopedId,
   findVisibleNodeByScopedId,
-  pruneContradictedNodeErrors,
+  pruneContradictedNodeErrorMaps,
 } from "../../web/js/lib/asset-staleness.js";
 import { applyRuntimeExecFailure, boundExecFailurePayload } from "../../web/js/lib/exec-error-bounds.js";
 import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
@@ -76,7 +76,7 @@ const GRAPH_GET_ERRORS_DEPS = [
   "findNodeByScopedId",
   "getPiniaStore",
   "combineNodeErrorMaps",
-  "pruneContradictedNodeErrors",
+  "pruneContradictedNodeErrorMaps",
   "coerceMessageText",
   "lastExecFailure",
   "applyRuntimeExecFailure",
@@ -160,7 +160,7 @@ export async function runProductionGraphGetErrors({
     // production-path test drives the SHIPPED pruning rather than a stub of it.
     getPiniaStore: () => (storeNodeErrors ? { lastNodeErrors: storeNodeErrors } : null),
     combineNodeErrorMaps,
-    pruneContradictedNodeErrors,
+    pruneContradictedNodeErrorMaps,
     coerceMessageText: (value) => String(value ?? ""),
     lastExecFailure,
     applyRuntimeExecFailure,

--- a/browser_tests/unit/_graph-get-errors-harness.mjs
+++ b/browser_tests/unit/_graph-get-errors-harness.mjs
@@ -2,7 +2,12 @@
 // production-path regressions can drive the shipped executor without importing and running
 // this file's unrelated test cases.
 import { PANEL_SRC } from "./_panel-constants.mjs";
-import { findNodeByScopedId, findVisibleNodeByScopedId } from "../../web/js/lib/asset-staleness.js";
+import {
+  combineNodeErrorMaps,
+  findNodeByScopedId,
+  findVisibleNodeByScopedId,
+  pruneContradictedNodeErrors,
+} from "../../web/js/lib/asset-staleness.js";
 import { applyRuntimeExecFailure, boundExecFailurePayload } from "../../web/js/lib/exec-error-bounds.js";
 import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
@@ -71,6 +76,7 @@ const GRAPH_GET_ERRORS_DEPS = [
   "findNodeByScopedId",
   "getPiniaStore",
   "combineNodeErrorMaps",
+  "pruneContradictedNodeErrors",
   "coerceMessageText",
   "lastExecFailure",
   "applyRuntimeExecFailure",
@@ -98,6 +104,8 @@ export async function runProductionGraphGetErrors({
   graph,
   rootGraph,
   lastExecFailure,
+  lastNodeErrors = null,
+  storeNodeErrors = null,
   scan = async () => null,
   fetchSingleNodeInfo = () => {},
   // The extracted executor's default scan is a no-op test double. Give it a
@@ -127,7 +135,7 @@ export async function runProductionGraphGetErrors({
     withRefreshTimeout,
     getRefreshInFlight,
     nodeDefRefreshInFlight: null,
-    getGraphCtx: () => ({ app: { lastNodeErrors: null }, graph, rootGraph }),
+    getGraphCtx: () => ({ app: { lastNodeErrors }, graph, rootGraph }),
     objectInfoCache,
     objectInfoSnapshot,
     verifiedNodeDefCache,
@@ -148,8 +156,11 @@ export async function runProductionGraphGetErrors({
     LiteGraph: {},
     findVisibleNodeByScopedId,
     findNodeByScopedId,
-    getPiniaStore: () => null,
-    combineNodeErrorMaps: () => null,
+    // The real validation-map union and the real live-graph correlation, so a
+    // production-path test drives the SHIPPED pruning rather than a stub of it.
+    getPiniaStore: () => (storeNodeErrors ? { lastNodeErrors: storeNodeErrors } : null),
+    combineNodeErrorMaps,
+    pruneContradictedNodeErrors,
     coerceMessageText: (value) => String(value ?? ""),
     lastExecFailure,
     applyRuntimeExecFailure,

--- a/browser_tests/unit/_validation-banner-harness.mjs
+++ b/browser_tests/unit/_validation-banner-harness.mjs
@@ -7,7 +7,7 @@
 // function body, run with injected dependencies, so a test observes what SHIPS rather
 // than a re-implementation of it.
 import { PANEL_SRC } from "./_panel-constants.mjs";
-import { pruneContradictedNodeErrors } from "../../web/js/lib/asset-staleness.js";
+import { pruneContradictedNodeErrorMaps } from "../../web/js/lib/asset-staleness.js";
 
 function extractFunctionBody(source, signature) {
   const start = source.indexOf(signature);
@@ -64,7 +64,7 @@ const VALIDATION_BANNER_DEPS = [
   "isRegisteredNodeType",
   "LiteGraph",
   "coerceMessageText",
-  "pruneContradictedNodeErrors",
+  "pruneContradictedNodeErrorMaps",
 ];
 
 const makeValidationBanner = new Function(
@@ -106,7 +106,7 @@ export async function runProductionValidationBanner({
     isRegisteredNodeType: () => false,
     LiteGraph: {},
     coerceMessageText: (value) => String(value ?? ""),
-    pruneContradictedNodeErrors,
+    pruneContradictedNodeErrorMaps,
   };
   const banner = makeValidationBanner(...VALIDATION_BANNER_DEPS.map((name) => deps[name]));
   return banner();

--- a/browser_tests/unit/_validation-banner-harness.mjs
+++ b/browser_tests/unit/_validation-banner-harness.mjs
@@ -1,0 +1,113 @@
+// Production-path harness for validationBanner — the turn-start injection that tells the
+// agent what the user's canvas looks like. Kept outside a *.test.mjs module so other
+// production-path regressions can drive the shipped function without importing and
+// running this file's callers' test cases.
+//
+// Extracted the same way _graph-get-errors-harness.mjs extracts its executor: the real
+// function body, run with injected dependencies, so a test observes what SHIPS rather
+// than a re-implementation of it.
+import { PANEL_SRC } from "./_panel-constants.mjs";
+import { pruneContradictedNodeErrors } from "../../web/js/lib/asset-staleness.js";
+
+function extractFunctionBody(source, signature) {
+  const start = source.indexOf(signature);
+  if (start === -1) throw new Error(`${signature} not found in panel source`);
+  const open = source.indexOf("{", source.indexOf(")", start));
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "/" && source[i + 1] === "/") {
+      i = source.indexOf("\n", i + 2);
+      continue;
+    }
+    if (ch === "/" && source[i + 1] === "*") {
+      i = source.indexOf("*/", i + 2) + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < source.length; i += 1) {
+        if (source[i] === "\\") i += 1;
+        else if (source[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`unterminated ${signature}`);
+}
+
+const VALIDATION_BANNER_SOURCE = extractFunctionBody(PANEL_SRC, "async function validationBanner() {");
+
+const VALIDATION_BANNER_DEPS = [
+  "app",
+  "lastExecFailure",
+  "lastInjectedValidationSig",
+  "monotonicNow",
+  "getErrorsStepBudgetMs",
+  "getGraphCtx",
+  "activeWorkflowRef",
+  "hasRawMissingAssetCandidates",
+  "GET_ERRORS_REFRESH_CAP_MS",
+  "GET_ERRORS_STEP_CAP_MS",
+  "nodeDefsRefreshConfirmed",
+  "refreshMissingAssetTrust",
+  "refreshComfyNodeDefs",
+  "withRefreshTimeout",
+  "nodeDefRefreshInFlight",
+  "graphReadBindingChanged",
+  "collectMissingAssets",
+  "filterServerConfirmedInputSubfolderMedia",
+  "collectAllGraphs",
+  "adjudicateRecordedMissingNodeTypes",
+  "isRegisteredNodeType",
+  "LiteGraph",
+  "coerceMessageText",
+  "pruneContradictedNodeErrors",
+];
+
+const makeValidationBanner = new Function(
+  ...VALIDATION_BANNER_DEPS,
+  `return (${VALIDATION_BANNER_SOURCE.replace(/^async function validationBanner\(\)/, "async function ()")});`,
+);
+
+const noMissing = () => ({ models: [], media: [], nodeTypes: [], nodeCount: 0 });
+
+/** Run the SHIPPED validationBanner. Returns the banner text it would inject. */
+export async function runProductionValidationBanner({
+  lastNodeErrors = null,
+  rootGraph = null,
+  lastExecFailure = null,
+  collectMissingAssets = noMissing,
+  graphReadBindingChanged = () => false,
+} = {}) {
+  const deps = {
+    app: { lastNodeErrors },
+    lastExecFailure,
+    lastInjectedValidationSig: null,
+    monotonicNow: () => 0,
+    getErrorsStepBudgetMs: () => 1000,
+    getGraphCtx: () => ({ rootGraph }),
+    activeWorkflowRef: () => "wf",
+    hasRawMissingAssetCandidates: () => false,
+    GET_ERRORS_REFRESH_CAP_MS: 18000,
+    GET_ERRORS_STEP_CAP_MS: 4000,
+    nodeDefsRefreshConfirmed: false,
+    refreshMissingAssetTrust: async () => false,
+    refreshComfyNodeDefs: () => {},
+    withRefreshTimeout: () => {},
+    nodeDefRefreshInFlight: null,
+    graphReadBindingChanged,
+    collectMissingAssets,
+    filterServerConfirmedInputSubfolderMedia: async (media) => media,
+    collectAllGraphs: (value) => [value],
+    adjudicateRecordedMissingNodeTypes: (types) => ({ stillMissing: types, stalePlaceholders: [] }),
+    isRegisteredNodeType: () => false,
+    LiteGraph: {},
+    coerceMessageText: (value) => String(value ?? ""),
+    pruneContradictedNodeErrors,
+  };
+  const banner = makeValidationBanner(...VALIDATION_BANNER_DEPS.map((name) => deps[name]));
+  return banner();
+}

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -232,6 +232,95 @@ test("#2192 P1: a non-array argument is still accepted as a single map", () => {
   assert.equal(pruneContradictedNodeErrorMaps(graph, null).nodeErrors, null);
 });
 
+// ── codex gate round 2: the two halves of the claim, and the right type field ──
+
+test("#2192 r2: class_type is matched against comfyClass, not just node.type", async () => {
+  // The frontend's prompt compiler writes `class_type: e.comfyClass`, and registration
+  // sets type and comfyClass from different sources (`registerNodeType(n.id, i)` vs
+  // `i.comfyClass = t.name`). Comparing against `type` alone dropped live errors.
+  const node = { id: 2, type: "b2f0…-subgraph-uuid", comfyClass: "LoadImage", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const live = { type: "value_not_in_list", message: "image not in list" };
+
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastNodeErrors: { 2: { class_type: "LoadImage", errors: [live] } },
+  });
+  assert.deepEqual(result.node_errors?.[2]?.errors, [live], "comfyClass agrees — nothing to drop");
+  assert.equal(result.errored_count, 1);
+  assert.equal(result.stale_node_errors, undefined);
+});
+
+test("#2192 r2: a class that matches NEITHER field is still dropped", () => {
+  const node = { id: 2, type: "SomeType", comfyClass: "LoadImage", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(graph, {
+    2: { class_type: "KSampler", errors: [{ message: "from another workflow" }] },
+  });
+  assert.equal(nodeErrors, null);
+  assert.match(dropped[0].contradicted_by, /not the KSampler/);
+});
+
+test("#2192 r2: re-pointing the input at a different OUTPUT SLOT of the same node is a repair", () => {
+  // linked_node is [node_id, slot_index] and received_type is RETURN_TYPES[slot_index],
+  // so moving from output 0 (IMAGE) to output 1 (INT) fixes the mismatch without the
+  // source node changing at all. Comparing the id alone reported it forever.
+  const target = { id: 9, type: "ImpactSwitch", comfyClass: "ImpactSwitch", inputs: [{ name: "select", type: "INT", link: 900 }] };
+  const graph = makeGraph({
+    id: "root",
+    nodes: [{ id: 7, type: "MultiOut" }, target],
+    links: { 900: { id: 900, origin_id: 7, origin_slot: 1, target_id: 9, target_slot: 0 } },
+  });
+  const err = {
+    type: "return_type_mismatch",
+    details: "select, received_type(IMAGE) mismatch input_type(INT)",
+    extra_info: { input_name: "select", received_type: "IMAGE", linked_node: [7, 0] },
+  };
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(graph, {
+    9: { class_type: "ImpactSwitch", errors: [err] },
+  });
+  assert.equal(nodeErrors, null, "the slot the error names no longer feeds this input");
+  assert.equal(dropped.length, 1);
+});
+
+test("#2192 r2: the SAME node AND slot is still a live error", () => {
+  const target = { id: 9, type: "ImpactSwitch", comfyClass: "ImpactSwitch", inputs: [{ name: "select", type: "INT", link: 900 }] };
+  const graph = makeGraph({
+    id: "root",
+    nodes: [{ id: 7, type: "MultiOut" }, target],
+    links: { 900: { id: 900, origin_id: 7, origin_slot: 0, target_id: 9, target_slot: 0 } },
+  });
+  const nodeErrors = {
+    9: {
+      class_type: "ImpactSwitch",
+      errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }],
+    },
+  };
+  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192 r2: a slot neither side states is unreadable, not a disagreement", () => {
+  const target = { id: 9, type: "ImpactSwitch", inputs: [{ name: "select", type: "INT", link: 900 }] };
+  // Live link carries no readable origin_slot.
+  const graph = makeGraph({
+    id: "root",
+    nodes: [{ id: 7, type: "MultiOut" }, target],
+    links: { 900: { id: 900, origin_id: 7, target_id: 9, target_slot: 0 } },
+  });
+  const withSlot = { 9: { errors: [{ extra_info: { input_name: "select", linked_node: [7, 3] } }] } };
+  assert.deepEqual(pruneContradictedNodeErrors(graph, withSlot).nodeErrors, withSlot, "no live slot → keep");
+
+  // …and the mirror: a live slot with no claimed one.
+  const graph2 = makeGraph({
+    id: "root",
+    nodes: [{ id: 7, type: "MultiOut" }, { id: 9, type: "ImpactSwitch", inputs: [{ name: "select", link: 900 }] }],
+    links: { 900: { id: 900, origin_id: 7, origin_slot: 2, target_id: 9, target_slot: 0 } },
+  });
+  const noSlot = { 9: { errors: [{ extra_info: { input_name: "select", linked_node: [7] } }] } };
+  assert.deepEqual(pruneContradictedNodeErrors(graph2, noSlot).nodeErrors, noSlot, "no claimed slot → keep");
+});
+
 // ── the OTHER consumer: the turn-start banner ──────────────────────────────
 //
 // `validationBanner` reads the same map and injects it into the agent's turn asserting

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -28,6 +28,7 @@ import { fileURLToPath } from "node:url";
 
 import { pruneContradictedNodeErrors } from "../../web/js/lib/asset-staleness.js";
 import { runProductionGraphGetErrors } from "./_graph-get-errors-harness.mjs";
+import { runProductionValidationBanner } from "./_validation-banner-harness.mjs";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 
@@ -169,6 +170,51 @@ test("#2192: a disclosure list cut at the cap says so (#809)", async () => {
   assert.equal(typeof result.stale_node_errors_truncation_hint, "string");
 });
 
+// ── the OTHER consumer: the turn-start banner ──────────────────────────────
+//
+// `validationBanner` reads the same map and injects it into the agent's turn asserting
+// the user "is seeing these RIGHT NOW". A fix that corrected only panel_get_errors would
+// leave the stale claim on the louder surface.
+
+test("#2192: the turn-start banner does not claim the repaired link is on screen", async () => {
+  const { rootGraph } = reporterGraphs();
+  const banner = await runProductionValidationBanner({
+    rootGraph,
+    lastNodeErrors: { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } },
+  });
+  assert.equal(banner, "", "a repaired graph injects nothing");
+});
+
+test("#2192: the banner still fires for the STILL-BROKEN wire", async () => {
+  const { rootGraph } = reporterGraphs({ originId: "265" });
+  const banner = await runProductionValidationBanner({
+    rootGraph,
+    lastNodeErrors: { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } },
+  });
+  assert.match(banner, /GRAPH VALIDATION ERRORS/);
+  assert.match(banner, /received_type\(IMAGE\) mismatch input_type\(INT\)/);
+});
+
+test("#2192: NO root graph is not evidence — the banner reports every error unchanged", async () => {
+  // validationBanner's `getGraphCtx()` probe is try/catch-wrapped and yields null when
+  // the binding is unresolvable. Reading that as "none of these nodes exist" would drop
+  // the whole map on a real code path; absence of evidence is not disproof.
+  const banner = await runProductionValidationBanner({
+    rootGraph: null,
+    lastNodeErrors: { 5: { class_type: "KSampler", errors: [{ message: "boom" }] } },
+  });
+  assert.match(banner, /node 5 \(KSampler\): boom/);
+});
+
+test("#2192: pruneContradictedNodeErrors fails open on a nullish graph", () => {
+  const nodeErrors = { 5: { class_type: "KSampler", errors: [SELECT_MISMATCH] } };
+  for (const graph of [null, undefined, 0, ""]) {
+    const out = pruneContradictedNodeErrors(graph, nodeErrors);
+    assert.deepEqual(out.nodeErrors, nodeErrors, `nullish graph ${String(graph)} must not drop anything`);
+    assert.equal(out.dropped.length, 0);
+  }
+});
+
 // ── the classifier: what it drops, and everything it refuses to ────────────────
 
 test("#2192: an entry naming a node that is not on the graph at all is dropped", () => {
@@ -276,6 +322,18 @@ test("#2192 wiring: graph_get_errors prunes the map it reports, not a copy besid
     "the raw union must not be bound as `nodeErrors` anywhere",
   );
   assert.match(src, /stale_node_errors: contradictedNodeErrors\.slice\(0, MAX_STATE_NODES\)/);
+  // BOTH consumers of the map, not just the one the issue names. A green helper test
+  // proves nothing about a call path that never calls it.
+  assert.equal(
+    (src.match(/pruneContradictedNodeErrors\(/g) ?? []).length,
+    2,
+    "graph_get_errors AND validationBanner must each prune",
+  );
+  assert.match(
+    src,
+    /nodeErrors = pruneContradictedNodeErrors\(postProbeRootGraph, nodeErrors\)\.nodeErrors;/,
+    "the banner must prune against the root graph its own binding guard just cleared",
+  );
   // The cut must be reported with the REAL total, not the shown count — a hint that
   // says "50 of 50" is the silent-cut defect wearing a disclosure.
   assert.match(

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -368,13 +368,28 @@ test("#2192: pruneContradictedNodeErrors fails open on a nullish graph", () => {
 
 // ── the classifier: what it drops, and everything it refuses to ────────────────
 
-test("#2192: an entry naming a node that is not on the graph at all is dropped", () => {
+test("#2192: an entry naming a node that does not resolve is KEPT, not dropped", () => {
+  // Absence of a node is absence of evidence. Two separate review P1s came from reading
+  // "does not resolve" as "does not exist": a null root graph (a real validationBanner
+  // state) and a momentarily EMPTY graph (ComfyUI clears and repopulates `_nodes` while
+  // loading) both make every id unresolvable while the errors are perfectly live.
   const { rootGraph } = reporterGraphs();
-  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
-    777: { class_type: "KSampler", errors: [{ message: "boom" }] },
-  });
-  assert.equal(nodeErrors, null);
-  assert.match(dropped[0].contradicted_by, /no node 777 is on the active graph/);
+  const nodeErrors = { 777: { class_type: "KSampler", errors: [{ message: "boom" }] } };
+  const out = pruneContradictedNodeErrors(rootGraph, nodeErrors);
+  assert.deepEqual(out.nodeErrors, nodeErrors);
+  assert.equal(out.dropped.length, 0);
+});
+
+test("#2192: a momentarily EMPTY graph drops nothing (the mid-load state)", async () => {
+  const empty = makeGraph({ id: "root", nodes: [] });
+  const nodeErrors = { 5: { class_type: "KSampler", errors: [{ message: "ckpt not in list" }] } };
+
+  const result = await runProductionGraphGetErrors({ graph: empty, rootGraph: empty, lastNodeErrors: nodeErrors });
+  assert.deepEqual(result.node_errors, nodeErrors, "a load in flight is not a repaired graph");
+  assert.equal(result.stale_node_errors, undefined);
+
+  const banner = await runProductionValidationBanner({ rootGraph: empty, lastNodeErrors: nodeErrors });
+  assert.match(banner, /GRAPH VALIDATION ERRORS/, "the banner must not go silent mid-load");
 });
 
 test("#2192: an id ComfyUI reused for a different class is dropped (#1448, for validation)", () => {

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -308,7 +308,9 @@ test("#2192 r2: a slot neither side states is unreadable, not a disagreement", (
     nodes: [{ id: 7, type: "MultiOut" }, target],
     links: { 900: { id: 900, origin_id: 7, target_id: 9, target_slot: 0 } },
   });
-  const withSlot = { 9: { errors: [{ extra_info: { input_name: "select", linked_node: [7, 3] } }] } };
+  const withSlot = {
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 3] } }] },
+  };
   assert.deepEqual(pruneContradictedNodeErrors(graph, withSlot).nodeErrors, withSlot, "no live slot → keep");
 
   // …and the mirror: a live slot with no claimed one.
@@ -317,8 +319,64 @@ test("#2192 r2: a slot neither side states is unreadable, not a disagreement", (
     nodes: [{ id: 7, type: "MultiOut" }, { id: 9, type: "ImpactSwitch", inputs: [{ name: "select", link: 900 }] }],
     links: { 900: { id: 900, origin_id: 7, origin_slot: 2, target_id: 9, target_slot: 0 } },
   });
-  const noSlot = { 9: { errors: [{ extra_info: { input_name: "select", linked_node: [7] } }] } };
+  const noSlot = {
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7] } }] },
+  };
   assert.deepEqual(pruneContradictedNodeErrors(graph2, noSlot).nodeErrors, noSlot, "no claimed slot → keep");
+});
+
+// ── codex gate round 4: only ONE error type files its linked_node this way ────
+
+test("#2192 r4: exception_during_inner_validation is never judged by the link check", async () => {
+  // execution.py files this one under the UPSTREAM node — `validated[o_id] = (False,
+  // reasons, o_id)` — while `input_name` names an input of the DOWNSTREAM node and
+  // `linked_node` points back at the errored node itself. Read with return_type_mismatch's
+  // premise it finds a same-named input on the wrong node and drops a live error.
+  const node1 = { id: 1, type: "Upstream", comfyClass: "Upstream", inputs: [{ name: "x", type: "IMAGE", link: null }] };
+  const graph = makeGraph({ id: "root", nodes: [node1, { id: 2, type: "Downstream" }] });
+  const nodeErrors = {
+    1: {
+      class_type: "Upstream",
+      errors: [
+        {
+          type: "exception_during_inner_validation",
+          message: "Exception when validating inner node",
+          extra_info: { input_name: "x", linked_node: [2, 0] },
+        },
+      ],
+    },
+  };
+
+  const result = await runProductionGraphGetErrors({ graph, rootGraph: graph, lastNodeErrors: nodeErrors });
+  assert.deepEqual(result.node_errors, nodeErrors, "a live inner-validation exception must survive");
+  assert.equal(result.errored_count, 1);
+  assert.equal(result.note, undefined);
+});
+
+test("#2192 r4: an unknown error type carrying linked_node is never judged either", () => {
+  // Whitelist, not blocklist: a newer ComfyUI's error type, or a custom validator's, must
+  // not be read with semantics borrowed from return_type_mismatch.
+  const target = { id: 9, type: "Sw", comfyClass: "Sw", inputs: [{ name: "select", link: 900 }] };
+  const graph = makeGraph({
+    id: "root",
+    nodes: [{ id: 7, type: "A" }, { id: 8, type: "B" }, target],
+    links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
+  });
+  const nodeErrors = {
+    9: { class_type: "Sw", errors: [{ type: "some_future_error", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
+  };
+  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192 r4: an error with NO type is not judged", () => {
+  const target = { id: 9, type: "Sw", inputs: [{ name: "select", link: 900 }] };
+  const graph = makeGraph({
+    id: "root",
+    nodes: [{ id: 7, type: "A" }, { id: 8, type: "B" }, target],
+    links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
+  });
+  const nodeErrors = { 9: { errors: [{ extra_info: { input_name: "select", linked_node: [7, 0] } }] } };
+  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
 });
 
 // ── the OTHER consumer: the turn-start banner ──────────────────────────────

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -749,7 +749,10 @@ test("#2192 invariant: a demoted entry carries its errors, not just a label", as
   });
   assert.deepEqual(result.stale_node_errors[0].errors, [SELECT_MISMATCH]);
   assert.match(result.stale_node_errors_note, /IN FULL/);
-  assert.match(result.stale_node_errors_note, /nothing is discarded/);
+  // The note must state the limitation rather than promise more than it delivers: the
+  // judgement reads THIS TAB's node defs, and the list is capped with the cut disclosed.
+  assert.match(result.stale_node_errors_note, /THIS TAB loaded/);
+  assert.match(result.stale_node_errors_note, /capped/);
 });
 
 test("#2192 invariant: a class-mismatch demotion carries its errors too", () => {

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -1,0 +1,250 @@
+/**
+ * #2192 — `panel_get_errors` kept echoing a validation error for a link that had
+ * already been repaired.
+ *
+ * The reporter rewired an `ImpactSwitch.select` (INT) inside a subgraph. Mid-rewire it
+ * was briefly fed by an IMAGE node, ComfyUI rejected the queue, and the frontend stored
+ * that rejection in `app.lastNodeErrors`. They then fixed the wire and confirmed the fix
+ * with `panel_query_graph`. Every subsequent `panel_get_errors` — twice in a row, after a
+ * save, and again from root scope — still shipped:
+ *
+ *     "errored_count": 0,
+ *     "node_errors": { "249:252": { errors: [{ type: "return_type_mismatch",
+ *       details: "select, received_type(IMAGE) mismatch input_type(INT)",
+ *       extra_info: { input_name: "select", linked_node: ["249:265", 0] } }] } }
+ *
+ * Two halves to that. The map is only replaced on the NEXT queue attempt, so a repaired
+ * graph never clears it; and its key is a SCOPED locator that never string-equals a
+ * visible node's own id, so the entry reached no per-node reason either — which is how a
+ * populated `node_errors` came to ship beside `errored_count: 0` in one payload.
+ *
+ * These tests drive the SHIPPED `graph_get_errors` (via the production-path harness) on
+ * the reporter's exact shapes, plus the pure classifier's fail-open paths.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { pruneContradictedNodeErrors } from "../../web/js/lib/asset-staleness.js";
+import { runProductionGraphGetErrors } from "./_graph-get-errors-harness.mjs";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+// ── the reporter's graph ────────────────────────────────────────────────────────
+// root: [249 = subgraph host] · inside 249: 251 (INT source), 265 (IMAGE source),
+// 252 (ImpactSwitch, whose `select` input is now fed by 251).
+
+const SELECT_MISMATCH = {
+  type: "return_type_mismatch",
+  message: "Return type mismatch between linked nodes",
+  details: "select, received_type(IMAGE) mismatch input_type(INT)",
+  extra_info: {
+    input_name: "select",
+    received_type: "IMAGE",
+    linked_node: ["249:265", 0],
+  },
+};
+
+/** A LiteGraph-shaped graph: `_nodes`, `getNodeById`, and a link store keyed by id. */
+function makeGraph({ id, nodes, links = {} }) {
+  const byId = new Map(nodes.map((n) => [String(n.id), n]));
+  const graph = {
+    id,
+    _nodes: nodes,
+    links,
+    getNodeById: (nid) => byId.get(String(nid)) ?? null,
+  };
+  for (const n of nodes) n.graph = graph;
+  return graph;
+}
+
+/**
+ * `select` fed by `originId` (or by nothing when null). Link id 900 is the live wire;
+ * the error above names 265, so origin 251 is the REPAIRED state and 265 the broken one.
+ */
+function reporterGraphs({ originId = "251", selectInputName = "select" } = {}) {
+  const impactSwitch = {
+    id: 252,
+    type: "ImpactSwitch",
+    inputs: [
+      { name: "input1", type: "IMAGE", link: null },
+      { name: selectInputName, type: "INT", link: originId == null ? null : 900 },
+    ],
+  };
+  const inner = makeGraph({
+    id: "249",
+    nodes: [{ id: 251, type: "ImpactInt" }, { id: 265, type: "PreviewImage" }, impactSwitch],
+    links: originId == null ? {} : { 900: { id: 900, origin_id: originId, origin_slot: 0, target_id: 252, target_slot: 1 } },
+  });
+  const host = { id: 249, type: "SubgraphNode", subgraph: inner };
+  const rootGraph = makeGraph({ id: "root", nodes: [host] });
+  return { rootGraph, inner, impactSwitch };
+}
+
+// ── the production path ─────────────────────────────────────────────────────────
+
+test("#2192: the repaired link's validation error is gone from a subgraph-scope read", async () => {
+  const { rootGraph, inner } = reporterGraphs();
+  const result = await runProductionGraphGetErrors({
+    graph: inner,
+    rootGraph,
+    lastNodeErrors: { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } },
+  });
+
+  assert.equal(result.errored_count, 0);
+  assert.equal(result.node_errors, null, "the repaired link must not still be reported");
+  // The self-contradiction the report is about: a clean count beside a populated map.
+  // Now the count and the map agree, and the payload says so out loud.
+  assert.equal(result.note, "no errors recorded since the last execution start");
+  assert.equal(result.stale_node_errors.length, 1);
+  assert.equal(result.stale_node_errors[0].node_id, "249:252");
+  assert.equal(result.stale_node_errors[0].class_type, "ImpactSwitch");
+  assert.match(result.stale_node_errors[0].contradicted_by, /select/);
+});
+
+test("#2192: exiting to ROOT scope does not resurrect it (the reporter's step 5)", async () => {
+  const { rootGraph } = reporterGraphs();
+  const result = await runProductionGraphGetErrors({
+    graph: rootGraph,
+    rootGraph,
+    lastNodeErrors: { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } },
+  });
+  assert.equal(result.errored_count, 0);
+  assert.equal(result.node_errors, null);
+  assert.equal(result.stale_node_errors.length, 1);
+});
+
+test("#2192: the STILL-BROKEN wire is reported exactly as before", async () => {
+  // Same call, only the live origin differs — `select` really is fed by 265 (IMAGE).
+  const { rootGraph, inner } = reporterGraphs({ originId: "265" });
+  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
+  const result = await runProductionGraphGetErrors({ graph: inner, rootGraph, lastNodeErrors: nodeErrors });
+
+  assert.deepEqual(result.node_errors, nodeErrors, "a live rejection must survive untouched");
+  assert.equal(result.stale_node_errors, undefined);
+  assert.equal(result.note, undefined, "a graph with a live validation error is not clean");
+});
+
+test("#2192: the execution-error store is pruned too, not just app.lastNodeErrors", async () => {
+  // ComfyUI can clear the app map while the store retains the rejection, which is why
+  // the two are unioned before they are reported — the prune must cover both.
+  const { rootGraph, inner } = reporterGraphs();
+  const result = await runProductionGraphGetErrors({
+    graph: inner,
+    rootGraph,
+    lastNodeErrors: null,
+    storeNodeErrors: { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } },
+  });
+  assert.equal(result.node_errors, null);
+  assert.equal(result.stale_node_errors.length, 1);
+});
+
+// ── the classifier: what it drops, and everything it refuses to ────────────────
+
+test("#2192: an entry naming a node that is not on the graph at all is dropped", () => {
+  const { rootGraph } = reporterGraphs();
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
+    777: { class_type: "KSampler", errors: [{ message: "boom" }] },
+  });
+  assert.equal(nodeErrors, null);
+  assert.match(dropped[0].contradicted_by, /no node 777 is on the active graph/);
+});
+
+test("#2192: an id ComfyUI reused for a different class is dropped (#1448, for validation)", () => {
+  const { rootGraph } = reporterGraphs();
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
+    "249:252": { class_type: "LoadImage", errors: [{ message: "boom" }] },
+  });
+  assert.equal(nodeErrors, null);
+  assert.match(dropped[0].contradicted_by, /ImpactSwitch now, not the LoadImage/);
+});
+
+test("#2192: sibling errors on the same node survive the one that falsified", () => {
+  const { rootGraph } = reporterGraphs();
+  const live = { type: "value_not_in_list", message: "ckpt not in list", extra_info: { input_name: "ckpt_name" } };
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
+    "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH, live] },
+  });
+  assert.deepEqual(nodeErrors["249:252"].errors, [live]);
+  assert.equal(nodeErrors["249:252"].class_type, "ImpactSwitch");
+  assert.equal(dropped.length, 1);
+});
+
+test("#2192: a slot the live node no longer exposes is NOT falsified by its absence", () => {
+  // Impact-Pack renames dynamic slots by position (#1873). An input we cannot find is
+  // unjudgeable, not disproven — keep reporting.
+  const { rootGraph } = reporterGraphs({ selectInputName: "select_renamed" });
+  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
+  const { nodeErrors: kept, dropped } = pruneContradictedNodeErrors(rootGraph, nodeErrors);
+  assert.deepEqual(kept, nodeErrors);
+  assert.equal(dropped.length, 0);
+});
+
+test("#2192: an unreadable link store keeps the error rather than clearing it", () => {
+  const { rootGraph, inner } = reporterGraphs();
+  inner.links = {}; // link 900 is referenced by the input but not resolvable
+  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192: a linked_node in a DIFFERENT scope is not judged against a local origin id", () => {
+  const { rootGraph } = reporterGraphs();
+  const crossScope = {
+    ...SELECT_MISMATCH,
+    extra_info: { ...SELECT_MISMATCH.extra_info, linked_node: ["999:265", 0] },
+  };
+  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [crossScope] } };
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192: an error with no linked_node claim is never dropped by this check", () => {
+  const { rootGraph } = reporterGraphs();
+  const nodeErrors = {
+    "249:252": {
+      class_type: "ImpactSwitch",
+      errors: [{ type: "required_input_missing", extra_info: { input_name: "select" } }],
+    },
+  };
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192: an UNRECOGNIZED locator fails open even though it resolves to nothing", () => {
+  const { rootGraph } = reporterGraphs();
+  const nodeErrors = { "a:b:c:": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192: a graph that throws on lookup reports the entry verbatim", () => {
+  const exploding = {
+    getNodeById: () => {
+      throw new Error("detached graph");
+    },
+  };
+  const nodeErrors = { 5: { class_type: "KSampler", errors: [SELECT_MISMATCH] } };
+  assert.deepEqual(pruneContradictedNodeErrors(exploding, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192: null / non-object maps pass through unchanged", () => {
+  const { rootGraph } = reporterGraphs();
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, null), { nodeErrors: null, dropped: [] });
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, undefined), { nodeErrors: null, dropped: [] });
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, []).nodeErrors, []);
+});
+
+// ── wiring: the shipped monolith must actually call it ─────────────────────────
+
+test("#2192 wiring: graph_get_errors prunes the map it reports, not a copy beside it", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /pruneContradictedNodeErrors,/, "imported from asset-staleness.js");
+  // One binding: the pruned map is what the per-node join, `clean` and the payload read.
+  // A second `const nodeErrors =` from the raw union would silently un-ship the fix.
+  const bindings = src.match(/const \{ nodeErrors, dropped: contradictedNodeErrors \} = pruneContradictedNodeErrors\(/g);
+  assert.equal(bindings?.length, 1);
+  assert.equal(
+    (src.match(/const nodeErrors = combineNodeErrorMaps\(/g) ?? []).length,
+    0,
+    "the raw union must not be bound as `nodeErrors` anywhere",
+  );
+  assert.match(src, /stale_node_errors: contradictedNodeErrors\.slice\(0, MAX_STATE_NODES\)/);
+});

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -671,6 +671,73 @@ test("#2192: the banner still fires for the STILL-BROKEN wire", async () => {
   assert.match(banner, /received_type\(IMAGE\) mismatch input_type\(INT\)/);
 });
 
+// ── THE INVARIANT: nothing is ever discarded ─────────────────────────────────
+//
+// Every judgement in this module reads the FRONTEND's view of the graph, and a node def
+// the tab loaded can fall behind the server's (a pack update plus a reconnect). Review
+// found that on the input side and again on the source side, and the source side has no
+// corroborator inside the error to close it with. So the mechanism is built not to need
+// one: a demoted entry keeps its errors IN FULL under `stale_node_errors`, which makes
+// the worst case of a wrong judgement a mislabelled error the caller can still read —
+// never a lost one.
+
+test("#2192 invariant: every input error survives somewhere in the payload", async () => {
+  const { rootGraph, inner } = reporterGraphs();
+  const foreign = { class_type: "LoadImage", errors: [{ message: "from another workflow" }] };
+  const live = { class_type: "ImpactSwitch", errors: [{ type: "value_not_in_list", message: "still live" }] };
+  const lastNodeErrors = {
+    "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] }, // proved repaired
+    7: foreign, // class mismatch — but node 7 is not on this graph, so it is untouched
+    "249:251": live,
+  };
+
+  const result = await runProductionGraphGetErrors({ graph: inner, rootGraph, lastNodeErrors });
+
+  const seen = new Set();
+  for (const entry of Object.values(result.node_errors ?? {})) {
+    for (const e of entry.errors ?? []) seen.add(e);
+  }
+  for (const record of result.stale_node_errors ?? []) {
+    for (const e of record.errors ?? []) seen.add(e);
+  }
+  for (const [id, entry] of Object.entries(lastNodeErrors)) {
+    for (const e of entry.errors) {
+      assert.ok(seen.has(e), `error on ${id} vanished from the payload entirely`);
+    }
+  }
+});
+
+test("#2192 invariant: a demoted entry carries its errors, not just a label", async () => {
+  const { rootGraph, inner } = reporterGraphs();
+  const result = await runProductionGraphGetErrors({
+    graph: inner,
+    rootGraph,
+    lastNodeErrors: { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } },
+  });
+  assert.deepEqual(result.stale_node_errors[0].errors, [SELECT_MISMATCH]);
+  assert.match(result.stale_node_errors_note, /IN FULL/);
+  assert.match(result.stale_node_errors_note, /nothing is discarded/);
+});
+
+test("#2192 invariant: a class-mismatch demotion carries its errors too", () => {
+  const { rootGraph } = reporterGraphs();
+  const errors = [{ message: "boom" }, { message: "bang" }];
+  const { dropped } = pruneContradictedNodeErrors(rootGraph, {
+    "249:252": { class_type: "LoadImage", errors },
+  });
+  assert.deepEqual(dropped[0].errors, errors);
+});
+
+test("#2192 invariant: only the FALSIFIED half of a mixed entry is demoted", () => {
+  const { rootGraph } = reporterGraphs();
+  const live = { type: "value_not_in_list", message: "ckpt not in list" };
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
+    "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH, live] },
+  });
+  assert.deepEqual(nodeErrors["249:252"].errors, [live], "the live one stays in node_errors");
+  assert.deepEqual(dropped[0].errors, [SELECT_MISMATCH], "the repaired one moves, and moves whole");
+});
+
 // ── wiring: the shipped monolith must actually call it ────────────────────────
 
 test("#2192 wiring: both consumers prune, and neither merges before it prunes", () => {

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -18,8 +18,16 @@
  * visible node's own id, so the entry reached no per-node reason either — which is how a
  * populated `node_errors` came to ship beside `errored_count: 0` in one payload.
  *
- * These tests drive the SHIPPED `graph_get_errors` (via the production-path harness) on
- * the reporter's exact shapes, plus the pure classifier's fail-open paths.
+ * THE RULE THESE TESTS PIN. An entry is withheld only on positive proof from the live
+ * graph, and for a `return_type_mismatch` that proof is local and about TYPES: the input
+ * the error names now receives exactly the type it declares. It is deliberately NOT
+ * "the link named by `extra_info.linked_node` changed" — `linked_node` is a coordinate in
+ * the COMPILED prompt, which flattens subgraphs, renames dynamic slots and resolves
+ * through virtual/muted/bypassed nodes, and a changed link is not even sufficient (moving
+ * to another output of the same type repairs nothing).
+ *
+ * Both shipped consumers are driven through production-path harnesses: `graph_get_errors`
+ * and `validationBanner`, which reads the same map and asserts the user is seeing it now.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -34,10 +42,6 @@ import { runProductionGraphGetErrors } from "./_graph-get-errors-harness.mjs";
 import { runProductionValidationBanner } from "./_validation-banner-harness.mjs";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
-
-// ── the reporter's graph ────────────────────────────────────────────────────────
-// root: [249 = subgraph host] · inside 249: 251 (INT source), 265 (IMAGE source),
-// 252 (ImpactSwitch, whose `select` input is now fed by 251).
 
 const SELECT_MISMATCH = {
   type: "return_type_mismatch",
@@ -64,13 +68,15 @@ function makeGraph({ id, nodes, links = {} }) {
 }
 
 /**
- * `select` fed by `originId` (or by nothing when null). Link id 900 is the live wire;
- * the error above names 265, so origin 251 is the REPAIRED state and 265 the broken one.
+ * The reporter's graph. Root holds subgraph host 249; inside it, 251 emits INT, 265 emits
+ * IMAGE, and 252 is the ImpactSwitch whose `select` (INT) is fed by `originId`.
+ * `originId: "251"` is the REPAIRED state; `"265"` is the broken one the error describes.
  */
 function reporterGraphs({ originId = "251", selectInputName = "select" } = {}) {
   const impactSwitch = {
     id: 252,
     type: "ImpactSwitch",
+    comfyClass: "ImpactSwitch",
     inputs: [
       { name: "input1", type: "IMAGE", link: null },
       { name: selectInputName, type: "INT", link: originId == null ? null : 900 },
@@ -78,15 +84,22 @@ function reporterGraphs({ originId = "251", selectInputName = "select" } = {}) {
   };
   const inner = makeGraph({
     id: "249",
-    nodes: [{ id: 251, type: "ImpactInt" }, { id: 265, type: "PreviewImage" }, impactSwitch],
-    links: originId == null ? {} : { 900: { id: 900, origin_id: originId, origin_slot: 0, target_id: 252, target_slot: 1 } },
+    nodes: [
+      { id: 251, type: "ImpactInt", outputs: [{ name: "INT", type: "INT" }] },
+      { id: 265, type: "LoadImage", outputs: [{ name: "IMAGE", type: "IMAGE" }] },
+      impactSwitch,
+    ],
+    links:
+      originId == null
+        ? {}
+        : { 900: { id: 900, origin_id: originId, origin_slot: 0, target_id: 252, target_slot: 1 } },
   });
   const host = { id: 249, type: "SubgraphNode", subgraph: inner };
   const rootGraph = makeGraph({ id: "root", nodes: [host] });
   return { rootGraph, inner, impactSwitch };
 }
 
-// ── the production path ─────────────────────────────────────────────────────────
+// ── the reported bug, through the shipped executor ──────────────────────────────
 
 test("#2192: the repaired link's validation error is gone from a subgraph-scope read", async () => {
   const { rootGraph, inner } = reporterGraphs();
@@ -99,7 +112,6 @@ test("#2192: the repaired link's validation error is gone from a subgraph-scope 
   assert.equal(result.errored_count, 0);
   assert.equal(result.node_errors, null, "the repaired link must not still be reported");
   // The self-contradiction the report is about: a clean count beside a populated map.
-  // Now the count and the map agree, and the payload says so out loud.
   assert.equal(result.note, "no errors recorded since the last execution start");
   assert.equal(result.stale_node_errors.length, 1);
   assert.equal(result.stale_node_errors[0].node_id, "249:252");
@@ -146,22 +158,27 @@ test("#2192: the execution-error store is pruned too, not just app.lastNodeError
 
 test("#2192: a disclosure list cut at the cap says so (#809)", async () => {
   // A silently short list inside the field whose whole job is disclosure would be the
-  // same defect the field exists to close. 60 nodes, all contradicted, cap is 50.
-  const impactSwitches = [];
+  // same defect the field exists to close. 60 nodes, all repaired, cap is 50.
+  const switches = [];
   const links = {};
   for (let i = 0; i < 60; i += 1) {
     const id = 300 + i;
-    impactSwitches.push({
+    switches.push({
       id,
       type: "ImpactSwitch",
+      comfyClass: "ImpactSwitch",
       inputs: [{ name: "select", type: "INT", link: 1000 + i }],
     });
-    links[1000 + i] = { id: 1000 + i, origin_id: "251", origin_slot: 0, target_id: id, target_slot: 0 };
+    links[1000 + i] = { id: 1000 + i, origin_id: 251, origin_slot: 0, target_id: id, target_slot: 0 };
   }
-  const inner = makeGraph({ id: "249", nodes: [{ id: 251, type: "ImpactInt" }, ...impactSwitches], links });
+  const inner = makeGraph({
+    id: "249",
+    nodes: [{ id: 251, type: "ImpactInt", outputs: [{ type: "INT" }] }, ...switches],
+    links,
+  });
   const rootGraph = makeGraph({ id: "root", nodes: [{ id: 249, type: "SubgraphNode", subgraph: inner }] });
   const lastNodeErrors = Object.fromEntries(
-    impactSwitches.map((n) => [`249:${n.id}`, { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] }]),
+    switches.map((n) => [`249:${n.id}`, { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] }]),
   );
 
   const result = await runProductionGraphGetErrors({ graph: inner, rootGraph, lastNodeErrors });
@@ -173,167 +190,241 @@ test("#2192: a disclosure list cut at the cap says so (#809)", async () => {
   assert.equal(typeof result.stale_node_errors_truncation_hint, "string");
 });
 
-// ── codex gate P1: one map's label must never decide the other map's fate ────
+// ── the type rule: what counts as proof, and what does not ─────────────────────
 
-test("#2192 P1: a stale STORE entry does not take the live APP error down with it", async () => {
-  // combineNodeErrorMaps merges same-id entries with {...previous, ...entry}, so the
-  // LAST map's class_type governs an entry whose errors came from BOTH. Pruning after
-  // that merge let a retained foreign label drop a live error: node_errors null,
-  // errored_count 0, real error suppressed. Reproduced against the shipped executor
-  // before the fix; adjudicating each map on its own is what makes it survive.
-  const node = { id: 2, type: "Current", inputs: [] };
-  const graph = makeGraph({ id: "root", nodes: [node] });
-  const live = { type: "value_not_in_list", message: "ckpt not in list", extra_info: { input_name: "ckpt_name" } };
-
-  const result = await runProductionGraphGetErrors({
-    graph,
-    rootGraph: graph,
-    lastNodeErrors: { 2: { class_type: "Current", errors: [live] } },
-    storeNodeErrors: { 2: { class_type: "OldWorkflowType", errors: [{ message: "stale from another workflow" }] } },
-  });
-
-  assert.deepEqual(result.node_errors?.[2]?.errors, [live], "the live app error must survive");
-  assert.equal(result.node_errors[2].class_type, "Current", "and keep its OWN source's label");
-  assert.equal(result.errored_count, 1, "and still count as an error on the graph");
-  assert.equal(result.note, undefined, "a graph with a live validation error is not clean");
-  // The foreign entry IS withheld, and says why.
-  assert.equal(result.stale_node_errors.length, 1);
-  assert.match(result.stale_node_errors[0].contradicted_by, /not the OldWorkflowType/);
-});
-
-test("#2192 P1: the same stale entry in BOTH stores is one withheld fact, not two", () => {
-  const node = { id: 2, type: "Current", inputs: [] };
-  const graph = makeGraph({ id: "root", nodes: [node] });
-  const foreign = { class_type: "OldWorkflowType", errors: [{ message: "stale" }] };
-  const { nodeErrors, dropped } = pruneContradictedNodeErrorMaps(graph, [{ 2: foreign }, { 2: foreign }]);
-  assert.equal(nodeErrors, null);
-  assert.equal(dropped.length, 1, "deduplicated on (node id, reason)");
-});
-
-test("#2192 P1: the composer keeps combineNodeErrorMaps' union of two LIVE sources", () => {
-  // The reason that union exists (#579): ComfyUI can clear the app map while the store
-  // still holds the rejection. Pruning per-map must not cost that.
-  const node = { id: 2, type: "Current", inputs: [] };
-  const graph = makeGraph({ id: "root", nodes: [node] });
-  const a = { message: "from the app map" };
-  const b = { message: "from the execution store" };
-  const { nodeErrors } = pruneContradictedNodeErrorMaps(graph, [
-    { 2: { class_type: "Current", errors: [a] } },
-    { 2: { class_type: "Current", errors: [b] } },
-  ]);
-  assert.deepEqual(nodeErrors[2].errors, [a, b]);
-});
-
-test("#2192 P1: a non-array argument is still accepted as a single map", () => {
-  const node = { id: 2, type: "Current", inputs: [] };
-  const graph = makeGraph({ id: "root", nodes: [node] });
-  const map = { 2: { class_type: "Current", errors: [{ message: "live" }] } };
-  assert.deepEqual(pruneContradictedNodeErrorMaps(graph, map).nodeErrors, map);
-  assert.equal(pruneContradictedNodeErrorMaps(graph, null).nodeErrors, null);
-});
-
-// ── codex gate round 2: the two halves of the claim, and the right type field ──
-
-test("#2192 r2: class_type is matched against comfyClass, not just node.type", async () => {
-  // The frontend's prompt compiler writes `class_type: e.comfyClass`, and registration
-  // sets type and comfyClass from different sources (`registerNodeType(n.id, i)` vs
-  // `i.comfyClass = t.name`). Comparing against `type` alone dropped live errors.
-  const node = { id: 2, type: "b2f0…-subgraph-uuid", comfyClass: "LoadImage", inputs: [] };
-  const graph = makeGraph({ id: "root", nodes: [node] });
-  const live = { type: "value_not_in_list", message: "image not in list" };
-
-  const result = await runProductionGraphGetErrors({
-    graph,
-    rootGraph: graph,
-    lastNodeErrors: { 2: { class_type: "LoadImage", errors: [live] } },
-  });
-  assert.deepEqual(result.node_errors?.[2]?.errors, [live], "comfyClass agrees — nothing to drop");
-  assert.equal(result.errored_count, 1);
-  assert.equal(result.stale_node_errors, undefined);
-});
-
-test("#2192 r2: a class that matches NEITHER field is still dropped", () => {
-  const node = { id: 2, type: "SomeType", comfyClass: "LoadImage", inputs: [] };
-  const graph = makeGraph({ id: "root", nodes: [node] });
-  const { nodeErrors, dropped } = pruneContradictedNodeErrors(graph, {
-    2: { class_type: "KSampler", errors: [{ message: "from another workflow" }] },
-  });
-  assert.equal(nodeErrors, null);
-  assert.match(dropped[0].contradicted_by, /not the KSampler/);
-});
-
-test("#2192 r2: re-pointing the input at a different OUTPUT SLOT of the same node is a repair", () => {
-  // linked_node is [node_id, slot_index] and received_type is RETURN_TYPES[slot_index],
-  // so moving from output 0 (IMAGE) to output 1 (INT) fixes the mismatch without the
-  // source node changing at all. Comparing the id alone reported it forever.
-  const target = { id: 9, type: "ImpactSwitch", comfyClass: "ImpactSwitch", inputs: [{ name: "select", type: "INT", link: 900 }] };
-  const graph = makeGraph({
-    id: "root",
-    nodes: [{ id: 7, type: "MultiOut" }, target],
-    links: { 900: { id: 900, origin_id: 7, origin_slot: 1, target_id: 9, target_slot: 0 } },
-  });
-  const err = {
-    type: "return_type_mismatch",
-    details: "select, received_type(IMAGE) mismatch input_type(INT)",
-    extra_info: { input_name: "select", received_type: "IMAGE", linked_node: [7, 0] },
+/** `target.select` (INT) fed by output `slot` of node 7, whose outputs are `outTypes`. */
+function typeGraph({ outTypes, slot, via = {} }) {
+  const source = {
+    id: 7,
+    type: "MultiOut",
+    comfyClass: "MultiOut",
+    outputs: outTypes.map((t) => ({ type: t })),
+    ...via,
   };
-  const { nodeErrors, dropped } = pruneContradictedNodeErrors(graph, {
-    9: { class_type: "ImpactSwitch", errors: [err] },
-  });
-  assert.equal(nodeErrors, null, "the slot the error names no longer feeds this input");
-  assert.equal(dropped.length, 1);
-});
-
-test("#2192 r2: the SAME node AND slot is still a live error", () => {
-  const target = { id: 9, type: "ImpactSwitch", comfyClass: "ImpactSwitch", inputs: [{ name: "select", type: "INT", link: 900 }] };
+  const target = {
+    id: 9,
+    type: "ImpactSwitch",
+    comfyClass: "ImpactSwitch",
+    inputs: [{ name: "select", type: "INT", link: 900 }],
+  };
   const graph = makeGraph({
     id: "root",
-    nodes: [{ id: 7, type: "MultiOut" }, target],
-    links: { 900: { id: 900, origin_id: 7, origin_slot: 0, target_id: 9, target_slot: 0 } },
+    nodes: [source, target],
+    links: { 900: { id: 900, origin_id: 7, origin_slot: slot, target_id: 9, target_slot: 0 } },
   });
   const nodeErrors = {
     9: {
       class_type: "ImpactSwitch",
-      errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }],
+      errors: [
+        {
+          type: "return_type_mismatch",
+          details: "select, received_type(IMAGE) mismatch input_type(INT)",
+          extra_info: { input_name: "select", received_type: "IMAGE", linked_node: [7, 0] },
+        },
+      ],
     },
+  };
+  return { graph, nodeErrors };
+}
+
+test("#2192 types: the input now receives exactly its own type ⇒ repaired", () => {
+  const { graph, nodeErrors } = typeGraph({ outTypes: ["IMAGE", "INT"], slot: 1 });
+  assert.equal(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, null);
+});
+
+test("#2192 types: a slot move between two SAME-typed outputs repairs nothing", () => {
+  // The link the error names ([7,0]) is no longer the live one ([7,1]) — but both emit
+  // IMAGE, so ComfyUI produces the identical mismatch. A link-identity rule got this
+  // wrong; a type rule cannot.
+  const { graph, nodeErrors } = typeGraph({ outTypes: ["IMAGE", "IMAGE"], slot: 1 });
+  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192 types: a DIFFERENT source node that still emits the wrong type is still wrong", () => {
+  const source = { id: 7, type: "A", outputs: [{ type: "IMAGE" }] };
+  const other = { id: 8, type: "B", outputs: [{ type: "IMAGE" }] };
+  const target = { id: 9, type: "Sw", inputs: [{ name: "select", type: "INT", link: 900 }] };
+  const graph = makeGraph({
+    id: "root",
+    nodes: [source, other, target],
+    links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
+  });
+  const nodeErrors = {
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
   };
   assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
 });
 
-test("#2192 r2: a slot neither side states is unreadable, not a disagreement", () => {
-  const target = { id: 9, type: "ImpactSwitch", inputs: [{ name: "select", type: "INT", link: 900 }] };
-  // Live link carries no readable origin_slot.
-  const graph = makeGraph({
-    id: "root",
-    nodes: [{ id: 7, type: "MultiOut" }, target],
-    links: { 900: { id: 900, origin_id: 7, target_id: 9, target_slot: 0 } },
-  });
-  const withSlot = {
-    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 3] } }] },
-  };
-  assert.deepEqual(pruneContradictedNodeErrors(graph, withSlot).nodeErrors, withSlot, "no live slot → keep");
-
-  // …and the mirror: a live slot with no claimed one.
-  const graph2 = makeGraph({
-    id: "root",
-    nodes: [{ id: 7, type: "MultiOut" }, { id: 9, type: "ImpactSwitch", inputs: [{ name: "select", link: 900 }] }],
-    links: { 900: { id: 900, origin_id: 7, origin_slot: 2, target_id: 9, target_slot: 0 } },
-  });
-  const noSlot = {
-    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7] } }] },
-  };
-  assert.deepEqual(pruneContradictedNodeErrors(graph2, noSlot).nodeErrors, noSlot, "no claimed slot → keep");
+test("#2192 types: the linked_node coordinates are not consulted at all", () => {
+  // A claim naming a node in another scope entirely still resolves on the live types,
+  // because the prompt's coordinates are not what the verdict is made of.
+  const { graph, nodeErrors } = typeGraph({ outTypes: ["INT"], slot: 0 });
+  nodeErrors[9].errors[0].extra_info.linked_node = ["999:12345", 7];
+  assert.equal(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, null);
 });
 
-// ── codex gate round 4: only ONE error type files its linked_node this way ────
+test("#2192 types: an UNCONNECTED input is not proof of repair", () => {
+  // Nothing feeds it, so there is no source type to prove anything with. ComfyUI would
+  // report `required_input_missing` — a different error — rather than nothing at all.
+  const { rootGraph, inner } = reporterGraphs({ originId: null });
+  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
+  assert.equal(inner.getNodeById(252).inputs[1].link, null);
+});
 
-test("#2192 r4: exception_during_inner_validation is never judged by the link check", async () => {
+test("#2192 types: a `*` wildcard on either side is never exact proof", () => {
+  for (const [inType, outType] of [
+    ["*", "*"],
+    ["INT", "*"],
+    ["*", "INT"],
+  ]) {
+    const source = { id: 7, type: "A", outputs: [{ type: outType }] };
+    const target = { id: 9, type: "Sw", inputs: [{ name: "select", type: inType, link: 900 }] };
+    const graph = makeGraph({
+      id: "root",
+      nodes: [source, target],
+      links: { 900: { id: 900, origin_id: 7, origin_slot: 0, target_id: 9, target_slot: 0 } },
+    });
+    const nodeErrors = {
+      9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
+    };
+    assert.deepEqual(
+      pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors,
+      nodeErrors,
+      `wildcard ${inType}/${outType} must not be read as a match`,
+    );
+  }
+});
+
+test("#2192 types: an unreadable slot type or output index keeps the error", () => {
+  const cases = {
+    "no output at that index": { outputs: [{ type: "INT" }], slot: 5 },
+    "output with no type": { outputs: [{}], slot: 0 },
+    "output type not a string": { outputs: [{ type: 7 }], slot: 0 },
+  };
+  for (const [label, { outputs, slot }] of Object.entries(cases)) {
+    const graph = makeGraph({
+      id: "root",
+      nodes: [
+        { id: 7, type: "A", outputs },
+        { id: 9, type: "Sw", inputs: [{ name: "select", type: "INT", link: 900 }] },
+      ],
+      links: { 900: { id: 900, origin_id: 7, origin_slot: slot, target_id: 9, target_slot: 0 } },
+    });
+    const nodeErrors = {
+      9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
+    };
+    assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors, label);
+  }
+});
+
+test("#2192 types: a link with no readable origin_slot keeps the error", () => {
+  const graph = makeGraph({
+    id: "root",
+    nodes: [
+      { id: 7, type: "A", outputs: [{ type: "INT" }] },
+      { id: 9, type: "Sw", inputs: [{ name: "select", type: "INT", link: 900 }] },
+    ],
+    links: { 900: { id: 900, origin_id: 7, target_id: 9, target_slot: 0 } },
+  });
+  const nodeErrors = {
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
+  };
+  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192: a slot the live node no longer exposes is NOT proof of repair", () => {
+  // Impact-Pack renames dynamic slots by position (#1873). An input we cannot find is
+  // unjudgeable, not repaired.
+  const { rootGraph } = reporterGraphs({ selectInputName: "select_renamed" });
+  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
+  const out = pruneContradictedNodeErrors(rootGraph, nodeErrors);
+  assert.deepEqual(out.nodeErrors, nodeErrors);
+  assert.equal(out.dropped.length, 0);
+});
+
+test("#2192: an unreadable link store keeps the error rather than clearing it", () => {
+  const { rootGraph, inner } = reporterGraphs();
+  inner.links = {}; // link 900 is referenced by the input but not resolvable
+  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192: sibling errors on the same node survive the one that proved repaired", () => {
+  const { rootGraph } = reporterGraphs();
+  const live = { type: "value_not_in_list", message: "ckpt not in list", extra_info: { input_name: "ckpt_name" } };
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
+    "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH, live] },
+  });
+  assert.deepEqual(nodeErrors["249:252"].errors, [live]);
+  assert.equal(nodeErrors["249:252"].class_type, "ImpactSwitch");
+  assert.equal(dropped.length, 1);
+});
+
+// ── the prompt is COMPILED; the graph is not ──────────────────────────────────
+//
+// The serializer skips `isVirtualNode || mode === NEVER || mode === BYPASS` and the input
+// receives the type of whatever is further upstream, so the immediate source's own output
+// type is not evidence about what this input actually gets.
+
+for (const [label, via] of [
+  ["a BYPASSED node (mode 4)", { mode: 4 }],
+  ["a MUTED node (mode 2)", { mode: 2 }],
+  ["a virtual Reroute", { isVirtualNode: true }],
+  ["a subgraph container", { isVirtualNode: true, subgraph: {} }],
+]) {
+  test(`#2192 compiled: a matching type read through ${label} is not proof`, async () => {
+    const { graph, nodeErrors } = typeGraph({ outTypes: ["INT"], slot: 0, via });
+    const result = await runProductionGraphGetErrors({ graph, rootGraph: graph, lastNodeErrors: nodeErrors });
+    assert.deepEqual(result.node_errors, nodeErrors, "the compiler resolves through it — read no verdict off it");
+    assert.equal(result.errored_count, 1);
+    assert.equal(result.note, undefined);
+  });
+}
+
+test("#2192 compiled: an ORDINARY source is judged — the guard does not disable the fix", () => {
+  // mode 0 and mode-absent are both ordinary; the reporter's repair is exactly this shape.
+  for (const mode of [0, undefined]) {
+    const { graph, nodeErrors } = typeGraph({ outTypes: ["INT"], slot: 0, via: { mode } });
+    assert.equal(
+      pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors,
+      null,
+      `mode ${String(mode)} is a real source, so the matching type is proof`,
+    );
+  }
+});
+
+test("#2192 compiled: an unresolvable source node keeps the error", () => {
+  const graph = makeGraph({
+    id: "root",
+    nodes: [{ id: 9, type: "Sw", inputs: [{ name: "select", type: "INT", link: 900 }] }],
+    links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
+  });
+  const nodeErrors = {
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [5, 0] } }] },
+  };
+  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+// ── only ONE ComfyUI error type files its input_name this way ─────────────────
+
+test("#2192: exception_during_inner_validation is never judged by the type check", async () => {
   // execution.py files this one under the UPSTREAM node — `validated[o_id] = (False,
-  // reasons, o_id)` — while `input_name` names an input of the DOWNSTREAM node and
-  // `linked_node` points back at the errored node itself. Read with return_type_mismatch's
-  // premise it finds a same-named input on the wrong node and drops a live error.
-  const node1 = { id: 1, type: "Upstream", comfyClass: "Upstream", inputs: [{ name: "x", type: "IMAGE", link: null }] };
-  const graph = makeGraph({ id: "root", nodes: [node1, { id: 2, type: "Downstream" }] });
+  // reasons, o_id)` — while `input_name` names an input of the DOWNSTREAM node. Read with
+  // return_type_mismatch's premise it finds a same-named input on the wrong node.
+  const node1 = {
+    id: 1,
+    type: "Upstream",
+    comfyClass: "Upstream",
+    inputs: [{ name: "x", type: "INT", link: 900 }],
+    outputs: [{ type: "INT" }],
+  };
+  const src = { id: 3, type: "IntSrc", outputs: [{ type: "INT" }] };
+  const graph = makeGraph({
+    id: "root",
+    nodes: [src, node1, { id: 2, type: "Downstream" }],
+    links: { 900: { id: 900, origin_id: 3, origin_slot: 0, target_id: 1, target_slot: 0 } },
+  });
   const nodeErrors = {
     1: {
       class_type: "Upstream",
@@ -353,105 +444,177 @@ test("#2192 r4: exception_during_inner_validation is never judged by the link ch
   assert.equal(result.note, undefined);
 });
 
-test("#2192 r4: an unknown error type carrying linked_node is never judged either", () => {
+test("#2192: an unknown or absent error type is never judged either", () => {
   // Whitelist, not blocklist: a newer ComfyUI's error type, or a custom validator's, must
   // not be read with semantics borrowed from return_type_mismatch.
-  const target = { id: 9, type: "Sw", comfyClass: "Sw", inputs: [{ name: "select", link: 900 }] };
-  const graph = makeGraph({
-    id: "root",
-    nodes: [{ id: 7, type: "A" }, { id: 8, type: "B" }, target],
-    links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
-  });
-  const nodeErrors = {
-    9: { class_type: "Sw", errors: [{ type: "some_future_error", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
-  };
-  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
-});
-
-test("#2192 r4: an error with NO type is not judged", () => {
-  const target = { id: 9, type: "Sw", inputs: [{ name: "select", link: 900 }] };
-  const graph = makeGraph({
-    id: "root",
-    nodes: [{ id: 7, type: "A" }, { id: 8, type: "B" }, target],
-    links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
-  });
-  const nodeErrors = { 9: { errors: [{ extra_info: { input_name: "select", linked_node: [7, 0] } }] } };
-  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
-});
-
-// ── codex gate round 5: the prompt is COMPILED; the graph is not ─────────────
-//
-// The serializer skips `isVirtualNode || mode === NEVER || mode === BYPASS` and attributes
-// the link to whatever is upstream, so an input fed through any of those has a
-// `linked_node` that CANNOT equal its immediate origin_id. Reading that as a repair drops
-// live errors on any graph with a reroute in it.
-
-/** target.select fed by `via` (id 7), which is upstream-fed by the real source 5. */
-function indirectionGraph(via) {
-  const target = { id: 9, type: "Sw", comfyClass: "Sw", inputs: [{ name: "select", link: 900 }] };
-  return {
-    graph: makeGraph({
-      id: "root",
-      nodes: [{ id: 5, type: "RealSource" }, via, target],
-      links: { 900: { id: 900, origin_id: 7, origin_slot: 0, target_id: 9, target_slot: 0 } },
-    }),
-    nodeErrors: {
-      9: {
-        class_type: "Sw",
-        errors: [
-          {
-            type: "return_type_mismatch",
-            details: "select, received_type(IMAGE) mismatch input_type(INT)",
-            extra_info: { input_name: "select", linked_node: [5, 0] },
-          },
-        ],
-      },
-    },
-  };
-}
-
-for (const [label, via] of [
-  ["a BYPASSED node (mode 4)", { id: 7, type: "Passthrough", mode: 4 }],
-  ["a MUTED node (mode 2)", { id: 7, type: "Passthrough", mode: 2 }],
-  ["a virtual Reroute", { id: 7, type: "Reroute", isVirtualNode: true }],
-  ["a subgraph container", { id: 7, type: "SubgraphNode", isVirtualNode: true, subgraph: {} }],
-]) {
-  test(`#2192 r5: an error whose source is reached through ${label} is NOT dropped`, async () => {
-    const { graph, nodeErrors } = indirectionGraph(via);
-    const result = await runProductionGraphGetErrors({ graph, rootGraph: graph, lastNodeErrors: nodeErrors });
-    assert.deepEqual(result.node_errors, nodeErrors, "the compiler resolves through it — this is not a repair");
-    assert.equal(result.errored_count, 1);
-    assert.equal(result.note, undefined);
-  });
-}
-
-test("#2192 r5: an unresolvable source node keeps the error", () => {
-  const target = { id: 9, type: "Sw", inputs: [{ name: "select", link: 900 }] };
-  const graph = makeGraph({
-    id: "root",
-    nodes: [target], // node 8 is referenced by the link but absent from the graph
-    links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
-  });
-  const nodeErrors = {
-    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [5, 0] } }] },
-  };
-  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
-});
-
-test("#2192 r5: an ORDINARY source node is still judged — the fix survives the guard", () => {
-  // mode 0 and mode-absent are both ordinary; the reporter's repair is exactly this shape.
-  for (const mode of [0, undefined]) {
-    const { graph, nodeErrors } = indirectionGraph({ id: 7, type: "RealPassthrough", mode });
-    const out = pruneContradictedNodeErrors(graph, nodeErrors);
-    assert.equal(out.nodeErrors, null, `mode ${String(mode)} is a real source, so [5,0] is falsified`);
+  for (const type of ["some_future_error", "required_input_missing", undefined]) {
+    const { graph, nodeErrors } = typeGraph({ outTypes: ["INT"], slot: 0 });
+    if (type === undefined) delete nodeErrors[9].errors[0].type;
+    else nodeErrors[9].errors[0].type = type;
+    assert.deepEqual(
+      pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors,
+      nodeErrors,
+      `error type ${String(type)} must not be judged`,
+    );
   }
 });
 
-// ── the OTHER consumer: the turn-start banner ──────────────────────────────
-//
-// `validationBanner` reads the same map and injects it into the agent's turn asserting
-// the user "is seeing these RIGHT NOW". A fix that corrected only panel_get_errors would
-// leave the stale claim on the louder surface.
+// ── the class-type check ──────────────────────────────────────────────────────
+
+test("#2192: an id ComfyUI reused for a different class is dropped (#1448, for validation)", () => {
+  const { rootGraph } = reporterGraphs();
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
+    "249:252": { class_type: "LoadImage", errors: [{ message: "boom" }] },
+  });
+  assert.equal(nodeErrors, null);
+  assert.match(dropped[0].contradicted_by, /ImpactSwitch now, not the LoadImage/);
+});
+
+test("#2192: class_type is matched against comfyClass, not just node.type", async () => {
+  // The frontend's prompt compiler writes `class_type: e.comfyClass`, and registration
+  // sets type and comfyClass from different sources (`registerNodeType(n.id, i)` vs
+  // `i.comfyClass = t.name`). Comparing against `type` alone dropped live errors.
+  const node = { id: 2, type: "b2f0-subgraph-uuid", comfyClass: "LoadImage", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const live = { type: "value_not_in_list", message: "image not in list" };
+
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastNodeErrors: { 2: { class_type: "LoadImage", errors: [live] } },
+  });
+  assert.deepEqual(result.node_errors?.[2]?.errors, [live], "comfyClass agrees — nothing to drop");
+  assert.equal(result.errored_count, 1);
+  assert.equal(result.stale_node_errors, undefined);
+});
+
+test("#2192: a class that matches NEITHER field is still dropped", () => {
+  const node = { id: 2, type: "SomeType", comfyClass: "LoadImage", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const { nodeErrors, dropped } = pruneContradictedNodeErrors(graph, {
+    2: { class_type: "KSampler", errors: [{ message: "from another workflow" }] },
+  });
+  assert.equal(nodeErrors, null);
+  assert.match(dropped[0].contradicted_by, /not the KSampler/);
+});
+
+// ── absence is never evidence ─────────────────────────────────────────────────
+
+test("#2192: an entry naming a node that does not resolve is KEPT, not dropped", () => {
+  // Two separate review findings came from reading "does not resolve" as "does not
+  // exist": a null root graph (a real validationBanner state) and a momentarily EMPTY
+  // graph (ComfyUI clears and repopulates `_nodes` while loading).
+  const { rootGraph } = reporterGraphs();
+  const nodeErrors = { 777: { class_type: "KSampler", errors: [{ message: "boom" }] } };
+  const out = pruneContradictedNodeErrors(rootGraph, nodeErrors);
+  assert.deepEqual(out.nodeErrors, nodeErrors);
+  assert.equal(out.dropped.length, 0);
+});
+
+test("#2192: a momentarily EMPTY graph drops nothing (the mid-load state)", async () => {
+  const empty = makeGraph({ id: "root", nodes: [] });
+  const nodeErrors = { 5: { class_type: "KSampler", errors: [{ message: "ckpt not in list" }] } };
+
+  const result = await runProductionGraphGetErrors({ graph: empty, rootGraph: empty, lastNodeErrors: nodeErrors });
+  assert.deepEqual(result.node_errors, nodeErrors, "a load in flight is not a repaired graph");
+  assert.equal(result.stale_node_errors, undefined);
+
+  const banner = await runProductionValidationBanner({ rootGraph: empty, lastNodeErrors: nodeErrors });
+  assert.match(banner, /GRAPH VALIDATION ERRORS/, "the banner must not go silent mid-load");
+});
+
+test("#2192: NO root graph is not evidence — the banner reports every error unchanged", async () => {
+  const banner = await runProductionValidationBanner({
+    rootGraph: null,
+    lastNodeErrors: { 5: { class_type: "KSampler", errors: [{ message: "boom" }] } },
+  });
+  assert.match(banner, /node 5 \(KSampler\): boom/);
+});
+
+test("#2192: pruneContradictedNodeErrors fails open on a nullish graph", () => {
+  const nodeErrors = { 5: { class_type: "KSampler", errors: [SELECT_MISMATCH] } };
+  for (const graph of [null, undefined, 0, ""]) {
+    const out = pruneContradictedNodeErrors(graph, nodeErrors);
+    assert.deepEqual(out.nodeErrors, nodeErrors, `nullish graph ${String(graph)} must not drop anything`);
+    assert.equal(out.dropped.length, 0);
+  }
+});
+
+test("#2192: a graph that throws on lookup reports the entry verbatim", () => {
+  const exploding = {
+    getNodeById: () => {
+      throw new Error("detached graph");
+    },
+  };
+  const nodeErrors = { 5: { class_type: "KSampler", errors: [SELECT_MISMATCH] } };
+  assert.deepEqual(pruneContradictedNodeErrors(exploding, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192: null / non-object maps pass through unchanged", () => {
+  const { rootGraph } = reporterGraphs();
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, null), { nodeErrors: null, dropped: [] });
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, undefined), { nodeErrors: null, dropped: [] });
+  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, []).nodeErrors, []);
+});
+
+// ── one map's label must never decide the other map's fate ────────────────────
+
+test("#2192: a stale STORE entry does not take the live APP error down with it", async () => {
+  // combineNodeErrorMaps merges same-id entries with {...previous, ...entry}, so the
+  // LAST map's class_type governs an entry whose errors came from BOTH. Pruning after
+  // that merge let a retained foreign label drop a live error: node_errors null,
+  // errored_count 0, real error suppressed.
+  const node = { id: 2, type: "Current", comfyClass: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const live = { type: "value_not_in_list", message: "ckpt not in list", extra_info: { input_name: "ckpt_name" } };
+
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastNodeErrors: { 2: { class_type: "Current", errors: [live] } },
+    storeNodeErrors: { 2: { class_type: "OldWorkflowType", errors: [{ message: "stale from another workflow" }] } },
+  });
+
+  assert.deepEqual(result.node_errors?.[2]?.errors, [live], "the live app error must survive");
+  assert.equal(result.node_errors[2].class_type, "Current", "and keep its OWN source's label");
+  assert.equal(result.errored_count, 1, "and still count as an error on the graph");
+  assert.equal(result.note, undefined, "a graph with a live validation error is not clean");
+  assert.equal(result.stale_node_errors.length, 1);
+  assert.match(result.stale_node_errors[0].contradicted_by, /not the OldWorkflowType/);
+});
+
+test("#2192: the same stale entry in BOTH stores is one withheld fact, not two", () => {
+  const node = { id: 2, type: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const foreign = { class_type: "OldWorkflowType", errors: [{ message: "stale" }] };
+  const { nodeErrors, dropped } = pruneContradictedNodeErrorMaps(graph, [{ 2: foreign }, { 2: foreign }]);
+  assert.equal(nodeErrors, null);
+  assert.equal(dropped.length, 1, "deduplicated on (node id, reason)");
+});
+
+test("#2192: the composer keeps combineNodeErrorMaps' union of two LIVE sources", () => {
+  // The reason that union exists (#579): ComfyUI can clear the app map while the store
+  // still holds the rejection. Pruning per-map must not cost that.
+  const node = { id: 2, type: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const a = { message: "from the app map" };
+  const b = { message: "from the execution store" };
+  const { nodeErrors } = pruneContradictedNodeErrorMaps(graph, [
+    { 2: { class_type: "Current", errors: [a] } },
+    { 2: { class_type: "Current", errors: [b] } },
+  ]);
+  assert.deepEqual(nodeErrors[2].errors, [a, b]);
+});
+
+test("#2192: a non-array argument is still accepted as a single map", () => {
+  const node = { id: 2, type: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const map = { 2: { class_type: "Current", errors: [{ message: "live" }] } };
+  assert.deepEqual(pruneContradictedNodeErrorMaps(graph, map).nodeErrors, map);
+  assert.equal(pruneContradictedNodeErrorMaps(graph, null).nodeErrors, null);
+});
+
+// ── the OTHER consumer: the turn-start banner ─────────────────────────────────
 
 test("#2192: the turn-start banner does not claim the repaired link is on screen", async () => {
   const { rootGraph } = reporterGraphs();
@@ -472,134 +635,7 @@ test("#2192: the banner still fires for the STILL-BROKEN wire", async () => {
   assert.match(banner, /received_type\(IMAGE\) mismatch input_type\(INT\)/);
 });
 
-test("#2192: NO root graph is not evidence — the banner reports every error unchanged", async () => {
-  // validationBanner's `getGraphCtx()` probe is try/catch-wrapped and yields null when
-  // the binding is unresolvable. Reading that as "none of these nodes exist" would drop
-  // the whole map on a real code path; absence of evidence is not disproof.
-  const banner = await runProductionValidationBanner({
-    rootGraph: null,
-    lastNodeErrors: { 5: { class_type: "KSampler", errors: [{ message: "boom" }] } },
-  });
-  assert.match(banner, /node 5 \(KSampler\): boom/);
-});
-
-test("#2192: pruneContradictedNodeErrors fails open on a nullish graph", () => {
-  const nodeErrors = { 5: { class_type: "KSampler", errors: [SELECT_MISMATCH] } };
-  for (const graph of [null, undefined, 0, ""]) {
-    const out = pruneContradictedNodeErrors(graph, nodeErrors);
-    assert.deepEqual(out.nodeErrors, nodeErrors, `nullish graph ${String(graph)} must not drop anything`);
-    assert.equal(out.dropped.length, 0);
-  }
-});
-
-// ── the classifier: what it drops, and everything it refuses to ────────────────
-
-test("#2192: an entry naming a node that does not resolve is KEPT, not dropped", () => {
-  // Absence of a node is absence of evidence. Two separate review P1s came from reading
-  // "does not resolve" as "does not exist": a null root graph (a real validationBanner
-  // state) and a momentarily EMPTY graph (ComfyUI clears and repopulates `_nodes` while
-  // loading) both make every id unresolvable while the errors are perfectly live.
-  const { rootGraph } = reporterGraphs();
-  const nodeErrors = { 777: { class_type: "KSampler", errors: [{ message: "boom" }] } };
-  const out = pruneContradictedNodeErrors(rootGraph, nodeErrors);
-  assert.deepEqual(out.nodeErrors, nodeErrors);
-  assert.equal(out.dropped.length, 0);
-});
-
-test("#2192: a momentarily EMPTY graph drops nothing (the mid-load state)", async () => {
-  const empty = makeGraph({ id: "root", nodes: [] });
-  const nodeErrors = { 5: { class_type: "KSampler", errors: [{ message: "ckpt not in list" }] } };
-
-  const result = await runProductionGraphGetErrors({ graph: empty, rootGraph: empty, lastNodeErrors: nodeErrors });
-  assert.deepEqual(result.node_errors, nodeErrors, "a load in flight is not a repaired graph");
-  assert.equal(result.stale_node_errors, undefined);
-
-  const banner = await runProductionValidationBanner({ rootGraph: empty, lastNodeErrors: nodeErrors });
-  assert.match(banner, /GRAPH VALIDATION ERRORS/, "the banner must not go silent mid-load");
-});
-
-test("#2192: an id ComfyUI reused for a different class is dropped (#1448, for validation)", () => {
-  const { rootGraph } = reporterGraphs();
-  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
-    "249:252": { class_type: "LoadImage", errors: [{ message: "boom" }] },
-  });
-  assert.equal(nodeErrors, null);
-  assert.match(dropped[0].contradicted_by, /ImpactSwitch now, not the LoadImage/);
-});
-
-test("#2192: sibling errors on the same node survive the one that falsified", () => {
-  const { rootGraph } = reporterGraphs();
-  const live = { type: "value_not_in_list", message: "ckpt not in list", extra_info: { input_name: "ckpt_name" } };
-  const { nodeErrors, dropped } = pruneContradictedNodeErrors(rootGraph, {
-    "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH, live] },
-  });
-  assert.deepEqual(nodeErrors["249:252"].errors, [live]);
-  assert.equal(nodeErrors["249:252"].class_type, "ImpactSwitch");
-  assert.equal(dropped.length, 1);
-});
-
-test("#2192: a slot the live node no longer exposes is NOT falsified by its absence", () => {
-  // Impact-Pack renames dynamic slots by position (#1873). An input we cannot find is
-  // unjudgeable, not disproven — keep reporting.
-  const { rootGraph } = reporterGraphs({ selectInputName: "select_renamed" });
-  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
-  const { nodeErrors: kept, dropped } = pruneContradictedNodeErrors(rootGraph, nodeErrors);
-  assert.deepEqual(kept, nodeErrors);
-  assert.equal(dropped.length, 0);
-});
-
-test("#2192: an unreadable link store keeps the error rather than clearing it", () => {
-  const { rootGraph, inner } = reporterGraphs();
-  inner.links = {}; // link 900 is referenced by the input but not resolvable
-  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
-  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
-});
-
-test("#2192: a linked_node in a DIFFERENT scope is not judged against a local origin id", () => {
-  const { rootGraph } = reporterGraphs();
-  const crossScope = {
-    ...SELECT_MISMATCH,
-    extra_info: { ...SELECT_MISMATCH.extra_info, linked_node: ["999:265", 0] },
-  };
-  const nodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [crossScope] } };
-  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
-});
-
-test("#2192: an error with no linked_node claim is never dropped by this check", () => {
-  const { rootGraph } = reporterGraphs();
-  const nodeErrors = {
-    "249:252": {
-      class_type: "ImpactSwitch",
-      errors: [{ type: "required_input_missing", extra_info: { input_name: "select" } }],
-    },
-  };
-  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
-});
-
-test("#2192: an UNRECOGNIZED locator fails open even though it resolves to nothing", () => {
-  const { rootGraph } = reporterGraphs();
-  const nodeErrors = { "a:b:c:": { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] } };
-  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, nodeErrors).nodeErrors, nodeErrors);
-});
-
-test("#2192: a graph that throws on lookup reports the entry verbatim", () => {
-  const exploding = {
-    getNodeById: () => {
-      throw new Error("detached graph");
-    },
-  };
-  const nodeErrors = { 5: { class_type: "KSampler", errors: [SELECT_MISMATCH] } };
-  assert.deepEqual(pruneContradictedNodeErrors(exploding, nodeErrors).nodeErrors, nodeErrors);
-});
-
-test("#2192: null / non-object maps pass through unchanged", () => {
-  const { rootGraph } = reporterGraphs();
-  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, null), { nodeErrors: null, dropped: [] });
-  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, undefined), { nodeErrors: null, dropped: [] });
-  assert.deepEqual(pruneContradictedNodeErrors(rootGraph, []).nodeErrors, []);
-});
-
-// ── wiring: the shipped monolith must actually call it ─────────────────────────
+// ── wiring: the shipped monolith must actually call it ────────────────────────
 
 test("#2192 wiring: both consumers prune, and neither merges before it prunes", () => {
   const src = readFileSync(PANEL_JS, "utf8");
@@ -613,9 +649,9 @@ test("#2192 wiring: both consumers prune, and neither merges before it prunes", 
     "graph_get_errors AND validationBanner must each prune",
   );
 
-  // THE ORDERING INVARIANT (codex gate P1). `combineNodeErrorMaps` merges same-id entries
-  // with {...previous, ...entry}, so merging FIRST lets the last map's class_type govern
-  // the first map's errors and a stale store entry drops a live app error. The panel must
+  // THE ORDERING INVARIANT. `combineNodeErrorMaps` merges same-id entries with
+  // {...previous, ...entry}, so merging FIRST lets the last map's class_type govern the
+  // first map's errors and a stale store entry drops a live app error. The panel must
   // therefore never invoke the union itself — the composer owns that order.
   assert.equal(
     (src.match(/combineNodeErrorMaps\(/g) ?? []).length,

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -140,6 +140,35 @@ test("#2192: the execution-error store is pruned too, not just app.lastNodeError
   assert.equal(result.stale_node_errors.length, 1);
 });
 
+test("#2192: a disclosure list cut at the cap says so (#809)", async () => {
+  // A silently short list inside the field whose whole job is disclosure would be the
+  // same defect the field exists to close. 60 nodes, all contradicted, cap is 50.
+  const impactSwitches = [];
+  const links = {};
+  for (let i = 0; i < 60; i += 1) {
+    const id = 300 + i;
+    impactSwitches.push({
+      id,
+      type: "ImpactSwitch",
+      inputs: [{ name: "select", type: "INT", link: 1000 + i }],
+    });
+    links[1000 + i] = { id: 1000 + i, origin_id: "251", origin_slot: 0, target_id: id, target_slot: 0 };
+  }
+  const inner = makeGraph({ id: "249", nodes: [{ id: 251, type: "ImpactInt" }, ...impactSwitches], links });
+  const rootGraph = makeGraph({ id: "root", nodes: [{ id: 249, type: "SubgraphNode", subgraph: inner }] });
+  const lastNodeErrors = Object.fromEntries(
+    impactSwitches.map((n) => [`249:${n.id}`, { class_type: "ImpactSwitch", errors: [SELECT_MISMATCH] }]),
+  );
+
+  const result = await runProductionGraphGetErrors({ graph: inner, rootGraph, lastNodeErrors });
+  assert.equal(result.node_errors, null);
+  assert.equal(result.stale_node_errors.length, 50);
+  assert.equal(result.stale_node_errors_truncated, true);
+  // The harness stubs fixedCapNote, so the TEXT is pinned in the wiring test below
+  // (against the shipped source); here the observable facts are the cut and its flag.
+  assert.equal(typeof result.stale_node_errors_truncation_hint, "string");
+});
+
 // ── the classifier: what it drops, and everything it refuses to ────────────────
 
 test("#2192: an entry naming a node that is not on the graph at all is dropped", () => {
@@ -247,4 +276,10 @@ test("#2192 wiring: graph_get_errors prunes the map it reports, not a copy besid
     "the raw union must not be bound as `nodeErrors` anywhere",
   );
   assert.match(src, /stale_node_errors: contradictedNodeErrors\.slice\(0, MAX_STATE_NODES\)/);
+  // The cut must be reported with the REAL total, not the shown count — a hint that
+  // says "50 of 50" is the silent-cut defect wearing a disclosure.
+  assert.match(
+    src,
+    /stale_node_errors_truncation_hint: fixedCapNote\(\s*"dropped stale validation error\(s\)",\s*MAX_STATE_NODES,\s*contradictedNodeErrors\.length,/,
+  );
 });

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -379,6 +379,74 @@ test("#2192 r4: an error with NO type is not judged", () => {
   assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
 });
 
+// ── codex gate round 5: the prompt is COMPILED; the graph is not ─────────────
+//
+// The serializer skips `isVirtualNode || mode === NEVER || mode === BYPASS` and attributes
+// the link to whatever is upstream, so an input fed through any of those has a
+// `linked_node` that CANNOT equal its immediate origin_id. Reading that as a repair drops
+// live errors on any graph with a reroute in it.
+
+/** target.select fed by `via` (id 7), which is upstream-fed by the real source 5. */
+function indirectionGraph(via) {
+  const target = { id: 9, type: "Sw", comfyClass: "Sw", inputs: [{ name: "select", link: 900 }] };
+  return {
+    graph: makeGraph({
+      id: "root",
+      nodes: [{ id: 5, type: "RealSource" }, via, target],
+      links: { 900: { id: 900, origin_id: 7, origin_slot: 0, target_id: 9, target_slot: 0 } },
+    }),
+    nodeErrors: {
+      9: {
+        class_type: "Sw",
+        errors: [
+          {
+            type: "return_type_mismatch",
+            details: "select, received_type(IMAGE) mismatch input_type(INT)",
+            extra_info: { input_name: "select", linked_node: [5, 0] },
+          },
+        ],
+      },
+    },
+  };
+}
+
+for (const [label, via] of [
+  ["a BYPASSED node (mode 4)", { id: 7, type: "Passthrough", mode: 4 }],
+  ["a MUTED node (mode 2)", { id: 7, type: "Passthrough", mode: 2 }],
+  ["a virtual Reroute", { id: 7, type: "Reroute", isVirtualNode: true }],
+  ["a subgraph container", { id: 7, type: "SubgraphNode", isVirtualNode: true, subgraph: {} }],
+]) {
+  test(`#2192 r5: an error whose source is reached through ${label} is NOT dropped`, async () => {
+    const { graph, nodeErrors } = indirectionGraph(via);
+    const result = await runProductionGraphGetErrors({ graph, rootGraph: graph, lastNodeErrors: nodeErrors });
+    assert.deepEqual(result.node_errors, nodeErrors, "the compiler resolves through it — this is not a repair");
+    assert.equal(result.errored_count, 1);
+    assert.equal(result.note, undefined);
+  });
+}
+
+test("#2192 r5: an unresolvable source node keeps the error", () => {
+  const target = { id: 9, type: "Sw", inputs: [{ name: "select", link: 900 }] };
+  const graph = makeGraph({
+    id: "root",
+    nodes: [target], // node 8 is referenced by the link but absent from the graph
+    links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
+  });
+  const nodeErrors = {
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [5, 0] } }] },
+  };
+  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192 r5: an ORDINARY source node is still judged — the fix survives the guard", () => {
+  // mode 0 and mode-absent are both ordinary; the reporter's repair is exactly this shape.
+  for (const mode of [0, undefined]) {
+    const { graph, nodeErrors } = indirectionGraph({ id: 7, type: "RealPassthrough", mode });
+    const out = pruneContradictedNodeErrors(graph, nodeErrors);
+    assert.equal(out.nodeErrors, null, `mode ${String(mode)} is a real source, so [5,0] is falsified`);
+  }
+});
+
 // ── the OTHER consumer: the turn-start banner ──────────────────────────────
 //
 // `validationBanner` reads the same map and injects it into the agent's turn asserting

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -26,7 +26,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { pruneContradictedNodeErrors } from "../../web/js/lib/asset-staleness.js";
+import {
+  pruneContradictedNodeErrors,
+  pruneContradictedNodeErrorMaps,
+} from "../../web/js/lib/asset-staleness.js";
 import { runProductionGraphGetErrors } from "./_graph-get-errors-harness.mjs";
 import { runProductionValidationBanner } from "./_validation-banner-harness.mjs";
 
@@ -170,6 +173,65 @@ test("#2192: a disclosure list cut at the cap says so (#809)", async () => {
   assert.equal(typeof result.stale_node_errors_truncation_hint, "string");
 });
 
+// ── codex gate P1: one map's label must never decide the other map's fate ────
+
+test("#2192 P1: a stale STORE entry does not take the live APP error down with it", async () => {
+  // combineNodeErrorMaps merges same-id entries with {...previous, ...entry}, so the
+  // LAST map's class_type governs an entry whose errors came from BOTH. Pruning after
+  // that merge let a retained foreign label drop a live error: node_errors null,
+  // errored_count 0, real error suppressed. Reproduced against the shipped executor
+  // before the fix; adjudicating each map on its own is what makes it survive.
+  const node = { id: 2, type: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const live = { type: "value_not_in_list", message: "ckpt not in list", extra_info: { input_name: "ckpt_name" } };
+
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastNodeErrors: { 2: { class_type: "Current", errors: [live] } },
+    storeNodeErrors: { 2: { class_type: "OldWorkflowType", errors: [{ message: "stale from another workflow" }] } },
+  });
+
+  assert.deepEqual(result.node_errors?.[2]?.errors, [live], "the live app error must survive");
+  assert.equal(result.node_errors[2].class_type, "Current", "and keep its OWN source's label");
+  assert.equal(result.errored_count, 1, "and still count as an error on the graph");
+  assert.equal(result.note, undefined, "a graph with a live validation error is not clean");
+  // The foreign entry IS withheld, and says why.
+  assert.equal(result.stale_node_errors.length, 1);
+  assert.match(result.stale_node_errors[0].contradicted_by, /not the OldWorkflowType/);
+});
+
+test("#2192 P1: the same stale entry in BOTH stores is one withheld fact, not two", () => {
+  const node = { id: 2, type: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const foreign = { class_type: "OldWorkflowType", errors: [{ message: "stale" }] };
+  const { nodeErrors, dropped } = pruneContradictedNodeErrorMaps(graph, [{ 2: foreign }, { 2: foreign }]);
+  assert.equal(nodeErrors, null);
+  assert.equal(dropped.length, 1, "deduplicated on (node id, reason)");
+});
+
+test("#2192 P1: the composer keeps combineNodeErrorMaps' union of two LIVE sources", () => {
+  // The reason that union exists (#579): ComfyUI can clear the app map while the store
+  // still holds the rejection. Pruning per-map must not cost that.
+  const node = { id: 2, type: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const a = { message: "from the app map" };
+  const b = { message: "from the execution store" };
+  const { nodeErrors } = pruneContradictedNodeErrorMaps(graph, [
+    { 2: { class_type: "Current", errors: [a] } },
+    { 2: { class_type: "Current", errors: [b] } },
+  ]);
+  assert.deepEqual(nodeErrors[2].errors, [a, b]);
+});
+
+test("#2192 P1: a non-array argument is still accepted as a single map", () => {
+  const node = { id: 2, type: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const map = { 2: { class_type: "Current", errors: [{ message: "live" }] } };
+  assert.deepEqual(pruneContradictedNodeErrorMaps(graph, map).nodeErrors, map);
+  assert.equal(pruneContradictedNodeErrorMaps(graph, null).nodeErrors, null);
+});
+
 // ── the OTHER consumer: the turn-start banner ──────────────────────────────
 //
 // `validationBanner` reads the same map and injects it into the agent's turn asserting
@@ -309,31 +371,46 @@ test("#2192: null / non-object maps pass through unchanged", () => {
 
 // ── wiring: the shipped monolith must actually call it ─────────────────────────
 
-test("#2192 wiring: graph_get_errors prunes the map it reports, not a copy beside it", () => {
+test("#2192 wiring: both consumers prune, and neither merges before it prunes", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  assert.match(src, /pruneContradictedNodeErrors,/, "imported from asset-staleness.js");
-  // One binding: the pruned map is what the per-node join, `clean` and the payload read.
-  // A second `const nodeErrors =` from the raw union would silently un-ship the fix.
-  const bindings = src.match(/const \{ nodeErrors, dropped: contradictedNodeErrors \} = pruneContradictedNodeErrors\(/g);
-  assert.equal(bindings?.length, 1);
-  assert.equal(
-    (src.match(/const nodeErrors = combineNodeErrorMaps\(/g) ?? []).length,
-    0,
-    "the raw union must not be bound as `nodeErrors` anywhere",
-  );
-  assert.match(src, /stale_node_errors: contradictedNodeErrors\.slice\(0, MAX_STATE_NODES\)/);
+  assert.match(src, /pruneContradictedNodeErrorMaps,/, "imported from asset-staleness.js");
+
   // BOTH consumers of the map, not just the one the issue names. A green helper test
   // proves nothing about a call path that never calls it.
   assert.equal(
-    (src.match(/pruneContradictedNodeErrors\(/g) ?? []).length,
+    (src.match(/pruneContradictedNodeErrorMaps\(/g) ?? []).length,
     2,
     "graph_get_errors AND validationBanner must each prune",
   );
+
+  // THE ORDERING INVARIANT (codex gate P1). `combineNodeErrorMaps` merges same-id entries
+  // with {...previous, ...entry}, so merging FIRST lets the last map's class_type govern
+  // the first map's errors and a stale store entry drops a live app error. The panel must
+  // therefore never invoke the union itself — the composer owns that order.
+  assert.equal(
+    (src.match(/combineNodeErrorMaps\(/g) ?? []).length,
+    0,
+    "the panel must not union the maps itself; pruneContradictedNodeErrorMaps does it after pruning",
+  );
+  assert.equal(
+    (src.match(/pruneContradictedNodeErrors\(/g) ?? []).length,
+    0,
+    "the single-map prune is the composer's internal; a direct call here would invite the merge-first order back",
+  );
+
+  // One binding: the pruned map is what the per-node join, `clean` and the payload read.
+  assert.equal(
+    (src.match(/const \{ nodeErrors, dropped: contradictedNodeErrors \} = pruneContradictedNodeErrorMaps\(/g) ?? [])
+      .length,
+    1,
+  );
   assert.match(
     src,
-    /nodeErrors = pruneContradictedNodeErrors\(postProbeRootGraph, nodeErrors\)\.nodeErrors;/,
+    /nodeErrors = pruneContradictedNodeErrorMaps\(postProbeRootGraph, \[nodeErrors\]\)\.nodeErrors;/,
     "the banner must prune against the root graph its own binding guard just cleared",
   );
+
+  assert.match(src, /stale_node_errors: contradictedNodeErrors\.slice\(0, MAX_STATE_NODES\)/);
   // The cut must be reported with the REAL total, not the shown count — a hint that
   // says "50 of 50" is the silent-cut defect wearing a disclosure.
   assert.match(

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -691,7 +691,19 @@ test("#2192 invariant: every input error survives somewhere in the payload", asy
     "249:251": live,
   };
 
-  const result = await runProductionGraphGetErrors({ graph: inner, rootGraph, lastNodeErrors });
+  // The execution store holds a DISTINCT error object that reduces to the SAME reason as
+  // the app map's, so this walk covers the dedupe path too — which is precisely where the
+  // first version of this invariant leaked (it passed the same object through both maps
+  // and so could not tell merging from skipping).
+  const alsoRepaired = { ...SELECT_MISMATCH, message: "same reason, a different object" };
+  const storeNodeErrors = { "249:252": { class_type: "ImpactSwitch", errors: [alsoRepaired] } };
+
+  const result = await runProductionGraphGetErrors({
+    graph: inner,
+    rootGraph,
+    lastNodeErrors,
+    storeNodeErrors,
+  });
 
   const seen = new Set();
   for (const entry of Object.values(result.node_errors ?? {})) {
@@ -700,11 +712,32 @@ test("#2192 invariant: every input error survives somewhere in the payload", asy
   for (const record of result.stale_node_errors ?? []) {
     for (const e of record.errors ?? []) seen.add(e);
   }
-  for (const [id, entry] of Object.entries(lastNodeErrors)) {
-    for (const e of entry.errors) {
-      assert.ok(seen.has(e), `error on ${id} vanished from the payload entirely`);
+  for (const source of [lastNodeErrors, storeNodeErrors]) {
+    for (const [id, entry] of Object.entries(source)) {
+      for (const e of entry.errors) {
+        assert.ok(seen.has(e), `error on ${id} vanished from the payload entirely`);
+      }
     }
   }
+});
+
+test("#2192 invariant: dedupe must MERGE the two stores' errors, never drop one", () => {
+  // The dedupe key is (node id, reason), and two stores can hold DIFFERENT errors that
+  // reduce to the same reason. Skipping the second record discards its errors — the
+  // non-loss invariant broken by the very step meant to tidy it. The earlier invariant
+  // test passed the same object twice and could not see this.
+  const node = { id: 2, type: "Current", comfyClass: "Current", inputs: [] };
+  const graph = makeGraph({ id: "root", nodes: [node] });
+  const fromApp = { message: "recorded by app.lastNodeErrors" };
+  const fromStore = { message: "recorded by the execution-error store" };
+
+  const { dropped } = pruneContradictedNodeErrorMaps(graph, [
+    { 2: { class_type: "OldWorkflowType", errors: [fromApp] } },
+    { 2: { class_type: "OldWorkflowType", errors: [fromStore] } },
+  ]);
+
+  assert.equal(dropped.length, 1, "still one withheld fact");
+  assert.deepEqual(dropped[0].errors, [fromApp, fromStore], "carrying BOTH stores' errors");
 });
 
 test("#2192 invariant: a demoted entry carries its errors, not just a label", async () => {

--- a/browser_tests/unit/stale-node-errors-2192.test.mjs
+++ b/browser_tests/unit/stale-node-errors-2192.test.mjs
@@ -50,6 +50,7 @@ const SELECT_MISMATCH = {
   extra_info: {
     input_name: "select",
     received_type: "IMAGE",
+    input_config: ["INT", {}],
     linked_node: ["249:265", 0],
   },
 };
@@ -219,7 +220,7 @@ function typeGraph({ outTypes, slot, via = {} }) {
         {
           type: "return_type_mismatch",
           details: "select, received_type(IMAGE) mismatch input_type(INT)",
-          extra_info: { input_name: "select", received_type: "IMAGE", linked_node: [7, 0] },
+          extra_info: { input_name: "select", received_type: "IMAGE", input_config: ["INT", {}], linked_node: [7, 0] },
         },
       ],
     },
@@ -250,7 +251,7 @@ test("#2192 types: a DIFFERENT source node that still emits the wrong type is st
     links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
   });
   const nodeErrors = {
-    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", input_config: ["INT", {}], linked_node: [7, 0] } }] },
   };
   assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
 });
@@ -286,7 +287,7 @@ test("#2192 types: a `*` wildcard on either side is never exact proof", () => {
       links: { 900: { id: 900, origin_id: 7, origin_slot: 0, target_id: 9, target_slot: 0 } },
     });
     const nodeErrors = {
-      9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
+      9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", input_config: ["INT", {}], linked_node: [7, 0] } }] },
     };
     assert.deepEqual(
       pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors,
@@ -312,7 +313,7 @@ test("#2192 types: an unreadable slot type or output index keeps the error", () 
       links: { 900: { id: 900, origin_id: 7, origin_slot: slot, target_id: 9, target_slot: 0 } },
     });
     const nodeErrors = {
-      9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
+      9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", input_config: ["INT", {}], linked_node: [7, 0] } }] },
     };
     assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors, label);
   }
@@ -328,7 +329,7 @@ test("#2192 types: a link with no readable origin_slot keeps the error", () => {
     links: { 900: { id: 900, origin_id: 7, target_id: 9, target_slot: 0 } },
   });
   const nodeErrors = {
-    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [7, 0] } }] },
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", input_config: ["INT", {}], linked_node: [7, 0] } }] },
   };
   assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
 });
@@ -359,6 +360,41 @@ test("#2192: sibling errors on the same node survive the one that proved repaire
   assert.deepEqual(nodeErrors["249:252"].errors, [live]);
   assert.equal(nodeErrors["249:252"].class_type, "ImpactSwitch");
   assert.equal(dropped.length, 1);
+});
+
+// ── the frontend's socket types are the FRONTEND's ────────────────────────────
+
+test("#2192 defs: a live socket type the SERVER did not validate against is no proof", () => {
+  // A pack update plus a reconnect moves the server ahead of the node def this tab
+  // loaded. The server validated `select` as STRING; the tab still draws it INT, and an
+  // INT link therefore still fails at the server. `input_config[0]` is the server's own
+  // word on it — execution.py's `info = (input_type, extra_info)` — so a disagreement
+  // means the frontend's view cannot corroborate anything.
+  const { graph, nodeErrors } = typeGraph({ outTypes: ["INT"], slot: 0 });
+  nodeErrors[9].errors[0].extra_info.input_config = ["STRING", {}];
+  assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
+});
+
+test("#2192 defs: an absent or non-string input_config gives nothing to corroborate", () => {
+  // A combo input's `input_type` is the option LIST, not a name — nothing to compare.
+  for (const config of [undefined, null, [], [["a", "b"], {}], ["", {}], [7, {}]]) {
+    const { graph, nodeErrors } = typeGraph({ outTypes: ["INT"], slot: 0 });
+    if (config === undefined) delete nodeErrors[9].errors[0].extra_info.input_config;
+    else nodeErrors[9].errors[0].extra_info.input_config = config;
+    assert.deepEqual(
+      pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors,
+      nodeErrors,
+      `input_config ${JSON.stringify(config)} must not be read as corroboration`,
+    );
+  }
+});
+
+test("#2192 defs: server and frontend agreeing is what makes the type proof usable", () => {
+  // The positive case, stated explicitly so the guard above cannot silently become the
+  // only outcome: server says INT, the tab draws INT, the live source emits INT.
+  const { graph, nodeErrors } = typeGraph({ outTypes: ["INT"], slot: 0 });
+  assert.equal(nodeErrors[9].errors[0].extra_info.input_config[0], "INT");
+  assert.equal(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, null);
 });
 
 // ── the prompt is COMPILED; the graph is not ──────────────────────────────────
@@ -401,7 +437,7 @@ test("#2192 compiled: an unresolvable source node keeps the error", () => {
     links: { 900: { id: 900, origin_id: 8, origin_slot: 0, target_id: 9, target_slot: 0 } },
   });
   const nodeErrors = {
-    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", linked_node: [5, 0] } }] },
+    9: { errors: [{ type: "return_type_mismatch", extra_info: { input_name: "select", input_config: ["INT", {}], linked_node: [5, 0] } }] },
   };
   assert.deepEqual(pruneContradictedNodeErrors(graph, nodeErrors).nodeErrors, nodeErrors);
 });

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -896,7 +896,7 @@
       "then_click_connect_above": "…then click Connect above.",
       "then_start_the_agent_on_this_machine": "Start the agent (on this machine)",
       "these_are_panel_shortcuts_for_what_the": "these are panel shortcuts; for what the agent itself can do, see the docs: {url}",
-      "these_validation_errors_from_the_last_queue": "These validation errors from the last queue attempt name links the live graph no longer has, so they were dropped. The frontend only replaces that map on the next queue attempt.",
+      "these_validation_errors_from_the_last_queue": "Recorded at the LAST queue attempt; the live graph disagrees with each, so they are reported here rather than in node_errors (the frontend only replaces that map on the next queue attempt). Every entry carries its errors IN FULL plus the evidence in contradicted_by — nothing is discarded, so for the conservative reading treat these as still live.",
       "thinking": "Thinking…",
       "thinking_tokens": "Thinking… ({tokens} tokens)",
       "this_affects_every_workflow_and_open_comfyui": "This affects every workflow and open ComfyUI tab. It cannot be undone. Your workflows and their stable identities will not be deleted.",

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -896,7 +896,7 @@
       "then_click_connect_above": "…then click Connect above.",
       "then_start_the_agent_on_this_machine": "Start the agent (on this machine)",
       "these_are_panel_shortcuts_for_what_the": "these are panel shortcuts; for what the agent itself can do, see the docs: {url}",
-      "these_validation_errors_from_the_last_queue": "Recorded at the LAST queue attempt; the live graph disagrees with each, so they are reported here rather than in node_errors (the frontend only replaces that map on the next queue attempt). Every entry carries its errors IN FULL plus the evidence in contradicted_by — nothing is discarded, so for the conservative reading treat these as still live.",
+      "these_validation_errors_from_the_last_queue": "Recorded at the LAST queue attempt; the live graph disagrees with each, so they are reported here rather than in node_errors (the frontend only replaces that map on the next queue attempt). Every entry carries its errors IN FULL plus the evidence in contradicted_by, so for the conservative reading treat these as still live. This judgement reads the node definitions THIS TAB loaded, which a server-side pack update can get ahead of; the list itself is capped, and a cut is always reported with the true total.",
       "thinking": "Thinking…",
       "thinking_tokens": "Thinking… ({tokens} tokens)",
       "this_affects_every_workflow_and_open_comfyui": "This affects every workflow and open ComfyUI tab. It cannot be undone. Your workflows and their stable identities will not be deleted.",

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -896,6 +896,7 @@
       "then_click_connect_above": "…then click Connect above.",
       "then_start_the_agent_on_this_machine": "Start the agent (on this machine)",
       "these_are_panel_shortcuts_for_what_the": "these are panel shortcuts; for what the agent itself can do, see the docs: {url}",
+      "these_validation_errors_from_the_last_queue": "These validation errors from the last queue attempt name links the live graph no longer has, so they were dropped. The frontend only replaces that map on the next queue attempt.",
       "thinking": "Thinking…",
       "thinking_tokens": "Thinking… ({tokens} tokens)",
       "this_affects_every_workflow_and_open_comfyui": "This affects every workflow and open ComfyUI tab. It cannot be undone. Your workflows and their stable identities will not be deleted.",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21626,7 +21626,7 @@ const GRAPH_TOOL_EXECUTORS = {
             stale_node_errors: contradictedNodeErrors.slice(0, MAX_STATE_NODES),
             stale_node_errors_note: tr(
               "panel.these_validation_errors_from_the_last_queue",
-              "Recorded at the LAST queue attempt; the live graph disagrees with each, so they are reported here rather than in node_errors (the frontend only replaces that map on the next queue attempt). Every entry carries its errors IN FULL plus the evidence in contradicted_by — nothing is discarded, so for the conservative reading treat these as still live.",
+              "Recorded at the LAST queue attempt; the live graph disagrees with each, so they are reported here rather than in node_errors (the frontend only replaces that map on the next queue attempt). Every entry carries its errors IN FULL plus the evidence in contradicted_by, so for the conservative reading treat these as still live. This judgement reads the node definitions THIS TAB loaded, which a server-side pack update can get ahead of; the list itself is capped, and a cut is always reported with the true total.",
             ),
             ...(contradictedNodeErrors.length > MAX_STATE_NODES
               ? {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12510,6 +12510,23 @@ async function validationBanner() {
   } catch {
     bannerStalePlaceholders = [];
   }
+  // #2192 — the SAME correlation graph_get_errors now runs, for the same reason and
+  // with more at stake: this banner asserts the user "is seeing these RIGHT NOW", so a
+  // rejection whose link has since been repaired makes the panel state something about
+  // the user's screen that is not true. `app.lastNodeErrors` is only replaced on the
+  // NEXT queue attempt, so nothing about repairing the graph clears it.
+  //
+  // Placed after the binding guard above, on the root graph that guard just proved is
+  // still the one this read started against — correlating against a graph that changed
+  // mid-read is how a live error would get dropped. Pruning HERE (not at the top, where
+  // nodeErrors is read) also puts the corrected map inside `missing.any`'s clean check
+  // and inside `sig`, so repairing the link both stops the banner and counts as a change
+  // — matching what the missing-asset entries in that signature already do.
+  try {
+    nodeErrors = pruneContradictedNodeErrors(postProbeRootGraph, nodeErrors).nodeErrors;
+  } catch {
+    /* a banner must never throw; an unpruned map is the safe direction */
+  }
   missing.any = !!(
     missing.models.length ||
     missing.media.length ||

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21626,7 +21626,7 @@ const GRAPH_TOOL_EXECUTORS = {
             stale_node_errors: contradictedNodeErrors.slice(0, MAX_STATE_NODES),
             stale_node_errors_note: tr(
               "panel.these_validation_errors_from_the_last_queue",
-              "These validation errors from the last queue attempt name links the live graph no longer has, so they were dropped. The frontend only replaces that map on the next queue attempt.",
+              "Recorded at the LAST queue attempt; the live graph disagrees with each, so they are reported here rather than in node_errors (the frontend only replaces that map on the next queue attempt). Every entry carries its errors IN FULL plus the evidence in contradicted_by — nothing is discarded, so for the conservative reading treat these as still live.",
             ),
             ...(contradictedNodeErrors.length > MAX_STATE_NODES
               ? {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -228,6 +228,7 @@ import {
   collectMissingNodeTypeReasons,
   collectUnexplainedRedOutlines,
   combineNodeErrorMaps,
+  pruneContradictedNodeErrors,
   graphErrorsFindingCounts,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
@@ -21375,7 +21376,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // These are independent live stores. The app map can be an empty object
     // after a reset while the execution store still retains the actual rejected
     // prompt, so never let nullish selection make an empty app map mask it.
-    const nodeErrors = combineNodeErrorMaps([comfy?.lastNodeErrors ?? null, storeNodeErrors]);
+    // #2192 — that union is a snapshot of the LAST queue rejection and the frontend
+    // only replaces it on the NEXT one, so a repaired link keeps being reported. Drop
+    // the entries the LIVE graph contradicts before anything downstream reads them —
+    // the per-node join, `clean`, the red-outline adjudication and the payload all
+    // have to agree, and the contradiction the reporter saw (`errored_count: 0` beside
+    // a populated `node_errors`) is exactly what happens when they do not.
+    const { nodeErrors, dropped: contradictedNodeErrors } = pruneContradictedNodeErrors(
+      rootGraph,
+      combineNodeErrorMaps([comfy?.lastNodeErrors ?? null, storeNodeErrors]),
+    );
     if (nodeErrors) {
       for (const [id, entry] of Object.entries(nodeErrors)) {
         for (const e of entry?.errors ?? []) {
@@ -21586,6 +21596,18 @@ const GRAPH_TOOL_EXECUTORS = {
       // current_inputs/current_outputs and huge traceback lines (41k+ tokens).
       last_execution_error: boundExecFailurePayload(execFailureDetail),
       node_errors: nodeErrors,
+      // #2192 — a removal is disclosed, never silent: the caller can see WHICH stale
+      // rejection was withheld and on what evidence, instead of wondering whether a
+      // real error went missing between two reads.
+      ...(contradictedNodeErrors.length
+        ? {
+            stale_node_errors: contradictedNodeErrors.slice(0, MAX_STATE_NODES),
+            stale_node_errors_note: tr(
+              "panel.these_validation_errors_from_the_last_queue",
+              "These validation errors from the last queue attempt name links the live graph no longer has, so they were dropped. The frontend only replaces that map on the next queue attempt.",
+            ),
+          }
+        : {}),
       ...(clean ? { note: tr("panel.no_errors_recorded_since_the_last_execution", "no errors recorded since the last execution start") } : {}),
     };
   },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -228,7 +228,7 @@ import {
   collectMissingNodeTypeReasons,
   collectUnexplainedRedOutlines,
   combineNodeErrorMaps,
-  pruneContradictedNodeErrors,
+  pruneContradictedNodeErrorMaps,
   graphErrorsFindingCounts,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
@@ -12523,7 +12523,7 @@ async function validationBanner() {
   // and inside `sig`, so repairing the link both stops the banner and counts as a change
   // — matching what the missing-asset entries in that signature already do.
   try {
-    nodeErrors = pruneContradictedNodeErrors(postProbeRootGraph, nodeErrors).nodeErrors;
+    nodeErrors = pruneContradictedNodeErrorMaps(postProbeRootGraph, [nodeErrors]).nodeErrors;
   } catch {
     /* a banner must never throw; an unpruned map is the safe direction */
   }
@@ -21399,9 +21399,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // the per-node join, `clean`, the red-outline adjudication and the payload all
     // have to agree, and the contradiction the reporter saw (`errored_count: 0` beside
     // a populated `node_errors`) is exactly what happens when they do not.
-    const { nodeErrors, dropped: contradictedNodeErrors } = pruneContradictedNodeErrors(
+    // Each map is adjudicated on its own and the survivors are unioned — never the other
+    // way round. Merging first lets the LAST map's `class_type` govern the FIRST map's
+    // errors, and a stale store entry then drops a live app error with it (codex gate P1).
+    const { nodeErrors, dropped: contradictedNodeErrors } = pruneContradictedNodeErrorMaps(
       rootGraph,
-      combineNodeErrorMaps([comfy?.lastNodeErrors ?? null, storeNodeErrors]),
+      [comfy?.lastNodeErrors ?? null, storeNodeErrors],
     );
     if (nodeErrors) {
       for (const [id, entry] of Object.entries(nodeErrors)) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21598,7 +21598,9 @@ const GRAPH_TOOL_EXECUTORS = {
       node_errors: nodeErrors,
       // #2192 — a removal is disclosed, never silent: the caller can see WHICH stale
       // rejection was withheld and on what evidence, instead of wondering whether a
-      // real error went missing between two reads.
+      // real error went missing between two reads. Capped like its sibling lists — and
+      // the cut is stated, because a silently short list inside a list whose whole job
+      // is disclosure would be the same defect this field exists to close (#809).
       ...(contradictedNodeErrors.length
         ? {
             stale_node_errors: contradictedNodeErrors.slice(0, MAX_STATE_NODES),
@@ -21606,6 +21608,17 @@ const GRAPH_TOOL_EXECUTORS = {
               "panel.these_validation_errors_from_the_last_queue",
               "These validation errors from the last queue attempt name links the live graph no longer has, so they were dropped. The frontend only replaces that map on the next queue attempt.",
             ),
+            ...(contradictedNodeErrors.length > MAX_STATE_NODES
+              ? {
+                  stale_node_errors_truncated: true,
+                  stale_node_errors_truncation_hint: fixedCapNote(
+                    "dropped stale validation error(s)",
+                    MAX_STATE_NODES,
+                    contradictedNodeErrors.length,
+                    "These were withheld as contradicted, not reported as errors; there is no parameter to page them.",
+                  ),
+                }
+              : {}),
           }
         : {}),
       ...(clean ? { note: tr("panel.no_errors_recorded_since_the_last_execution", "no errors recorded since the last execution start") } : {}),

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -410,6 +410,25 @@ function liveInputOrigin(node, inputName) {
  * live inner graph cannot express as a plain origin id) all return false — kept.
  */
 function nodeErrorLinkClaimFalsified(node, errorNodeId, error) {
+  // ONLY `return_type_mismatch`. Exactly two error types in execution.py carry a
+  // `linked_node`, and they file it under DIFFERENT nodes (codex gate round 4):
+  //
+  //   return_type_mismatch          → `errors.append(error)` — recorded on the node being
+  //                                   validated, so `input_name` IS an input of that node
+  //                                   and `linked_node` is what feeds it. This function's
+  //                                   whole premise.
+  //   exception_during_inner_validation
+  //                                 → `validated[o_id] = (False, reasons, o_id)` — recorded
+  //                                   on the UPSTREAM node, while `input_name` names an input
+  //                                   of the DOWNSTREAM one and `linked_node` points back at
+  //                                   the errored node itself. Reading it with the premise
+  //                                   above finds a same-named input on the wrong node and
+  //                                   drops a live error.
+  //
+  // A whitelist rather than a blocklist, so an error type this panel has never seen — a
+  // newer ComfyUI's, or a custom validator's — is never judged by semantics borrowed from
+  // a different one.
+  if (error?.type !== "return_type_mismatch") return false;
   const extra = error?.extra_info;
   if (!extra || typeof extra !== "object") return false;
   const inputName = extra.input_name;

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -353,6 +353,156 @@ export function combineNodeErrorMaps(nodeErrorsMaps) {
   return Object.keys(combined).length ? combined : null;
 }
 
+/** Split a locator into its containing scope and its graph-local id. */
+function splitLocatorScope(id) {
+  const raw = String(id ?? "");
+  const cut = raw.lastIndexOf(":");
+  return cut === -1 ? { scope: "", local: raw } : { scope: raw.slice(0, cut), local: raw.slice(cut + 1) };
+}
+
+/** Read a link record out of a LiteGraph link store (Map in newer builds, object in older). */
+function lookupLink(links, linkId) {
+  if (links == null || linkId == null) return null;
+  return typeof links.get === "function" ? links.get(linkId) ?? null : links[linkId] ?? null;
+}
+
+/**
+ * The live source id feeding `inputName` on `node`, or `undefined` when the graph
+ * cannot answer (no such input, no readable link store). `null` means the input is
+ * genuinely unconnected — a real answer, distinct from "cannot tell".
+ */
+function liveInputOriginId(node, inputName) {
+  const inputs = Array.isArray(node?.inputs) ? node.inputs : null;
+  if (!inputs) return undefined;
+  const input = inputs.find((i) => i?.name === inputName);
+  // A slot the live node does not have (renamed by a dynamic pack's position-based
+  // re-slotting, #1873) leaves the error unjudgeable — never falsified by absence.
+  if (!input) return undefined;
+  if (input.link == null) return null;
+  const links = node?.graph?.links;
+  if (links == null) return undefined;
+  const link = lookupLink(links, input.link);
+  if (link == null) return undefined;
+  const originId = link.origin_id ?? link[1];
+  return originId == null ? undefined : String(originId);
+}
+
+/**
+ * True when this validation error is a claim about ONE specific link that the live
+ * graph falsifies. ComfyUI's `return_type_mismatch` (execution.py `validate_inputs`)
+ * carries `extra_info.input_name` and `extra_info.linked_node = [nodeId, outputSlot]`
+ * — i.e. "input X is fed by node Y and Y's type is wrong". When X is now fed by a
+ * different node, or by nothing, that sentence is no longer true of this graph.
+ *
+ * Only decides on POSITIVE evidence. A missing/odd `extra_info`, an input the live
+ * node no longer exposes, an unreadable link store, or a `linked_node` in a different
+ * subgraph scope than the errored node (which the live inner graph cannot express as
+ * a plain origin id) all return false — the error is kept.
+ */
+function nodeErrorLinkClaimFalsified(node, errorNodeId, error) {
+  const extra = error?.extra_info;
+  if (!extra || typeof extra !== "object") return false;
+  const inputName = extra.input_name;
+  if (typeof inputName !== "string" || !inputName) return false;
+  const claimed = Array.isArray(extra.linked_node) ? extra.linked_node[0] : undefined;
+  if (claimed == null) return false;
+  // Compare inside ONE graph: the error's ids are the flattened prompt's, the live
+  // link's origin is local to the node's own (sub)graph. Same scope ⇒ same graph.
+  const here = splitLocatorScope(errorNodeId);
+  const there = splitLocatorScope(claimed);
+  if (there.scope !== here.scope) return false;
+  const liveOrigin = liveInputOriginId(node, inputName);
+  if (liveOrigin === undefined) return false;
+  return liveOrigin !== there.local;
+}
+
+/**
+ * Drop validation-map entries that the LIVE graph CONTRADICTS (#2192).
+ *
+ * `node_errors` is the raw union of `app.lastNodeErrors` and the execution-error
+ * store — a snapshot of the LAST queue rejection, which the frontend only replaces on
+ * the NEXT queue attempt. Every other source `graph_get_errors` reports is correlated
+ * against the live graph before it ships: missing assets through `isStaleAssetCandidate`
+ * (still-referenced + active-graph scope, #316), the runtime failure by node id AND
+ * class type (#1448) with scoped-locator resolution (#1685). The validation map never
+ * was, so a `return_type_mismatch` naming a link the user has since repaired is echoed
+ * verbatim forever. It does not even reach the per-node join, because its key is a
+ * SCOPED locator ("249:252") that never string-equals a visible node's own id — which
+ * is how `errored_count: 0` came to ship beside a populated, contradicting `node_errors`.
+ *
+ * Three checks, each needing POSITIVE evidence from the live graph:
+ *
+ *   1. the entry's RECOGNIZED locator resolves to no node in `rootGraph` — these stores
+ *      are not cleared on a workflow-tab switch, so it is another tab's node or a
+ *      deleted one (the #316 scope check, applied to validation errors);
+ *   2. it resolves, but the live node's type differs from the entry's `class_type` —
+ *      ComfyUI reuses ids across workflows (#1448, applied to validation errors);
+ *   3. per error, `nodeErrorLinkClaimFalsified` above. Sibling errors on the same entry
+ *      are untouched; an entry whose errors ALL falsify is removed.
+ *
+ * Nothing here expires an entry by age, by a save, or by a re-read — only by
+ * contradiction. Every unexpected shape, unresolvable locator or unreadable link fails
+ * OPEN (keeps the error), so a genuine rejection is never swallowed.
+ *
+ * Returns `{ nodeErrors, dropped }`. `nodeErrors` is null when nothing survives, so the
+ * caller's `clean` verdict and its note are computed on the CORRECTED map; `dropped`
+ * carries one record per removed entry for in-band disclosure.
+ */
+export function pruneContradictedNodeErrors(rootGraph, nodeErrors) {
+  const dropped = [];
+  if (!nodeErrors || typeof nodeErrors !== "object" || Array.isArray(nodeErrors)) {
+    return { nodeErrors: nodeErrors ?? null, dropped };
+  }
+  const kept = {};
+  for (const [id, entry] of Object.entries(nodeErrors)) {
+    let verdict = null;
+    try {
+      verdict = classifyContradictedNodeError(rootGraph, id, entry);
+    } catch {
+      verdict = null; // any throw ⇒ report the entry verbatim
+    }
+    if (!verdict) {
+      kept[id] = entry;
+      continue;
+    }
+    if (verdict.entry) kept[id] = verdict.entry;
+    dropped.push({
+      node_id: id,
+      ...(typeof entry?.class_type === "string" && entry.class_type
+        ? { class_type: entry.class_type }
+        : {}),
+      contradicted_by: verdict.reason,
+    });
+  }
+  return { nodeErrors: Object.keys(kept).length ? kept : null, dropped };
+}
+
+/**
+ * Null when the entry must be reported as-is; otherwise `{ reason, entry }` where
+ * `entry` is the surviving remnant (null when the whole entry goes). Split out so the
+ * three checks read in falsification order and each one's fail-open path is visible.
+ */
+function classifyContradictedNodeError(rootGraph, id, entry) {
+  if (locatorIsRecognized(id) === false) return null;
+  const node = findNodeByScopedId(rootGraph, id);
+  if (node == null) {
+    return { reason: `no node ${id} is on the active graph`, entry: null };
+  }
+  const claimedType = typeof entry?.class_type === "string" ? entry.class_type : "";
+  const liveType = typeof node?.type === "string" ? node.type : "";
+  if (claimedType && liveType && claimedType !== liveType) {
+    return { reason: `node ${id} is a ${liveType} now, not the ${claimedType} this error is about`, entry: null };
+  }
+  const errors = Array.isArray(entry?.errors) ? entry.errors : null;
+  if (!errors || !errors.length) return null;
+  const survivors = errors.filter((e) => !nodeErrorLinkClaimFalsified(node, id, e));
+  if (survivors.length === errors.length) return null;
+  const falsified = errors.filter((e) => nodeErrorLinkClaimFalsified(node, id, e));
+  const inputs = [...new Set(falsified.map((e) => e?.extra_info?.input_name))].join(", ");
+  const reason = `${inputs} on node ${id} is no longer fed by the node the error names`;
+  return { reason, entry: survivors.length ? { ...entry, errors: survivors } : null };
+}
+
 /**
  * Return visual LiteGraph red outlines that have no current source-confirmed
  * explanation. A saved workflow can retain `has_errors` from an older run even

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -446,15 +446,15 @@ function nodeErrorLinkClaimFalsified(node, errorNodeId, error) {
  * SCOPED locator ("249:252") that never string-equals a visible node's own id — which
  * is how `errored_count: 0` came to ship beside a populated, contradicting `node_errors`.
  *
- * Three checks, each needing POSITIVE evidence from the live graph:
+ * TWO checks, both requiring a RESOLVED live node and POSITIVE contradicting evidence:
  *
- *   1. the entry's RECOGNIZED locator resolves to no node in `rootGraph` — these stores
- *      are not cleared on a workflow-tab switch, so it is another tab's node or a
- *      deleted one (the #316 scope check, applied to validation errors);
- *   2. it resolves, but the live node's type differs from the entry's `class_type` —
- *      ComfyUI reuses ids across workflows (#1448, applied to validation errors);
- *   3. per error, `nodeErrorLinkClaimFalsified` above. Sibling errors on the same entry
+ *   1. the live node's class is not the entry's `class_type` — ComfyUI reuses ids across
+ *      workflows (#1448, applied to validation errors);
+ *   2. per error, `nodeErrorLinkClaimFalsified` above. Sibling errors on the same entry
  *      are untouched; an entry whose errors ALL falsify is removed.
+ *
+ * An id that does NOT resolve is left alone — see the note on
+ * `classifyContradictedNodeError` for why that is load-bearing rather than lenient.
  *
  * Nothing here expires an entry by age, by a save, or by a re-read — only by
  * contradiction. Every unexpected shape, unresolvable locator or unreadable link fails
@@ -469,11 +469,9 @@ export function pruneContradictedNodeErrors(rootGraph, nodeErrors) {
   if (!nodeErrors || typeof nodeErrors !== "object" || Array.isArray(nodeErrors)) {
     return { nodeErrors: nodeErrors ?? null, dropped };
   }
-  // NO graph is not evidence about any node — it is the absence of evidence, and check
-  // (1) would read it as "none of these nodes exist" and drop the entire map. Callers
-  // reach here with a null root legitimately: validationBanner's `getGraphCtx()` probe
-  // is wrapped in try/catch and yields null when the binding is unresolvable. Caught by
-  // running the shipped banner rather than by reading it.
+  // Redundant since neither remaining check can fire without a resolved node, and kept
+  // deliberately: it states at the entry point that no graph means no verdict, so a
+  // future check that reads absence cannot be added without meeting this line first.
   if (!rootGraph) return { nodeErrors, dropped };
   const kept = {};
   for (const [id, entry] of Object.entries(nodeErrors)) {
@@ -542,15 +540,28 @@ export function pruneContradictedNodeErrorMaps(rootGraph, nodeErrorsMaps) {
 
 /**
  * Null when the entry must be reported as-is; otherwise `{ reason, entry }` where
- * `entry` is the surviving remnant (null when the whole entry goes). Split out so the
- * three checks read in falsification order and each one's fail-open path is visible.
+ * `entry` is the surviving remnant (null when the whole entry goes). Split out so both
+ * checks read in falsification order and each one's fail-open path is visible.
+ *
+ * NOTE ON WHAT IS DELIBERATELY *NOT* CHECKED. An earlier revision also dropped an entry
+ * whose recognized locator resolved to NO node, on the #316 reasoning that these stores
+ * survive a workflow-tab switch. That check produced two separate P1s in review, both the
+ * same mistake: a node that does not resolve is not a node that does not EXIST. It fails
+ * to resolve when the root graph is null (validationBanner's `getGraphCtx()` probe is
+ * try/catch-wrapped and yields null by design), and equally when the graph is momentarily
+ * EMPTY — ComfyUI clears and repopulates `_nodes` while loading a workflow, so a real
+ * rejection would be dropped and the banner would go silent mid-load.
+ *
+ * The check is gone rather than hardened, because no amount of hardening changes its
+ * shape: it is the only one that reads ABSENCE as evidence, and it was never what this
+ * issue needed — a stale cross-tab entry is over-reporting, which is the safe direction
+ * and the pre-existing behaviour. Both surviving checks require a RESOLVED live node and
+ * positive contradicting data, so an unresolvable id now simply leaves its entry alone.
  */
 function classifyContradictedNodeError(rootGraph, id, entry) {
-  if (locatorIsRecognized(id) === false) return null;
   const node = findNodeByScopedId(rootGraph, id);
-  if (node == null) {
-    return { reason: `no node ${id} is on the active graph`, entry: null };
-  }
+  // Absence of a node is absence of evidence — never a verdict. See the note above.
+  if (node == null) return null;
   // `class_type` comes from `node.comfyClass`, NOT `node.type` — the frontend's prompt
   // compiler writes `class_type: e.comfyClass` (verified in the 1.49.6 bundle), and the
   // two have genuinely different sources at registration: `registerNodeType(n.id, i)`

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -13,6 +13,7 @@
  */
 
 import { authoritativeComboValues, parseAnnotatedFilepath } from "./input-asset.js";
+import { isFrontendVirtualNode } from "./frontend-virtual-nodes.js";
 
 // mcp#1940 — `authoritativeComboValues` moved to the LEAF module input-asset.js so
 // `serverDeclaresEmptyComboOptions` (which lives there) can share the one canonical
@@ -388,7 +389,38 @@ function liveInputOrigin(node, inputName) {
   const originId = link.origin_id ?? link[1];
   if (originId == null) return undefined;
   const originSlot = link.origin_slot ?? link[2];
-  return { id: String(originId), slot: Number.isInteger(originSlot) ? originSlot : null };
+  return {
+    id: String(originId),
+    slot: Number.isInteger(originSlot) ? originSlot : null,
+    // The source NODE, so the caller can ask whether the prompt would even name it.
+    node: node?.graph?.getNodeById?.(originId) ?? null,
+  };
+}
+
+/**
+ * True when this live node is one the prompt compiler would name as a link source.
+ *
+ * The panel compares a COMPILED artifact (the prompt's `linked_node`) against the RAW
+ * graph, and those two disagree wherever the compiler resolves *through* a node. The
+ * frontend's serializer states the rule exactly (quoted in frontend-virtual-nodes.js):
+ *
+ *     if (e.isVirtualNode || e.mode === NEVER || e.mode === BYPASS) continue;
+ *
+ * so a Reroute, a Get/Set bus node, a subgraph container (also `isVirtualNode`), a MUTED
+ * node or a BYPASSED one never appears in the prompt — the link is attributed to whatever
+ * is upstream of it instead. An input fed through any of those has a `linked_node` that
+ * CANNOT equal its immediate `origin_id`, and reading that difference as a repair drops a
+ * live error on any graph using a reroute (codex gate round 5).
+ *
+ * Positive proof only: an unresolvable origin node answers false, i.e. keep the error.
+ */
+function originIsNamedInPrompt(originNode) {
+  if (!originNode || typeof originNode !== "object") return false;
+  if (isFrontendVirtualNode(originNode)) return false;
+  const mode = originNode.mode;
+  // 2 = NEVER (mute), 4 = BYPASS. `undefined`/0 is an ordinary always-execute node.
+  if (mode === 2 || mode === 4) return false;
+  return true;
 }
 
 /**
@@ -443,6 +475,10 @@ function nodeErrorLinkClaimFalsified(node, errorNodeId, error) {
   const live = liveInputOrigin(node, inputName);
   if (live === undefined) return false;
   if (live === null) return true; // the input exists and nothing feeds it now
+  // The claim is about the COMPILED prompt. Only compare when the live source is a node
+  // the compiler would actually name — otherwise the difference is indirection through a
+  // reroute / subgraph container / muted / bypassed node, not a repair.
+  if (!originIsNamedInPrompt(live.node)) return false;
   if (live.id !== there.local) return true;
   // Same source node: the slot is the remainder of the claim. Judge it only when BOTH
   // sides state one — an absent slot on either side is unreadable, not a disagreement.

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -367,11 +367,13 @@ function lookupLink(links, linkId) {
 }
 
 /**
- * The live source id feeding `inputName` on `node`, or `undefined` when the graph
- * cannot answer (no such input, no readable link store). `null` means the input is
- * genuinely unconnected — a real answer, distinct from "cannot tell".
+ * The live `{ id, slot }` feeding `inputName` on `node` — the SOURCE side of the link,
+ * which is exactly what `extra_info.linked_node` names. `undefined` when the graph
+ * cannot answer (no such input, no readable link store); `null` when the input is
+ * genuinely unconnected — a real answer, distinct from "cannot tell". `slot` is null
+ * when the link record does not carry a readable one.
  */
-function liveInputOriginId(node, inputName) {
+function liveInputOrigin(node, inputName) {
   const inputs = Array.isArray(node?.inputs) ? node.inputs : null;
   if (!inputs) return undefined;
   const input = inputs.find((i) => i?.name === inputName);
@@ -384,7 +386,9 @@ function liveInputOriginId(node, inputName) {
   const link = lookupLink(links, input.link);
   if (link == null) return undefined;
   const originId = link.origin_id ?? link[1];
-  return originId == null ? undefined : String(originId);
+  if (originId == null) return undefined;
+  const originSlot = link.origin_slot ?? link[2];
+  return { id: String(originId), slot: Number.isInteger(originSlot) ? originSlot : null };
 }
 
 /**
@@ -394,10 +398,16 @@ function liveInputOriginId(node, inputName) {
  * — i.e. "input X is fed by node Y and Y's type is wrong". When X is now fed by a
  * different node, or by nothing, that sentence is no longer true of this graph.
  *
+ * `linked_node` is `[node_id, slot_index]`, and BOTH halves are part of the claim: the
+ * received type is `RETURN_TYPES[slot_index]`, so re-pointing the same input at a
+ * DIFFERENT OUTPUT of the SAME node is a complete repair of a type mismatch and one the
+ * reporter's own scenario could have taken (codex gate round 2). Comparing the node id
+ * alone left that repair reported forever.
+ *
  * Only decides on POSITIVE evidence. A missing/odd `extra_info`, an input the live
- * node no longer exposes, an unreadable link store, or a `linked_node` in a different
- * subgraph scope than the errored node (which the live inner graph cannot express as
- * a plain origin id) all return false — the error is kept.
+ * node no longer exposes, an unreadable link store, a slot index neither side states,
+ * or a `linked_node` in a different subgraph scope than the errored node (which the
+ * live inner graph cannot express as a plain origin id) all return false — kept.
  */
 function nodeErrorLinkClaimFalsified(node, errorNodeId, error) {
   const extra = error?.extra_info;
@@ -411,9 +421,15 @@ function nodeErrorLinkClaimFalsified(node, errorNodeId, error) {
   const here = splitLocatorScope(errorNodeId);
   const there = splitLocatorScope(claimed);
   if (there.scope !== here.scope) return false;
-  const liveOrigin = liveInputOriginId(node, inputName);
-  if (liveOrigin === undefined) return false;
-  return liveOrigin !== there.local;
+  const live = liveInputOrigin(node, inputName);
+  if (live === undefined) return false;
+  if (live === null) return true; // the input exists and nothing feeds it now
+  if (live.id !== there.local) return true;
+  // Same source node: the slot is the remainder of the claim. Judge it only when BOTH
+  // sides state one — an absent slot on either side is unreadable, not a disagreement.
+  const claimedSlot = Array.isArray(extra.linked_node) ? extra.linked_node[1] : undefined;
+  if (!Number.isInteger(claimedSlot) || live.slot === null) return false;
+  return live.slot !== claimedSlot;
 }
 
 /**
@@ -535,10 +551,19 @@ function classifyContradictedNodeError(rootGraph, id, entry) {
   if (node == null) {
     return { reason: `no node ${id} is on the active graph`, entry: null };
   }
+  // `class_type` comes from `node.comfyClass`, NOT `node.type` — the frontend's prompt
+  // compiler writes `class_type: e.comfyClass` (verified in the 1.49.6 bundle), and the
+  // two have genuinely different sources at registration: `registerNodeType(n.id, i)`
+  // sets the type while `i.comfyClass = t.name` sets the class. Comparing against `type`
+  // alone dropped live errors on any node where they diverge (codex gate round 2).
+  // Matching EITHER counts as agreement, which is the fail-open direction.
   const claimedType = typeof entry?.class_type === "string" ? entry.class_type : "";
-  const liveType = typeof node?.type === "string" ? node.type : "";
-  if (claimedType && liveType && claimedType !== liveType) {
-    return { reason: `node ${id} is a ${liveType} now, not the ${claimedType} this error is about`, entry: null };
+  const liveTypes = [node?.comfyClass, node?.type].filter((t) => typeof t === "string" && t);
+  if (claimedType && liveTypes.length && !liveTypes.includes(claimedType)) {
+    return {
+      reason: `node ${id} is a ${liveTypes[0]} now, not the ${claimedType} this error is about`,
+      entry: null,
+    };
   }
   const errors = Array.isArray(entry?.errors) ? entry.errors : null;
   if (!errors || !errors.length) return null;

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -484,6 +484,47 @@ export function pruneContradictedNodeErrors(rootGraph, nodeErrors) {
 }
 
 /**
+ * Adjudicate each INDEPENDENT validation map on its own, then union the survivors.
+ *
+ * Order matters, and getting it backwards loses live errors (codex gate P1, reproduced).
+ * `combineNodeErrorMaps` merges same-id entries with `{...previous, ...entry}`, so the
+ * LAST map's `class_type` governs the merged entry while its `errors` array holds BOTH
+ * maps' errors. Pruning after that merge let one source's label decide the other
+ * source's fate: with a live `{2:{class_type:"Current",errors:[…]}}` in `app.lastNodeErrors`
+ * and a retained `{2:{class_type:"OldWorkflowType",errors:[…]}}` in the execution store,
+ * the class-type check saw a type the live node does not have and dropped the whole
+ * entry — `node_errors: null`, `errored_count: 0`, with a real error suppressed.
+ *
+ * Pruning FIRST keeps every entry paired with the `class_type` its own source recorded,
+ * which is the only label that says anything about its own errors. A stale store entry is
+ * then dropped alone and the live app entry survives untouched.
+ *
+ * `dropped` is deduplicated on (node id, reason): the same stale entry retained by both
+ * stores is one withheld fact, not two. A node can legitimately appear in BOTH the
+ * returned map and `dropped` — one of its recorded errors was contradicted and another
+ * was not — which is reported rather than hidden.
+ */
+export function pruneContradictedNodeErrorMaps(rootGraph, nodeErrorsMaps) {
+  const maps = Array.isArray(nodeErrorsMaps) ? nodeErrorsMaps : [nodeErrorsMaps];
+  const pruned = [];
+  const dropped = [];
+  const seen = new Set();
+  for (const map of maps) {
+    const result = pruneContradictedNodeErrors(rootGraph, map);
+    pruned.push(result.nodeErrors);
+    for (const record of result.dropped) {
+      // JSON-encoded pair, not a delimiter join: both halves are free-form strings and
+      // any separator character could occur inside one of them.
+      const key = JSON.stringify([record.node_id, record.contradicted_by]);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      dropped.push(record);
+    }
+  }
+  return { nodeErrors: combineNodeErrorMaps(pruned), dropped };
+}
+
+/**
  * Null when the entry must be reported as-is; otherwise `{ reason, entry }` where
  * `entry` is the surviving remnant (null when the whole entry goes). Split out so the
  * three checks read in falsification order and each one's fail-open path is visible.

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -354,13 +354,6 @@ export function combineNodeErrorMaps(nodeErrorsMaps) {
   return Object.keys(combined).length ? combined : null;
 }
 
-/** Split a locator into its containing scope and its graph-local id. */
-function splitLocatorScope(id) {
-  const raw = String(id ?? "");
-  const cut = raw.lastIndexOf(":");
-  return cut === -1 ? { scope: "", local: raw } : { scope: raw.slice(0, cut), local: raw.slice(cut + 1) };
-}
-
 /** Read a link record out of a LiteGraph link store (Map in newer builds, object in older). */
 function lookupLink(links, linkId) {
   if (links == null || linkId == null) return null;
@@ -368,51 +361,16 @@ function lookupLink(links, linkId) {
 }
 
 /**
- * The live `{ id, slot }` feeding `inputName` on `node` — the SOURCE side of the link,
- * which is exactly what `extra_info.linked_node` names. `undefined` when the graph
- * cannot answer (no such input, no readable link store); `null` when the input is
- * genuinely unconnected — a real answer, distinct from "cannot tell". `slot` is null
- * when the link record does not carry a readable one.
- */
-function liveInputOrigin(node, inputName) {
-  const inputs = Array.isArray(node?.inputs) ? node.inputs : null;
-  if (!inputs) return undefined;
-  const input = inputs.find((i) => i?.name === inputName);
-  // A slot the live node does not have (renamed by a dynamic pack's position-based
-  // re-slotting, #1873) leaves the error unjudgeable — never falsified by absence.
-  if (!input) return undefined;
-  if (input.link == null) return null;
-  const links = node?.graph?.links;
-  if (links == null) return undefined;
-  const link = lookupLink(links, input.link);
-  if (link == null) return undefined;
-  const originId = link.origin_id ?? link[1];
-  if (originId == null) return undefined;
-  const originSlot = link.origin_slot ?? link[2];
-  return {
-    id: String(originId),
-    slot: Number.isInteger(originSlot) ? originSlot : null,
-    // The source NODE, so the caller can ask whether the prompt would even name it.
-    node: node?.graph?.getNodeById?.(originId) ?? null,
-  };
-}
-
-/**
  * True when this live node is one the prompt compiler would name as a link source.
  *
- * The panel compares a COMPILED artifact (the prompt's `linked_node`) against the RAW
- * graph, and those two disagree wherever the compiler resolves *through* a node. The
- * frontend's serializer states the rule exactly (quoted in frontend-virtual-nodes.js):
+ * The frontend's serializer states the rule exactly (quoted in frontend-virtual-nodes.js):
  *
  *     if (e.isVirtualNode || e.mode === NEVER || e.mode === BYPASS) continue;
  *
  * so a Reroute, a Get/Set bus node, a subgraph container (also `isVirtualNode`), a MUTED
- * node or a BYPASSED one never appears in the prompt — the link is attributed to whatever
- * is upstream of it instead. An input fed through any of those has a `linked_node` that
- * CANNOT equal its immediate `origin_id`, and reading that difference as a repair drops a
- * live error on any graph using a reroute (codex gate round 5).
- *
- * Positive proof only: an unresolvable origin node answers false, i.e. keep the error.
+ * node or a BYPASSED one never appears in the prompt — the type the input actually
+ * receives comes from further upstream, and this node's own output type is not evidence
+ * about it. Positive proof only: an unresolvable node answers false, i.e. keep the error.
  */
 function originIsNamedInPrompt(originNode) {
   if (!originNode || typeof originNode !== "object") return false;
@@ -424,67 +382,92 @@ function originIsNamedInPrompt(originNode) {
 }
 
 /**
- * True when this validation error is a claim about ONE specific link that the live
- * graph falsifies. ComfyUI's `return_type_mismatch` (execution.py `validate_inputs`)
- * carries `extra_info.input_name` and `extra_info.linked_node = [nodeId, outputSlot]`
- * — i.e. "input X is fed by node Y and Y's type is wrong". When X is now fed by a
- * different node, or by nothing, that sentence is no longer true of this graph.
+ * True when the live graph proves a `return_type_mismatch` has been REPAIRED.
  *
- * `linked_node` is `[node_id, slot_index]`, and BOTH halves are part of the claim: the
- * received type is `RETURN_TYPES[slot_index]`, so re-pointing the same input at a
- * DIFFERENT OUTPUT of the SAME node is a complete repair of a type mismatch and one the
- * reporter's own scenario could have taken (codex gate round 2). Comparing the node id
- * alone left that repair reported forever.
+ * ## Why this asks about types and not about the link the error names
  *
- * Only decides on POSITIVE evidence. A missing/odd `extra_info`, an input the live
- * node no longer exposes, an unreadable link store, a slot index neither side states,
- * or a `linked_node` in a different subgraph scope than the errored node (which the
- * live inner graph cannot express as a plain origin id) all return false — kept.
+ * The obvious reading of `extra_info.linked_node` is "the error is about this link; if the
+ * input is fed by something else now, the error is stale". Four review rounds killed that
+ * reading, each for a different reason, and they share one cause: **`linked_node` is a
+ * coordinate in the COMPILED prompt and the panel only has the RAW graph.** The compiler
+ * flattens subgraphs, renames dynamic slots, and resolves through every virtual, muted and
+ * bypassed node, so "the link changed" and "the graph was repaired" are simply different
+ * questions. Worse, the final round showed the reading is not even sound when the link
+ * genuinely did change: moving an input from output 0 to output 1 of the SAME node repairs
+ * nothing when both outputs are `IMAGE`, yet the named link is now different.
+ *
+ * So the question this asks is the one that actually determines the verdict, and it is
+ * entirely local: **does the input's own type now exactly equal the type of the output
+ * feeding it?** If it does, ComfyUI cannot produce this mismatch from this graph — the
+ * repair is proven, whatever route the link took to get there. If it does not, the error
+ * is kept, and that covers every case the earlier reading got wrong for free:
+ *
+ *   - fed by a different node that still produces `IMAGE` — types still disagree → kept;
+ *   - moved to another same-typed output of the same node → kept (the round-6 case);
+ *   - fed through a reroute / bypass whose own output type is not the effective one →
+ *     `originIsNamedInPrompt` refuses to read it → kept;
+ *   - now unconnected → there is no source type to prove anything with → kept. (This also
+ *     retires an earlier judgement call: a disconnected input used to be treated as a
+ *     repair, which reported clean on a graph that may still be broken.)
+ *
+ * EXACT equality only. ComfyUI's own `validate_node_input` understands wildcards and
+ * comma-separated unions, and re-implementing it here would be a second compiler to get
+ * wrong; an identical string is the one case that needs no interpretation. A `*` on either
+ * side, an unreadable type, or a missing slot all answer false — the error is kept.
  */
-function nodeErrorLinkClaimFalsified(node, errorNodeId, error) {
+function nodeErrorMismatchRepaired(node, error) {
   // ONLY `return_type_mismatch`. Exactly two error types in execution.py carry a
-  // `linked_node`, and they file it under DIFFERENT nodes (codex gate round 4):
+  // `linked_node`, and they file it under DIFFERENT nodes:
   //
   //   return_type_mismatch          → `errors.append(error)` — recorded on the node being
-  //                                   validated, so `input_name` IS an input of that node
-  //                                   and `linked_node` is what feeds it. This function's
-  //                                   whole premise.
+  //                                   validated, so `input_name` IS an input of that node.
+  //                                   This function's whole premise.
   //   exception_during_inner_validation
   //                                 → `validated[o_id] = (False, reasons, o_id)` — recorded
-  //                                   on the UPSTREAM node, while `input_name` names an input
-  //                                   of the DOWNSTREAM one and `linked_node` points back at
-  //                                   the errored node itself. Reading it with the premise
-  //                                   above finds a same-named input on the wrong node and
-  //                                   drops a live error.
+  //                                   on the UPSTREAM node, while `input_name` names an
+  //                                   input of the DOWNSTREAM one. Read with the premise
+  //                                   above it finds a same-named input on the wrong node.
   //
   // A whitelist rather than a blocklist, so an error type this panel has never seen — a
   // newer ComfyUI's, or a custom validator's — is never judged by semantics borrowed from
   // a different one.
   if (error?.type !== "return_type_mismatch") return false;
-  const extra = error?.extra_info;
-  if (!extra || typeof extra !== "object") return false;
-  const inputName = extra.input_name;
+  const inputName = error?.extra_info?.input_name;
   if (typeof inputName !== "string" || !inputName) return false;
-  const claimed = Array.isArray(extra.linked_node) ? extra.linked_node[0] : undefined;
-  if (claimed == null) return false;
-  // Compare inside ONE graph: the error's ids are the flattened prompt's, the live
-  // link's origin is local to the node's own (sub)graph. Same scope ⇒ same graph.
-  const here = splitLocatorScope(errorNodeId);
-  const there = splitLocatorScope(claimed);
-  if (there.scope !== here.scope) return false;
-  const live = liveInputOrigin(node, inputName);
-  if (live === undefined) return false;
-  if (live === null) return true; // the input exists and nothing feeds it now
-  // The claim is about the COMPILED prompt. Only compare when the live source is a node
-  // the compiler would actually name — otherwise the difference is indirection through a
-  // reroute / subgraph container / muted / bypassed node, not a repair.
-  if (!originIsNamedInPrompt(live.node)) return false;
-  if (live.id !== there.local) return true;
-  // Same source node: the slot is the remainder of the claim. Judge it only when BOTH
-  // sides state one — an absent slot on either side is unreadable, not a disagreement.
-  const claimedSlot = Array.isArray(extra.linked_node) ? extra.linked_node[1] : undefined;
-  if (!Number.isInteger(claimedSlot) || live.slot === null) return false;
-  return live.slot !== claimedSlot;
+
+  const inputs = Array.isArray(node?.inputs) ? node.inputs : null;
+  if (!inputs) return false;
+  // A slot the live node does not have (renamed by a dynamic pack's position-based
+  // re-slotting, #1873) leaves the error unjudgeable — never repaired by absence.
+  const input = inputs.find((i) => i?.name === inputName);
+  if (!input) return false;
+  const inputType = readableSlotType(input);
+  if (!inputType) return false;
+  if (input.link == null) return false; // nothing feeds it ⇒ no source type ⇒ no proof
+
+  const links = node?.graph?.links;
+  if (links == null) return false;
+  const link = lookupLink(links, input.link);
+  if (link == null) return false;
+  const originId = link.origin_id ?? link[1];
+  if (originId == null) return false;
+  const originSlot = link.origin_slot ?? link[2];
+  if (!Number.isInteger(originSlot)) return false;
+
+  const source = node?.graph?.getNodeById?.(originId) ?? null;
+  if (!originIsNamedInPrompt(source)) return false;
+  const outputType = readableSlotType(source?.outputs?.[originSlot]);
+  if (!outputType) return false;
+
+  return outputType === inputType;
+}
+
+/** A slot's declared type, or "" when it is absent, non-string, or the `*` wildcard. */
+function readableSlotType(slot) {
+  const type = slot?.type;
+  if (typeof type !== "string") return "";
+  const trimmed = type.trim();
+  return !trimmed || trimmed === "*" ? "" : trimmed;
 }
 
 /**
@@ -505,8 +488,10 @@ function nodeErrorLinkClaimFalsified(node, errorNodeId, error) {
  *
  *   1. the live node's class is not the entry's `class_type` — ComfyUI reuses ids across
  *      workflows (#1448, applied to validation errors);
- *   2. per error, `nodeErrorLinkClaimFalsified` above. Sibling errors on the same entry
- *      are untouched; an entry whose errors ALL falsify is removed.
+ *   2. per error, `nodeErrorMismatchRepaired` above — the input the error names now
+ *      receives exactly the type it declares, so this mismatch cannot be produced from
+ *      this graph. Sibling errors on the same entry are untouched; an entry whose errors
+ *      ALL prove repaired is removed.
  *
  * An id that does NOT resolve is left alone — see the note on
  * `classifyContradictedNodeError` for why that is load-bearing rather than lenient.
@@ -633,11 +618,11 @@ function classifyContradictedNodeError(rootGraph, id, entry) {
   }
   const errors = Array.isArray(entry?.errors) ? entry.errors : null;
   if (!errors || !errors.length) return null;
-  const survivors = errors.filter((e) => !nodeErrorLinkClaimFalsified(node, id, e));
+  const survivors = errors.filter((e) => !nodeErrorMismatchRepaired(node, e));
   if (survivors.length === errors.length) return null;
-  const falsified = errors.filter((e) => nodeErrorLinkClaimFalsified(node, id, e));
+  const falsified = errors.filter((e) => nodeErrorMismatchRepaired(node, e));
   const inputs = [...new Set(falsified.map((e) => e?.extra_info?.input_name))].join(", ");
-  const reason = `${inputs} on node ${id} is no longer fed by the node the error names`;
+  const reason = `${inputs} on node ${id} now receives the type it declares`;
   return { reason, entry: survivors.length ? { ...entry, errors: survivors } : null };
 }
 

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -443,6 +443,19 @@ function nodeErrorMismatchRepaired(node, error) {
   if (!input) return false;
   const inputType = readableSlotType(input);
   if (!inputType) return false;
+  // The socket types read below are the FRONTEND's, from the node def this tab loaded.
+  // A pack update plus a reconnect can move the server ahead of them, and then an
+  // apparently-matching frontend type says nothing about what the server will accept
+  // (codex gate round 7). The error itself carries the server's own word on it:
+  // `extra_info.input_config` is execution.py's `info = (input_type, extra_info)`, so
+  // element 0 is the input type the SERVER validated against. Requiring the live socket
+  // to still agree with it turns "the frontend believes X" into "the frontend and the
+  // server agreed on X at queue time", which is what the proof below needs.
+  //
+  // Absent or non-string (a combo input's `input_type` is the option LIST, not a name)
+  // means there is nothing to corroborate against, so no proof is available — keep.
+  const serverInputType = error.extra_info.input_config?.[0];
+  if (typeof serverInputType !== "string" || serverInputType !== inputType) return false;
   if (input.link == null) return false; // nothing feeds it ⇒ no source type ⇒ no proof
 
   const links = node?.graph?.links;

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -583,7 +583,7 @@ export function pruneContradictedNodeErrorMaps(rootGraph, nodeErrorsMaps) {
   const maps = Array.isArray(nodeErrorsMaps) ? nodeErrorsMaps : [nodeErrorsMaps];
   const pruned = [];
   const dropped = [];
-  const seen = new Set();
+  const seen = new Map();
   for (const map of maps) {
     const result = pruneContradictedNodeErrors(rootGraph, map);
     pruned.push(result.nodeErrors);
@@ -591,9 +591,22 @@ export function pruneContradictedNodeErrorMaps(rootGraph, nodeErrorsMaps) {
       // JSON-encoded pair, not a delimiter join: both halves are free-form strings and
       // any separator character could occur inside one of them.
       const key = JSON.stringify([record.node_id, record.contradicted_by]);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      dropped.push(record);
+      const existing = seen.get(key);
+      if (!existing) {
+        seen.set(key, record);
+        dropped.push(record);
+        continue;
+      }
+      // Same node and same reason — one withheld FACT — but the two stores can hold
+      // DIFFERENT errors that reduce to it. Skipping the second record here would
+      // discard them, breaking the non-loss guarantee inside the very step meant to
+      // tidy the list (codex gate round 9). Union instead, by identity, exactly as
+      // `combineNodeErrorMaps` does: a duplicate is noise, a dropped error is a defect.
+      const merged = Array.isArray(existing.errors) ? [...existing.errors] : [];
+      for (const error of record.errors ?? []) {
+        if (!merged.includes(error)) merged.push(error);
+      }
+      if (merged.length) existing.errors = merged;
     }
   }
   return { nodeErrors: combineNodeErrorMaps(pruned), dropped };

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -453,6 +453,12 @@ export function pruneContradictedNodeErrors(rootGraph, nodeErrors) {
   if (!nodeErrors || typeof nodeErrors !== "object" || Array.isArray(nodeErrors)) {
     return { nodeErrors: nodeErrors ?? null, dropped };
   }
+  // NO graph is not evidence about any node — it is the absence of evidence, and check
+  // (1) would read it as "none of these nodes exist" and drop the entire map. Callers
+  // reach here with a null root legitimately: validationBanner's `getGraphCtx()` probe
+  // is wrapped in try/catch and yields null when the binding is unresolvable. Caught by
+  // running the shipped banner rather than by reading it.
+  if (!rootGraph) return { nodeErrors, dropped };
   const kept = {};
   for (const [id, entry] of Object.entries(nodeErrors)) {
     let verdict = null;

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -545,6 +545,14 @@ export function pruneContradictedNodeErrors(rootGraph, nodeErrors) {
         ? { class_type: entry.class_type }
         : {}),
       contradicted_by: verdict.reason,
+      // THE ERRORS THEMSELVES, in full. This is what makes the whole mechanism
+      // non-lossy: an entry is never destroyed, only moved out of "errors the graph
+      // has right now" into "recorded at the last queue attempt, and the live graph
+      // disagrees". Every judgement here rests on the FRONTEND's view of the graph,
+      // and a node def the tab loaded can fall behind the server's (a pack update plus
+      // a reconnect); carrying the payload means the worst case of a wrong judgement is
+      // a mislabelled error the caller can still read in full, never a lost one.
+      ...(verdict.errors?.length ? { errors: verdict.errors } : {}),
     });
   }
   return { nodeErrors: Object.keys(kept).length ? kept : null, dropped };
@@ -627,6 +635,7 @@ function classifyContradictedNodeError(rootGraph, id, entry) {
     return {
       reason: `node ${id} is a ${liveTypes[0]} now, not the ${claimedType} this error is about`,
       entry: null,
+      errors: Array.isArray(entry?.errors) ? entry.errors : [],
     };
   }
   const errors = Array.isArray(entry?.errors) ? entry.errors : null;
@@ -636,7 +645,7 @@ function classifyContradictedNodeError(rootGraph, id, entry) {
   const falsified = errors.filter((e) => nodeErrorMismatchRepaired(node, e));
   const inputs = [...new Set(falsified.map((e) => e?.extra_info?.input_name))].join(", ");
   const reason = `${inputs} on node ${id} now receives the type it declares`;
-  return { reason, entry: survivors.length ? { ...entry, errors: survivors } : null };
+  return { reason, entry: survivors.length ? { ...entry, errors: survivors } : null, errors: falsified };
 }
 
 /**

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -545,13 +545,18 @@ export function pruneContradictedNodeErrors(rootGraph, nodeErrors) {
         ? { class_type: entry.class_type }
         : {}),
       contradicted_by: verdict.reason,
-      // THE ERRORS THEMSELVES, in full. This is what makes the whole mechanism
-      // non-lossy: an entry is never destroyed, only moved out of "errors the graph
-      // has right now" into "recorded at the last queue attempt, and the live graph
-      // disagrees". Every judgement here rests on the FRONTEND's view of the graph,
+      // THE ERRORS THEMSELVES, in full. This is what stops a judgement here from
+      // destroying anything: an entry is not deleted, it is moved out of "errors the
+      // graph has right now" into "recorded at the last queue attempt, and the live
+      // graph disagrees". Every judgement rests on the FRONTEND's view of the graph,
       // and a node def the tab loaded can fall behind the server's (a pack update plus
-      // a reconnect); carrying the payload means the worst case of a wrong judgement is
-      // a mislabelled error the caller can still read in full, never a lost one.
+      // a reconnect); carrying the payload makes the worst case of a wrong judgement a
+      // mislabelled error the caller can still read in full, rather than a lost one.
+      //
+      // Precisely: nothing is dropped SILENTLY. The caller's list of these is capped
+      // like every sibling list in that payload, and a cut is reported with the true
+      // total (`stale_node_errors_truncated` + its hint) — an honest cut, not a
+      // guarantee of unbounded delivery.
       ...(verdict.errors?.length ? { errors: verdict.errors } : {}),
     });
   }


### PR DESCRIPTION
Fixes #2192.

## What was wrong

`graph_get_errors` reports five sources and correlates four of them against the live graph before shipping:

| source | live-graph correlation |
| --- | --- |
| missingModel / missingMedia | `isStaleAssetCandidate` — still-referenced + active-graph scope (#316) |
| missing node types | adjudicated against the live registry (#1332) |
| combo availability | the #745 live scan |
| the runtime exec failure | node id **and** class type (#1448), scoped-locator resolution (#1685) |
| **`app.lastNodeErrors` + the execution-error store** | **none** |

That last one is `node_errors`. It is a snapshot of the LAST queue rejection, and the ComfyUI frontend only replaces it on the NEXT queue attempt — so nothing a user does to *repair* a graph ever clears it. The reporter fixed an `ImpactSwitch.select` wire, confirmed the fix with `panel_query_graph`, and then got the pre-fix `return_type_mismatch` back from three more reads, a save, and a subgraph exit.

The self-contradiction they flagged (`errored_count: 0` beside a populated `node_errors`) has its own cause, and it is worth stating because it is what made the stale entry *permanent* rather than merely wrong. The entry's key is a scoped locator, `249:252`. `byId` only indexes the graph currently on screen, so `byId.has("249:252")` is false inside the subgraph (where the node is `252`) **and** at root (where it is `249`). The entry therefore never became a per-node reason, never counted toward `errored_count`, and never reached any of the adjudication that would have questioned it — it fell straight through to the backwards-compat payload.

## The fix

`pruneContradictedNodeErrors` (web/js/lib/asset-staleness.js) runs the union through the same kind of correlation the other four sources already get, before *anything* downstream reads it — the per-node join, `collectUnexplainedRedOutlines`, the `clean` verdict and the payload all now see one map, which is what stops them from disagreeing.

Three checks, each requiring **positive** evidence:

1. a RECOGNIZED locator that resolves to no node in `rootGraph` — these stores are not cleared on a workflow-tab switch, so it belongs to another tab or a deleted node (the #316 scope check, applied to validation errors);
2. it resolves, but the live node's type is not the entry's `class_type` — ComfyUI reuses ids across workflows (#1448, applied to validation errors);
3. per error: `return_type_mismatch` carries `extra_info.input_name` and `extra_info.linked_node`, i.e. "input X is fed by node Y and Y's type is wrong". When X is now fed by something else, that sentence is false *of this graph*. Sibling errors on the entry are untouched; an entry whose errors all falsify is removed.

Nothing expires by age, by a save, or by a re-read — only by contradiction.

## Both consumers, not just the one the issue names

`validationBanner` reads the same `app.lastNodeErrors` and injects it at turn start under **"GRAPH VALIDATION ERRORS — the user is seeing these in the frontend's error panel RIGHT NOW."** Fixing only `panel_get_errors` would have left the stale claim on the louder surface — the one that speaks for the user's screen. It prunes too, against the root graph its own `graphReadBindingChanged` guard has just proven unchanged for this read. The wiring test asserts there are exactly **two** call sites, because a green helper is no evidence about a path that never calls it.

## Where to look hardest

**This is a suppression path, so the interesting question is what it must never suppress.** Every unexpected shape fails OPEN and keeps the error:

- **no root graph at all** → the whole map is returned untouched. See below; this one was a real bug in the first commit.
- **an input the live node no longer exposes** → kept. Impact-Pack renames dynamic slots by position (#1873, the very mechanism that caused this report), so a slot we cannot find is unjudgeable, not disproven. `liveInputOriginId` distinguishes `undefined` ("cannot tell") from `null` ("genuinely unconnected") for exactly this reason.
- **a `linked_node` in a different subgraph scope** → kept. The error's ids are the flattened prompt's; the live link's `origin_id` is local to the node's own graph. Only a same-scope claim is comparable.
- **an unreadable / unresolvable link store** → kept.
- **an unrecognized locator** → kept, even though it resolves to nothing (that is `locatorIsRecognized`'s whole job).
- **any throw** → the entry is reported verbatim.

**The one deliberate judgement call:** when the input exists and is now fed by *nothing*, I treat the claim as falsified and drop it. Rationale: the error is a statement about one named link, and that link is gone either way. The cost is that if the input was required, the panel no longer names it — ComfyUI reports `required_input_missing`, a **different** error type this prune never touches (verified in source, below). I took the view that echoing a specific false claim is worse than silence, because a false claim is what the reporter acted on. Flagging it as the load-bearing choice.

Removals are disclosed in-band as `stale_node_errors` (node id, class type, evidence), capped like its sibling lists with the cut stated and the real total (#809) — a silently short list inside a list whose whole job is disclosure would be the same defect wearing a different hat.

## The bug the harness found that reading would not have

The repo has only **source-order** assertions for `validationBanner` (`indexOf` comparisons), so I built an executable harness for it instead — the real function body run with injected deps, same technique as `_graph-get-errors-harness.mjs`.

Its very first run returned an **empty banner** for a live, uncontradicted `KSampler` error. Cause: with a nullish `rootGraph`, check (1) resolves no node for *any* id and reads that as "none of these nodes exist" — dropping the entire map. `validationBanner` reaches that state on a real path: its `getGraphCtx()` probe is `try`/`catch`-wrapped and yields `null` when the binding is unresolvable. Absence of a graph is absence of evidence, so the guard now returns the map untouched, protecting both callers. A source-order assertion would have shipped it green.

## Verification

`browser_tests/unit/stale-node-errors-2192.test.mjs` — **20 tests**, driving the **shipped** `graph_get_errors` and the **shipped** `validationBanner` through production-path harnesses on the reporter's exact payload, not re-implementations. The get-errors harness previously stubbed `combineNodeErrorMaps` to `() => null`, so no test could reach this map at all; it now injects `app.lastNodeErrors` / the store and uses the real union + the real prune.

Verified by mutation, six times — each committed first, then broken, then restored:

| mutation | result |
| --- | --- |
| `graph_get_errors` call site reverted to the raw union | **4 red** — and the failure diff is the reporter's payload verbatim: `errored_count: 0` with `'249:252'` still claiming `received_type(IMAGE)` |
| `nodeErrorLinkClaimFalsified` stops reading the live graph | **4 red**, including the sibling-survivor test |
| the missing-slot fail-open turned into disproof | **1 red** — the #1873 rename case |
| the cap disclosure removed | **1 red** |
| `validationBanner` call site removed | **2 red** (behaviour + the two-call-site wiring assertion) |
| the nullish-graph fail-open removed | **2 red** |

Full gates on this branch: `npm run test:unit` → **8194 pass / 0 fail** (i18n check, i18n render check, tool vocabulary, `check-panel-scope` OK). One new `tr()` key, catalog rebuilt with `npm run i18n:build`.

The `#2192: the STILL-BROKEN wire is reported exactly as before` tests are the counterweight to the suppression: same call, same map, only the live origin differs, and the entry survives byte-identical on both surfaces with `clean` still false.

## Input shapes verified against the real install, not from memory

Every field this fix reads was checked against the ComfyUI the panel actually runs on (frontend package **1.49.6**), because a correct guard reading the wrong shape is inert and green:

- `execution.py:940` — `return_type_mismatch` carries `extra_info.linked_node = val`, and `val = inputs[x]` is asserted a `[node_id, slot_index]` pair three lines up. So the claim really is "this input, from that node".
- `execution.py:905` — **`required_input_missing` carries `input_name` but no `linked_node`.** That is the load-bearing confirmation for the judgement call above: when an input becomes unconnected, ComfyUI reports a *different* error type, which this prune never touches (pinned by `an error with no linked_node claim is never dropped by this check`).
- Frontend bundle `settingStore-CwkLtSKP.js` — `LGraph.add`/`configure` assign `node.graph = this` (4 sites), `graph.links` is a **Map** (`links.get(...)`), `node.inputs[i].link` is a link id, and `LLink.origin_id` exists (112 refs). `lookupLink` reads Map-or-object, so both LiteGraph shapes work.

## Browser verification — NOT run, and why

`npx playwright test` was not run: **no ComfyUI is listening on this machine** (nothing on 8188, no `main.py` process), and this run had no instance allocated. I am stating that rather than implying coverage.

What that does and does not leave uncovered: this change alters the `panel_get_errors` **tool reply** and the turn-start banner **text**, not anything the sidebar renders — no DOM, no CSS. The orchestrator forwards the reply verbatim (`withTruncationHints` in `panel-tools.ts` only *adds* hint fields; I checked that no field whitelist or reply schema would drop `stale_node_errors`), so the new keys are additive for older orchestrators too. Both shipped functions ARE exercised — the harnesses extract and run the real bodies, which is why a call-site mutation shows up as red tests rather than as nothing.


---

## Round 2 — codex gate returned NEEDS-REVISION with one P1, and it was right

**The finding:** `combineNodeErrorMaps` merges same-id entries with `{...previous, ...entry}`, so the **last** map's `class_type` governs the merged entry while its `errors` array holds **both** maps' errors. Pruning *after* that merge let one source's label decide the other source's fate.

Reproduced against the shipped executor before touching anything:

```
app.lastNodeErrors = { 2: { class_type: "Current",         errors: [live value_not_in_list] } }
executionErrorStore= { 2: { class_type: "OldWorkflowType", errors: [stale from another workflow] } }
live node 2 is a "Current"

  →  node_errors   = null
     errored_count = 0          ← a real, live validation error silently suppressed
```

**The fix:** `pruneContradictedNodeErrorMaps` adjudicates each map on its own and unions the survivors, so every entry stays paired with the `class_type` its own source recorded — the only label that says anything about its own errors. The stale store entry is dropped alone; the live app entry survives untouched with `errored_count: 1`.

Same repro after the fix:

```
node_errors   = { "2": { class_type: "Current", errors: [live value_not_in_list] } }
errored_count = 1
stale_node_errors = [{ node_id: "2", class_type: "OldWorkflowType",
                       contradicted_by: "node 2 is a Current now, not the OldWorkflowType this error is about" }]
```

**The wiring test now pins the ORDER, not just the calls.** It asserts the panel never invokes `combineNodeErrorMaps` itself, because re-introducing `prune(combine([...]))` at a call site is the only way this defect comes back.

Four new tests: the P1 repro through the shipped executor; dedupe of one stale entry retained by both stores; that the #579 union of two *live* sources is preserved (pruning per-map must not cost the thing the union exists for); and non-array/null arguments.

Mutation: restoring the merge-then-prune order → the P1 test goes red on its own. Unwiring the `get_errors` call site → 6 red.

**Also fixed in this round:** a stray **NUL byte** landed in the dedupe key where a separator was intended. The repo's shipped-source control-character guard (`open-node-difference.test.mjs`) caught it in the full run. The key is now a JSON-encoded pair, which cannot collide on free-form strings either.

Suite after round 2: **8198 pass / 0 fail**.


---

## Round 3 — one P1, and the check that caused it is gone

**The finding:** a momentarily **empty** graph was read as proof the nodes had been deleted. ComfyUI clears and repopulates `_nodes` while loading a workflow, so mid-load every id resolves to nothing, a live rejection was dropped, and the banner returned empty string.

That is the *second* P1 from the same check — the locator-resolves-to-nothing rule. Round 1 caught its null-graph form (my own harness found that one); round 3 caught its empty-graph form. Two failures, one shape: **a node that does not RESOLVE is not a node that does not EXIST.**

**So the check is removed, not hardened.** No amount of hardening changes its shape — it was the only one of the three that read *absence* as evidence, and it was never what this issue needed. It was a #316 cross-tab nicety; keeping such an entry is over-reporting, which is both the safe direction and the pre-existing behaviour. The reporter's entry resolves fine, and the link-claim check is what falsifies it, so the fix is unaffected.

What remains is two checks, each requiring a **resolved live node plus positive contradicting data**:

1. the live node's class is not the entry's `class_type`;
2. the input the error names is no longer fed by the `[node_id, slot_index]` it names.

The `!rootGraph` guard stays — now redundant — as a statement at the entry point that no graph means no verdict, so a future check that reads absence has to meet that line first.

New tests: an unresolvable id is KEPT; and a momentarily empty graph drops nothing, asserted through **both** shipped surfaces (`graph_get_errors` returns the map intact, and the banner still says GRAPH VALIDATION ERRORS). Mutation: re-adding the absence check → 3 red.

## Round tally

Three gate rounds, three real defects, each reproduced independently before being accepted — two of them against the installed ComfyUI's own source rather than against the reviewer's wording:

| round | finding | how I confirmed it |
| --- | --- | --- |
| 1 | merged maps let one source's `class_type` drop the other's live errors | reproduced through the shipped executor: `errored_count: 0` with a live error suppressed |
| 2a | `class_type` is `comfyClass`, not `type` | frontend bundle 1.49.6: prompt compiler writes `class_type: e.comfyClass`; `registerNodeType(n.id, i)` vs `i.comfyClass = t.name` are different sources |
| 2b | `linked_node` slot ignored | `execution.py`: `received_type = r[val[1]]` — the slot IS the type, so a same-node slot move is a full repair |
| 3 | empty graph read as deletion | second instance of the round-1 defect class; check removed |

The reviewer's round-2a example (`type:"Load Image"`) was illustrative rather than literal — `type` vs `title` — but the underlying claim was correct, which is why I checked the bundle instead of arguing with the example.

Suite: **8204 pass / 0 fail**.


---

## Round 4 — one P1: only ONE ComfyUI error type files `linked_node` the way this check assumed

**The finding:** `exception_during_inner_validation` also carries `input_name` + `linked_node`, but ComfyUI files it under the **upstream** node:

```python
# execution.py — return_type_mismatch
errors.append(error)                          # → the node BEING VALIDATED
                                              #    input_name IS its own input ✓

# execution.py — exception_during_inner_validation
validated[o_id] = (False, reasons, o_id)      # → the UPSTREAM node
                                              #    input_name names an input of the
                                              #    DOWNSTREAM node, and linked_node
                                              #    points back at the errored node itself
```

Read with `return_type_mismatch`'s premise, the second finds a same-named input on the wrong node. The reviewer's repro is minimal and exact: node 1 with an unrelated **disconnected** input called `x` is enough — the input resolves, nothing feeds it, the claim reads as falsified, and a live inner-validation exception is dropped with `graph_get_errors` reporting clean.

**The fix:** the link check now runs **only** for `return_type_mismatch`. I enumerated every `"linked_node"` site in the installed `execution.py` — there are exactly two, listed above — and it is a **whitelist, not a blocklist**, so an error type this panel has never seen (a newer ComfyUI's, or a custom validator's) is never judged by semantics borrowed from a different one.

Three tests: the reviewer's exact repro through the shipped executor, an unknown future error type, and an error with no `type` at all.

**A test-quality catch that came with it.** Two of the round-2 slot tests used errors with no `type` field, so the new whitelist would have made them pass *vacuously* — green while asserting nothing. They now carry `type: "return_type_mismatch"`, and a mutation removing the slot fail-open turns one of them red, which is what proves they still bite.

## Where this leaves the change

The suppression surface is now two checks, both requiring a resolved live node **and** positive contradicting evidence, both scoped to semantics verified in the installed ComfyUI rather than assumed:

1. the live node's `comfyClass`/`type` is not the entry's `class_type`;
2. for a `return_type_mismatch` only: the input it names is no longer fed by the `[node_id, slot_index]` it names.

Four gate rounds found four real defects, every one reproduced before it was accepted, and two of them traced to ComfyUI's own source rather than to the reviewer's wording. The net effect of review was to make the fix **smaller**: one check deleted outright, one narrowed to a single error type.

Suite: **8207 pass / 0 fail**.


---

## Round 5 — the finding that explains all the others

**The finding:** an error whose source is reached through a **bypassed** node was dropped. Generalised, that is the root of rounds 2b, 4 and 5 together: **the prompt is a compiled artifact and the graph is not.** This check compares `linked_node` (compiled) against the live link (raw), and the two disagree wherever the compiler resolves *through* something.

The frontend's serializer states the rule in one line, and the panel already quotes it in `frontend-virtual-nodes.js`:

```js
if (e.isVirtualNode || e.mode === NEVER || e.mode === BYPASS) continue;
```

So a Reroute, a KJNodes Get/Set bus node, a **subgraph container** (also `isVirtualNode`), a muted node or a bypassed one never appears in the prompt — the link is attributed to whatever sits upstream. An input fed through any of them has a `linked_node` that **cannot** equal its immediate `origin_id`, and reading that difference as a repair suppressed a live error on any graph containing a reroute. Which is most graphs.

**The fix is structural rather than another special case.** The comparison now runs only when the live source is a node the compiler would actually name, reusing `isFrontendVirtualNode` — the panel's existing, documented statement of the serializer's own rule — instead of a new list of types. That covers every "resolved through" case at once, including ones nobody has enumerated yet: a pack's virtual node that does not set the flag is serialized into the prompt and fails at the server, so it cannot both omit the flag and work.

Six tests: bypassed (mode 4), muted (mode 2), virtual Reroute, subgraph container, an unresolvable source — plus **an ordinary source for mode 0 and mode-absent**, so the guard cannot quietly disable the whole feature. That last one is the important one: the reporter's repair is an ordinary node, and it still prunes. Mutation: removing the guard → 5 red; removing only the virtual arm → 2 red.

**The second round-5 finding (cross-scope) I did not "fix".** It is correct as an observation but it is the documented fail-open: the error's ids are the flattened prompt's, the live link's origin is local to its own graph, so a cross-boundary claim is not comparable. Leaving such an error reported is over-reporting — the safe direction, and the pre-existing behaviour.

## What review actually did to this change

| round | finding | outcome |
| --- | --- | --- |
| 1 | merged maps let one source's `class_type` drop the other's live errors | prune each map before the union |
| 2a | `class_type` is `comfyClass`, not `type` | match either field |
| 2b | `linked_node` slot ignored | judge the slot too |
| 3 | empty graph read as deletion | **check deleted** |
| 4 | `exception_during_inner_validation` files under the upstream node | **narrowed to one error type** |
| 5a | source reached through bypass/reroute/subgraph | **gated on the serializer's own rule** |
| 5b | cross-scope link not pruned | not a defect — documented fail-open |

Every finding was reproduced before it was accepted, and four were settled against the installed ComfyUI's own `execution.py` or its 1.49.6 frontend bundle rather than against the reviewer's wording — one example (`type: "Load Image"`) was illustrative and wrong in its particulars while the claim underneath it was right.

The net effect is that the suppression got **smaller** at every round. It now fires only when all of these hold: the node resolves; its class matches; the error is a `return_type_mismatch`; the input still exists on it; the live source resolves and is a node the compiler names; the claim is in the same subgraph scope — and only then, if the source id or output slot differs. Everything else keeps the error.

Suite: **8213 pass / 0 fail**.


---

## Round 6 — the finding that made the fix simpler instead of bigger

**The finding:** moving an input from output 0 to output 1 of the **same** node was treated as a repair. When both outputs emit `IMAGE`, it repairs nothing — ComfyUI produces the identical mismatch — yet the link the error names is now different.

That is not a fifth special case. It is the demonstration that the whole reading was unsound. Every finding from round 2 on had one cause: **`extra_info.linked_node` is a coordinate in the COMPILED prompt and the panel only has the RAW graph.** The compiler flattens subgraphs, renames dynamic slots and resolves through every virtual, muted and bypassed node — so "the link changed" and "the graph was repaired" are simply different questions, and round 6 showed a changed link isn't even *sufficient*.

**So the check now asks the question that decides the verdict, and it is entirely local:**

> does the input's own type exactly equal the type of the output feeding it?

If it does, ComfyUI cannot produce this mismatch from this graph — whatever route the link took to get there. That subsumes every earlier patch and closes round 6 by construction:

| case | old rule | new rule |
| --- | --- | --- |
| different source, still emits `IMAGE` | dropped ✗ | types disagree → **kept** |
| same node, other same-typed output | dropped ✗ | types disagree → **kept** |
| fed through a reroute / bypass | needed a special guard | source refused → **kept** |
| now unconnected | dropped (my judgement call) | no source type → **kept** |

That last row **retires the one contentious judgement call in this PR.** A disconnected input used to count as a repair, which could report clean on a graph that is still broken. It no longer does — and the reviewer never had to raise it, because the sound rule simply doesn't have that hole.

**EXACT string equality only.** ComfyUI's `validate_node_input` understands wildcards and comma-separated unions; re-implementing it here would be a second compiler to get wrong. A `*` on either side, an unreadable type, an out-of-range slot, or a link with no readable `origin_slot` all keep the error.

The scope-splitting helper was the last consumer of prompt coordinates and is deleted. Net effect: **the module got smaller and the rule fits in one sentence**, while the reporter's repair is still proven — pinned for an ordinary source at both mode 0 and mode-absent, so the compiled-source guard cannot quietly disable the whole feature.

Mutation: dropping the type equality → 4 red (including both STILL-BROKEN tests, on both surfaces); treating `*` as an ordinary type → 1 red.

## What review did to this change, in total

| round | finding | outcome |
| --- | --- | --- |
| 1 | merged maps let one source's `class_type` drop the other's live errors | prune each map before the union |
| 2a | `class_type` is `comfyClass`, not `type` | match either field |
| 2b | `linked_node` slot ignored | *(superseded by round 6)* |
| 3 | empty graph read as deletion | **check deleted** |
| 4 | `exception_during_inner_validation` files under the upstream node | narrowed to one error type |
| 5a | source reached through bypass/reroute/subgraph | gated on the serializer's own rule |
| 5b | cross-scope link not pruned | not a defect — and now moot, coordinates are unused |
| 6 | same-typed slot move is not a repair | **link-identity rule replaced by a type rule** |

Every finding was reproduced before it was accepted, and four were settled against the installed ComfyUI's own `execution.py` or its 1.49.6 frontend bundle rather than against the reviewer's wording — one example (`type: "Load Image"`) was illustrative and wrong in its particulars while the claim underneath it was right.

Review made this **smaller at every round**: one check deleted, one narrowed to a single error type, and the core rule replaced by a simpler one that needs no knowledge of the prompt's coordinate system at all. The suppression now fires only when the node resolves, its class matches, the error is a `return_type_mismatch`, the named input still exists, it is connected, its source resolves and is a node the compiler names, and both slot types are readable, non-wildcard and identical. Everything else keeps the error.

Suite: **8214 pass / 0 fail**. 40 tests in the regression file.


---

## Rounds 7 & 8 — the limitation that cannot be checked away, and what to do about it

Round 7: the socket types the proof reads are the **frontend's**, from the node def this tab loaded. A pack update plus a reconnect moves the server ahead of them, and an apparently-matching frontend type then says nothing about what the server will accept.

That one **was** closable, because the error carries the server's own word: `extra_info.input_config` is `execution.py`'s `info = (input_type, extra_info)`, so element 0 is the input type the **server** validated against. Requiring the live socket to still agree with it turns "the frontend believes X" into "the frontend and the server agreed on X at queue time". Absent or non-string (a combo's `input_type` is the option *list*) means nothing to corroborate against — the error is kept.

Round 8 is the same finding mirrored onto the **source** side, and it is **not** closable that way. `received_type` describes the *old* link; the new source's type is only knowable from the frontend. There is no corroborator in the error.

### So the mechanism was rebuilt not to need one

Eight rounds of trying to check this away is the evidence that it cannot be. Every judgement here reads the frontend's view of the graph — as does every other live-graph correlation in this file — so instead of pretending otherwise:

**A demoted entry now carries its errors IN FULL under `stale_node_errors`, next to the evidence in `contradicted_by`.** Nothing is deleted; an entry is only moved out of "errors this graph has right now" into "recorded at the last queue attempt, and the live graph disagrees — here is why". The note says so, and says to treat them as live if you want the conservative reading.

That changes the worst case of a wrong judgement from **a lost rejection** to **a mislabelled one the caller can still read in full**. It is also the direction this repo already takes everywhere — the #985 comment in this very file puts it plainly: *"over-warning is the safe direction here — a wrong QUIET answer is what cost the reporter 18 minutes."*

And it answers #2192 on its own terms. The report is about **misleading output**: *"a user or agent reading `node_errors` non-empty would reasonably conclude there's still a live validation error."* Relocating the entry under a field that explains exactly what it is fixes the misleading framing without ever destroying a rejection.

### The invariant this buys, and the test that enforces it

> Every error present in the input map appears somewhere in the payload — in `node_errors` or in `stale_node_errors`.

One test walks every error in a mixed map (a proved-repaired entry, a foreign-class entry, a live entry) and asserts each object is still reachable in the result. Mutation: discarding the demoted errors → 4 red. No future change can quietly start dropping.

| round | finding | outcome |
| --- | --- | --- |
| 1 | merged maps let one source's `class_type` drop the other's live errors | prune each map before the union |
| 2a | `class_type` is `comfyClass`, not `type` | match either field |
| 2b | `linked_node` slot ignored | *(superseded by round 6)* |
| 3 | empty graph read as deletion | check deleted |
| 4 | `exception_during_inner_validation` files under the upstream node | narrowed to one error type |
| 5a | source reached through bypass/reroute/subgraph | gated on the serializer's own rule |
| 5b | cross-scope link not pruned | not a defect; moot once coordinates went unused |
| 6 | same-typed slot move is not a repair | link-identity rule replaced by a type rule |
| 7 | frontend input type may be stale vs the server | corroborated against `input_config[0]` |
| 8 | same on the source side, no corroborator exists | **demotion made non-lossy** |

Eight rounds, ten findings, every one reproduced before it was accepted and five settled against the installed ComfyUI's own `execution.py` or its 1.49.6 frontend bundle rather than against the reviewer's wording. Review made this change **smaller and safer at every single round** — one check deleted, one narrowed to a single error type, the core rule replaced by a simpler local one, and finally the whole operation made incapable of losing data.

Suite: **8221 pass / 0 fail**. 47 tests in the regression file.
