### PR TITLE
fix(#2225): rebuild promoted-terminal mapping after reopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- After panel_open_workflow reopens a modified subgraph, promoted width/height/seed host rails rebind onto the unique inner input-rail slots and graph_get_subgraph publishes a complete promoted-terminal witness, so panel_set_widget can write those widgets instead of refusing an unresolved mapping. panel_refresh_nodes runs the same rebind. A stale properties.proxyWidgets pair from the file is not a veto once the live parent rail is authenticated (#2225)
+
 ## [0.15.165] - 2026-09-04
 
 ### Fixed

--- a/browser_tests/unit/promoted-terminal-reopen-modified.test.mjs
+++ b/browser_tests/unit/promoted-terminal-reopen-modified.test.mjs
@@ -1,0 +1,212 @@
+/**
+ * #2225 — after panel_open_workflow reopens a modified subgraph, outline lists
+ * promoted width/height/seed while `_subgraphSlot` is still unbound and
+ * properties.proxyWidgets still names the FILE's inner Primitive `value`
+ * widgets. graph_get_subgraph must publish a complete promoted-terminal
+ * witness so panel_set_widget can dispatch.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { isPromotedContainer } from "../../web/js/lib/graph-read.js";
+import {
+  applyWidgetWrite,
+  followPromotionToConcrete,
+  MAX_PROMOTION_CHAIN_DEPTH,
+  promotedInputAliases,
+  resolvePromotedInnerTarget,
+} from "../../web/js/lib/widget-write.js";
+import { rebindLoadedPromotedMappings } from "../../web/js/lib/subgraph-instance-widgets.js";
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+
+function extractPromotedTerminalWitnesses() {
+  const helperStart = PANEL_SRC.indexOf("function resolveSubgraphLink(");
+  const helperEnd = PANEL_SRC.indexOf("\nfunction findPromotedHostInput", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production promotion helper range must remain extractable");
+  return new Function(
+    "resolvePromotedInnerTarget",
+    "followPromotionToConcrete",
+    "MAX_PROMOTION_CHAIN_DEPTH",
+    "promotedInputAliases",
+    "isPromotedContainer",
+    `${PANEL_SRC.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
+  )(
+    resolvePromotedInnerTarget,
+    followPromotionToConcrete,
+    MAX_PROMOTION_CHAIN_DEPTH,
+    promotedInputAliases,
+    isPromotedContainer,
+  );
+}
+
+const ROOT_GRAPH_ID = "c4a254bb-935e-4013-b380-5e36954de4b0";
+
+function makePrimitive(id, value) {
+  const inner = { name: "value", type: "INT", value };
+  const node = {
+    id,
+    type: "PrimitiveInt",
+    inputs: [{ name: "value", widget: { name: "value" }, type: "INT", link: id }],
+    widgets: [inner],
+  };
+  return { node, inner };
+}
+
+/** Modified subgraph after reopen: host rails exist, slots not rebound,
+ * proxyWidgets still names inner `value` (and may keep the FILE's host names). */
+function makeReopenedModifiedHost({ includeHostInputs = true, staleProxyNodeIds = false } = {}) {
+  const width = makePrimitive(10, 1024);
+  const height = makePrimitive(11, 1024);
+  const seed = makePrimitive(12, 42);
+  const links = {
+    10: { id: 10, origin_id: -10, origin_slot: 0, target_id: 10, target_slot: 0 },
+    11: { id: 11, origin_id: -10, origin_slot: 1, target_id: 11, target_slot: 0 },
+    12: { id: 12, origin_id: -10, origin_slot: 2, target_id: 12, target_slot: 0 },
+  };
+  const subgraphInputs = [
+    { name: "width", linkIds: [] },
+    { name: "height", linkIds: [] },
+    { name: "seed", linkIds: [] },
+  ];
+  const subgraph = {
+    _nodes: [width.node, height.node, seed.node],
+    inputs: subgraphInputs,
+    inputNode: { id: -10, slots: subgraphInputs },
+    links,
+    getNodeById: (id) => {
+      if (String(id) === "10") return width.node;
+      if (String(id) === "11") return height.node;
+      if (String(id) === "12") return seed.node;
+      return null;
+    },
+    getLink: (id) => links[id] ?? null,
+  };
+
+  const rails = {};
+  const widgets = [];
+  for (const name of ["width", "height", "seed"]) {
+    const widgetId = `${ROOT_GRAPH_ID}:42:${name}`;
+    const rail = { name, type: "INT", value: name === "seed" ? 42 : 1024, widgetId };
+    rails[name] = rail;
+    widgets.push(rail);
+  }
+  const hostInput = (name) => ({ name });
+  const host = {
+    id: 42,
+    type: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    subgraph,
+    inputs: includeHostInputs ? [hostInput("width"), hostInput("height"), hostInput("seed")] : [],
+    widgets,
+    properties: {
+      proxyWidgets: staleProxyNodeIds
+        ? [
+            [99, "width"],
+            [98, "height"],
+            [97, "seed"],
+          ]
+        : [
+            [10, "value"],
+            [11, "value"],
+            [12, "value"],
+            [10, "width"],
+            [11, "height"],
+            [12, "seed"],
+          ],
+    },
+  };
+  return { host, rails, width, height, seed };
+}
+
+function assertCompleteWitness(entries, name, terminalId, terminalType) {
+  const witness = entries.find((entry) => entry.widget === name);
+  assert.ok(witness, `missing witness for ${name}`);
+  assert.equal(witness.error, undefined, `${name} must not publish an incomplete witness`);
+  assert.equal(witness.parent_rail?.authoritative, true);
+  assert.equal(witness.terminal_widget, "value");
+  assert.equal(witness.terminal_node_id, terminalId);
+  assert.equal(witness.terminal_node_type, terminalType);
+  assert.ok(Array.isArray(witness.terminal_inputs));
+}
+
+test("#2225 rebindLoadedPromotedMappings binds unique IO slots onto host inputs", () => {
+  const { host } = makeReopenedModifiedHost();
+  assert.equal(host.inputs[0]._subgraphSlot, undefined);
+  const result = rebindLoadedPromotedMappings({ _nodes: [host] });
+  assert.equal(result.rebound, 6);
+  assert.equal(host.inputs[0]._subgraphSlot, host.subgraph.inputs[0]);
+  assert.equal(host.inputs[1]._subgraphSlot, host.subgraph.inputs[1]);
+  assert.equal(host.widgets[0]._subgraphSlot, host.subgraph.inputs[0]);
+});
+
+test("#2225 after reopen, host width/height/seed resolve to PrimitiveInt.value via -10", () => {
+  const { host, width, height, seed } = makeReopenedModifiedHost();
+  const w = resolvePromotedInnerTarget(host, "width", () => null);
+  assert.equal(w.promoted, true);
+  assert.equal(w.target.node, width.node);
+  assert.equal(w.target.widget, width.inner);
+  assert.equal(w.target.parentWidget?.name, "width");
+  const h = resolvePromotedInnerTarget(host, "height", () => null);
+  assert.equal(h.target.node, height.node);
+  const s = resolvePromotedInnerTarget(host, "seed", () => null);
+  assert.equal(s.target.node, seed.node);
+  assert.equal(s.target.widget.name, "value");
+});
+
+test("#2225 after reopen with no host inputs, unique IO-slot host widgets still resolve", () => {
+  const { host, width } = makeReopenedModifiedHost({ includeHostInputs: false });
+  const res = resolvePromotedInnerTarget(host, "width", () => null);
+  assert.equal(res.promoted, true);
+  assert.equal(res.target.node, width.node);
+  assert.equal(res.target.parentWidget?.name, "width");
+});
+
+test("#2225 production witness completes for reopened PrimitiveInt width/height/seed", () => {
+  const makeWitnesses = extractPromotedTerminalWitnesses();
+  const { host } = makeReopenedModifiedHost();
+  const entries = makeWitnesses(host);
+  assertCompleteWitness(entries, "width", 10, "PrimitiveInt");
+  assertCompleteWitness(entries, "height", 11, "PrimitiveInt");
+  assertCompleteWitness(entries, "seed", 12, "PrimitiveInt");
+});
+
+test("#2225 stale file proxyWidgets ids do not veto a live parent-rail resolution", () => {
+  const makeWitnesses = extractPromotedTerminalWitnesses();
+  const { host } = makeReopenedModifiedHost({ staleProxyNodeIds: true });
+  const entries = makeWitnesses(host);
+  assertCompleteWitness(entries, "width", 10, "PrimitiveInt");
+  assert.equal(entries.find((entry) => entry.widget === "width")?.error, undefined);
+});
+
+test("#2225 applyWidgetWrite sets reopened promoted width without unpacking", () => {
+  const { host, width, rails } = makeReopenedModifiedHost();
+  const set = applyWidgetWrite(host, "width", 1280, { resolveSource: () => null });
+  assert.equal(set.value, 1280);
+  assert.equal(width.inner.value, 1280);
+  assert.equal(rails.width.value, 1280);
+});
+
+test("#2225 workflow_open / graph_load / refresh_nodes all rebind the mapping", () => {
+  assert.match(
+    PANEL_SRC,
+    /rebindLoadedPromotedMappings/,
+    "the post-load mapping rebuild must be imported",
+  );
+  assert.match(
+    PANEL_SRC,
+    /applySavedSubgraphHostWidgets\(app\?\.graph, clone\)/,
+    "graph_load still restores host widgets (which now rebinds slots first)",
+  );
+  const refreshStart = PANEL_SRC.indexOf("async refresh_nodes() {");
+  const refreshEnd = PANEL_SRC.indexOf("\n  graph_serialize()", refreshStart);
+  assert.ok(refreshStart >= 0 && refreshEnd > refreshStart, "refresh_nodes must remain extractable");
+  assert.match(
+    PANEL_SRC.slice(refreshStart, refreshEnd),
+    /rebindLoadedPromotedMappings\(app\?\.graph\)/,
+    "panel_refresh_nodes must rebuild promoted-terminal slots after a defs refresh",
+  );
+});

--- a/browser_tests/unit/subgraph-instance-widgets.test.mjs
+++ b/browser_tests/unit/subgraph-instance-widgets.test.mjs
@@ -364,3 +364,16 @@ test("#874 graph_load and the disk-reload open path both re-apply saved host wid
     "workflow_open's on-disk reload must re-apply the FILE after loadGraphData",
   );
 });
