### PR TITLE
fix(2050): adaptive object_info fetch budget so add_node lands after large installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- After a large custom-node install, adding a node waits for /object_info with an adaptive command-budget cap instead of a fixed 10s fetch, and still refuses if the schema never arrives (#2050)
+
+
 ## [0.15.161] - 2026-09-03
 
 ### Fixed

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -20,6 +20,7 @@ import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-previ
 import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { OBJECT_INFO_DEADLINE_MS } from "../../web/js/lib/object-info-oracle.js";
+import { objectInfoFetchBudgetMs } from "../../web/js/lib/object-info-probe-budget.js";
 import { COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
 import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
@@ -250,6 +251,11 @@ export function addNodeCommandBudgetDeps() {
     safeRemoveNode,
     // #2029 — graph_add_node arms inert control_after_generate combos after graph.add.
     ensureControlAfterGenerateQueueHooks,
+    // #2050 — adaptive whole-schema wait. Harnesses that rebuild graph_add_node must
+    // name these or the resolver reports a false "object_info is unavailable".
+    objectInfoFetchBudgetMs,
+    lastWholeObjectInfoMs: 0,
+    noteWholeObjectInfoDuration: () => {},
   };
 }
 

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -65,6 +65,7 @@ import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 import { createVerifiedNodeDefCache } from "../../web/js/lib/verified-node-def-cache.js";
 import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
 import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
+import { objectInfoFetchBudgetMs } from "../../web/js/lib/object-info-probe-budget.js";
 import { reconcileFreshDynamicWidgets } from "../../web/js/lib/dynamic-widget-reconcile.js";
 import { safeRemoveNode } from "../../web/js/lib/safe-remove-node.js";
 import { ensureControlAfterGenerateQueueHooks } from "../../web/js/lib/control-after-generate.js";
@@ -407,6 +408,9 @@ function realGraphAddNode({
     OBJECT_INFO_SEED_WAIT_MS: 8000,
     ADD_NODE_COMMAND_BUDGET_MS: budgetMs,
     ADD_NODE_POST_REFRESH_RESERVE_MS: reserveMs,
+    objectInfoFetchBudgetMs,
+    lastWholeObjectInfoMs: 0,
+    noteWholeObjectInfoDuration: () => {},
     ...overrides,
   };
 
@@ -1336,11 +1340,12 @@ test("#1192: an ALREADY-registered class takes the fast path and never reaches t
 // ---------------------------------------------------------------------------
 
 test("#1192: a /object_info read that eats the budget leaves the add a bound, not a hang", async () => {
-  // The whole-schema fetch draws `budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS)`. With the
-  // command nearly spent that is a small number, and the add fails closed on the path an
-  // unreadable schema already takes — rather than parking on a 10s bound the command cannot
-  // afford. Both live routes must hang: #2050 asks `/object_info/<Type>` after the whole
-  // dump is silent, and a working per-class route is the success path for that issue.
+  // The whole-schema fetch draws `budget.bounded(wholeFetchMs)` from the remaining command
+  // budget. With the command nearly spent that is a small number, and the add fails closed
+  // on the path an unreadable schema already takes — rather than parking on a 10s bound the
+  // command cannot afford. Both live routes must hang: #2050 asks `/object_info/<Type>`
+  // after the whole dump is silent, and a working per-class route is the success path for
+  // that issue.
   const comfy = makeComfy();
   const built = realGraphAddNode({
     comfy,
@@ -1803,4 +1808,38 @@ test("#2050: graph_add_node asks the per-class route after a silent whole dump",
     /wholeUsable[\s\S]*!isRegisteredNodeType/,
     "the fallback is gated on a silent whole dump AND an unregistered class",
   );
+  assert.match(
+    body,
+    /objectInfoFetchBudgetMs\([\s\S]*?floorMs:\s*NODE_DEFS_FETCH_TIMEOUT_MS/,
+    "the whole dump wait is adaptive, not a nested 10s floor alone",
+  );
+  assert.match(
+    body,
+    /boundedGetNodeDefs\(budget\.bounded\(wholeFetchMs\)\)/,
+    "the adaptive wait is still command-capped",
+  );
+});
+
+test("#2050: a whole dump slower than the 10s floor still adds inside the command budget", async () => {
+  // Per-class hangs so the type-scoped fallback cannot rescue a too-short whole wait.
+  // The old nested 10s floor, injected here as 80ms, would abandon this 250ms dump.
+  const comfy = makeComfy();
+  const built = realGraphAddNode({
+    comfy,
+    budgetMs: 2000,
+    overrides: {
+      NODE_DEFS_FETCH_TIMEOUT_MS: 80,
+      api: {
+        getNodeDefs: async () => {
+          await sleep(250);
+          return backendObjectInfo();
+        },
+        fetchApi: () => new Promise(() => {}),
+      },
+    },
+  });
+  const started = Date.now();
+  const { added } = await built.graph_add_node({ class_type: "NewNode" });
+  assert.equal(added.type, "NewNode");
+  assert.ok(Date.now() - started < 1800, "the dump must be waited out, not abandoned at the 80ms floor");
 });

--- a/browser_tests/unit/object-info-probe-budget.test.mjs
+++ b/browser_tests/unit/object-info-probe-budget.test.mjs
@@ -4,8 +4,10 @@ import { readFileSync } from "node:fs";
 
 import {
   objectInfoSnapshotProbeDeadline,
+  objectInfoFetchBudgetMs,
   OBJECT_INFO_SNAPSHOT_PROBE_DEADLINE_MS,
   OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS,
+  OBJECT_INFO_FETCH_MARGIN,
 } from "../../web/js/lib/object-info-probe-budget.js";
 
 const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
@@ -48,6 +50,35 @@ test("#1734 treats an unknown origin conservatively without becoming unbounded",
     );
   }
   assert.ok(OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS < 25_000);
+});
+
+test("#2050: a large-install whole-schema wait uses remaining command time, not only the 10s floor", () => {
+  assert.equal(
+    objectInfoFetchBudgetMs({ remainingMs: 25000, floorMs: 10000, ceilingMs: 25000 }),
+    25000,
+    "with no prior duration the first fetch may spend what the command still has",
+  );
+  assert.equal(
+    objectInfoFetchBudgetMs({ remainingMs: 200, floorMs: 10000, ceilingMs: 25000 }),
+    200,
+    "a nearly-spent command still bounds; it does not restore the 10s floor",
+  );
+  assert.equal(
+    objectInfoFetchBudgetMs({ observedMs: 20840, remainingMs: 25000, floorMs: 10000, ceilingMs: 25000 }),
+    25000,
+    "a prior 20.84s dump pads the next wait up to the command ceiling",
+  );
+  assert.ok(OBJECT_INFO_FETCH_MARGIN >= 1);
+  assert.equal(
+    objectInfoFetchBudgetMs({ remainingMs: 0, floorMs: 10000 }),
+    1,
+    "an exhausted budget yields 1ms so withTimeout still bounds",
+  );
+  assert.equal(
+    objectInfoFetchBudgetMs({ remainingMs: -5, floorMs: 10000 }),
+    1,
+    "a negative remainder is fail-closed, never unbounded",
+  );
 });
 
 test("#1734 production wiring selects from the page origin and keeps command bounding", () => {

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -1456,6 +1456,8 @@ function buildShippedSeed({
      let seeded = false;
      const recordObjectInfoTypes = (defs) => { recorded.push(defs); return defs; };
      const markObjectInfoHistorySeeded = () => { seeded = true; return true; };
+     const monotonicNow = () => 0;
+     const noteWholeObjectInfoDuration = () => {};
      ${body}
      return {
        run: () => seedObjectInfoHistory(),

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -204,7 +204,7 @@ test("#767 WIRING: the fast path is gated on the type ALREADY being registered",
   // which read as agreement with set_widget only by coincidence.
   assert.match(
     body,
-    /await boundedGetNodeDefs\(budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)\)/,
+    /await boundedGetNodeDefs\(budget\.bounded\(wholeFetchMs\)\)/,
     "the whole-schema fallback must still be there, bounded by the command budget",
   );
   assert.match(
@@ -691,12 +691,12 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
   // Every step draws from it. Named individually rather than counted, so adding a step
   // cannot silently satisfy a total.
   const wired = [
-    [/await awaitObjectInfoHistorySeed\(budget\.bounded\(OBJECT_INFO_SEED_WAIT_MS\)\)/, "the baseline seed wait"],
+    [/await awaitObjectInfoHistorySeed\(\s*budget\.bounded\(\s*objectInfoFetchBudgetMs\(/, "the baseline seed wait"],
     [
       /fetchSingleNodeInfo\(class_type[\s\S]{0,400}?budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)/,
       "the single-class fast path",
     ],
-    [/await boundedGetNodeDefs\(budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)\)/, "the whole-schema fetch"],
+    [/await boundedGetNodeDefs\(budget\.bounded\(wholeFetchMs\)\)/, "the whole-schema fetch"],
     // The fifth wait — the coalescer join — is NOT a row here. #1385: it has two call sites,
     // so a body-wide match is satisfied by whichever one is left. It is pinned per call site
     // below instead.
@@ -709,6 +709,8 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
   // …and NO step may still name one of those constants raw. This is what catches a bound
   // added to this path LATER: the failure mode is not that an existing site regresses, it is
   // that the sixth site nobody thought about is written the way the first five used to be.
+  // #2050 — seed wait and the whole dump take an adaptive floor through objectInfoFetchBudgetMs
+  // and THEN `budget.bounded(that)`, so `floorMs: NAME` is still command-capped.
   const stripped = body.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
   for (const name of [
     "OBJECT_INFO_SEED_WAIT_MS",
@@ -717,12 +719,18 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
   ]) {
     const total = (stripped.match(new RegExp(name, "g")) ?? []).length;
     const capped = (stripped.match(new RegExp(`budget\\.bounded\\(${name}\\)`, "g")) ?? []).length;
+    const floor = (stripped.match(new RegExp(`floorMs:\\s*${name}`, "g")) ?? []).length;
     assert.equal(
       total,
-      capped,
-      `${name} appears ${total} time(s) in graph_add_node but only ${capped} are capped by the command budget`,
+      capped + floor,
+      `${name} appears ${total} time(s) in graph_add_node but only ${capped + floor} are command-capped (bounded or adaptive floor)`,
     );
   }
+  assert.match(
+    body,
+    /objectInfoFetchBudgetMs\(\{[\s\S]*?floorMs:\s*NODE_DEFS_FETCH_TIMEOUT_MS/,
+    "the whole-schema fetch must size its wait from the remaining command budget, not a nested 10s floor alone",
+  );
 
   // ── THE FIFTH WAIT: EVERY coalescer call, not "one of them somewhere" ─────────
   //

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -377,7 +377,7 @@ import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
 import { createSettingsBackendDefault } from "./lib/settings-backend-default.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
-import { objectInfoSnapshotProbeDeadline } from "./lib/object-info-probe-budget.js";
+import { objectInfoSnapshotProbeDeadline, objectInfoFetchBudgetMs } from "./lib/object-info-probe-budget.js";
 import {
   fetchWholeObjectInfo,
   objectInfoOracleFailureNote,
@@ -1633,6 +1633,13 @@ function monotonicNow() {
 // unit-testable rather than loose module state in this bundle.
 const objectInfoHistory = createObjectInfoHistory();
 const recordObjectInfoTypes = (defs) => objectInfoHistory.recordTypes(defs);
+// #2050 — last successful whole-schema duration on this tab, so the next add can wait
+// that long instead of the warm-install 10s floor. Zero until a fetch actually lands.
+let lastWholeObjectInfoMs = 0;
+function noteWholeObjectInfoDuration(startedAt) {
+  const elapsed = monotonicNow() - startedAt;
+  if (Number.isFinite(elapsed) && elapsed > 0) lastWholeObjectInfoMs = elapsed;
+}
 // ONLY seedObjectInfoHistory() may call this. See the RECORD ONLY note in
 // registerComfyNodeDefs: any observation taken after an unobserved window cannot support
 // the "never backend-defined this session" claim a baseline makes.
@@ -1674,8 +1681,10 @@ function seedObjectInfoHistory() {
           // out — found no snapshot and was refused exactly as before the fix.
           const observedAtEpoch = backendReconnectEpoch;
           const observedAtGeneration = verifiedNodeDefCache.generation();
+          const fetchStartedAt = monotonicNow();
           const defs = await api.getNodeDefs();
           if (defs && typeof defs === "object" && Object.keys(defs).length > 0) {
+            noteWholeObjectInfoDuration(fetchStartedAt);
             const currentEpoch = backendReconnectEpoch;
             const currentGeneration = verifiedNodeDefCache.generation();
             if (currentEpoch !== observedAtEpoch || currentGeneration !== observedAtGeneration) continue;
@@ -15971,7 +15980,19 @@ const GRAPH_TOOL_EXECUTORS = {
     // seeds, so the next call succeeds without a reload.
     // #1192 — capped by the command budget. Standalone this waits 8000ms, which is a third
     // of the whole command spent before the backend has even been asked what it provides.
-    await awaitObjectInfoHistorySeed(budget.bounded(OBJECT_INFO_SEED_WAIT_MS));
+    // #2050 — a large-install seed is the same whole dump the 10s tool cap cannot finish.
+    // Wait up to what this command still has (padded by a prior success), so the seed can
+    // land and the add can consume it instead of starting a competing getNodeDefs.
+    await awaitObjectInfoHistorySeed(
+      budget.bounded(
+        objectInfoFetchBudgetMs({
+          observedMs: lastWholeObjectInfoMs,
+          remainingMs: budget.remaining(),
+          floorMs: OBJECT_INFO_SEED_WAIT_MS,
+          ceilingMs: ADD_NODE_COMMAND_BUDGET_MS,
+        }),
+      ),
+    );
     // Captured from the SAME fresh /object_info the resolvability assert just
     // fetched. The widget guards below scan THIS def — the backend's current
     // truth — not the possibly-stale registered nodeData: frontend-injected
@@ -16096,15 +16117,20 @@ const GRAPH_TOOL_EXECUTORS = {
           epoch: backendReconnectEpoch,
         };
         addNodeObservedAtEpoch = issued.epoch;
-        // #1192 — allowed 10,000 ms here, capped by the caller's remaining budget.
-        // #1418 — what this comment used to claim about the OTHER path was never true: it
-        // said `graph_set_widget`'s oracle "allows 10,000 ms" and that both were capped, but
-        // that oracle is fetchWholeObjectInfo at OBJECT_INFO_DEADLINE_MS (20,000 ms), and
-        // nothing capped it until #1418 gave it the same budget.bounded(...) treatment. The
-        // two paths genuinely agree now. The earlier sentence is left corrected rather than
-        // deleted because it did real harm twice: a reassurance-shaped claim concealed the
-        // very next occurrence of the defect it described (#1413's note, then this one).
-        const whole = await boundedGetNodeDefs(budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS));
+        // #1192 — capped by the caller's remaining budget.
+        // #2050 — that remainder IS the bound on a large install, not a nested 10s floor:
+        // a 21s `/object_info` completes inside the 25s command and is abandoned at 10s
+        // otherwise. A prior success pads the next wait; a never-arriving schema still
+        // fails closed at whatever this command has left.
+        const wholeFetchMs = objectInfoFetchBudgetMs({
+          observedMs: lastWholeObjectInfoMs,
+          remainingMs: budget.remaining(),
+          floorMs: NODE_DEFS_FETCH_TIMEOUT_MS,
+          ceilingMs: ADD_NODE_COMMAND_BUDGET_MS,
+        });
+        const fetchStartedAt = monotonicNow();
+        const whole = await boundedGetNodeDefs(budget.bounded(wholeFetchMs));
+        if (whole && whole !== NODE_DEFS_NO_ANSWER) noteWholeObjectInfoDuration(fetchStartedAt);
         if (!schemaProbeIsCurrent(issued)) {
           // A response issued on the previous cache generation or backend connection is no
           // answer for this command. In particular, do not let it become a whole-schema

--- a/web/js/lib/object-info-probe-budget.js
+++ b/web/js/lib/object-info-probe-budget.js
@@ -41,3 +41,36 @@ export function objectInfoSnapshotProbeDeadline(origin) {
     return OBJECT_INFO_REMOTE_SNAPSHOT_PROBE_DEADLINE_MS;
   }
 }
+
+/**
+ * #2050 — how long a whole-schema fetch may wait on a large install.
+ *
+ * The warm-install 10s getNodeDefs floor is too small after a pack install whose
+ * `/object_info` takes ~21s (#1562 measured 25,104,088 bytes / 20.84s). Size from a
+ * prior successful duration when we have one; otherwise from what the command still
+ * has. Always finite and at least 1ms so `withTimeout` still bounds. A never-arriving
+ * schema still fails closed at that bound.
+ */
+export const OBJECT_INFO_FETCH_MARGIN = 1.25;
+
+export function objectInfoFetchBudgetMs({
+  observedMs = 0,
+  remainingMs,
+  floorMs = 0,
+  ceilingMs,
+  margin = OBJECT_INFO_FETCH_MARGIN,
+} = {}) {
+  const remaining = Number(remainingMs);
+  if (!Number.isFinite(remaining) || remaining <= 0) return 1;
+  const floor = Number.isFinite(floorMs) && floorMs > 0 ? floorMs : 0;
+  const ceiling = Number.isFinite(ceilingMs) && ceilingMs > 0 ? ceilingMs : remaining;
+  const factor = Number.isFinite(margin) && margin >= 1 ? margin : 1;
+  const observed = Number(observedMs);
+  let want = floor;
+  if (Number.isFinite(observed) && observed > 0) {
+    want = Math.max(floor, Math.ceil(observed * factor));
+  } else {
+    want = Math.max(floor, remaining);
+  }
+  return Math.max(1, Math.min(want, ceiling, remaining));
+}


### PR DESCRIPTION
## Summary
- After installing a pack and restarting, adding a node still refused on a large custom-node install: the nested 10s `api.getNodeDefs()` cap could not finish `/object_info` (measured elsewhere at ~21s / 25MB), so schema-guarded mutations failed while live graph reads worked.
- `graph_add_node` now sizes the whole-schema wait from remaining command budget (and a prior successful duration), still through `budget.bounded(...)`. The seed wait uses the same helper. A never-arriving schema still fails closed at a 1ms floor; it does not hang forever.
- The type-scoped `/object_info/<Type>` fallback from #2084 is unchanged. Membership-only snapshots are still not an add oracle.

Fixes #2050

## Tests
- `node --test browser_tests/unit/object-info-probe-budget.test.mjs browser_tests/unit/add-node-command-budget.test.mjs browser_tests/unit/single-node-def.test.mjs`
- `npm run test:unit` (8225 pass, 0 fail, 1 todo)
