### PR TITLE
fix(#2057): classify promoted host after enter/rewire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- After entering a MiniMax H3 subgraph and replacing inner loaders, graph_get_subgraph still classifies the HOST wrapper and publishes a complete promoted-terminal witness for `value` / `value_2`, so panel_set_widget can dispatch instead of treating the in-subgraph lookup as an unclassifiable container (#2057)
+
 ## [0.15.167] - 2026-09-04
 
 ### Fixed

--- a/browser_tests/unit/graph-get-subgraph-root-container.test.mjs
+++ b/browser_tests/unit/graph-get-subgraph-root-container.test.mjs
@@ -20,6 +20,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import { isPromotedContainer } from "../../web/js/lib/graph-read.js";
+import { resolveLiveNode } from "../../web/js/lib/node-id.js";
+import { resolvePromotedContainerForRead } from "../../web/js/lib/subgraph-scope.js";
 
 const PANEL_SRC = readFileSync(
   new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
@@ -53,6 +55,7 @@ function loadGetSubgraph() {
       "summarizeNode",
       "promotedTerminalWitnesses",
       "isPromotedContainer",
+      "resolvePromotedContainerForRead",
       `return ({${method}}).graph_get_subgraph;`,
     )(
       () => ({ graph: {} }),
@@ -66,6 +69,7 @@ function loadGetSubgraph() {
       (inner) => ({ id: inner.id, type: inner.type }),
       () => [],
       isPromotedContainer,
+      resolvePromotedContainerForRead,
     );
 }
 
@@ -265,4 +269,82 @@ test("#2057 graph_get_subgraph does not cap the inner list used as an ownership 
     "asserting truncated:true is a promoted-write veto even when promoted_terminals is complete",
   );
   assert.match(src, /truncated:\s*false/, "complete ownership envelopes emit truncated:false");
+  assert.match(
+    src,
+    /resolvePromotedContainerForRead\(graph, rootGraph \?\? graph, node_id\)/,
+    "MCP's classifier must find the HOST while the canvas is inside it",
+  );
+});
+
+test("#2057 resolvePromotedContainerForRead finds the host while viewing its inner graph", () => {
+  const inner = { _nodes: [{ id: 139, type: "PrimitiveBoolean" }] };
+  const host = { id: 140, type: "SubgraphNode", subgraph: inner };
+  const root = { _nodes: [host] };
+  assert.equal(resolveLiveNode(inner, 140), null);
+  assert.equal(resolvePromotedContainerForRead(inner, root, 140), host);
+  assert.equal(resolvePromotedContainerForRead(inner, root, "140"), host);
+});
+
+test("#2057 graph_get_subgraph classifies the host from inside instead of a missing-id throw", () => {
+  const innerNode = { id: 139, type: "PrimitiveBoolean" };
+  const inner = { _nodes: [innerNode] };
+  const host = { id: 140, type: "SubgraphNode", title: "Image to Video (MiniMax H3)", subgraph: inner };
+  const root = { _nodes: [host] };
+  const start = PANEL_SRC.indexOf("graph_get_subgraph({ node_id }) {");
+  const end = PANEL_SRC.indexOf("async graph_add_node(", start);
+  const method = PANEL_SRC.slice(start, end).replace(/,\s*$/, "");
+  const getSubgraph = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "describeActiveGraph",
+    "subgraphValueProvenance",
+    "redactWidgetValue",
+    "graphViewIdentityFor",
+    "MAX_STATE_NODES",
+    "fixedCapNote",
+    "summarizeNode",
+    "promotedTerminalWitnesses",
+    "isPromotedContainer",
+    "resolvePromotedContainerForRead",
+    `return ({${method}}).graph_get_subgraph;`,
+  )(
+    () => ({ graph: inner, rootGraph: root }),
+    (graph, nodeId) => {
+      const found = resolveLiveNode(graph, nodeId);
+      if (!found) throw new Error(`No node with id ${nodeId} in the current graph`);
+      return found;
+    },
+    () => ({ scope: "subgraph", owner_node_id: 140, graph_identity: "graph:inner" }),
+    () => ({}),
+    () => ({}),
+    () => "graph:inner",
+    50,
+    () => "truncation note",
+    (n) => ({ id: n.id, type: n.type }),
+    () => [],
+    isPromotedContainer,
+    resolvePromotedContainerForRead,
+  );
+  const out = getSubgraph({ node_id: 140 });
+  assert.equal(out.subgraph_of.node_id, 140);
+  assert.equal(out.truncated, false);
+  assert.equal(out.node_count, 1);
+  assert.equal(out.nodes[0].id, 139);
+});
+
+test("#2057 an inner ordinary node still throws the definitive non-container line", () => {
+  const innerNode = { id: 139, type: "PrimitiveBoolean" };
+  const inner = { _nodes: [innerNode] };
+  const host = { id: 140, type: "SubgraphNode", subgraph: inner };
+  const root = { _nodes: [host] };
+  assert.equal(resolvePromotedContainerForRead(inner, root, 139), innerNode);
+  const getSubgraph = loadGetSubgraph()(innerNode);
+  assert.throws(
+    () => getSubgraph({ node_id: 139 }),
+    (err) => {
+      assert.match(String(err.message), /Node 139 \(PrimitiveBoolean\) is not a subgraph/);
+      assert.match(asOrchestratorError(err), DEFINITIVE_NON_SUBGRAPH_RE);
+      return true;
+    },
+  );
 });

