### PR TITLE
fix(2194): restamp nested workflow_path without a dead-end ImpactSwitch restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_save_workflow restamps a leftover nested `extra.comfyui_mcp.workflow_path` when the canvas uuid already matches the tab, and ImpactSwitch `findInputSlot` restore failures no longer dead-end that rebind behind an unrestorable open (#2194)
+
 ## [0.15.160] - 2026-09-03
 
 ### Fixed

--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -17,6 +17,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  applySerializedNodeState,
   installNodeConfigureIsolation,
   loadRestoreCompleted,
   loadGraphDataWithCompletionProof,
@@ -787,6 +788,82 @@ test("#1668 skips the retry when the workflow changes during the settle wait", a
   assert.deepEqual(result.failed, [
     { id: 122, type: "ImpactSwitch", error: "active workflow changed during restore retry", retry: "workflow-switched" },
   ]);
+});
+
+test("#2194 applies serialized ImpactSwitch state when retry configure still throws findInputSlot", async () => {
+  const info = {
+    id: 436,
+    type: "ImpactSwitch",
+    pos: [120, 80],
+    size: [210, 90],
+    mode: 0,
+    flags: { collapsed: false },
+    properties: { ue_properties: { version: 2 } },
+    widgets_values: ["saved-select", "saved-other"],
+    widgets_values_named: { select: "saved-select" },
+  };
+  const node = {
+    id: 436,
+    type: "ImpactSwitch",
+    pos: [10, 10],
+    size: [200, 100],
+    mode: 0,
+    flags: {},
+    properties: {},
+    inputs: [{ name: "select", link: 901, widget: { name: "select" } }],
+    outputs: [],
+    widgets: [
+      { name: "select", value: 1, callback() { throw new TypeError("t.findInputSlot is not a function"); } },
+      { name: "other", value: "construction" },
+    ],
+    serialize() {
+      return {
+        id: this.id,
+        type: this.type,
+        pos: this.pos,
+        size: this.size,
+        mode: this.mode,
+        flags: this.flags,
+        properties: this.properties,
+        widgets_values: this.widgets.map((widget) => widget.value),
+        widgets_values_named: this.widgets_values_named,
+      };
+    },
+    configure() {
+      throw new TypeError("t.findInputSlot is not a function");
+    },
+  };
+  const result = await retryNodeRestores(
+    { getNodeById: () => node },
+    [{
+      id: 436,
+      type: "ImpactSwitch",
+      error: "t.findInputSlot is not a function",
+      linkDisconnectCrash: true,
+      linkDisconnectEvidence: true,
+      info,
+    }],
+  );
+  assert.deepEqual(result.restored, [{ id: 436, type: "ImpactSwitch" }]);
+  assert.deepEqual(result.failed, []);
+  assert.equal(result.recovered[0].id, 436);
+  assert.equal(node.widgets[0].value, "saved-select");
+  assert.deepEqual(node.pos, [120, 80]);
+  assert.equal(node.properties.ue_properties.version, 2);
+});
+
+test("#2194 applySerializedNodeState does not fire ImpactSwitch widget callbacks", () => {
+  let callbackCalls = 0;
+  const node = {
+    widgets: [{ name: "select", value: 1, callback() { callbackCalls += 1; } }],
+  };
+  assert.equal(
+    applySerializedNodeState(node, { widgets_values: ["saved-select"] }),
+    true,
+  );
+  assert.equal(node.widgets[0].value, "saved-select");
+  assert.equal(callbackCalls, 0);
+  assert.equal(typeof node.widgets[0].callback, "function");
 });
 
 test("#1668 cannot upgrade an unrelated initial failure from a link-shaped retry", async () => {

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -562,6 +562,34 @@ test("panel#1283 a refusal on an ABORTED restore names what aborted it", () => {
   assert.match(msg, /carries NO fence refresh/, "the recovery #702 added must still ride along");
 });
 
+test("#2194 ImpactSwitch findInputSlot defaults do not dead-end the rebind path", () => {
+  const msg = describeOpenRebindOutcome(
+    resolveOpenRebindVerdict({
+      instanceStillTarget: true,
+      markerMatches: true,
+      identityMatches: true,
+      contentMatches: false,
+    }),
+    {
+      targetLabel: "Ultimate Illustrious SDXL Detailer.json",
+      contentComparable: true,
+      contentSurfaces: ["nodes"],
+      contentNodeDifference: differing(["properties", "widgets_values", "widgets_values_named"]),
+      contentLoadRanToCompletion: false,
+      contentRestoreFailures: [
+        { id: 436, type: "ImpactSwitch", error: "t.findInputSlot is not a function" },
+      ],
+    },
+  );
+  assert.match(msg, /identity is proven/);
+  assert.match(msg, /ImpactSwitch/);
+  assert.match(msg, /CONSTRUCTION DEFAULTS/);
+  assert.match(msg, /persist\/rebind/);
+  assert.match(msg, /fail closed/);
+  assert.doesNotMatch(msg, /Do NOT save from here/);
+  assert.doesNotMatch(msg, /then open again/);
+});
+
 test("panel#1283 an aborted restore whose difference is only COSMETIC still refuses, and says so", () => {
   // The dangerous combination: `pos` moved (cosmetic) AND a node threw. #1623's reassurance
   // would have fired — "you are on the right workflow and there is no missing work to redo" —

--- a/browser_tests/unit/save-path-guard.test.mjs
+++ b/browser_tests/unit/save-path-guard.test.mjs
@@ -35,6 +35,7 @@ import { dirname, join } from "node:path";
 
 import {
   decideWorkflowSaveVerdict,
+  rebindForeignStampIfIdentityMatches,
   workflowSaveRefusalError,
   SAVE_PATH_GUARD_REASON,
 } from "../../web/js/lib/save-path-guard.js";
@@ -143,6 +144,55 @@ test("#1667 the refusal names both paths, states NOTHING was written, and names 
   // Honesty pin: the message must present the two readings, not assert one cause.
   assert.match(err.message, /stale/);
   assert.match(err.message, /deliberately/);
+  // #2194 — open-then-restore is no longer the only recovery; a matching uuid
+  // restamps the nested path without requiring ImpactSwitch configure to succeed.
+  assert.match(err.message, /restamping extra\.comfyui_mcp\.workflow_path/);
+  assert.match(err.message, /fail closed/);
+});
+
+test("#2194 matching canvas uuid restamps a nested leftover path", () => {
+  const state = {
+    extra: {
+      comfyui_mcp: {
+        workflow_uuid: "tab-uuid",
+        workflow_path: "workflows/iKki/Ultimate Illustrious SDXL Detailer.json",
+      },
+    },
+  };
+  assert.equal(
+    rebindForeignStampIfIdentityMatches({
+      state,
+      destinationPath: "workflows/Ultimate Illustrious SDXL Detailer.json",
+      destinationUuid: "tab-uuid",
+    }),
+    true,
+  );
+  assert.equal(state.extra.comfyui_mcp.workflow_path, "workflows/Ultimate Illustrious SDXL Detailer.json");
+});
+
+test("#2194 disagreeing or missing uuid fails closed — no restamp, no overwrite", () => {
+  const nested = "workflows/iKki/Ultimate Illustrious SDXL Detailer.json";
+  for (const { destinationUuid, stampedUuid } of [
+    { destinationUuid: "tab-a", stampedUuid: "tab-b" },
+    { destinationUuid: "tab-a", stampedUuid: "" },
+    { destinationUuid: "", stampedUuid: "tab-a" },
+    { destinationUuid: null, stampedUuid: "tab-a" },
+    { destinationUuid: "tab-a", stampedUuid: null },
+  ]) {
+    const state = {
+      extra: { comfyui_mcp: { workflow_uuid: stampedUuid, workflow_path: nested } },
+    };
+    assert.equal(
+      rebindForeignStampIfIdentityMatches({
+        state,
+        destinationPath: "workflows/Ultimate Illustrious SDXL Detailer.json",
+        destinationUuid,
+      }),
+      false,
+      `${JSON.stringify({ destinationUuid, stampedUuid })} must not restamp`,
+    );
+    assert.equal(state.extra.comfyui_mcp.workflow_path, nested);
+  }
 });
 
 test("#1667 a verdict with missing paths still produces a coherent refusal", () => {
@@ -187,7 +237,9 @@ function buildInstaller() {
     "WORKFLOW_PATH_FIELD",
     "sameWorkflowObject",
     "decideWorkflowSaveVerdict",
+    "rebindForeignStampIfIdentityMatches",
     "workflowSaveRefusalError",
+    "workflowObjectUuid",
     "activeWorkflowRef",
     "trackerCaptureSuppressed",
     "trackerExposesCaptureComparator",
@@ -207,7 +259,9 @@ function buildInstaller() {
         "workflow_path",
         sameWorkflowObject,
         decideWorkflowSaveVerdict,
+        rebindForeignStampIfIdentityMatches,
         workflowSaveRefusalError,
+        (wf) => wf?.uuid ?? null,
         () => activeWorkflow,
         trackerCaptureSuppressed,
         trackerExposesCaptureComparator,
@@ -246,6 +300,34 @@ function fakeStore({ stampedPath } = {}) {
   };
   return { store, wfA, appRef: { extensionManager: { workflow: store } } };
 }
+
+test("#2194 WRAPPER: a nested leftover path with matching uuid restamps and saves", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const install = build();
+  const { store, wfA, appRef } = fakeStore({
+    stampedPath: "workflows/B.json",
+  });
+  wfA.uuid = "tab-uuid";
+  wfA.changeTracker.activeState.extra.comfyui_mcp.workflow_uuid = "tab-uuid";
+  install(appRef);
+  await store.saveWorkflow(wfA);
+  assert.deepEqual(store.saved, ["workflows/A.json"]);
+  assert.equal(wfA.changeTracker.activeState.extra.comfyui_mcp.workflow_path, "workflows/A.json");
+});
+
+test("#2194 WRAPPER: a nested leftover path with a FOREIGN uuid is still refused", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const install = build();
+  const { store, wfA, appRef } = fakeStore({
+    stampedPath: "workflows/B.json",
+  });
+  wfA.uuid = "tab-a";
+  wfA.changeTracker.activeState.extra.comfyui_mcp.workflow_uuid = "tab-b";
+  install(appRef);
+  await assert.rejects(() => store.saveWorkflow(wfA), /REFUSED to save/);
+  assert.deepEqual(store.saved, []);
+  assert.equal(wfA.changeTracker.activeState.extra.comfyui_mcp.workflow_path, "workflows/B.json");
+});
 
 test("#1667 WRAPPER: a crossed save is refused and the original save is NEVER called", async () => {
   const { buildInstaller: build } = buildInstaller();
@@ -525,6 +607,20 @@ test("#1563 r2 WRAPPER: the reported case still refuses — comparability is a f
   install(fx.appRef);
   await assert.rejects(() => fx.store.saveWorkflow(fx.wfA), /BEHIND the live canvas/);
   assert.deepEqual(fx.store.saved, []);
+});
+
+test("#2194 WIRING: the save funnel restamps a matching-uuid leftover path before refusing", () => {
+  const source = PANEL_SRC();
+  const decide = source.indexOf("verdict = decideWorkflowSaveVerdict({");
+  assert.ok(decide > 0);
+  const body = source.slice(decide, source.indexOf("if (!verdict.allow)", decide) + 80);
+  assert.match(body, /rebindForeignStampIfIdentityMatches\(\{/);
+  assert.match(body, /destinationUuid: typeof workflowObjectUuid === "function"/);
+  assert.match(body, /verdict = \{ allow: true \}/);
+  assert.ok(
+    body.indexOf("rebindForeignStampIfIdentityMatches") < body.indexOf('if (!verdict.allow)'),
+    "the restamp must run before the refusal throw",
+  );
 });
 
 test("#1563 WIRING: the wrapper passes its own observation, not a constant", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -214,7 +214,11 @@ import {
   pruneGroundingIdentities,
   groundedWorkflowPath,
 } from "./lib/workflow-chat-identity.js";
-import { decideWorkflowSaveVerdict, workflowSaveRefusalError } from "./lib/save-path-guard.js";
+import {
+  decideWorkflowSaveVerdict,
+  rebindForeignStampIfIdentityMatches,
+  workflowSaveRefusalError,
+} from "./lib/save-path-guard.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import {
@@ -4695,6 +4699,35 @@ function installSavePathGuard(appRef) {
           // never be looking at different things.
           snapshotIsStale: saveWouldPersistStaleSnapshot(wf, state),
         });
+        // #2194 — leftover nested workflow_path on THIS tab's uuid. Restamp the
+        // snapshot (and the live extra when it carries the same uuid) so save
+        // does not send the caller through panel_open_workflow, whose ImpactSwitch
+        // restore can dead-end. Fail closed when uuid is missing or disagrees.
+        // `typeof` keeps a sliced test installer fail-closed if the helper is not
+        // injected — a throw here would hit the outer catch and ALLOW the write.
+        if (
+          verdict?.allow === false &&
+          verdict.reason === "stamped_path_foreign" &&
+          typeof rebindForeignStampIfIdentityMatches === "function" &&
+          rebindForeignStampIfIdentityMatches({
+            state,
+            destinationPath: wf?.path ?? null,
+            destinationUuid: typeof workflowObjectUuid === "function" ? workflowObjectUuid(wf) || null : null,
+          })
+        ) {
+          try {
+            const destUuid = typeof workflowObjectUuid === "function" ? workflowObjectUuid(wf) || null : null;
+            const liveExtra =
+              appRef?.rootGraph?.extra?.[WORKFLOW_META_NAMESPACE] ??
+              (typeof app !== "undefined" ? app?.rootGraph?.extra?.[WORKFLOW_META_NAMESPACE] : null);
+            if (liveExtra && destUuid && liveExtra[WORKFLOW_UUID_FIELD] === destUuid) {
+              liveExtra[WORKFLOW_PATH_FIELD] = wf.path;
+            }
+          } catch {
+            /* snapshot stamp is what the write serializes */
+          }
+          verdict = { allow: true };
+        }
       } catch {
         verdict = { allow: true }; // a guard that cannot read its evidence must never invent a refusal
       }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -2265,6 +2265,19 @@ function abortedRestoreClause(observed = {}) {
       `byte-identical, which is why the content stays unconfirmed rather than applied`
     );
   }
+  const impactSwitchSlotFailure = failures.every((failure) => {
+    const type = String(failure?.type ?? "");
+    const error = String(failure?.error ?? "");
+    return type === "ImpactSwitch" && /find(Input|Output)Slot is not a function/.test(error);
+  });
+  if (impactSwitchSlotFailure) {
+    return (
+      `. AND THE RESTORE DID NOT RUN TO COMPLETION: ${failures.length} ImpactSwitch node(s) ` +
+      `are still at CONSTRUCTION DEFAULTS after a post-load retry — ${named}` +
+      (failures.length > 10 ? `, and ${failures.length - 10} more` : "") +
+      `. Do not re-open to heal them: persist/rebind the path stamp when identity matches`
+    );
+  }
   return (
     `. AND THE RESTORE DID NOT RUN TO COMPLETION: the panel watched this load and ` +
     `${failures.length} node(s) are still at CONSTRUCTION DEFAULTS after a post-load retry — ` +
@@ -2432,6 +2445,35 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
     // A reply that says two opposite things about one observation is the defect #1623 was
     // reported for, one level down.
     if (compared && observed.contentLoadRanToCompletion === false) {
+      const restoreFailures = Array.isArray(observed.contentRestoreFailures)
+        ? observed.contentRestoreFailures
+        : [];
+      const impactSwitchSlotFailure =
+        restoreFailures.length > 0 &&
+        restoreFailures.every((failure) => {
+          const type = String(failure?.type ?? "");
+          const error = String(failure?.error ?? "");
+          return (
+            type === "ImpactSwitch" &&
+            /find(Input|Output)Slot is not a function/.test(error)
+          );
+        });
+      if (impactSwitchSlotFailure) {
+        // #2194 — identity is proven; another open/restore of these defaulted
+        // ImpactSwitch nodes is the dead end the save-path recovery used to
+        // recommend. Persist/rebind the path stamp when uuid matches; fail
+        // closed if it does not.
+        return (
+          `workflow_open RAN and the canvas IS bound to ${workflow} — identity is proven — but ` +
+          `ImpactSwitch restore left node(s) at CONSTRUCTION DEFAULTS after t.findInputSlot is not ` +
+          `a function.${because} Do NOT re-open this tab to heal it: another restore of those ` +
+          `broken defaulted nodes is the same dead end. Identity is settled, so persist/rebind ` +
+          `extra.comfyui_mcp.workflow_path onto this file without requiring those nodes to ` +
+          `configure cleanly, then save. If the canvas uuid does NOT match this tab, fail closed ` +
+          `— that is a foreign graph and must not overwrite ${workflow}.` +
+          FENCE_NOT_REFRESHED
+        );
+      }
       return (
         `workflow_open RAN and the canvas IS bound to ${workflow} — that much was proven — but the ` +
         `RESTORE ITSELF DID NOT FINISH, so the graph on the canvas is not what was loaded. This is ` +

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -198,6 +198,87 @@ export function verifyNodeRestore(node, info) {
   }
 }
 
+/**
+ * #2194 — apply a node's serialized restore payload WITHOUT `configure()`.
+ *
+ * ImpactSwitch (and the same LiteGraph link-restore path) can throw
+ * `t.findInputSlot is not a function` while `configure` is still applying
+ * saved widgets/properties. Re-invoking `configure` repeats that throw and
+ * leaves the node at construction defaults. Copying the snapshot onto the
+ * already-created node does not call the slot lookup, so a later
+ * `verifyNodeRestore` can accept the saved values.
+ *
+ * Widget callbacks are silenced for the assignment: ImpactSwitch's `select`
+ * callback is the same hook that throws.
+ */
+export function applySerializedNodeState(node, info) {
+  if (!node || !info || typeof info !== "object") return false;
+  try {
+    if (Array.isArray(info.pos)) node.pos = info.pos.slice();
+    if (Array.isArray(info.size)) node.size = info.size.slice();
+    if (info.mode != null) node.mode = info.mode;
+    if (typeof info.title === "string") node.title = info.title;
+    if (Object.prototype.hasOwnProperty.call(info, "color")) node.color = info.color;
+    if (Object.prototype.hasOwnProperty.call(info, "bgcolor")) node.bgcolor = info.bgcolor;
+    if (info.flags && typeof info.flags === "object") {
+      node.flags = cloneSerializedValue(info.flags);
+    }
+    if (info.properties && typeof info.properties === "object") {
+      node.properties = cloneSerializedValue(info.properties);
+    }
+    if (info.widgets_values_named && typeof info.widgets_values_named === "object") {
+      node.widgets_values_named = cloneSerializedValue(info.widgets_values_named);
+    }
+    const values = info.widgets_values;
+    if (Array.isArray(values)) {
+      node.widgets_values = cloneSerializedValue(values);
+      const widgets = Array.isArray(node.widgets)
+        ? node.widgets.filter((widget) => widget && widget.serialize !== false)
+        : [];
+      for (let index = 0; index < Math.min(values.length, widgets.length); index += 1) {
+        const widget = widgets[index];
+        const callback = widget.callback;
+        try {
+          widget.callback = undefined;
+          widget.value = cloneSerializedValue(values[index]);
+        } finally {
+          widget.callback = callback;
+        }
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function recoveredRestoreReceipt(failure, verification) {
+  const ownerGraphToken = failure.ownerGraphToken ?? graphIdentityToken(failure.ownerGraph);
+  return {
+    restored: { id: failure.id, type: failure.type },
+    recovered: {
+      id: failure.id,
+      type: failure.type,
+      ...(ownerGraphToken != null ? { ownerGraphToken } : {}),
+      linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences,
+    },
+  };
+}
+
+function recoverBySerializedState(node, failure) {
+  const infoHasWidgets = Array.isArray(failure?.info?.widgets_values) && failure.info.widgets_values.length > 0;
+  const liveWidgets = Array.isArray(node?.widgets)
+    ? node.widgets.filter((widget) => widget && widget.serialize !== false)
+    : [];
+  // serialize() after a throwing configure is not proof (#1668). Snapshot
+  // recovery is only for a node that still has live widgets to copy onto.
+  if (infoHasWidgets && liveWidgets.length === 0) return null;
+  if (!applySerializedNodeState(node, failure.info)) return null;
+  const verification = verifyNodeRestore(node, failure.info);
+  if (!verification.verified) return null;
+  return recoveredRestoreReceipt(failure, verification);
+}
+
 function waitForLinkStateToSettle() {
   return new Promise((resolve) => {
     let settled = false;
@@ -347,6 +428,12 @@ export function installNodeConfigureIsolation(LG, graph = null) {
         // retain an independent serialized snapshot for the retry/verification.
         info: serializedSnapshot,
       });
+      // #2194 — a findInputSlot throw aborts configure after construction. Copy
+      // the snapshot now so later nodes are not the only ones restored, and so
+      // the retry can verify instead of re-entering the throwing connect path.
+      if (isLinkDisconnectCrash(err) && serializedSnapshot) {
+        applySerializedNodeState(this, serializedSnapshot);
+      }
       return undefined;
     } finally {
       if (callbackWrapper && this.onConnectionsChange === callbackWrapper) {
@@ -481,14 +568,15 @@ export async function retryNodeRestores(graph, failures, options = {}) {
       // strict snapshot check is the only safe way to accept this path.
       const verification = verifyNodeRestore(node, failure.info);
       if (verification.verified) {
-        restored.push({ id: failure.id, type: failure.type });
-        const ownerGraphToken = failure.ownerGraphToken ?? graphIdentityToken(failure.ownerGraph);
-        recovered.push({
-          id: failure.id,
-          type: failure.type,
-          ...(ownerGraphToken != null ? { ownerGraphToken } : {}),
-          linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences,
-        });
+        const receipt = recoveredRestoreReceipt(failure, verification);
+        restored.push(receipt.restored);
+        recovered.push(receipt.recovered);
+        continue;
+      }
+      const snapshotRecovery = recoverBySerializedState(node, failure);
+      if (snapshotRecovery) {
+        restored.push(snapshotRecovery.restored);
+        recovered.push(snapshotRecovery.recovered);
         continue;
       }
       failed.push({
@@ -518,23 +606,30 @@ export async function retryNodeRestores(graph, failures, options = {}) {
       retryError = err;
     }
     if (linkDisconnectCrash) {
-      // The initial crash makes the retry worth attempting, but ANY exception
-      // from that retry means configure still failed. Serialization after a
-      // throwing configure is not proof that the node was restored.
+      // The initial crash makes the retry worth attempting. If configure throws
+      // the same findInputSlot shape again, do not dead-end: apply the snapshot
+      // without the throwing connect path and verify (#2194).
       if (retryError) {
+        const snapshotRecovery = isLinkDisconnectCrash(retryError) ? recoverBySerializedState(node, failure) : null;
+        if (snapshotRecovery) {
+          restored.push(snapshotRecovery.restored);
+          recovered.push(snapshotRecovery.recovered);
+          continue;
+        }
         failed.push({ id: failure.id, type: failure.type, error: errorText(retryError) });
         continue;
       }
       const verification = verifyNodeRestore(node, failure.info);
       if (verification.verified) {
-        restored.push({ id: failure.id, type: failure.type });
-        const ownerGraphToken = failure.ownerGraphToken ?? graphIdentityToken(failure.ownerGraph);
-        recovered.push({
-          id: failure.id,
-          type: failure.type,
-          ...(ownerGraphToken != null ? { ownerGraphToken } : {}),
-          linkDrivenWidgetDifferences: verification.linkDrivenWidgetDifferences,
-        });
+        const receipt = recoveredRestoreReceipt(failure, verification);
+        restored.push(receipt.restored);
+        recovered.push(receipt.recovered);
+        continue;
+      }
+      const snapshotRecovery = recoverBySerializedState(node, failure);
+      if (snapshotRecovery) {
+        restored.push(snapshotRecovery.restored);
+        recovered.push(snapshotRecovery.recovered);
         continue;
       }
       failed.push({

--- a/web/js/lib/save-path-guard.js
+++ b/web/js/lib/save-path-guard.js
@@ -142,6 +142,33 @@ export function decideWorkflowSaveVerdict({
 }
 
 /**
+ * #2194 — restamp a leftover nested `workflow_path` when graph identity is THIS
+ * tab's, so save does not require `panel_open_workflow` (whose restore can leave
+ * ImpactSwitch nodes at construction defaults).
+ *
+ * Fail closed unless both uuids are non-empty strings and equal: a missing or
+ * disagreeing identity is the #1667 foreign-canvas case and must not overwrite.
+ *
+ * Mutates `state.extra.comfyui_mcp.workflow_path` only. Returns true when the
+ * stamp now names the destination.
+ */
+export function rebindForeignStampIfIdentityMatches({
+  state,
+  destinationPath,
+  destinationUuid,
+} = {}) {
+  if (typeof destinationUuid !== "string" || !destinationUuid) return false;
+  if (typeof destinationPath !== "string" || !destinationPath) return false;
+  const extra = state?.extra?.comfyui_mcp;
+  const stampedUuid = extra?.workflow_uuid;
+  if (typeof stampedUuid !== "string" || !stampedUuid) return false;
+  if (stampedUuid !== destinationUuid) return false;
+  if (!extra || typeof extra !== "object" || Array.isArray(extra)) return false;
+  extra.workflow_path = destinationPath;
+  return true;
+}
+
+/**
  * The refusal a blocked save throws. States what was compared, what was NOT written,
  * both readings of the evidence (stale canvas vs deliberate copy), and the recovery.
  * Deliberately does not claim which reading is true — the panel cannot tell them apart;
@@ -178,8 +205,11 @@ export function workflowSaveRefusalError(verdict) {
       `belong to it — this is the #1667 stale-canvas data-loss guard, and NOTHING was written. ` +
       `Either this tab's canvas is stale (mounted from another workflow — reload the file from ` +
       `disk before losing it), or you deliberately built this content under a copied identity. ` +
-      `If the canvas really is what you want in "${dest}", re-bind the tab first — open the ` +
-      `workflow via panel_open_workflow so its identity is re-verified against the file — then ` +
-      `save again.`,
+      `If the canvas uuid already matches this tab, persist by restamping extra.comfyui_mcp.workflow_path ` +
+      `to "${dest}" — that rebind does not require a clean restore of ImpactSwitch nodes that throw ` +
+      `findInputSlot and stay at construction defaults. Do NOT open-then-restore as the only path: ` +
+      `panel_open_workflow can report identity match, leave those nodes unrestored, and then forbid ` +
+      `save (panel#2194). If the canvas uuid does NOT match this tab, fail closed — that is a ` +
+      `foreign graph and must not overwrite "${dest}".`,
   );
 }


### PR DESCRIPTION
## Summary
Fixes #2194.

`panel_save_workflow` refused an in-place overwrite when `extra.comfyui_mcp.workflow_path` named a nested sibling file. The recovery hint was `panel_open_workflow`, which could report an identity match while ImpactSwitch threw `t.findInputSlot is not a function` and left nodes at construction defaults. The panel then forbade save, so an approved canvas change could not be persisted.

## Approach
- When the canvas uuid already matches the destination tab, restamp the leftover `workflow_path` and allow the write. A missing or disagreeing uuid still fails closed (#1667 foreign canvas).
- When ImpactSwitch `configure` still throws `findInputSlot` on retry, copy the serialized snapshot onto live widgets instead of re-entering the throwing connect path.
- Open/save copy no longer tells the caller that open-then-restore is the only exit.

## Tests
`npm run test:unit` — 8231 pass, 0 fail, 1 todo.