### PR TITLE
fix(#2234): reuse storyboard identity on refused completion retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- Refused completion retries of a finished video reuse the composed storyboard identity and skip re-upload, so a down bridge cannot fill ComfyUI/temp with unique `storyboard_*.png` / `poster_*.png` copies every sweep (#2234)
+
 ## [0.15.168] - 2026-09-04
 
 ### Fixed

--- a/browser_tests/unit/run-completion-storyboard-reuse.test.mjs
+++ b/browser_tests/unit/run-completion-storyboard-reuse.test.mjs
@@ -1,0 +1,232 @@
+/**
+ * panel#2234 — a refused completion retry must not fill ComfyUI/temp.
+ *
+ * Two deliberate behaviours combine into unbounded disk write when the bridge
+ * is down: `releaseUnackedDelivery()` decrements the replay budget on a
+ * transport refusal (#370 / #1739: a run whose frames are ALWAYS refused still
+ * retries), and each retry used to mint a FRESH storyboard identity (#1718 /
+ * #1834 cache-busting) so `storyboard_<base>_<identity>.png` was a new file
+ * every 20 s sweep.
+ *
+ * The decrement stays. What these tests pin is the remaining hole: retries of
+ * the SAME finished video record reuse the composed identity and skip
+ * sample/upload, while a genuinely new completion still cache-busts.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+import { createRunCompletionFlushHandler } from "../../web/js/lib/run-completion-delivery.js";
+
+function sheetBlob({ size = 4096, paintedFrames = 20, posterBlob } = {}) {
+  const b = { size, paintedFrames };
+  if (posterBlob !== undefined) b.posterBlob = posterBlob;
+  return b;
+}
+
+function videoRecord() {
+  return {
+    m: { filename: "LOOP_HQ_00001_.mp4", subfolder: "", type: "output", format: "video/h264-mp4" },
+    nodeId: 12,
+  };
+}
+
+function videoPayload(overrides = {}) {
+  return {
+    promptId: "p-2234",
+    images: [],
+    videos: [videoRecord()],
+    durationMs: 8000,
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides = {}) {
+  const calls = { uploads: [], samples: [], painted: [], frames: [] };
+  const deps = {
+    sendFrame: (frame) => {
+      calls.frames.push(frame);
+      return false;
+    },
+    coerceMessageText: (v) => (typeof v === "string" ? v : v == null ? "" : String(v)),
+    formatDuration: (ms) => `${Math.round(ms / 1000)}s`,
+    formatClock: () => "1:51:14 AM",
+    imageViewUrl: (ref) => `/view?filename=${ref?.filename ?? ""}`,
+    fetchImageBytes: async () => 5_400_000,
+    fetchImageDimensions: async () => null,
+    humanizeBytes: (n) => (n == null ? null : `${n} B`),
+    buildVideoStoryboard: async (url) => {
+      calls.samples.push(url);
+      return sheetBlob();
+    },
+    uploadBlobToInput: async (blob, name) => {
+      calls.uploads.push({ name, blob });
+      return { filename: name, subfolder: "", type: "temp" };
+    },
+    storyboardFrameCount: () => 20,
+    paintImage: (url, caption) => calls.painted.push({ url, caption }),
+    applyVideoPoster: () => {},
+    videoStoryboardEnabled: true,
+    agentReceivesImages: () => true,
+    warn: () => {},
+    videoStoryboardTimeoutMs: 25_000,
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+function sheetNames(calls) {
+  return calls.uploads.map((u) => u.name).filter((name) => name.startsWith("storyboard_"));
+}
+
+async function settle(turns = 8) {
+  for (let i = 0; i < turns; i += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("#2234: refused retries of the SAME finished record reuse the identity and skip re-upload", async () => {
+  const payload = videoPayload();
+  const { deps, calls } = makeDeps({
+    buildVideoStoryboard: async (url) => {
+      calls.samples.push(url);
+      return sheetBlob({ posterBlob: { size: 718_372 } });
+    },
+  });
+
+  const first = await composeRunCompletionFrame(payload, deps);
+  const second = await composeRunCompletionFrame(payload, deps);
+  await settle(4);
+
+  assert.equal(calls.samples.length, 1, "the source is sampled once — re-composing cannot change it");
+  const sheets = sheetNames(calls);
+  const posters = calls.uploads.map((u) => u.name).filter((name) => name.startsWith("poster_"));
+  assert.equal(sheets.length, 1, "one temp storyboard filename, not one per retry");
+  assert.equal(posters.length, 1, "the poster is uploaded once, under the same identity");
+  assert.equal(first.images[0]?.filename, sheets[0]);
+  assert.equal(second.images[0]?.filename, sheets[0], "the retry attaches the already-uploaded sheet");
+  assert.match(sheets[0], new RegExp(`^storyboard_LOOP_HQ_00001__${payload.videos[0].storyboardIdentity}\\.png$`));
+  assert.match(posters[0], new RegExp(`^poster_LOOP_HQ_00001__${payload.videos[0].storyboardIdentity}\\.png$`));
+  assert.equal(calls.painted.length, 1, "the chat card is not re-painted on every sweep");
+});
+
+test("#2234: overlapping produces of the same record share one pipeline", async () => {
+  let release;
+  const payload = videoPayload();
+  const { deps, calls } = makeDeps({
+    buildVideoStoryboard: async (url) => {
+      calls.samples.push(url);
+      await new Promise((resolve) => {
+        release = resolve;
+      });
+      return sheetBlob();
+    },
+  });
+
+  const first = composeRunCompletionFrame(payload, deps);
+  const second = composeRunCompletionFrame(payload, deps);
+  await settle(4);
+  assert.equal(typeof release, "function", "the first produce is waiting on the sample");
+  release();
+  const frames = await Promise.all([first, second]);
+
+  assert.equal(calls.samples.length, 1, "a sweep that overlaps the first encode must not start a second");
+  assert.equal(sheetNames(calls).length, 1);
+  assert.equal(frames[0].images[0]?.filename, frames[1].images[0]?.filename);
+});
+
+test("#1718 CONTROL: a genuinely new completion still mints a fresh identity", async () => {
+  const attempts = [];
+  for (let i = 0; i < 2; i += 1) {
+    const { deps, calls } = makeDeps({
+      buildVideoStoryboard: async (url) => {
+        attempts.push({ url });
+        return sheetBlob();
+      },
+    });
+    await composeRunCompletionFrame(videoPayload({ promptId: `p-2234-new-${i}` }), deps);
+    attempts[i].name = sheetNames(calls)[0] ?? null;
+  }
+  assert.notEqual(attempts[0].url, attempts[1].url, "a new completion must not reuse the previous /view cache key");
+  assert.notEqual(attempts[0].name, attempts[1].name, "a new completion must not reuse the previous temp filename");
+});
+
+test("#2234: a down-bridge history sweep keeps retrying the frame but writes the sheet once", async () => {
+  const PROMPT = "9f0f7d2e-6c1a-49f0-9f0a-2234-loop";
+  const ROUTE = "route-a";
+  const SESSION = "sess-1";
+  const VIDEO = { filename: "LOOP_HQ_00001_.mp4", subfolder: "", type: "output", format: "video/h264-mp4" };
+  const HISTORY = {
+    outputs: { 9: { gifs: [VIDEO] } },
+    status: { status_str: "success", completed: true, messages: [] },
+  };
+
+  const uploads = [];
+  const samples = [];
+  const sendAttempts = [];
+  let tracker;
+
+  const onFlush = createRunCompletionFlushHandler({
+    sendFrame: (frame) => {
+      sendAttempts.push(frame);
+      return false;
+    },
+    markDelivered: (promptId, completionKey) => tracker.markDelivered(promptId, completionKey),
+    markUndelivered: (promptId, completionKey) => tracker.markUndelivered(promptId, completionKey),
+    pruneRebootMarker: () => {},
+    coerceMessageText: (v) => (v == null ? "" : typeof v === "string" ? v : String(v)),
+    formatDuration: (ms) => (ms == null ? null : `${Math.round(ms / 1000)}s`),
+    formatClock: () => "1:51:14 AM",
+    imageViewUrl: (m) => `/view?filename=${m?.filename ?? "x"}`,
+    fetchImageBytes: async () => 5_400_000,
+    fetchImageDimensions: async () => null,
+    humanizeBytes: (n) => (n == null ? null : `${n} B`),
+    buildVideoStoryboard: async (url) => {
+      samples.push(url);
+      return sheetBlob();
+    },
+    uploadBlobToInput: async (_blob, name) => {
+      uploads.push(name);
+      return { filename: name, subfolder: "", type: "temp" };
+    },
+    storyboardFrameCount: () => 20,
+    paintImage: () => {},
+    applyVideoPoster: () => {},
+    videoStoryboardEnabled: true,
+    agentReceivesImages: () => true,
+    isAgentMuted: () => false,
+    warn: () => {},
+  });
+
+  tracker = createRunCompletionTracker({
+    onFlush,
+    setTimer: () => 0,
+    clearTimer: () => {},
+  });
+
+  const completionKey = tracker.onQueued(PROMPT, { routeId: ROUTE, sessionId: SESSION });
+  assert.ok(completionKey);
+
+  const sweep = async () => {
+    await tracker.reconcile({
+      fetchHistory: async () => HISTORY,
+      fetchQueued: async () => false,
+      isVideo: (m) => /\.(mp4|webm|mov)$/i.test(String(m?.filename || "")),
+    });
+    await settle();
+  };
+
+  await sweep();
+  assert.equal(sendAttempts.length, 1, "the first sweep still composes and attempts delivery");
+  assert.equal(tracker.hasPending(), true, "a refusal re-pends — #370 / #1739 stay fail-closed");
+
+  for (let tick = 0; tick < 8; tick += 1) await sweep();
+
+  assert.ok(sendAttempts.length >= 2, "refused frames keep retrying; the decrement is not a cap");
+  const sheets = uploads.filter((name) => name.startsWith("storyboard_"));
+  const posters = uploads.filter((name) => name.startsWith("poster_"));
+  assert.equal(new Set(sheets).size, 1, "temp storyboard filenames must not multiply across sweeps");
+  assert.equal(sheets.length, 1, "the already-uploaded sheet is not written again");
+  assert.equal(samples.length, 1, "the source video is not re-sampled every sweep");
+  assert.equal(posters.length, 0, "no poster blob in this double, so none uploaded");
+  assert.equal(tracker.hasPending(), true, "the run stays owed until something acknowledges it");
+});

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -50,6 +50,44 @@ import {
 // enrich the note; a stall cannot beat the grace.
 export const STILLS_METADATA_TIMEOUT_MS = 1000;
 
+// #2234 — overlapping compose() calls for the SAME video record (a 20 s sweep
+// that re-enters while the first sample is still encoding) must share one
+// pipeline, not mint a second identity. WeakMap so a finished record does not
+// keep the promise alive; the durable reuse lives on the record itself.
+const inFlightStoryboards = new WeakMap();
+
+function reusedStoryboardSegment(v) {
+  if (!v || typeof v !== "object") return null;
+  const ref = v.storyboardRef;
+  const note = v.storyboardNote;
+  if (!ref || typeof note !== "string" || !note) return null;
+  const segment = { ref, note };
+  if (typeof v.storyboardNoteWhenBlind === "string" && v.storyboardNoteWhenBlind) {
+    segment.noteWhenBlind = v.storyboardNoteWhenBlind;
+  }
+  return segment;
+}
+
+function ensureStoryboardIdentity(v) {
+  if (!v || typeof v !== "object") return createStoryboardIdentity();
+  if (typeof v.storyboardIdentity !== "string" || !v.storyboardIdentity) {
+    v.storyboardIdentity = createStoryboardIdentity();
+  }
+  return v.storyboardIdentity;
+}
+
+function persistStoryboardSegment(v, storyboardIdentity, segment) {
+  if (!v || typeof v !== "object") return;
+  if (typeof storyboardIdentity === "string" && storyboardIdentity) {
+    v.storyboardIdentity = storyboardIdentity;
+  }
+  if (segment?.ref) v.storyboardRef = segment.ref;
+  if (typeof segment?.note === "string" && segment.note) v.storyboardNote = segment.note;
+  if (typeof segment?.noteWhenBlind === "string" && segment.noteWhenBlind) {
+    v.storyboardNoteWhenBlind = segment.noteWhenBlind;
+  }
+}
+
 /**
  * Build and send the single consolidated completion frame for one finished
  * prompt. Resolves to the frame that was sent (for tests), or null when the
@@ -765,6 +803,16 @@ async function buildVideoSegment(v, deps) {
   if (!videoStoryboardEnabled) {
     return { ref: null, note: noteOnly("storyboard preview is turned off in panel settings") };
   }
+  // #2234 — a refused retry of THIS finished record must not sample or upload
+  // again. The artifact cannot change; a fresh identity would only mint another
+  // temp filename. A genuinely new completion is a different `v` (and usually a
+  // different prompt id), so #1718 / #1834 cache-busting is unchanged.
+  const reused = reusedStoryboardSegment(v);
+  if (reused) return reused;
+  if (v && typeof v === "object") {
+    const inFlight = inFlightStoryboards.get(v);
+    if (inFlight) return inFlight;
+  }
   // The storyboard pipeline (sample → upload → HEAD) contains at least one
   // UNBOUNDED step (uploadBlobToInput does a fetch with no timeout). Bound the
   // whole pipeline: on timeout, degrade to the note-only fallback so a stalled
@@ -791,7 +839,13 @@ async function buildVideoSegment(v, deps) {
       // Give the source fetch and every derived artifact one attempt identity so
       // neither the browser nor ComfyUI's filename-based temp ref can return the
       // previous run's pixels.
-      const storyboardIdentity = v?.storyboardIdentity || createStoryboardIdentity();
+      //
+      // #2234 — write that identity back onto THIS record immediately, before
+      // any await. A refused retry of the same finished run (or a sweep that
+      // overlaps this produce) must reuse it; minting here would fill temp/
+      // with unique storyboard_*.png names. A new completion still mints,
+      // because it is a different record.
+      const storyboardIdentity = ensureStoryboardIdentity(v);
       const sourceUrl =
         v?.videoUrl || appendStoryboardCacheBust(imageViewUrl(m), storyboardIdentity);
       // The video's own byte size is wanted only for the note's metadata line.
@@ -948,14 +1002,23 @@ async function buildVideoSegment(v, deps) {
         `Blind mode is ON, so the storyboard was NOT sent to you (it is shown to the user). ` +
         `Do not comment on motion, sharpness, or visual quality — acknowledge completion and the metadata below only.` +
         metaSuffix(sizeStr, frames);
-      return { ref, note, noteWhenBlind };
+      const segment = { ref, note, noteWhenBlind };
+      persistStoryboardSegment(v, storyboardIdentity, segment);
+      return segment;
     } catch (err) {
       warn("[cmcp] storyboard pipeline failed:", err);
       return { ref: null, note: noteOnly("its storyboard preview failed to build") };
     }
   };
+  const work = produce();
+  if (v && typeof v === "object") {
+    inFlightStoryboards.set(v, work);
+    void work.finally(() => {
+      if (inFlightStoryboards.get(v) === work) inFlightStoryboards.delete(v);
+    });
+  }
   return withTimeout(
-    produce(),
+    work,
     videoStoryboardTimeoutMs,
     () => {
       warn("[cmcp] storyboard: timed out for", m?.filename);

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -134,9 +134,16 @@ export function createRunCompletionTracker({
   // replay this exact executed batch before falling back to /history. This
   // matters when a remote proxy permits the panel websocket but rejects the
   // separate history request: the panel already has the temp reference and
-  // must not throw it away with the failed send. SaveImage/video recovery keeps
-  // its existing /history behavior.
-  const liveReplays = new Map(); // key -> onFlush payload containing type:"temp"
+  // must not throw it away with the failed send.
+  //
+  // #2234 — VIDEO batches are retained for the same reason, plus a second one:
+  // each compose mints a storyboard identity and uploads a unique temp PNG.
+  // Rebuilding the batch from /history every sweep would mint a new identity
+  // and write another pair of files even though the source video has not
+  // changed. Replaying the same video records lets produce() reuse the
+  // identity and skip the re-upload. SaveImage (output stills) recovery still
+  // uses /history: those refs do not spawn derived temp files.
+  const liveReplays = new Map(); // key -> onFlush payload (temp images and/or videos)
   const active = new Set(); // keys ComfyUI currently reports as running
   const starts = new Map(); // key -> start timestamp
   // Keys whose start came from a real lifecycle signal, not a fallback (#986).
@@ -286,7 +293,17 @@ export function createRunCompletionTracker({
     return records.find((record) => record.routeId === route && record.sessionId === session) ?? null;
   }
 
+  function retainReplayBatch(k, payload) {
+    if (k === NO_PROMPT_KEY || !payload || typeof payload !== "object") return;
+    const images = payload.images;
+    const videos = payload.videos;
+    const hasTempImage = Array.isArray(images) && images.some((image) => image?.type === "temp");
+    const hasVideo = Array.isArray(videos) && videos.length > 0;
+    if (hasTempImage || hasVideo) liveReplays.set(k, payload);
+  }
+
   function flushWithCompletionRecords(k, payload) {
+    retainReplayBatch(k, payload);
     const records = completionRecords(k);
     if (!records.length) {
       onFlush(payload);
@@ -817,12 +834,6 @@ export function createRunCompletionTracker({
     markTerminal(k);
     markDispatched(k);
     if (!hasCompletionKey) markDelivered(k);
-    if (
-      k !== NO_PROMPT_KEY &&
-      payload.images.some((image) => image?.type === "temp")
-    ) {
-      liveReplays.set(k, payload);
-    }
     flushWithCompletionRecords(k, payload);
   }
 


### PR DESCRIPTION
## Summary
With the panel bridge down, a finished video's storyboard was re-sampled and re-uploaded to `ComfyUI/temp` on every 20s reconcile sweep. `releaseUnackedDelivery()` still decrements the unacked budget on a transport refusal (required for #370 / #1739). Each retry used to mint a fresh `createStoryboardIdentity()`, so `storyboard_*` / `poster_*` filenames multiplied.

This keeps that fail-closed retry, but:
- writes the identity and uploaded refs back onto the same video record
- retains video batches in `liveReplays` so a `/history` rebuild does not mint a new object
- skips sample/upload/paint when the composed sheet already exists

A genuinely new completion is still a different record, so #1718 / #1834 cache-busting is unchanged.

## Test plan
- `node --test browser_tests/unit/run-completion-storyboard-reuse.test.mjs`
- Also green: `run-completion-video-segment`, `run-completion-receiptless-delivery`, `run-completion-redelivery-storm`, `run-reconcile`, `run-completion`

Closes #2234