--- a/browser_tests/unit/promoted-terminal-minimax-rewire.test.mjs
+++ b/browser_tests/unit/promoted-terminal-minimax-rewire.test.mjs
@@ -1,0 +1,291 @@
+/**
+ * #2057 reopen — after entering MiniMax H3 T2V host 140 and replacing/rewiring
+ * inner loaders, panel_set_widget still refused promoted `value` / `value_2`
+ * because graph_get_subgraph could not classify the HOST (it is not in the
+ * viewed inner graph) and because `_subgraphSlot` was unbound after the
+ * reconfigure. MCP never dispatched graph_set_widget.
+ *
+ * Drives the shipped resolvePromotedContainerForRead / resolvePromotedInnerTarget
+ * / applyWidgetWrite and the production promotedTerminalWitnesses extractor.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { isPromotedContainer } from "../../web/js/lib/graph-read.js";
+import { resolveLiveNode } from "../../web/js/lib/node-id.js";
+import {
+  resolvePromotedContainerForRead,
+} from "../../web/js/lib/subgraph-scope.js";
+import { withPreservedPromotedInstanceWidgets } from "../../web/js/lib/subgraph-instance-widgets.js";
+import {
+  applyWidgetWrite,
+  followPromotionToConcrete,
+  MAX_PROMOTION_CHAIN_DEPTH,
+  promotedInputAliases,
+  resolvePromotedInnerTarget,
+} from "../../web/js/lib/widget-write.js";
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+
+const HOST_TYPE = "79dd8a95-ce9d-4c14-b264-2162e8bec5ce";
+const ROOT_GRAPH_ID = "e3f2b845-8f2c-4b5a-9caf-eac1029d3e7e";
+
+function extractPromotedTerminalWitnesses() {
+  const helperStart = PANEL_SRC.indexOf("function resolveSubgraphLink(");
+  const helperEnd = PANEL_SRC.indexOf("\nfunction findPromotedHostInput", helperStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "production promotion helper range must remain extractable");
+  return new Function(
+    "resolvePromotedInnerTarget",
+    "followPromotionToConcrete",
+    "MAX_PROMOTION_CHAIN_DEPTH",
+    "promotedInputAliases",
+    "isPromotedContainer",
+    `${PANEL_SRC.slice(helperStart, helperEnd)}; return promotedTerminalWitnesses;`,
+  )(
+    resolvePromotedInnerTarget,
+    followPromotionToConcrete,
+    MAX_PROMOTION_CHAIN_DEPTH,
+    promotedInputAliases,
+    isPromotedContainer,
+  );
+}
+
+function extractGetSubgraph() {
+  const start = PANEL_SRC.indexOf("graph_get_subgraph({ node_id }) {");
+  const end = PANEL_SRC.indexOf("async graph_add_node(", start);
+  assert.ok(start >= 0 && end > start, "graph_get_subgraph handler must remain extractable");
+  const method = PANEL_SRC.slice(start, end).replace(/,\s*$/, "");
+  const makeWitnesses = extractPromotedTerminalWitnesses();
+  return (ctx) =>
+    new Function(
+      "getGraphCtx",
+      "resolveNode",
+      "describeActiveGraph",
+      "subgraphValueProvenance",
+      "redactWidgetValue",
+      "graphViewIdentityFor",
+      "MAX_STATE_NODES",
+      "fixedCapNote",
+      "summarizeNode",
+      "promotedTerminalWitnesses",
+      "isPromotedContainer",
+      "resolvePromotedContainerForRead",
+      `return ({${method}}).graph_get_subgraph;`,
+    )(
+      () => ctx,
+      (graph, nodeId) => {
+        const found = resolveLiveNode(graph, nodeId);
+        if (!found) throw new Error(`No node with id ${nodeId} in the current graph`);
+        return found;
+      },
+      () => ({
+        scope: ctx.graph === ctx.rootGraph ? "root" : "subgraph",
+        owner_node_id: ctx.graph === ctx.rootGraph ? undefined : 140,
+        graph_identity: "graph:inner",
+      }),
+      () => ({}),
+      () => ({}),
+      () => "graph:inner",
+      50,
+      () => "truncation note",
+      (inner) => ({ id: inner.id, type: inner.type }),
+      (node) => makeWitnesses(node),
+      isPromotedContainer,
+      resolvePromotedContainerForRead,
+    );
+}
+
+function makePrimitive(id, type, value) {
+  const inner = { name: "value", type: type === "PrimitiveBoolean" ? "BOOLEAN" : "INT", value };
+  const node = {
+    id,
+    type,
+    inputs: [{ name: "value", widget: { name: "value" }, type: inner.type, link: id }],
+    widgets: [inner],
+  };
+  return { node, inner };
+}
+
+/** Official MiniMax H3 T2V host 140 after enter + replace UNETLoader.
+ * Host rails exist; `_subgraphSlot` unbound; several inner Primitive `value`
+ * widgets (so a name-only inner match is ambiguous); -10 still drives
+ * turbo_mode (`value`) and turbo_steps (`value_2`). */
+function makeRewiredMiniMaxHost() {
+  const turbo = makePrimitive(139, "PrimitiveBoolean", false);
+  const steps = makePrimitive(138, "PrimitiveInt", 8);
+  const duration = makePrimitive(133, "PrimitiveFloat", 5);
+  const unetInner = { name: "unet_name", type: "combo", value: "new.safetensors" };
+  const unet = {
+    id: 200,
+    type: "UNETLoader",
+    inputs: [{ name: "unet_name", widget: { name: "unet_name" }, type: "COMBO", link: 221 }],
+    widgets: [unetInner],
+  };
+  const slotNames = [
+    "first_frame",
+    "last_frame",
+    "prompt",
+    "width",
+    "height",
+    "value_1",
+    "noise_seed",
+    "unet_name",
+    "clip_name",
+    "vae_name",
+    "vae_name_1",
+    "value",
+    "lora_name",
+    "strength_model_1",
+    "value_2",
+  ];
+  const subgraphInputs = slotNames.map((name) => ({
+    name,
+    label: name === "value" ? "turbo_mode" : name === "value_2" ? "turbo_steps" : name === "value_1" ? "duration" : name,
+    linkIds: [],
+  }));
+  const links = {
+    133: { id: 133, origin_id: -10, origin_slot: 5, target_id: 133, target_slot: 0 },
+    138: { id: 138, origin_id: -10, origin_slot: 14, target_id: 138, target_slot: 0 },
+    139: { id: 139, origin_id: -10, origin_slot: 11, target_id: 139, target_slot: 0 },
+    221: { id: 221, origin_id: -10, origin_slot: 7, target_id: 200, target_slot: 0 },
+  };
+  const nodes = [duration.node, steps.node, turbo.node, unet];
+  const subgraph = {
+    _nodes: nodes,
+    inputs: subgraphInputs,
+    inputNode: { id: -10, slots: subgraphInputs },
+    links,
+    getNodeById: (id) => nodes.find((node) => String(node.id) === String(id)) ?? null,
+    getLink: (id) => links[id] ?? null,
+  };
+
+  const rail = (name, type, value, label) => {
+    const widget = {
+      name,
+      type,
+      value,
+      widgetId: `${ROOT_GRAPH_ID}:140:${name}`,
+      ...(label ? { label } : {}),
+    };
+    return widget;
+  };
+  const valueRail = rail("value", "BOOLEAN", false, "turbo_mode");
+  const value2Rail = rail("value_2", "INT", 8, "turbo_steps");
+  const host = {
+    id: 140,
+    type: HOST_TYPE,
+    title: "Image to Video (MiniMax H3)",
+    subgraph,
+    inputs: [
+      { name: "first_frame", type: "IMAGE", link: null },
+      { name: "last_frame", type: "IMAGE", link: null },
+      { name: "width", type: "INT", link: 246, widget: { name: "width" } },
+      { name: "height", type: "INT", link: 247, widget: { name: "height" } },
+      { name: "value_1", type: "FLOAT", link: null, widget: { name: "value_1" } },
+      { name: "value", type: "BOOLEAN", link: null, widget: valueRail, _widget: valueRail },
+      { name: "value_2", type: "INT", link: null, widget: value2Rail, _widget: value2Rail },
+    ],
+    widgets: [
+      rail("prompt", "STRING", "a prompt"),
+      rail("width", "INT", 1344),
+      rail("height", "INT", 768),
+      rail("value_1", "FLOAT", 5, "duration"),
+      rail("noise_seed", "INT", 1),
+      rail("unet_name", "combo", "new.safetensors"),
+      valueRail,
+      value2Rail,
+    ],
+    properties: {
+      proxyWidgets: [
+        [127, "unet_name"],
+        [139, "value"],
+        [138, "value"],
+      ],
+    },
+  };
+  const root = { _nodes: [host] };
+  return { host, root, subgraph, turbo, steps, valueRail, value2Rail };
+}
+
+function assertCompleteWitness(entries, name, terminalId, terminalType) {
+  const witness = entries.find((entry) => entry.widget === name);
+  assert.ok(witness, `missing witness for ${name}`);
+  assert.equal(witness.error, undefined, `${name} must not publish an incomplete witness`);
+  assert.equal(witness.parent_rail?.authoritative, true);
+  assert.equal(witness.terminal_widget, "value");
+  assert.equal(witness.terminal_node_id, terminalId);
+  assert.equal(witness.terminal_node_type, terminalType);
+}
+
+test("#2057 after enter, the MiniMax host is still a promoted container from the inner view", () => {
+  const { host, root, subgraph } = makeRewiredMiniMaxHost();
+  assert.equal(resolveLiveNode(subgraph, 140), null, "the wrapper is not an inner node");
+  assert.equal(resolvePromotedContainerForRead(subgraph, root, 140), host);
+  assert.equal(isPromotedContainer(host), true);
+});
+
+test("#2057 after loader rewire, host value/value_2 resolve to Primitive terminals via -10", () => {
+  const { host, turbo, steps } = makeRewiredMiniMaxHost();
+  const mode = resolvePromotedInnerTarget(host, "value", () => null);
+  assert.equal(mode.promoted, true);
+  assert.equal(mode.target.node, turbo.node);
+  assert.equal(mode.target.widget, turbo.inner);
+  assert.equal(mode.target.parentWidget?.name, "value");
+  const turboSteps = resolvePromotedInnerTarget(host, "value_2", () => null);
+  assert.equal(turboSteps.promoted, true);
+  assert.equal(turboSteps.target.node, steps.node);
+  assert.equal(turboSteps.target.widget, steps.inner);
+  assert.equal(turboSteps.target.parentWidget?.name, "value_2");
+});
+
+test("#2057 production witness completes for MiniMax value/value_2 after loader rewire", () => {
+  const makeWitnesses = extractPromotedTerminalWitnesses();
+  const { host } = makeRewiredMiniMaxHost();
+  const entries = makeWitnesses(host);
+  assertCompleteWitness(entries, "value", 139, "PrimitiveBoolean");
+  assertCompleteWitness(entries, "value_2", 138, "PrimitiveInt");
+});
+
+test("#2057 graph_get_subgraph classifies host 140 while the canvas is inside it", () => {
+  const { host, root, subgraph } = makeRewiredMiniMaxHost();
+  const getSubgraph = extractGetSubgraph()({ graph: subgraph, rootGraph: root });
+  const out = getSubgraph({ node_id: 140 });
+  assert.equal(out.subgraph_of.node_id, 140);
+  assert.equal(out.truncated, false);
+  assert.equal(out.node_count, subgraph._nodes.length);
+  assert.equal(out.nodes.length, subgraph._nodes.length);
+  assertCompleteWitness(out.promoted_terminals, "value", 139, "PrimitiveBoolean");
+  assertCompleteWitness(out.promoted_terminals, "value_2", 138, "PrimitiveInt");
+  assert.equal(host.type, HOST_TYPE);
+});
+
+test("#2057 applyWidgetWrite sets MiniMax promoted value/value_2 without unpacking", () => {
+  const { host, turbo, steps, valueRail, value2Rail } = makeRewiredMiniMaxHost();
+  const mode = applyWidgetWrite(host, "value", true, { resolveSource: () => null });
+  const turboSteps = applyWidgetWrite(host, "value_2", 4, { resolveSource: () => null });
+  assert.equal(mode.value, true);
+  assert.equal(turboSteps.value, 4);
+  assert.equal(turbo.inner.value, true);
+  assert.equal(steps.inner.value, 4);
+  assert.equal(valueRail.value, true);
+  assert.equal(value2Rail.value, 4);
+});
+
+test("#2057 inner mutations rebind unique promoted slots after restore", async () => {
+  assert.match(
+    readFileSync(new URL("../../web/js/lib/subgraph-instance-widgets.js", import.meta.url), "utf8"),
+    /rebindLoadedPromotedMappings\(rootGraph\)/,
+    "enter+rewire must rebuild host _subgraphSlot after the instance-rail restore",
+  );
+  const { host, root, subgraph } = makeRewiredMiniMaxHost();
+  assert.equal(host.inputs.find((input) => input.name === "value")?._subgraphSlot, undefined);
+  await withPreservedPromotedInstanceWidgets(root, subgraph, () => "ok");
+  assert.equal(
+    host.inputs.find((input) => input.name === "value")?._subgraphSlot,
+    subgraph.inputs.find((slot) => slot.name === "value"),
+  );
+});

