### PR TITLE
fix(2193): split combined video/ filenames for panel_show_media /view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - After a large custom-node install, adding a node waits for /object_info with an adaptive command-budget cap instead of a fixed 10s fetch, and still refuses if the schema never arrives (#2050)
-
+- panel_show_media splits a combined `video/<file>` output filename into `/view`'s `subfolder` + basename so a valid history reference no longer 404s (#2193)
 
 ## [0.15.161] - 2026-09-03
 
 ### Fixed
 - panel_save_workflow restamps a leftover nested `extra.comfyui_mcp.workflow_path` when the canvas uuid already matches the tab, and ImpactSwitch `findInputSlot` restore failures no longer dead-end that rebind behind an unrestorable open (#2194, #2206)
-
 
 ## [0.15.160] - 2026-09-03
 

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -20,6 +20,7 @@ import {
   MEDIA_PREVIEW_TIMEOUT_MS,
   MEDIA_SIZE_PROBE_TIMEOUT_MS,
   MEDIA_VIEW_PROBE_TIMEOUT_MS,
+  normalizeComfyViewRef,
 } from "../../web/js/lib/media-preview.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 
@@ -193,6 +194,78 @@ test("an image-only call paints exactly as before and claims no sampled preview"
   assert.equal(reply.painted, 2);
   assert.doesNotMatch(reply.note, /SAMPLED PREVIEW/);
   assert.doesNotMatch(reply.note, /contact sheet/);
+});
+
+test("#2193: a combined video/ output filename is split for ComfyUI /view", () => {
+  const combined = normalizeComfyViewRef({
+    filename: "video/H3_final_refined_2MP_00007_.mp4",
+    type: "output",
+  });
+  assert.equal(combined.filename, "H3_final_refined_2MP_00007_.mp4");
+  assert.equal(combined.subfolder, "video");
+  assert.equal(combined.type, "output");
+
+  const alreadySplit = normalizeComfyViewRef({
+    filename: "H3_final_refined_2MP_00007_.mp4",
+    subfolder: "video",
+    type: "output",
+  });
+  assert.equal(alreadySplit.filename, "H3_final_refined_2MP_00007_.mp4");
+  assert.equal(alreadySplit.subfolder, "video");
+
+  const duplicated = normalizeComfyViewRef({
+    filename: "video/H3_final_refined_2MP_00007_.mp4",
+    subfolder: "video",
+    type: "output",
+  });
+  assert.equal(duplicated.filename, "H3_final_refined_2MP_00007_.mp4");
+  assert.equal(duplicated.subfolder, "video", "must not become video/video");
+
+  const nested = normalizeComfyViewRef({
+    filename: "renders/final/clip.mp4",
+    type: "output",
+  });
+  assert.equal(nested.filename, "clip.mp4");
+  assert.equal(nested.subfolder, "renders/final");
+});
+
+test("#2193: panel_show_media must not /view 404 a valid video/ output reference", async () => {
+  const probes = [];
+  const h = harness({
+    probeMedia: async (url, ref) => {
+      probes.push({ url, filename: ref.filename, subfolder: ref.subfolder });
+      // ComfyUI /view basename()s filename and looks only under subfolder.
+      // A combined filename with empty subfolder 404s even when the file exists.
+      const parsed = new URL(url, "http://comfy.local");
+      const filename = parsed.searchParams.get("filename") || "";
+      const subfolder = parsed.searchParams.get("subfolder") || "";
+      if (filename.includes("/")) {
+        return { ok: false, reason: "/view returned HTTP 404" };
+      }
+      if (filename === "H3_final_refined_2MP_00007_.mp4" && subfolder === "video") {
+        return { ok: true };
+      }
+      return { ok: false, reason: "/view returned HTTP 404" };
+    },
+  });
+  const reply = await composeShowMediaReply(
+    [{
+      kind: "viewRef",
+      viewRef: { filename: "video/H3_final_refined_2MP_00007_.mp4", type: "output" },
+      filename: "video/H3_final_refined_2MP_00007_.mp4",
+    }],
+    h.deps,
+  );
+
+  assert.equal(probes.length, 1, "the panel must probe the same /view URL it would paint");
+  assert.equal(probes[0].filename, "H3_final_refined_2MP_00007_.mp4");
+  assert.equal(probes[0].subfolder, "video");
+  assert.match(probes[0].url, /filename=H3_final_refined_2MP_00007_\.mp4/);
+  assert.match(probes[0].url, /subfolder=video/);
+  assert.doesNotMatch(probes[0].url, /filename=video%2F|filename=video\//);
+  assert.equal(reply.painted, 1, "a valid output video must not be dropped as a /view 404");
+  assert.equal(h.calls.paintedVideos.length, 1);
+  assert.doesNotMatch(reply.note ?? "", /HTTP 404/);
 });
 
 test("a remote /view outage is dropped before it can be counted as painted (#1620)", async () => {
@@ -1335,7 +1408,7 @@ test("the show_media dispatcher answers with the handler's reply, not a fixed ac
   const src = panelSource();
   assert.match(
     src,
-    /import \{ composeShowMediaReply \} from "\.\/lib\/media-preview\.js";/,
+    /import \{ composeShowMediaReply, normalizeComfyViewRef \} from "\.\/lib\/media-preview\.js";/,
     "the panel must import the reply composer",
   );
   const i = src.indexOf('msg.cmd === "show_media"');
@@ -1423,6 +1496,15 @@ test("onShowMedia routes through composeShowMediaReply with the storyboard pipel
   for (const dep of ["paintAudio", "paintFileLink"]) {
     assert.ok(handler[0].includes(dep), `onShowMedia must pass ${dep} through (#710)`);
   }
+});
+
+test("#2193: imageViewUrl splits a combined video/ filename before building /view", () => {
+  const fn = panelFunctionBody(panelSource(), "function imageViewUrl(");
+  assert.match(
+    fn,
+    /normalizeComfyViewRef/,
+    "onExecuted / run-completion /view URLs must split video/ the same way show_media does",
+  );
 });
 
 test("the #1620 /view probe uses the panel browser session and the same media URL", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -865,7 +865,7 @@ import {
   stripMisattachedExecutionPreviews,
 } from "./lib/execution-preview-attach.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
-import { composeShowMediaReply } from "./lib/media-preview.js";
+import { composeShowMediaReply, normalizeComfyViewRef } from "./lib/media-preview.js";
 import { appendImageCacheBust, appendStoryboardCacheBust, createStoryboardIdentity } from "./lib/storyboard-cache-identity.js";
 import {
   bindSourcePlayback,
@@ -9120,12 +9120,15 @@ function normalizeImageList(images) {
 
 /** Build a ComfyUI /view URL for an output image descriptor. */
 function imageViewUrl(img) {
+  // #2193 — ComfyUI /view basename()s `filename` and looks under `subfolder`.
+  // A combined `video/clip.mp4` with empty subfolder 404s at output/clip.mp4.
+  const ref = normalizeComfyViewRef(img, coerceMessageText) || img;
   const qs = new URLSearchParams({
     // Coerce — a structured filename/subfolder must not become "[object Object]"
     // in the media URL (which reaches the agent via imageRefs / notes) (#276).
-    filename: coerceMessageText(img.filename),
-    subfolder: coerceMessageText(img.subfolder),
-    type: coerceMessageText(img.type) || "output",
+    filename: coerceMessageText(ref.filename),
+    subfolder: coerceMessageText(ref.subfolder),
+    type: coerceMessageText(ref.type) || "output",
   }).toString();
   const path = `/view?${qs}`;
   try {

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -129,6 +129,46 @@ function extensionOf(filename) {
 
 const defaultCoerce = (v) => (typeof v === "string" ? v : v == null ? "" : String(v));
 
+/**
+ * ComfyUI's /view handler always `os.path.basename()`s `filename` and looks
+ * under `subfolder` (or the type root when that is empty). A combined
+ * `filename: "video/clip.mp4"` with no subfolder therefore 404s: the basename
+ * `clip.mp4` is sought in output/, not output/video/ (#2193).
+ *
+ * Split a combined filename the way get_image already does. An explicit
+ * subfolder is kept — ComfyUI still basenames filename and uses that
+ * subfolder — so `video/clip.mp4` + subfolder `video` does not become
+ * `video/video`.
+ *
+ * Forward slashes only: ComfyUI history and agents join with POSIX `/`. A
+ * backslash is a literal filename character on POSIX servers (#513).
+ */
+function splitViewFilename(filename) {
+  const raw = String(filename ?? "");
+  const i = raw.lastIndexOf("/");
+  if (i < 0) return { subfolder: "", filename: raw };
+  const name = raw.slice(i + 1);
+  if (!name) return { subfolder: "", filename: raw };
+  return { subfolder: raw.slice(0, i), filename: name };
+}
+
+/** Normalize a ComfyUI `{filename, subfolder?, type?}` ref for `/view`. */
+export function normalizeComfyViewRef(ref, coerce = defaultCoerce) {
+  if (!ref || typeof ref !== "object" || Array.isArray(ref)) return ref;
+  const filenameRaw = coerce(ref.filename);
+  const subfolderRaw = coerce(ref.subfolder);
+  const typeRaw = coerce(ref.type);
+  const split = splitViewFilename(filenameRaw);
+  const filename = split.filename || filenameRaw;
+  const subfolder = subfolderRaw || split.subfolder;
+  const out = { ...ref, filename };
+  if (subfolder) out.subfolder = subfolder;
+  else if ("subfolder" in ref) out.subfolder = subfolderRaw;
+  if (typeRaw) out.type = typeRaw;
+  else if (!("type" in out) || out.type == null || out.type === "") out.type = "output";
+  return out;
+}
+
 function kindForExtension(ext) {
   if (VIDEO_EXTENSIONS.has(ext)) return "video";
   if (AUDIO_EXTENSIONS.has(ext)) return "audio";
@@ -444,7 +484,10 @@ export async function composeShowMediaReply(items, deps = {}) {
     let why = null;
     let name = text(item?.filename);
     if (item?.kind === "viewRef" && item?.viewRef) {
-      ref = item.viewRef;
+      // #2193 — split `video/clip.mp4` into subfolder + basename BEFORE the
+      // /view URL is built. ComfyUI basename()s filename, so a combined path
+      // 404s even when the file is a valid output (get_image already splits).
+      ref = normalizeComfyViewRef(item.viewRef, text);
       name = text(ref.filename) || name;
       try {
         url = imageViewUrl(ref);


### PR DESCRIPTION
## Summary
ComfyUI `/view` always basename()s `filename` and looks under `subfolder` (or the type root). `panel_show_media` forwarded a combined output like `{filename:"video/H3_final_refined_2MP_00007_.mp4", type:"output"}` unchanged, so `/view` sought `output/H3_....mp4` and 404ed even though `get_history` listed the file and `get_image` fetched it.

`normalizeComfyViewRef` now splits that path into `subfolder=video` + basename before the `/view` URL is built (and before the browser probe). An explicit subfolder is kept so `video/clip.mp4` plus `subfolder:"video"` does not become `video/video`.

## Test plan
- [x] Unit: combined `video/H3_....mp4` type=output is split and `panel_show_media` paints instead of reporting `/view returned HTTP 404` (ComfyUI basename semantics).
- [x] Unit: already-split refs and duplicated `video/` + `subfolder:"video"` stay `video/clip`.
- [x] Source pin: `imageViewUrl` uses the same splitter so run-completion / onExecuted URLs match.

Fixes #2193
