### PR TITLE
fix(2057): keep graph_get_subgraph ownership envelope untruncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented here. This project adheres to
 ### Fixed
 - After a large custom-node install, adding a node waits for /object_info with an adaptive command-budget cap instead of a fixed 10s fetch, and still refuses if the schema never arrives (#2050)
 - panel_show_media splits a combined `video/<file>` output filename into `/view`'s `subfolder` + basename so a valid history reference no longer 404s (#2193)
+- graph_get_subgraph no longer caps its inner node list at MAX_STATE_NODES, so a large subgraph's ownership envelope stays `truncated:false` with `node_count === nodes.length` and panel_set_widget can dispatch a promoted write instead of treating the listing cap as an incomplete witness (#2057)
 
 
 ## [0.15.161] - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - A custom video save node no longer looks like a preview-only run: a `{filename, subfolder, type:"output"}` MP4 under an unrecognised key (NKDVideoViewer's `nkd_video`) is collected as saved output, so panel_run completion names the file instead of saying "no saved output node ran … Add a SaveImage node" while describing the preview taps. CompareFrames temp dumps and a genuinely preview-only run are unchanged (#2128)
+- graph_get_subgraph no longer caps its inner node list at MAX_STATE_NODES, so a large subgraph's ownership envelope stays `truncated:false` with `node_count === nodes.length` and panel_set_widget can dispatch a promoted write instead of treating the listing cap as an incomplete witness (#2057)
 
 ## [0.15.162] - 2026-09-03
 
 ### Fixed
 - After a large custom-node install, adding a node waits for /object_info with an adaptive command-budget cap instead of a fixed 10s fetch, and still refuses if the schema never arrives (#2050)
 - panel_show_media splits a combined `video/<file>` output filename into `/view`'s `subfolder` + basename so a valid history reference no longer 404s (#2193)
-- graph_get_subgraph no longer caps its inner node list at MAX_STATE_NODES, so a large subgraph's ownership envelope stays `truncated:false` with `node_count === nodes.length` and panel_set_widget can dispatch a promoted write instead of treating the listing cap as an incomplete witness (#2057)
 
 
 ## [0.15.161] - 2026-09-03

--- a/browser_tests/unit/graph-get-subgraph-root-container.test.mjs
+++ b/browser_tests/unit/graph-get-subgraph-root-container.test.mjs
@@ -206,4 +206,63 @@ test("#1941 a live inner graph is still a container — the throw does not fire"
   assert.equal(out.node_count, 1);
   assert.equal(out.nodes[0].id, 12);
   assert.deepEqual(out.promoted_terminals, []);
+  assert.equal(out.truncated, false, "a complete ownership envelope must emit truncated:false, not omit it");
+});
+
+/** MCP's promoted-write fence: missing `truncated` used to be `!== false` and
+ *  a veto; current MCP still vetoes any asserted truncation and any
+ *  node_count/nodes length mismatch. Copied from
+ *  describePromotedSubgraphEnvelope so a listing cap cannot look like a
+ *  complete witness. */
+function mcpAcceptsOwnershipEnvelope(payload) {
+  if (!payload || typeof payload !== "object") return false;
+  // Older MCP: `truncated !== false` (unset is a veto).
+  if (payload.truncated !== false) return false;
+  if (!Number.isSafeInteger(payload.node_count) || payload.node_count < 0) return false;
+  if (!Array.isArray(payload.nodes)) return false;
+  if (payload.nodes.length !== payload.node_count) return false;
+  return true;
+}
+
+test("#2057 a 162-node subgraph still publishes a complete ownership envelope", () => {
+  // The reporter's wrapper 6066 had 162 inner nodes. graph_get_subgraph used to
+  // slice at MAX_STATE_NODES (50 in this harness, 100 in production) and set
+  // truncated:true — MCP then refused panel_set_widget on the promoted
+  // model_name before graph_set_widget dispatch.
+  const inner = Array.from({ length: 162 }, (_, i) => ({
+    id: i + 1,
+    type: i === 0 ? "UNETLoader" : "CLIPTextEncode",
+  }));
+  const getSubgraph = loadGetSubgraph()({
+    id: 6066,
+    type: "SubgraphNode",
+    title: "wrapper",
+    subgraph: { _nodes: inner },
+  });
+  const out = getSubgraph({ node_id: 6066 });
+  assert.equal(out.truncated, false, "truncated must be exactly false, not unset and not true");
+  assert.equal(out.node_count, 162);
+  assert.equal(out.nodes.length, 162);
+  assert.equal(out.nodes[0].id, 1);
+  assert.equal(out.nodes[161].id, 162);
+  assert.equal(out.truncation_hint, undefined);
+  assert.ok(mcpAcceptsOwnershipEnvelope(out), "MCP's ownership fence must accept this envelope");
+});
+
+test("#2057 graph_get_subgraph does not cap the inner list used as an ownership envelope", () => {
+  const src = PANEL_SRC.slice(
+    PANEL_SRC.indexOf("graph_get_subgraph({ node_id }) {"),
+    PANEL_SRC.indexOf("async graph_add_node(", PANEL_SRC.indexOf("graph_get_subgraph({ node_id }) {")),
+  );
+  assert.doesNotMatch(
+    src,
+    /inner\.slice\s*\(\s*0\s*,\s*MAX_STATE_NODES\s*\)/,
+    "slicing the inner list makes node_count disagree with nodes[] and vetoes the write",
+  );
+  assert.doesNotMatch(
+    src,
+    /truncated:\s*inner\.length\s*>\s*MAX_STATE_NODES/,
+    "asserting truncated:true is a promoted-write veto even when promoted_terminals is complete",
+  );
+  assert.match(src, /truncated:\s*false/, "complete ownership envelopes emit truncated:false");
 });

--- a/browser_tests/unit/graph-set-widget-target-fence.test.mjs
+++ b/browser_tests/unit/graph-set-widget-target-fence.test.mjs
@@ -178,7 +178,7 @@ test("structured production projections carry the same node identity witness", (
   const summary = PANEL_SRC.slice(summaryStart, summaryEnd);
   assert.match(summary, /nodeInstanceIdentity\(node\)/);
   assert.match(summary, /node_identity/);
-  assert.match(PANEL_SRC, /nodes: inner\.slice\(0, MAX_STATE_NODES\)\.map\(summarizeNode\)/);
+  assert.match(PANEL_SRC, /nodes: inner\.map\(summarizeNode\)/);
   assert.match(PANEL_SRC, /capSummaryWidgets\(summarizeNode\(n\)/);
 });
 

--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -189,12 +189,19 @@ test("#809 the MAX_STATE_NODES views state their cap instead of a bare boolean",
   // Each capped view must carry prose the model actually reads, not just `truncated:true`.
   // Views whose cap is FIXED and has no lever: they must say so, using the shared
   // wording that is honest about there being nothing to raise.
-  for (const sig of ["graph_view_selected()", "graph_get_subgraph({"]) {
+  // graph_get_subgraph is not a listing view: MCP uses it as the promoted-write
+  // ownership envelope, and a listing cap there is a write veto (#2057).
+  for (const sig of ["graph_view_selected()"]) {
     const body = handlerBody(src, sig);
     assert.ok(body, `${sig} must exist`);
     assert.match(body, /truncation_hint:/, `${sig} must emit a remedy, not only a boolean`);
     assert.match(body, /fixedCapNote\(/, `${sig} must use the shared fixed-cap wording`);
   }
+
+  const subgraph = handlerBody(src, "graph_get_subgraph({");
+  assert.ok(subgraph, "graph_get_subgraph must exist");
+  assert.doesNotMatch(subgraph, /fixedCapNote\(/, "the ownership envelope must not use the listing-cap wording");
+  assert.match(subgraph, /truncated:\s*false/, "the ownership envelope emits truncated:false, not a listing cut");
 
   // #845 — the viewport view now HAS a lever (`max_chars`), because a 100-node cap
   // bounded the wrong unit and still emitted 135k characters. It must therefore NOT

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15917,21 +15917,16 @@ const GRAPH_TOOL_EXECUTORS = {
       // per-instance override cannot be misread as stale data.
       ...safeProvenance,
       node_count: inner.length,
-      truncated: inner.length > MAX_STATE_NODES,
-      ...(inner.length > MAX_STATE_NODES
-        ? {
-            truncation_hint: fixedCapNote(
-              "inner node(s)",
-              MAX_STATE_NODES,
-              inner.length,
-              // Honest about the follow-up's OWN ceiling (codex gate): panel_query_graph
-              // clamps limit at 200 and has no cursor, so on a >200-node subgraph it is a
-              // way to read MORE, not a way to read all.
-              "panel_enter_subgraph into it, then panel_query_graph — which takes limit (max 200) and max_chars. It has no cursor, so beyond 200 inner nodes use its types/where filters to work through them.",
-            ),
-          }
-        : {}),
-      nodes: inner.slice(0, MAX_STATE_NODES).map(summarizeNode),
+      // #2057 — MCP's promoted-write fence treats `truncated !== false` as an
+      // incomplete ownership envelope and will not dispatch graph_set_widget.
+      // A listing cap here made a 162-node wrapper refuse its own promoted
+      // model_name write even though promoted_terminals was complete. This
+      // command IS the completeness proof (`node_count === nodes.length` and
+      // `truncated:false`); listing caps belong to graph_get_state /
+      // panel_query_graph. Emit the boolean even when false: older MCP treated
+      // an unset flag as a veto.
+      truncated: false,
+      nodes: inner.map(summarizeNode),
       // The hello capability promises a complete alias witness. Publish an
       // explicit empty array too, so the consumer can distinguish a subgraph
       // with no promoted aliases from a current/legacy capability-skewed


### PR DESCRIPTION
## Summary
`panel_set_widget` refused promoted writes on large subgraphs because `graph_get_subgraph` capped the inner node list at `MAX_STATE_NODES` (100) and published `truncated:true` with `node_count !== nodes.length`. MCP's ownership fence treats `truncated !== false` (and a count mismatch) as an incomplete witness and never dispatches `graph_set_widget`.

On a 162-node wrapper this showed up as a refused promoted `model_name` write even though `promoted_terminals` was complete. Older MCP also treated a missing `truncated` flag as a veto, so the envelope now always emits `truncated:false` for a complete inner list.

Listing caps stay on `graph_get_state` / `panel_query_graph`. This command is the completeness proof.

Fixes #2057.

## Tests
- `node --test browser_tests/unit/graph-get-subgraph-root-container.test.mjs browser_tests/unit/outline-coverage.test.mjs browser_tests/unit/subgraph-value-provenance.test.mjs browser_tests/unit/graph-view-identity.test.mjs`
- 57 passed, 0 failed