--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { isPromotedContainer } from "../../web/js/lib/graph-read.js";
+import { resolvePromotedContainerForRead } from "../../web/js/lib/subgraph-scope.js";
 import { graphViewIdentityFor } from "../../web/js/lib/graph-view-identity.js";
 import { subgraphValueProvenance } from "../../web/js/lib/subgraph-value-provenance.js";
 import { redactWidgetValue, REDACTED_WIDGET_VALUE } from "../../web/js/lib/widget-secret-redaction.js";
@@ -96,11 +97,13 @@ test("WIRING: production graph_get_subgraph gives MCP a definitive non-promoted 
     "getGraphCtx",
     "resolveNode",
     "isPromotedContainer",
+    "resolvePromotedContainerForRead",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph: {} }),
     (_graph, id) => ({ id, type: "OrdinaryNode" }),
     isPromotedContainer,
+    resolvePromotedContainerForRead,
   );
 
   assert.throws(
@@ -146,6 +149,7 @@ test("WIRING: production graph_get_subgraph publishes the terminal nested-promot
     "summarizeNode",
     "promotedTerminalWitnesses",
     "isPromotedContainer",
+    "resolvePromotedContainerForRead",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph }),
@@ -159,6 +163,7 @@ test("WIRING: production graph_get_subgraph publishes the terminal nested-promot
     (node) => ({ id: node.id, type: node.type }),
     () => [terminal],
     isPromotedContainer,
+    resolvePromotedContainerForRead,
   );
 
   const out = getSubgraph({ node_id: 78 });
