### PR TITLE
fix(#2228): preserve Comfy API this in fetch_comfyui_read URL helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- fetch_comfyui_read keeps the Comfy API object as `this` when calling apiURL/fileURL, so frontend helpers that read `this.api_base` still resolve after restart instead of throwing "Cannot read properties of undefined (reading 'api_base')" (#2228)
+
 ## [0.15.166] - 2026-09-04
 
 ### Fixed

--- a/browser_tests/unit/fetch-comfyui-read.test.mjs
+++ b/browser_tests/unit/fetch-comfyui-read.test.mjs
@@ -132,6 +132,58 @@ test("#2196/#2283: the allowed operations use only their fixed same-origin route
   }
 });
 
+test("#2228: apiURL and fileURL keep the Comfy API object as this when they read this.api_base", async () => {
+  function apiURL(path) {
+    return `${this.api_base}${path}`;
+  }
+  function fileURL(path) {
+    return `${this.api_base}${path}`;
+  }
+  const api = {
+    api_base: "https://panel.test/comfy/api",
+    apiURL,
+    fileURL,
+    fetchApi: async () => response({ body: '{"prompt-1":{"status":{"status_str":"success"}}}' }),
+  };
+
+  const history = await fetchComfyUIReadForMcp(
+    { operation: "history" },
+    { expectedOrigin: "https://panel.test", api },
+  );
+  assert.equal(history.operation, "history");
+  assert.equal(history.body, '{"prompt-1":{"status":{"status_str":"success"}}}');
+
+  const logs = await fetchComfyUIReadForMcp(
+    { operation: "logs" },
+    {
+      expectedOrigin: "https://panel.test",
+      api: { ...api, api_base: "https://panel.test/comfy" },
+      fetchImpl: async (url) => {
+        assert.equal(url, "https://panel.test/comfy/internal/logs/raw");
+        return response({ body: "ERROR: render failed\n", url });
+      },
+    },
+  );
+  assert.equal(logs.operation, "logs");
+  assert.equal(logs.body, "ERROR: render failed\n");
+
+  await rejection(
+    fetchComfyUIReadForMcp(
+      { operation: "system_stats" },
+      {
+        expectedOrigin: "https://panel.test",
+        api: {
+          api_base: "https://evil.test/api",
+          apiURL,
+          fetchApi: async () => { throw new Error("must not fetch"); },
+        },
+        fetchImpl: async () => { throw new Error("must not fetch"); },
+      },
+    ),
+    "invalid_origin",
+  );
+});
+
 test("#2283: logs raw transport retains origin, redirect, and body-size fences", async () => {
   const options = {
     expectedOrigin: "https://panel.test",

--- a/web/js/lib/fetch-comfyui-read.js
+++ b/web/js/lib/fetch-comfyui-read.js
@@ -119,7 +119,7 @@ function resolveSameOriginUrl(api, path, expectedOrigin = pageOrigin()) {
   const transportPath = useFileUrl ? LOGS_TRANSPORT_PATH : path;
   let rawUrl;
   try {
-    rawUrl = resolver(transportPath);
+    rawUrl = resolver.call(api, transportPath);
   } catch (error) {
     throw readError(
       "api_unavailable",


### PR DESCRIPTION
## Summary
After restart, `comfyui-mcp` direct reads to 127.0.0.1 fail as expected for a connected-panel setup, but the authenticated `fetch_comfyui_read` fallback also failed. `resolveSameOriginUrl` extracted `api.apiURL` / `api.fileURL` and invoked them detached. Current frontend helpers read `this.api_base`, so the call threw `Cannot read properties of undefined (reading 'api_base')` while resolving `/history` or `/system_stats`.

## Fix
- Invoke the resolver with `resolver.call(api, transportPath)` so `this` stays the Comfy API object.
- Origin, redirect, and body-size fences are unchanged (fail-closed).

## Tests
- `node --test browser_tests/unit/fetch-comfyui-*` (11 pass, 0 fail)

Closes #2228
