### PR TITLE
fix(#2222): accept just-uploaded LoadImage filenames from live inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget refreshes LoadImage/LoadVideo combo choices from the connected ComfyUI `/object_info/<Type>` input-file inventory after a combo miss, invalidates the cached whole-map list, and accepts only the exact uploaded relative filename — so a file `upload_image` just verified is not rejected against a stale page-load dropdown (#2222)
+
 ## [0.15.164] - 2026-09-03
 
 ### Fixed

--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -13,6 +13,9 @@ import {
   filterServerConfirmedInputSubfolderCandidates,
   inputPathsUseWindowsSeparators,
   addComboOption,
+  applyComboInventory,
+  uploadComboInventoryOf,
+  inventoryHasExactValue,
   inputAssetViewQuery,
   probeInputAssetPresence,
 } from "../../web/js/lib/input-asset.js";
@@ -419,6 +422,31 @@ test("addComboOption refuses to clobber a dynamic FUNCTION option source", () =>
   const w = { options: { values: fn } };
   assert.equal(addComboOption(w, "x.png"), false);
   assert.equal(w.options.values, fn, "function source left untouched");
+});
+
+test("#2222 uploadComboInventoryOf reads V1 LoadImage/LoadVideo upload lists", () => {
+  const defs = {
+    LoadImage: { input: { required: { image: [["old.png", "new.png"], { image_upload: true }] } } },
+    LoadVideo: { input: { required: { file: [["clip.mp4"], { video_upload: true }] } } },
+    CheckpointLoaderSimple: { input: { required: { ckpt_name: [["sd.safetensors"], {}] } } },
+  };
+  const images = uploadComboInventoryOf(defs, "LoadImage", "image");
+  assert.deepEqual(images.values, ["old.png", "new.png"]);
+  assert.equal(images.config.image_upload, true);
+  assert.equal(inventoryHasExactValue(images.values, "new.png"), true);
+  assert.equal(inventoryHasExactValue(images.values, "missing.png"), false);
+  assert.ok(uploadComboInventoryOf(defs, "LoadVideo", "file"));
+  assert.equal(uploadComboInventoryOf(defs, "CheckpointLoaderSimple", "ckpt_name"), null);
+});
+
+test("#2222 applyComboInventory replaces a stale list, including a function source", () => {
+  const w = { options: { values: ["old.png"] } };
+  assert.equal(applyComboInventory(w, ["old.png", "fresh.png"]), true);
+  assert.deepEqual(w.options.values, ["old.png", "fresh.png"]);
+  const fn = () => ["old.png"];
+  const dyn = { options: { values: fn } };
+  assert.equal(applyComboInventory(dyn, ["fresh.png"]), true);
+  assert.deepEqual(dyn.options.values, ["fresh.png"]);
 });
 
 function filenameParamOf(qs) {

--- a/browser_tests/unit/set-widget-upload-inventory.test.mjs
+++ b/browser_tests/unit/set-widget-upload-inventory.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * #2222 — panel_set_widget rejected a LoadImage filename that upload_image had
+ * just verified against a fresh `/object_info` listing, because the live widget
+ * (and the burst-cached whole map refreshCombos reuses) still held the page-load
+ * combo. Drive runSetWidget, the same unit graph_set_widget delegates to.
+ *
+ * Invariants:
+ *   1. A stale combo + stale refresh still accepts when the live inventory
+ *      contains the EXACT uploaded relative filename.
+ *   2. A lookalike / missing name in that inventory stays rejected (#240).
+ *   3. A non-upload combo never asks the upload inventory.
+ *   4. Production graph_set_widget wires fetchUploadComboInventory and
+ *      invalidates the object-info cache before the live read.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { PANEL_SRC } from "./_panel-constants.mjs";
+
+const REGISTRY = { LoadImage: {}, LoadVideo: {}, CheckpointLoaderSimple: {} };
+
+const STALE = {
+  LoadImage: { input: { required: { image: [["example.png"], { image_upload: true }] } } },
+  LoadVideo: { input: { required: { file: [["old.mp4"], { video_upload: true }] } } },
+  CheckpointLoaderSimple: { input: { required: { ckpt_name: [["sd15.safetensors"]] } } },
+};
+
+function refreshFromDefs(defs, target) {
+  const widget = target?.widgets?.[0];
+  const spec = defs?.[target?.type]?.input?.required?.[widget?.name];
+  if (widget && Array.isArray(spec?.[0])) widget.options.values = spec[0].slice();
+}
+
+test("#2222 a just-uploaded LoadImage filename the stale combo omitted is accepted from the live inventory", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["example.png"] }, value: "example.png" };
+  const node = { id: 12, type: "LoadImage", widgets: [widget] };
+  let asked = null;
+  const res = await runSetWidget(node, "image", "fresh_upload.png", {
+    registry: REGISTRY,
+    getFreshObjectInfo: async () => STALE,
+    refreshCombos: refreshFromDefs,
+    confirmServerAsset: async () => {
+      throw new Error("inventory hit must not fall through to /view");
+    },
+    fetchUploadComboInventory: async ({ type, widgetName, value }) => {
+      asked = { type, widgetName, value };
+      return {
+        values: ["example.png", "fresh_upload.png"],
+        config: { image_upload: true },
+      };
+    },
+  });
+  assert.deepEqual(asked, { type: "LoadImage", widgetName: "image", value: "fresh_upload.png" });
+  assert.equal(res.set.value, "fresh_upload.png");
+  assert.equal(res.refreshed, true);
+  assert.equal(res.server_confirmed, undefined);
+  assert.ok(widget.options.values.includes("fresh_upload.png"));
+});
+
+test("#2222 LoadVideo uses the same live inventory path", async () => {
+  const widget = { name: "file", type: "combo", options: { values: ["old.mp4"] }, value: "old.mp4" };
+  const node = { id: 4, type: "LoadVideo", widgets: [widget] };
+  const res = await runSetWidget(node, "file", "take.mp4", {
+    registry: REGISTRY,
+    getFreshObjectInfo: async () => STALE,
+    refreshCombos: refreshFromDefs,
+    fetchUploadComboInventory: async () => ({
+      values: ["old.mp4", "take.mp4"],
+      config: { video_upload: true },
+    }),
+  });
+  assert.equal(res.set.value, "take.mp4");
+});
+
+test("#2222 exact filename only — a live list without that relative path still rejects", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["example.png"] }, value: "example.png" };
+  const node = { id: 12, type: "LoadImage", widgets: [widget] };
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "fresh_upload.png", {
+        registry: REGISTRY,
+        getFreshObjectInfo: async () => STALE,
+        refreshCombos: refreshFromDefs,
+        confirmServerAsset: async () => false,
+        fetchUploadComboInventory: async () => ({
+          values: ["example.png", "fresh_upload (1).png"],
+          config: { image_upload: true },
+        }),
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(widget.value, "example.png");
+});
+
+test("#2222 a non-upload combo never asks the upload-file inventory", async () => {
+  const widget = {
+    name: "ckpt_name",
+    type: "combo",
+    options: { values: ["sd15.safetensors"] },
+    value: "sd15.safetensors",
+  };
+  const node = { id: 5, type: "CheckpointLoaderSimple", widgets: [widget] };
+  let asked = false;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "ckpt_name", "new.safetensors", {
+        registry: REGISTRY,
+        getFreshObjectInfo: async () => STALE,
+        refreshCombos: refreshFromDefs,
+        fetchUploadComboInventory: async () => {
+          asked = true;
+          return { values: ["new.safetensors"], config: {} };
+        },
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(asked, false);
+});
+
+test("#2222 production graph_set_widget invalidates combo cache then reads /object_info/<Type>", () => {
+  assert.match(PANEL_SRC, /fetchUploadComboInventory:/);
+  assert.match(PANEL_SRC, /objectInfoCache\.invalidate\(\)/);
+  assert.match(PANEL_SRC, /uploadComboInventoryOf\(scoped\.defs, type, widgetName\)/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -458,6 +458,7 @@ import {
   inputAssetViewQuery,
   inputPathsUseWindowsSeparators,
   probeInputAssetPresence as probeAssetOnServer,
+  uploadComboInventoryOf,
 } from "./lib/input-asset.js";
 import {
   GET_ERRORS_TOTAL_BUDGET_MS,
@@ -18964,6 +18965,30 @@ const GRAPH_TOOL_EXECUTORS = {
         } catch {
           return false;
         }
+      },
+      // #2222 — LoadImage/LoadVideo combo membership after upload_image. The
+      // authorization payload (and api.getNodeDefs) can predate the upload, so
+      // refreshCombos would copy a stale 462-item list and reject the exact
+      // filename the upload tool just verified. Drop that cache and re-read
+      // `/object_info/<Type>` from the connected ComfyUI — the same inventory
+      // INPUT_TYPES uses — then require an exact match before accepting.
+      fetchUploadComboInventory: async ({ type, widgetName }) => {
+        if (!type || !widgetName) return null;
+        objectInfoCache.invalidate();
+        const scopedEpoch = backendReconnectEpoch;
+        const scopedGeneration = verifiedNodeDefCache.generation();
+        const scoped = await fetchTypeScopedObjectInfo([type], {
+          fetchApi: typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
+          deadlineMs: budget.bounded(),
+        });
+        if (
+          scopedEpoch !== backendReconnectEpoch ||
+          scopedGeneration !== verifiedNodeDefCache.generation() ||
+          comfyBackendIsDown()
+        ) {
+          return null;
+        }
+        return uploadComboInventoryOf(scoped.defs, type, widgetName);
       },
       // #2025 — the remaining command budget bounds the write+ack. On timeout after
       // delivery, awaitSetWidgetAck readbacks the live widget instead of hanging

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -459,6 +459,54 @@ export async function filterServerConfirmedInputSubfolderCandidates(
 }
 
 /**
+ * The live upload-combo inventory a def publishes for `widgetName` on `type`:
+ * `{ values, config }` when the input is an upload combo with a readable option
+ * list, otherwise null. Used to judge a just-uploaded filename against the same
+ * connected-ComfyUI listing `upload_image` verifies (`/object_info/<Type>`), not
+ * the page-load widget snapshot (#2222).
+ */
+export function uploadComboInventoryOf(defsByType, type, widgetName) {
+  try {
+    if (!defsByType || !type || !widgetName) return null;
+    const input = defsByType[type]?.input;
+    if (!input) return null;
+    const spec =
+      (input.required && input.required[widgetName]) ??
+      (input.optional && input.optional[widgetName]);
+    if (!Array.isArray(spec)) return null;
+    const config = uploadConfigOf(spec[1]);
+    if (!config) return null;
+    const values = authoritativeComboValues(spec);
+    if (!Array.isArray(values)) return null;
+    return { values, config };
+  } catch {
+    return null;
+  }
+}
+
+/** Exact membership only — the upload tool's returned relative filename, not a lookalike. */
+export function inventoryHasExactValue(inventory, value) {
+  return Array.isArray(inventory) && inventory.includes(value);
+}
+
+/**
+ * Replace a combo widget's option list with a live server inventory. Unlike
+ * `addComboOption`, this MAY replace a function-valued source: after an upload the
+ * live `/object_info/<Type>` list is the authority, and a stale callback would keep
+ * rejecting a filename the server already enumerates (#2222).
+ */
+export function applyComboInventory(widget, inventory) {
+  try {
+    if (!widget || !Array.isArray(inventory)) return false;
+    if (!widget.options || typeof widget.options !== "object") widget.options = {};
+    widget.options.values = inventory.slice();
+    return Array.isArray(widget.options.values);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Add `value` to a combo widget's option list in place (so a following revalidation
  * accepts it) WITHOUT clobbering a dynamic function-valued option source. Returns
  * true if the option list now contains the value. Defensive; no-op on a bad widget.

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -53,6 +53,9 @@ import { REFRESH_JOIN_ABANDONED } from "./refresh-coalesce.js";
 import {
   uploadInputConfig,
   uploadInputAccepts,
+  uploadConfigOf,
+  inventoryHasExactValue,
+  applyComboInventory,
   addComboOption,
   serverDeclaresEmptyComboOptions,
   serverDeclaresRemoteComboOptions,
@@ -495,6 +498,13 @@ async function runSetWidgetBody(
     assertTargetStillCurrent,
     refreshCombos,
     confirmServerAsset,
+    // #2222 — live connected-ComfyUI upload-file inventory for LoadImage/LoadVideo
+    // (and any other upload combo). `upload_image` verifies the stored filename
+    // against a fresh `/object_info/<Type>` listing; panel_set_widget used to
+    // revalidate against the page-load widget snapshot (or a burst-cached whole
+    // map that predates the upload). This hook MUST bypass that cache and return
+    // `{ values, config }` from the same inventory, or null when it cannot.
+    fetchUploadComboInventory,
     // #1223 × #1126 — WHERE the schema `getFreshObjectInfo` answered with actually came
     // from. Read as a FUNCTION, at the moment of decision, because the answer is only known
     // AFTER the oracle has run.
@@ -1613,9 +1623,7 @@ async function runSetWidgetBody(
     // of THIS input's upload kind (e.g. an image extension for an image_upload combo),
     // never a stray `.txt` the LoadImage combo would never list.
     if (!uploadInputAccepts(cfg, value)) return false;
-    const uploadWidget = (resolvedTargetNode?.widgets ?? []).find(
-      (w) => w?.name === (writeTargetWidgetName ?? widgetName),
-    );
+    const uploadWidget = findUploadWidget();
     if (!uploadWidget) return false;
     let exists = false;
     try {
@@ -1628,6 +1636,47 @@ async function runSetWidgetBody(
     // not add an option to the captured widget after that switch (#718).
     assertTargetStillCurrentNow();
     return addComboOption(uploadWidget, value);
+  };
+
+  const uploadWidgetName = () => writeTargetWidgetName ?? widgetName;
+  const uploadDefInputName = () => concreteWidgetName ?? writeTargetWidgetName ?? widgetName;
+  const findUploadWidget = () =>
+    (resolvedTargetNode?.widgets ?? []).find((w) => w?.name === uploadWidgetName());
+
+  // #2222: a TOP-LEVEL upload the live connected inventory already lists, but the
+  // widget (and the burst-cached whole /object_info used by refreshCombos) does not.
+  // `upload_image` verifies against that inventory; rejecting here without asking it
+  // is the split-brain the issue reports. Exact filename match only.
+  const tryLiveUploadInventory = async () => {
+    if (typeof fetchUploadComboInventory !== "function") return false;
+    const type = authTarget?.type;
+    const defName = uploadDefInputName();
+    if (!type || !defName) return false;
+    // A readable NON-upload spec (ckpt_name, sampler_name, …) must not spend a
+    // live inventory fetch. Snapshot-only maps have no input spec, so they fall
+    // through and ask — LoadImage after upload_image is that case.
+    const knownSpec =
+      (freshDefs?.[type]?.input?.required && freshDefs[type].input.required[defName]) ??
+      (freshDefs?.[type]?.input?.optional && freshDefs[type].input.optional[defName]);
+    if (Array.isArray(knownSpec) && !uploadConfigOf(knownSpec[1])) return false;
+    let inventory = null;
+    try {
+      inventory = await fetchUploadComboInventory({
+        type,
+        widgetName: defName,
+        value,
+      });
+    } catch {
+      return false;
+    }
+    const values = inventory?.values;
+    const cfg = uploadConfigOf(inventory?.config) ?? uploadInputConfig(freshDefs ?? undefined, type, defName);
+    if (!cfg || !uploadInputAccepts(cfg, value)) return false;
+    if (!inventoryHasExactValue(values, value)) return false;
+    const uploadWidget = findUploadWidget();
+    if (!uploadWidget) return false;
+    assertTargetStillCurrentNow();
+    return applyComboInventory(uploadWidget, values);
   };
 
   try {
@@ -1703,6 +1752,22 @@ async function runSetWidgetBody(
         // Still a combo miss after the refresh — keep the freshest reason and try the
         // upload-asset fallback below.
         latest = retryErr;
+      }
+    }
+
+    // #2222: live input-file inventory from the connected ComfyUI (same listing
+    // upload_image consults). Applied BEFORE the /view existence probe so a
+    // top-level filename the server already enumerates is not rejected against
+    // a stale 462-item widget snapshot.
+    if (await tryLiveUploadInventory()) {
+      try {
+        return await succeedWrite({}, { refreshed: true });
+      } catch (invErr) {
+        if (!(invErr instanceof WidgetWriteError)) throw invErr;
+        if (!invErr.combo) {
+          throw refusalFrame(invErr, " after refreshing the upload-file inventory");
+        }
+        latest = invErr;
       }
     }
 


### PR DESCRIPTION
## Summary
upload_image verifies a new file against a fresh connected ComfyUI /object_info listing, but the immediately following panel_set_widget on live LoadImage.image (or LoadVideo) revalidated against the page-load combo / burst-cached whole map. A top-level PNG that the upload tool had just reported as selectable was rejected because that stale list (e.g. 462 items) did not contain it; retry kept failing; an already-listed older filename succeeded.

After a combo miss on an upload input, graph_set_widget now:
1. invalidates the cached whole-map combo list
2. re-reads /object_info/<Type> from the connected ComfyUI (the same INPUT_TYPES inventory upload_image uses)
3. accepts only when that inventory contains the exact returned relative filename
4. still falls through to the existing /view nested-upload probe (#387) when the live list does not enumerate the path

Nested/subfolder uploads, non-upload combos, and lookalike names stay fail-closed (#240).

## Test plan
- [x] browser_tests/unit/set-widget-upload-inventory.test.mjs — stale combo + live inventory accepts exact LoadImage/LoadVideo names; lookalike rejected; ckpt combo never asks inventory; production wiring present
- [x] browser_tests/unit/input-asset.test.mjs — uploadComboInventoryOf / applyComboInventory
- [x] existing #387 upload-asset tests still pass
- [x] npm run test:unit — 8273 pass / 0 fail

Fixes #2222