@@ -186,6 +191,7 @@ test("WIRING: production graph_get_subgraph publishes an explicit empty witness 
     "summarizeNode",
     "promotedTerminalWitnesses",
     "isPromotedContainer",
+    "resolvePromotedContainerForRead",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph: {} }),
@@ -199,6 +205,7 @@ test("WIRING: production graph_get_subgraph publishes an explicit empty witness 
     (node) => ({ id: node.id, type: node.type }),
     () => [],
     isPromotedContainer,
+    resolvePromotedContainerForRead,
   );
 
   assert.deepEqual(getSubgraph({ node_id: 78 }).promoted_terminals, []);
@@ -514,6 +521,7 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     "summarizeNode",
     "promotedTerminalWitnesses",
     "isPromotedContainer",
+    "resolvePromotedContainerForRead",
     `return ({${method}}).graph_get_subgraph;`,
   )(
     () => ({ graph }),
@@ -527,6 +535,7 @@ test("WIRING: production graph_get_subgraph redacts instance provenance", async 
     (node) => ({ id: node.id, mode: node.mode, inputs: node.inputs, outputs: node.outputs }),
     () => [],
     isPromotedContainer,
+    resolvePromotedContainerForRead,
   );
 
   const out = getSubgraph({ node_id: 173 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -421,6 +421,7 @@ import {
   resolveScope,
   describeScope,
   findSubgraphOwner,
+  resolvePromotedContainerForRead,
   isSubgraphInRoot,
   resolveRailNode,
   railKindFor,
@@ -15907,8 +15908,16 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   graph_get_subgraph({ node_id }) {
-    const { graph } = getGraphCtx();
-    const node = resolveNode(graph, node_id);
+    const { graph, rootGraph } = getGraphCtx();
+    // #2057 — after enter_subgraph the HOST wrapper is not in the viewed
+    // graph. MCP's promoted-write probe treats that missing-id throw as
+    // "could not determine whether the addressed node is a promoted
+    // container" and never dispatches graph_set_widget. Classify the live
+    // owner / unique root host first; fall through to resolveNode so an
+    // ordinary miss still uses the existing missing-id diagnosis.
+    const node =
+      resolvePromotedContainerForRead(graph, rootGraph ?? graph, node_id) ??
+      resolveNode(graph, node_id);
     // #1941 — MCP's promoted-write probe treats anything other than this exact
     // "is not a subgraph" line as indeterminate and refuses the write. A root
     // node is not a promoted container: only a live inner graph (nodes list or

--- a/web/js/lib/subgraph-instance-widgets.js
+++ b/web/js/lib/subgraph-instance-widgets.js
@@ -472,5 +472,13 @@ export async function withPreservedPromotedInstanceWidgets(rootGraph, subgraph, 
     } catch {
       /* #2001 — a restore throw must not turn a landed inner mutation into a missing reply */
     }
+    try {
+      // #2057 — inner add/rewire recreates host inputs without `_subgraphSlot`.
+      // Rebind unique IO slots so graph_get_subgraph still publishes a complete
+      // promoted-terminal witness for HOST rails (MiniMax value / value_2).
+      rebindLoadedPromotedMappings(rootGraph);
+    } catch {
+      /* a rebind throw must not turn a landed inner mutation into a missing reply */
+    }
   }
 }

--- a/web/js/lib/subgraph-scope.js
+++ b/web/js/lib/subgraph-scope.js
@@ -32,6 +32,8 @@
 // closed. resolveScope needs exactly that bar before it may repaint a canvas
 // away, so it borrows the proof rather than inventing a weaker one.
 import { graphRootProvenEmpty as graphProvenContentFree } from "./graph-binding.js";
+import { isPromotedContainer } from "./graph-read.js";
+import { canonicalNodeId, resolveLiveNode } from "./node-id.js";
 
 export const SUBGRAPH_INPUT_RAIL_ID = -10;
 export const SUBGRAPH_OUTPUT_RAIL_ID = -20;
@@ -126,6 +128,57 @@ export function findSubgraphOwner(rootGraph, subgraph) {
     }
   }
   return null;
+}
+
+/** Hard cap on graphs visited while classifying a promoted container from a
+ *  nested view. A `node.subgraph` getter that yields a new object each time
+ *  would otherwise walk forever on graph_get_subgraph's read path (#2057). */
+const MAX_PROMOTED_CONTAINER_WALKS = 10000;
+
+function nodeIdMatches(node, nodeId) {
+  if (node?.id == null || nodeId == null) return false;
+  return canonicalNodeId(node.id) === canonicalNodeId(nodeId);
+}
+
+/**
+ * #2057 — `graph_get_subgraph` is MCP's promoted-container classifier. Writes
+ * resolve against the VIEWED graph, so after `panel_enter_subgraph` the HOST
+ * wrapper is not in `_nodes` and `resolveNode` throws a missing-id line.
+ * MCP treats anything other than "is not a subgraph" as indeterminate and
+ * refuses the promoted write (`value` / `value_2` on MiniMax H3 host 140)
+ * before `graph_set_widget`.
+ *
+ * This read may therefore look at the live owner of the current view, then a
+ * unique matching SubgraphNode reachable from the root. An ordinary node in
+ * the current view is still returned so the caller can throw the definitive
+ * non-container line. Ambiguous same-id hosts are not guessed.
+ *
+ * @returns {object | null}
+ */
+export function resolvePromotedContainerForRead(graph, rootGraph, nodeId) {
+  const local = resolveLiveNode(graph, nodeId);
+  if (local) return local;
+  const owner = findSubgraphOwner(rootGraph, graph);
+  if (owner?.node && nodeIdMatches(owner.node, nodeId) && isPromotedContainer(owner.node)) {
+    return owner.node;
+  }
+  if (!rootGraph) return null;
+  const hits = [];
+  const seen = new Set();
+  const stack = [rootGraph];
+  let walks = 0;
+  while (stack.length) {
+    if (++walks > MAX_PROMOTED_CONTAINER_WALKS) break;
+    const next = stack.pop();
+    if (!next || seen.has(next)) continue;
+    seen.add(next);
+    for (const node of next._nodes ?? []) {
+      if (!node) continue;
+      if (node.subgraph) stack.push(node.subgraph);
+      if (nodeIdMatches(node, nodeId) && isPromotedContainer(node)) hits.push(node);
+    }
+  }
+  return hits.length === 1 ? hits[0] : null;
 }
 
 /** Ordered list of subgraph INSTANCE node ids from the root graph down to (but not


### PR DESCRIPTION
## Summary
After entering the official MiniMax H3 T2V subgraph and replacing/rewiring inner loaders, `panel_set_widget` still refused promoted HOST rails `value` / `value_2` (node 140) before `graph_set_widget`. MCP treated `graph_get_subgraph` as indeterminate: *could not determine whether the addressed node is a promoted container*.

0.15.163 already uncaps the inner node list (`truncated:false`). 0.15.166 already rebinds unique IO slots after `panel_open_workflow` / `panel_refresh_nodes`. Those are not re-shipped.

## Remaining hole
`graph_get_subgraph` resolved only the *viewed* graph (`web/js/comfyui-mcp-panel.js` `graph_get_subgraph`). After `panel_enter_subgraph` the HOST wrapper is not in `_nodes`, so `resolveNode` throws a missing-id line. MCP classifies anything other than `Node <id> (<type>) is not a subgraph` as indeterminate and never dispatches.

Inner add/rewire also recreates host inputs without `_subgraphSlot`. Rebind ran only on open/refresh, not after the inner-mutation restore.

## Fix
- `resolvePromotedContainerForRead` (`web/js/lib/subgraph-scope.js`): current-view node first, then the live owner of the viewed graph, then a unique matching SubgraphNode from the root. Ordinary nodes still throw the definitive non-container line.
- `withPreservedPromotedInstanceWidgets` rebinds unique IO slots after restoring instance rails so `value` / `value_2` still publish a complete promoted-terminal witness.

## Tests
```
node --test browser_tests/unit/promoted-terminal-minimax-rewire.test.mjs browser_tests/unit/graph-get-subgraph-root-container.test.mjs browser_tests/unit/subgraph-value-provenance.test.mjs
```
35 passed, 0 failed.

Also green: `subgraph-instance-widgets.test.mjs`, `promoted-terminal-reopen-modified.test.mjs`, `promoted-terminal-load-witness.test.mjs`, `set-widget-subgraph-timeout.test.mjs`, `set-widget-promoted-inner-sync.test.mjs`, `graph-set-widget-target-fence.test.mjs`.

`node scripts/check-panel-scope.mjs` OK. `node scripts/check-changelog.mjs` OK.

Closes #2057