+
+test("#2225 applySavedSubgraphHostWidgets rebinds promoted slots before restoring values", () => {
+  const applySrc = readFileSync(new URL("../../web/js/lib/subgraph-instance-widgets.js", import.meta.url), "utf8");
+  const start = applySrc.indexOf("export function applySavedSubgraphHostWidgets");
+  const end = applySrc.indexOf("\nexport async function withPreservedPromotedInstanceWidgets", start);
+  assert.ok(start >= 0 && end > start);
+  const body = applySrc.slice(start, end);
+  assert.match(body, /rebindLoadedPromotedMappings\(liveRoot\)/);
+  assert.ok(
+    body.indexOf("rebindLoadedPromotedMappings(liveRoot)") < body.indexOf("savedHostWidgetMap"),
+    "slot rebind must run before file values are written onto the rails",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -307,6 +307,7 @@ import {
 import {
   withPreservedPromotedInstanceWidgets,
   applySavedSubgraphHostWidgets,
+  rebindLoadedPromotedMappings,
 } from "./lib/subgraph-instance-widgets.js";
 import {
   snapshotExternalLinks,
@@ -10388,6 +10389,35 @@ function promotedHostAliasRecords(subgraphNode) {
       for (const value of promotedInputAliases(widget, widget._subgraphSlot)) add(value, null, null);
     }
   }
+  // #2225 — after a modified-definition reopen, host rails exist on
+  // node.widgets while `_subgraphSlot` is still unbound. A unique subgraph
+  // input-rail slot of the same name is that promotion.
+  const ioSlots = Array.isArray(subgraphNode?.subgraph?.inputs) && subgraphNode.subgraph.inputs.length
+    ? subgraphNode.subgraph.inputs
+    : Array.isArray(subgraphNode?.subgraph?.inputNode?.slots)
+      ? subgraphNode.subgraph.inputNode.slots
+      : [];
+  if (ioSlots.length) {
+    const slotKeys = new Map();
+    for (const slot of ioSlots) {
+      for (const raw of [slot?.name, slot?.label]) {
+        if (typeof raw !== "string" || raw.length === 0) continue;
+        const key = raw.toLowerCase();
+        slotKeys.set(key, slotKeys.has(key) ? null : slot);
+      }
+    }
+    for (const widget of projectedWidgets) {
+      const aliases = [widget?.name, widget?.label].filter(
+        (value) => typeof value === "string" && value.length > 0,
+      );
+      if (!aliases.length) continue;
+      const unique = aliases
+        .map((alias) => slotKeys.get(alias.toLowerCase()))
+        .filter((slot, index, all) => slot && all.indexOf(slot) === index);
+      if (unique.length !== 1) continue;
+      for (const value of aliases) add(value, null, null);
+    }
+  }
 
   const rawProxyWidgets = subgraphNode?.properties?.proxyWidgets;
   if (rawProxyWidgets === undefined) return records;
@@ -10558,19 +10588,10 @@ function promotedTerminalWitnesses(subgraphNode) {
       });
       continue;
     }
-    if (
-      record.relation &&
-      (String(resolution.target.node?.id) !== String(record.relation.nodeId) ||
-        resolution.target.widget?.name !== record.relation.widgetName)
-    ) {
-      entries.push({
-        widget,
-        immediate_node_id: resolution.target.node?.id,
-        immediate_widget: resolution.target.widget?.name,
-        error: "the live _subgraphSlot target disagreed with properties.proxyWidgets",
-      });
-      continue;
-    }
+    // After a modified-definition load, proxyWidgets can still name the FILE's
+    // inner id/widget while the live input-rail already points at the Primitive
+    // `value` terminal. The live parent-rail-authenticated resolution is the
+    // mapping graph_set_widget writes; a stale serialized pair is not a veto.
     entries.push({
       widget,
       parent_rail: {
@@ -14204,6 +14225,13 @@ const GRAPH_TOOL_EXECUTORS = {
       };
     }
     const refreshed = verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true);
+    if (refreshed) {
+      try {
+        rebindLoadedPromotedMappings(app?.graph);
+      } catch {
+        /* mapping rebind is best-effort; the witness still recomputes on the next read */
+      }
+    }
     // #981: the stale-placeholder disclosure has to survive BOTH paths. The producer
     // runs the scan whatever the verdict says — a refresh that failed at the combo phase
     // can still leave placeholders behind — but only this branch dropped it, because

--- a/web/js/lib/subgraph-instance-widgets.js
+++ b/web/js/lib/subgraph-instance-widgets.js
@@ -266,6 +266,122 @@ function savedDefinitionsById(savedGraph) {
   return byId;
 }
 
+function subgraphInputSlots(subgraph) {
+  if (Array.isArray(subgraph?.inputs) && subgraph.inputs.length) return subgraph.inputs;
+  if (Array.isArray(subgraph?.inputNode?.slots) && subgraph.inputNode.slots.length) {
+    return subgraph.inputNode.slots;
+  }
+  return [];
+}
+
+function aliasKey(value) {
+  return typeof value === "string" && value.length > 0 ? value.toLowerCase() : null;
+}
+
+function slotAliasKeys(slot) {
+  const keys = [];
+  const name = aliasKey(slot?.name);
+  const label = aliasKey(slot?.label);
+  if (name) keys.push(name);
+  if (label && label !== name) keys.push(label);
+  return keys;
+}
+
+function uniqueSlotForAliases(slots, aliases) {
+  const wanted = new Set();
+  for (const alias of aliases) {
+    const key = aliasKey(alias);
+    if (key) wanted.add(key);
+  }
+  if (!wanted.size) return null;
+  const hits = [];
+  for (const slot of slots) {
+    if (!slot) continue;
+    if (slotAliasKeys(slot).some((key) => wanted.has(key))) hits.push(slot);
+  }
+  return hits.length === 1 ? hits[0] : null;
+}
+
+function liveHostWidgets(host) {
+  try {
+    return Array.isArray(host?.widgets) ? host.widgets : [];
+  } catch {
+    return [];
+  }
+}
+
+function bindSlotIfMissing(target, slot, result) {
+  if (!target || !slot) {
+    result.skipped += 1;
+    return;
+  }
+  if (target._subgraphSlot) {
+    result.skipped += 1;
+    return;
+  }
+  target._subgraphSlot = slot;
+  result.rebound += 1;
+}
+
+function rebindOneLoadedHost(host, result) {
+  const slots = subgraphInputSlots(host?.subgraph);
+  if (!slots.length) return;
+  const inputs = Array.isArray(host.inputs) ? host.inputs : [];
+  for (const input of inputs) {
+    bindSlotIfMissing(
+      input,
+      uniqueSlotForAliases(slots, [
+        input?.name,
+        input?.label,
+        input?.widget?.name,
+        input?.widget?.label,
+        input?._widget?.name,
+        input?._widget?.label,
+      ]),
+      result,
+    );
+  }
+  for (const widget of liveHostWidgets(host)) {
+    bindSlotIfMissing(widget, uniqueSlotForAliases(slots, [widget?.name, widget?.label]), result);
+  }
+}
+
+/**
+ * #2225 — after workflow_open / graph_load of a modified subgraph, host rails
+ * exist (outline lists width/height/seed) while `_subgraphSlot` is still
+ * unbound. Rebind each host input/widget onto the unique same-named subgraph
+ * input-rail slot so graph_get_subgraph can publish a complete promoted-terminal
+ * witness. Name match is unique or skipped; an existing slot is left alone.
+ *
+ * @returns {{ rebound: number, skipped: number }}
+ */
+export function rebindLoadedPromotedMappings(rootGraph) {
+  const result = { rebound: 0, skipped: 0 };
+  if (!rootGraph) return result;
+  const stack = [rootGraph];
+  const seen = new Set();
+  let walks = 0;
+  while (stack.length) {
+    if (++walks > MAX_SUBGRAPH_WALKS) break;
+    const graph = stack.pop();
+    if (!graph || seen.has(graph)) continue;
+    seen.add(graph);
+    let nodes;
+    try {
+      nodes = graph._nodes ?? graph.nodes;
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(nodes)) continue;
+    for (const node of nodes) {
+      if (!node?.subgraph) continue;
+      rebindOneLoadedHost(node, result);
+      stack.push(node.subgraph);
+    }
+  }
+  return result;
+}
+
 /**
  * #874 remaining load path — `panel_load_workflow` / `graph_load` of a saved
  * subgraph host.
@@ -287,6 +403,7 @@ function savedDefinitionsById(savedGraph) {
 export function applySavedSubgraphHostWidgets(liveRoot, savedGraph) {
   const result = { restored: 0, skipped: 0 };
   if (!liveRoot || !savedGraph || typeof savedGraph !== "object") return result;
+  rebindLoadedPromotedMappings(liveRoot);
   const defs = savedDefinitionsById(savedGraph);
 
   const applyInGraph = (liveGraph, savedNodes) => {

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -2062,16 +2062,23 @@ function resolveWidgetOnlyLoadedPromotion(subgraphNode, widgetName) {
   const subgraph = subgraphNode?.subgraph;
   const wanted = String(widgetName).toLowerCase();
   const widgets = Array.isArray(subgraphNode?.widgets) ? subgraphNode.widgets : [];
-  const hostHits = widgets.filter(
-    (widget) => widget && typeof widget.name === "string" && widget.name.toLowerCase() === wanted,
-  );
+  const hostHits = widgets.filter((widget) => {
+    if (!widget) return false;
+    const name = typeof widget.name === "string" ? widget.name.toLowerCase() : "";
+    const label = typeof widget.label === "string" ? widget.label.toLowerCase() : "";
+    return name === wanted || label === wanted;
+  });
   if (hostHits.length !== 1) return { promoted: false };
-  const source = uniqueRailBackedInnerWidget(subgraph, widgetName);
+  const hostWidget = hostHits[0];
+  const slot = uniqueSlotMatchingAliases(subgraph, [widgetName, hostWidget.name, hostWidget.label]);
+  const fromSlot = slot ? sourcesFromInputRailSlot(subgraph, slot) : [];
+  const source =
+    fromSlot.length === 1 ? fromSlot[0] : uniqueRailBackedInnerWidget(subgraph, widgetName);
   if (!source) return { promoted: false };
   const innerNode = subgraphNodeById(subgraph, source.sourceNodeId);
   const innerWidget = (innerNode?.widgets ?? []).find((widget) => widget?.name === source.sourceWidgetName);
   if (!innerNode || !innerWidget) return { promoted: false };
-  const input = { name: hostHits[0].name, _widget: hostHits[0], widget: hostHits[0] };
+  const input = { name: hostWidget.name, _widget: hostWidget, widget: hostWidget };
   const parentWidgets = liveHostPromotedWidgets(subgraphNode, input, innerWidget);
   const parentWidget = parentWidgets[0] ?? null;
   if (!parentWidget) return { promoted: false };


### PR DESCRIPTION
## Summary
After `panel_open_workflow` reopened a modified subgraph with promoted width/height/seed, outline and query already listed the host rails, but `graph_get_subgraph` published incomplete `promoted_terminals` (unbound `_subgraphSlot`, stale `properties.proxyWidgets`). MCP then refused every `panel_set_widget` write: *promoted-terminal witness was incomplete or unresolved*. Rebind/refresh/reread did not rebuild the mapping.

## Fix
- Rebind each host input/widget onto the unique same-named subgraph input-rail slot after load (`applySavedSubgraphHostWidgets`) and after `panel_refresh_nodes`.
- Resolve PrimitiveInt `value` terminals through that slot when host rails have no live `_subgraphSlot`.
- Do not let a stale file `proxyWidgets` pair veto a live parent-rail-authenticated witness.

## Tests
- `node --test browser_tests/unit/promoted-terminal-reopen-modified.test.mjs`
- related: subgraph-instance-widgets, promoted-terminal-load-witness, subgraph-value-provenance, set-widget-promoted-inner-sync, graph-set-widget-target-fence, promoted-value-scope (75 pass)
- `node scripts/check-panel-scope.mjs`
- `node scripts/check-changelog.mjs`

Closes #2225