### PR TITLE
fix(#2233): ack long text widget writes without waiting on rAF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- graph_set_widget acknowledges a long CLIPTextEncode / multiline text write as soon as the live editor holds the value, instead of waiting on a backgrounded-tab rAF flush until the 90s relay times out (#2233)
 - Refused completion retries of a finished video reuse the composed storyboard identity and skip re-upload, so a down bridge cannot fill ComfyUI/temp with unique `storyboard_*.png` / `poster_*.png` copies every sweep (#2234)
 
 ## [0.15.168] - 2026-09-04

--- a/browser_tests/unit/set-widget-text-ack.test.mjs
+++ b/browser_tests/unit/set-widget-text-ack.test.mjs
@@ -1,0 +1,236 @@
+/**
+ * #2233 — long CLIPTextEncode / multiline text writes applied on the live
+ * canvas, but graph_set_widget did not acknowledge within 90s. query_graph
+ * then showed the new values, and a short filename_prefix write succeeded.
+ *
+ * The assignment is the receipt. A backgrounded-tab rAF flush, a hanging
+ * customtext callback, or a Vue getter that lags the live textarea must not
+ * own the command reply. Fail-closed: the write still applies.
+ *
+ * These drive applyWidgetWrite / runSetWidget / awaitSetWidgetAck — the SAME
+ * units graph_set_widget uses.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { applyWidgetWrite } from "../../web/js/lib/widget-write.js";
+import {
+  runSetWidget,
+  awaitSetWidgetAck,
+  readLiveWidgetValue,
+} from "../../web/js/lib/set-widget.js";
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+const SET_WIDGET_SRC = readFileSync(new URL("../../web/js/lib/set-widget.js", import.meta.url), "utf8");
+const WIDGET_WRITE_SRC = readFileSync(new URL("../../web/js/lib/widget-write.js", import.meta.url), "utf8");
+
+const NEVER = new Promise(() => {});
+const HANG_MS = 250;
+const REGISTRY = { CLIPTextEncode: {} };
+const FRESH = { CLIPTextEncode: {} };
+
+const LONG_POSITIVE = (
+  "masterpiece, best quality, chibi icon sheet, soft rim light,\n" + "volumetric haze, ".repeat(50)
+).trim();
+const LONG_NEGATIVE = ("blurry, extra fingers, watermark,\n" + "lowres, extra limbs, ".repeat(40)).trim();
+
+function withHangBudget(work) {
+  return Promise.race([
+    Promise.resolve().then(work),
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error(`#2233 hung: text write did not ack in ${HANG_MS}ms`)), HANG_MS);
+    }),
+  ]);
+}
+
+function fireableTimers() {
+  const timers = [];
+  return {
+    setTimer: (fn) => {
+      timers.push(fn);
+      return timers.length;
+    },
+    clearTimer: () => {},
+    fire: () => {
+      assert.equal(timers.length, 1, "the acknowledgement wait must arm a timeout");
+      timers[0]();
+    },
+  };
+}
+
+function makeClipTextEncode(initial = "old prompt") {
+  const store = { value: initial };
+  const textarea = {
+    tagName: "TEXTAREA",
+    value: initial,
+    dispatched: [],
+    dispatchEvent(ev) {
+      this.dispatched.push(ev?.type ?? ev);
+      widget.value = this.value;
+      widget.callback?.(widget.value);
+      return true;
+    },
+  };
+  const options = {
+    getValue() {
+      return store.value ?? textarea.value;
+    },
+    setValue(v) {
+      const text = String(v);
+      textarea.value = text;
+      store.value = text;
+    },
+  };
+  let callbackCalls = 0;
+  const widget = {
+    name: "text",
+    type: "customtext",
+    inputEl: textarea,
+    element: textarea,
+    options,
+    callback() {
+      callbackCalls += 1;
+      return NEVER;
+    },
+    get value() {
+      return options.getValue();
+    },
+    set value(v) {
+      options.setValue(v);
+      this.callback?.(this.value);
+    },
+  };
+  const node = { id: 3, type: "CLIPTextEncode", widgets: [widget] };
+  return {
+    node,
+    widget,
+    textarea,
+    store,
+    callbackCalls: () => callbackCalls,
+  };
+}
+
+function wired(extra = {}) {
+  return {
+    registry: REGISTRY,
+    getRegistry: () => REGISTRY,
+    getFreshObjectInfo: async () => FRESH,
+    beforeChange() {},
+    afterChange() {},
+    setDirty() {},
+    ...extra,
+  };
+}
+
+test("#2233 long CLIPTextEncode text is ~800 chars (the reported write)", () => {
+  assert.ok(LONG_POSITIVE.length >= 800, `positive prompt is ${LONG_POSITIVE.length} chars`);
+  assert.ok(LONG_NEGATIVE.length >= 650, `negative prompt is ${LONG_NEGATIVE.length} chars`);
+  assert.match(LONG_POSITIVE, /\n|,/);
+});
+
+test("#2233 applyWidgetWrite lands long customtext without awaiting the callback", async () => {
+  const { node, widget, textarea, store, callbackCalls } = makeClipTextEncode();
+  const set = await withHangBudget(() => applyWidgetWrite(node, "text", LONG_POSITIVE, {}));
+  assert.equal(set.value, LONG_POSITIVE);
+  assert.equal(store.value, LONG_POSITIVE);
+  assert.equal(textarea.value, LONG_POSITIVE);
+  assert.equal(widget.value, LONG_POSITIVE);
+  assert.equal(callbackCalls(), 0, "a live customtext must not re-enter a hanging callback");
+});
+
+test("#2233 runSetWidget acks a long text write while rAF never fires", async () => {
+  const { node, textarea, store } = makeClipTextEncode();
+  const res = await withHangBudget(() =>
+    runSetWidget(node, "text", LONG_POSITIVE, {
+      ...wired(),
+      awaitFrontendWidgetFlush: () => NEVER,
+    }),
+  );
+  assert.equal(res.applied, true);
+  assert.equal(res.set.value, LONG_POSITIVE);
+  assert.equal(store.value, LONG_POSITIVE);
+  assert.equal(textarea.value, LONG_POSITIVE);
+  assert.equal(res.error, undefined);
+});
+
+test("#2233 a second long negative-prompt write also acks (the reporter's pair)", async () => {
+  const first = makeClipTextEncode();
+  const second = makeClipTextEncode("old negative");
+  second.node.id = 4;
+  const flushNever = () => NEVER;
+  const a = await withHangBudget(() =>
+    runSetWidget(first.node, "text", LONG_POSITIVE, { ...wired(), awaitFrontendWidgetFlush: flushNever }),
+  );
+  const b = await withHangBudget(() =>
+    runSetWidget(second.node, "text", LONG_NEGATIVE, { ...wired(), awaitFrontendWidgetFlush: flushNever }),
+  );
+  assert.equal(a.applied, true);
+  assert.equal(b.applied, true);
+  assert.equal(first.textarea.value, LONG_POSITIVE);
+  assert.equal(second.textarea.value, LONG_NEGATIVE);
+});
+
+test("#2233 fail-closed: a hanging flush must not skip the write", async () => {
+  const { node, textarea } = makeClipTextEncode();
+  await withHangBudget(() =>
+    runSetWidget(node, "text", LONG_POSITIVE, {
+      ...wired(),
+      awaitFrontendWidgetFlush: () => NEVER,
+    }),
+  );
+  assert.equal(textarea.value, LONG_POSITIVE, "the mutation must land even if the canvas flush never settles");
+});
+
+test("#2233 timeout readback: a live textarea is applied even when .value lags", async () => {
+  const { node, widget, textarea, store } = makeClipTextEncode();
+  store.value = "old prompt";
+  textarea.value = LONG_POSITIVE;
+  Object.defineProperty(widget, "value", {
+    configurable: true,
+    get: () => store.value,
+    set(v) {
+      store.value = v;
+    },
+  });
+  const live = readLiveWidgetValue(node, "text");
+  assert.equal(live.found, true);
+  const clock = fireableTimers();
+  const pending = awaitSetWidgetAck(NEVER, {
+    node,
+    widget: "text",
+    requested: LONG_POSITIVE,
+    timeoutMs: 80,
+    delivered: true,
+    timers: { setTimer: clock.setTimer, clearTimer: clock.clearTimer },
+  });
+  clock.fire();
+  const out = await withHangBudget(() => pending);
+  assert.equal(out.applied, true, "a committed editor is not outcome-unknown");
+  assert.equal(out.verified, true);
+  assert.equal(out.set.value, LONG_POSITIVE);
+});
+
+test("#2233 a short filename_prefix write is unchanged when nothing hangs", async () => {
+  const widget = { name: "filename_prefix", type: "text", value: "ComfyUI" };
+  const node = { id: 9, type: "SaveImage", widgets: [widget] };
+  const res = await runSetWidget(node, "filename_prefix", "chibi_icon", {
+    registry: { SaveImage: {} },
+    getFreshObjectInfo: async () => ({ SaveImage: {} }),
+  });
+  assert.equal(res.applied, true);
+  assert.equal(widget.value, "chibi_icon");
+});
+
+test("#2233 wiring: live editor hold is the receipt, ahead of the rAF flush", () => {
+  const handlerStart = PANEL_SRC.indexOf("async graph_set_widget({");
+  const handlerEnd = PANEL_SRC.indexOf("\n  // artokun/comfyui-mcp#938", handlerStart);
+  assert.ok(handlerStart >= 0 && handlerEnd > handlerStart, "graph_set_widget handler not found");
+  const handler = PANEL_SRC.slice(handlerStart, handlerEnd);
+  assert.match(handler, /await runSetWidget\(node, widget, value, setWidgetOpts\)/);
+  assert.match(WIDGET_WRITE_SRC, /export function liveTextEditorHolds/);
+  assert.match(SET_WIDGET_SRC, /liveTextEditorHolds/);
+  const holdAt = SET_WIDGET_SRC.indexOf("liveTextEditorHolds(");
+  const flushAt = SET_WIDGET_SRC.indexOf("await flushFrontendWidgets()");
+  assert.ok(holdAt >= 0 && flushAt > holdAt, "the live editor receipt must be taken before waiting on rAF");
+});

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -33,6 +33,7 @@ import {
   resolveEnclosingPromotedWrite,
   followPromotionToConcrete,
   collectPromotionIntermediates,
+  liveTextEditorHolds,
 } from "./widget-write.js";
 import { reconcileUnknownWidgetNames } from "./asset-staleness.js";
 import {
@@ -218,9 +219,15 @@ export function readLiveWidgetValue(node, widgetName, occurrence = null) {
   try {
     const live = liveWidgetAt(node, widgetName, occurrence);
     if (!live) return { found: false, value: undefined };
+    let value;
+    try {
+      value = live.value;
+    } catch {
+      value = undefined;
+    }
     // `widget` is returned so the caller can attribute the read to the row it came from by
     // IDENTITY (#2143) rather than re-deriving it from the ordinal it asked for.
-    return { found: true, value: live.value, widget: live };
+    return { found: true, value, widget: live };
   } catch {
     return { found: false, value: undefined };
   }
@@ -292,10 +299,13 @@ export async function awaitSetWidgetAck(writePromise, {
     if (settled?.ok) noteLateSuccess(honestWidgetAck(settled.result));
   }, () => {});
   const live = readLiveWidgetValue(node, widget, occurrence);
+  // #2233 — a live multiline editor is what query_graph reads. A lagging Vue
+  // `.value` getter must not turn an already-committed text write into a hang.
+  const editorHolds = liveTextEditorHolds(live.widget, requested);
   const verified = widgetWriteTimeoutReadback({
     requested,
-    actual: live.value,
-    found: live.found,
+    actual: editorHolds ? requested : live.value,
+    found: live.found || editorHolds,
     node_id: node?.id,
     widget,
     // #2143 — this receipt stands in for the write's own reply, so it must carry the same
@@ -1441,7 +1451,18 @@ async function runSetWidgetBody(
     return { ...set, widget_occurrence: next };
   };
 
+  function liveTextEditorRetainsWrite(set) {
+    if (typeof value !== "string") return false;
+    const written = writtenWidgets.get(set);
+    return !!(written?.valueWidget && liveTextEditorHolds(written.valueWidget, value));
+  }
+
   async function retainVerifiedWrite(set, rewrite) {
+    // #2233 — a live textarea that already holds the committed string is the
+    // receipt. Waiting on rAF after that is how a backgrounded tab lost the
+    // graph_set_widget ack while query_graph already showed the write. A
+    // just-added primitive with no editor still takes the #1922 flush.
+    if (liveTextEditorRetainsWrite(set)) return withLiveOccurrence(set);
     await flushFrontendWidgets();
     assertNotAbandoned();
     assertTargetStillCurrentNow();

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -2255,8 +2255,13 @@ function isLiveCustomTextWidget(widget) {
   }
 }
 
-function customTextHolds(widget, coerced) {
-  if (widgetHoldsValue(widget, coerced)) return true;
+/**
+ * #2233 — true when the widget's live textarea / contenteditable already holds
+ * `coerced`. Distinct from `.value`: a Vue getter can lag while the editor
+ * that query_graph reads is already committed.
+ */
+export function liveTextEditorHolds(widget, coerced) {
+  if (typeof coerced !== "string" || !widget || typeof widget !== "object") return false;
   const el = liveTextEditorElement(widget);
   if (!el) return false;
   try {
@@ -2264,6 +2269,11 @@ function customTextHolds(widget, coerced) {
   } catch {
     return false;
   }
+}
+
+function customTextHolds(widget, coerced) {
+  if (widgetHoldsValue(widget, coerced)) return true;
+  return liveTextEditorHolds(widget, coerced);
 }
 
 /** When a string write did not stick on `.value`, copy it into the live editor. */


### PR DESCRIPTION
## Summary
Long panel_set_widget CLIPTextEncode / multiline text writes were applied on the live canvas, but graph_set_widget did not send an acknowledgement within 90s. Immediate panel_query_graph showed the new values, and a following short filename_prefix write succeeded.

The write path waited on a frontend rAF flush after the value was already committed. In a backgrounded tab rAF never fires, so the reply lost to the relay timeout even though the mutation had landed.

Once a live textarea / contenteditable already holds the committed string, treat that as the receipt and return without waiting on rAF. Just-added primitives with no editor still take the #1922 flush. Fail-closed: the write is not skipped.

Closes #2233

## Tests
```
node --test browser_tests/unit/set-widget-text-ack.test.mjs
```
8 pass, 0 fail