### PR TITLE
fix(2511): admit models inventory through fetch_comfyui_read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- fetch_comfyui_read now admits the closed `models` and `models/<folder>` inventory operations so list_local_models can relay a reachable remote ComfyUI through the live panel instead of dying on the diagnostics-only allowlist (comfyui-mcp#2511)
+
 ## [0.15.159] - 2026-09-02
 
 ### Fixed

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -165,10 +165,59 @@ test("#2283: logs raw transport retains origin, redirect, and body-size fences",
   );
 });
 
+test("#2511: models inventory operations use only their fixed same-origin /models routes", async () => {
+  const apiURLCalls = [];
+  const apiCalls = [];
+  const bodies = {
+    models: '["checkpoints","loras","diffusion_models"]',
+    "models/checkpoints": '["remote-ckpt.safetensors"]',
+    "models/loras": '["remote-lora.safetensors"]',
+    "models/diffusion_models": '["remote-unet.safetensors"]',
+  };
+  for (const operation of Object.keys(bodies)) {
+    const result = await fetchComfyUIReadForMcp(
+      { operation },
+      {
+        expectedOrigin: "https://panel.test",
+        api: {
+          apiURL: (path) => {
+            apiURLCalls.push(path);
+            return `https://panel.test/comfy/api${path}`;
+          },
+          fileURL: () => { throw new Error("models must not use fileURL"); },
+          fetchApi: async (path, init) => {
+            apiCalls.push({ path, init });
+            return response({ body: bodies[operation] });
+          },
+        },
+        fetchImpl: async () => { throw new Error("models must not use raw fetch"); },
+      },
+    );
+    assert.deepEqual(result, {
+      operation,
+      body: bodies[operation],
+      contentType: "application/json",
+      bytes: new TextEncoder().encode(bodies[operation]).byteLength,
+    });
+  }
+  assert.deepEqual(apiURLCalls, ["/models", "/models/checkpoints", "/models/loras", "/models/diffusion_models"]);
+  assert.deepEqual(apiCalls.map(({ path }) => path), ["/models", "/models/checkpoints", "/models/loras", "/models/diffusion_models"]);
+  for (const { init } of apiCalls) {
+    assert.equal(init.method, "GET");
+    assert.equal(init.cache, "no-store");
+    assert.equal(init.credentials, "include");
+    assert.equal(init.redirect, "manual");
+  }
+});
+
 test("#2283: arbitrary paths, URLs, origins, targets, and operation names are refused before fetch", async () => {
   const invalid = [
     {},
     { operation: "unknown" },
+    { operation: "models/" },
+    { operation: "models/../object_info" },
+    { operation: "models/foo/bar" },
+    { operation: "models/checkpoints?q=1" },
     { operation: "object_info", path: "/admin" },
     { operation: "history", path: "/admin" },
     { operation: "history", url: "https://evil.test" },

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -17,6 +17,27 @@ const READ_OPERATIONS = new Map([
   ["workflow_templates", "/workflow_templates"],
 ]);
 const LOGS_TRANSPORT_PATH = "/internal/logs/raw";
+// Same closed folder grammar MCP uses for `models/<folder>` (comfyui-mcp#2511).
+const MODELS_FOLDER_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const ALLOWED_OPERATION_NOTE =
+  "operation must be one of history, system_stats, logs, object_info, workflow_templates, models, or models/<folder>";
+
+function resolveReadOperation(operation) {
+  if (typeof operation !== "string") return null;
+  if (READ_OPERATIONS.has(operation)) {
+    return { operation, path: READ_OPERATIONS.get(operation) };
+  }
+  if (operation === "models") {
+    return { operation, path: "/models" };
+  }
+  if (operation.startsWith("models/")) {
+    const folder = operation.slice("models/".length);
+    if (MODELS_FOLDER_RE.test(folder)) {
+      return { operation, path: `/models/${folder}` };
+    }
+  }
+  return null;
+}
 
 function readTimeoutMs(operation) {
   return operation === "object_info"
@@ -73,10 +94,11 @@ export function validateFetchComfyUIReadArgs(args) {
   if (!hasOwn(args, "operation")) {
     throw invalidInput("operation is required");
   }
-  if (typeof args.operation !== "string" || !READ_OPERATIONS.has(args.operation)) {
-    throw invalidInput("operation must be one of history, system_stats, logs, object_info, workflow_templates");
+  const resolved = resolveReadOperation(args.operation);
+  if (!resolved) {
+    throw invalidInput(ALLOWED_OPERATION_NOTE);
   }
-  return { operation: args.operation, path: READ_OPERATIONS.get(args.operation) };
+  return resolved;
 }
 
 function pageOrigin() {


### PR DESCRIPTION
Fixes artokun/comfyui-mcp#2511

MCP `list_local_models` already falls back to authenticated `fetch_comfyui_read` with `models` / `models/<folder>` after a headless EHOSTUNREACH. Current Panel still allowed only history/system_stats/logs/object_info/workflow_templates, so a reachable remote inventory died on the diagnostics-only allowlist (reproduced on 0.15.150; still true on 0.15.159).

This admits the closed `models` and `models/<folder>` operations (same folder grammar MCP uses) and maps them to same-origin GET `/models` and `/models/<folder>`. Traversal spellings stay refused before fetch.

Tests: `node --test browser_tests/unit/fetch-comfyui-read.test.mjs` — 10 passed (new #2511 inventory routes plus existing #2283 fences).
