### PR TITLE
fix(#1215): refuse leftover previous-tab graph after a failed open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- After panel_open_workflow switches tabs but cannot repaint, panel_graph_outline / panel_query_graph refuse instead of serving the previous tab's graph under the new workflow's fence — panel_set_workflow_target is not a remedy (#1215)
+
 ## [0.15.169] - 2026-09-04
 
 ### Fixed
 - graph_set_widget acknowledges a long CLIPTextEncode / multiline text write as soon as the live editor holds the value, instead of waiting on a backgrounded-tab rAF flush until the 90s relay times out (#2233, #2236)
 - Refused completion retries of a finished video reuse the composed storyboard identity and skip re-upload, so a down bridge cannot fill ComfyUI/temp with unique `storyboard_*.png` / `poster_*.png` copies every sweep (#2234, #2235)
-
 
 ## [0.15.168] - 2026-09-04
 

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -21,6 +21,7 @@ import {
   activeWorkflowProvenEmpty,
   graphEmptyBindingUnproven,
   graphReadDesynced,
+  graphRootUnprovenAgainstActiveState,
   missingNodeStateReportsNodes,
   graphRootMidPopulation,
   graphRootMismatchesActiveWorkflow,
@@ -505,6 +506,140 @@ test("graphReadDesynced: FALSE — descended into an empty subgraph (legitimatel
 test("graphReadDesynced: defensive — missing args never throw, default to not-desynced", () => {
   assert.equal(graphReadDesynced(), false);
   assert.equal(graphReadDesynced({}), false);
+});
+
+// ── #1215: nonempty previous canvas + no comparable active state ─────────────
+
+test("#1215: a nonempty live canvas with no comparable active state is unproven", () => {
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      activeWorkflow: wf({}),
+    }),
+    true,
+  );
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      activeWorkflow: wf({ changeTracker: { activeState: { nodes: "bad" } } }),
+    }),
+    true,
+    "malformed nodes is the same as missing — that is the safe-repaint shape",
+  );
+});
+
+test("#1215: a comparable current state is the shape guard's job, not this one", () => {
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      activeWorkflow: wf({ changeTracker: { activeState: state(5) } }),
+    }),
+    false,
+  );
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      activeWorkflow: wf({ changeTracker: { activeState: state(0) } }),
+    }),
+    false,
+    "well-formed empty nodes must stay a shape mismatch (blank tab vs leftover canvas)",
+  );
+});
+
+test("#1215: empty live, no workflow service, and subgraph scope fail OPEN", () => {
+  assert.equal(graphRootUnprovenAgainstActiveState({ liveNodeCount: 0, activeWorkflow: wf({}) }), false);
+  assert.equal(graphRootUnprovenAgainstActiveState({ liveNodeCount: 118, activeWorkflow: null }), false);
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      inSubgraph: true,
+      activeWorkflow: wf({}),
+    }),
+    false,
+  );
+  assert.equal(graphRootUnprovenAgainstActiveState(), false);
+});
+
+test("#1215: outline/query refuse the previous canvas after a switch that could not repaint", () => {
+  const rootGraph = { _nodes: state(118).nodes };
+  const activeWorkflow = wf({});
+  for (const cmd of ["graph_outline", "graph_query"]) {
+    const verdict = resolveGraphBindingVerdict({
+      graph: rootGraph,
+      rootGraph,
+      activeWorkflow,
+      activeWorkflowUuid: "remove-bg-tab",
+      liveNodeCount: 118,
+      ...graphCommandBindingBar(cmd),
+    });
+    assert.equal(verdict?.reason, "root-state-unreadable", cmd);
+    assert.equal(verdict.live, 118);
+    assert.equal(verdict.expected, null);
+  }
+});
+
+test("#1215: a TARGET uuid on the leftover canvas is not ownership proof", () => {
+  const rootGraph = {
+    _nodes: state(118).nodes,
+    extra: { comfyui_mcp: { workflow_uuid: "remove-bg-tab" } },
+  };
+  const verdict = resolveGraphBindingVerdict({
+    graph: rootGraph,
+    rootGraph,
+    activeWorkflow: wf({}),
+    activeWorkflowUuid: "remove-bg-tab",
+    liveNodeCount: 118,
+    rootUuidMismatch: false,
+    ...graphCommandBindingBar("graph_outline"),
+  });
+  assert.equal(
+    verdict?.reason,
+    "root-state-unreadable",
+    "a stale/shared TARGET tag on the outgoing canvas (#1639) must not license the read",
+  );
+});
+
+test("#1215: already-current untagged canvas with matching state still admits (#2038)", () => {
+  const nodes = state(3).nodes;
+  const rootGraph = { _nodes: nodes, extra: {} };
+  const verdict = resolveGraphBindingVerdict({
+    graph: rootGraph,
+    rootGraph,
+    activeWorkflow: wf({ isModified: false, changeTracker: { activeState: { nodes, links: [], groups: [] } } }),
+    activeWorkflowUuid: "already-current",
+    liveNodeCount: 3,
+    ...graphCommandBindingBar("graph_outline"),
+    includeBaselineReadGuard: true,
+  });
+  assert.equal(verdict, null);
+});
+
+test("#1215: the refusal names the live count and says set_workflow_target is not a remedy", () => {
+  const msg = graphBindingRefusalMessage({ reason: "root-state-unreadable", live: 118, expected: null });
+  assert.match(msg, /^\[root-state-unreadable\]/);
+  assert.match(msg, /118 node\(s\)/);
+  assert.match(msg, /NOT applied/);
+  assert.match(msg, /previous workflow/);
+  assert.match(msg, /panel_open_workflow/);
+  assert.match(msg, /panel_load_workflow/);
+  assert.match(msg, /panel_set_workflow_target is NOT a remedy/);
+  assert.doesNotMatch(msg, /reports 0 node\(s\)/);
+});
+
+test("#1215: graph_outline and graph_query re-assert the binding bar in their executors", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  for (const cmd of ["graph_outline", "graph_query"]) {
+    const at = src.indexOf(`${cmd}({`);
+    assert.notEqual(at, -1, `${cmd} executor must remain`);
+    const slice = src.slice(at, at + 2200);
+    assert.match(slice, /assertGraphBoundToActiveWorkflow/, `${cmd} must re-assert before serving nodes`);
+    assert.match(
+      slice,
+      new RegExp(`graphCommandBindingBar\\("${cmd}"\\)`),
+      `${cmd} must keep the classified-read bar`,
+    );
+    assert.match(slice, /includeBaselineReadGuard: true/, `${cmd} must keep the #389 baseline guard on`);
+  }
 });
 
 test("missingNodeStateReportsNodes: only positive, shaped missing-node state is evidence", () => {
@@ -3638,8 +3773,8 @@ test("#618: a descended SUBGRAPH is exempt — an entered subgraph legitimately 
   assert.equal(verdict, null);
 });
 
-test("#618: no current-state evidence fails OPEN — an absent/malformed tracker read proves nothing", () => {
-  for (const wf of [midPopWorkflow(31, { withState: false }), null, undefined]) {
+test("#618: no current-state evidence does not manufacture a mid-population verdict", () => {
+  for (const wf of [null, undefined]) {
     const verdict = resolveGraphBindingVerdict({
       graph: midPopRoot(8),
       rootGraph: midPopRoot(8),
@@ -3647,8 +3782,21 @@ test("#618: no current-state evidence fails OPEN — an absent/malformed tracker
       liveNodeCount: 8,
       postReconnectWindow: true,
     });
-    assert.equal(verdict, null, "unreadable current state must never manufacture a mid-population verdict");
+    assert.equal(verdict, null, "no workflow service stays legacy-available");
   }
+  const missingState = resolveGraphBindingVerdict({
+    graph: midPopRoot(8),
+    rootGraph: midPopRoot(8),
+    activeWorkflow: midPopWorkflow(31, { withState: false }),
+    liveNodeCount: 8,
+    postReconnectWindow: true,
+  });
+  assert.equal(
+    missingState?.reason,
+    "root-state-unreadable",
+    "a present workflow with no current state is the #1215 leftover-canvas refuse, not mid-population",
+  );
+  assert.notEqual(missingState?.reason, "root-mid-population");
 });
 
 test("#618: equal or AHEAD live counts do not fire — only a canvas BEHIND the workflow's own state is mid-restore evidence", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -289,6 +289,7 @@ function buildDirtyStaleRouteHarness({
     "app",
     "WORKFLOW_META_NAMESPACE",
     "WORKFLOW_UUID_FIELD",
+    "switchRepaintUnproven",
     `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
   )(
     () => workflowA,
@@ -314,6 +315,7 @@ function buildDirtyStaleRouteHarness({
     { graph: rootB, extensionManager: { workflow: { openWorkflows } } },
     "comfyui_mcp",
     "workflow_uuid",
+    false,
   );
   return { src, workflowA, rawB, proxyB, rootB, objectUuids, stableUuid, assertBound };
 }
@@ -508,13 +510,33 @@ test("graphReadDesynced: defensive — missing args never throw, default to not-
   assert.equal(graphReadDesynced({}), false);
 });
 
-// ── #1215: nonempty previous canvas + no comparable active state ─────────────
+// ── #1215: leftover previous canvas after a switch that could not repaint ────
 
-test("#1215: a nonempty live canvas with no comparable active state is unproven", () => {
+test("#1215: missing current state alone is NOT leftover evidence", () => {
   assert.equal(
     graphRootUnprovenAgainstActiveState({
       liveNodeCount: 118,
       activeWorkflow: wf({}),
+    }),
+    false,
+    "graph_query fixtures and a first observation fail OPEN",
+  );
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      activeWorkflow: wf({ changeTracker: { activeState: { nodes: "bad" } } }),
+    }),
+    false,
+    "malformed nodes without switch proof stays available",
+  );
+});
+
+test("#1215: a failed switch repaint with no comparable active state is leftover", () => {
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      activeWorkflow: wf({}),
+      switchRepaintUnproven: true,
     }),
     true,
   );
@@ -522,6 +544,7 @@ test("#1215: a nonempty live canvas with no comparable active state is unproven"
     graphRootUnprovenAgainstActiveState({
       liveNodeCount: 118,
       activeWorkflow: wf({ changeTracker: { activeState: { nodes: "bad" } } }),
+      switchRepaintUnproven: true,
     }),
     true,
     "malformed nodes is the same as missing — that is the safe-repaint shape",
@@ -547,17 +570,42 @@ test("#1215: a comparable current state is the shape guard's job, not this one",
 });
 
 test("#1215: empty live, no workflow service, and subgraph scope fail OPEN", () => {
-  assert.equal(graphRootUnprovenAgainstActiveState({ liveNodeCount: 0, activeWorkflow: wf({}) }), false);
-  assert.equal(graphRootUnprovenAgainstActiveState({ liveNodeCount: 118, activeWorkflow: null }), false);
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({ liveNodeCount: 0, activeWorkflow: wf({}), switchRepaintUnproven: true }),
+    false,
+  );
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({ liveNodeCount: 118, activeWorkflow: null, switchRepaintUnproven: true }),
+    false,
+  );
   assert.equal(
     graphRootUnprovenAgainstActiveState({
       liveNodeCount: 118,
       inSubgraph: true,
       activeWorkflow: wf({}),
+      switchRepaintUnproven: true,
     }),
     false,
   );
   assert.equal(graphRootUnprovenAgainstActiveState(), false);
+});
+
+test("#1215: a previous open tab whose state matches the live root is leftover", () => {
+  const nodes = state(118).nodes.map((node) => ({ ...node, type: "KSampler" }));
+  const rootGraph = {
+    _nodes: nodes,
+    serialize: () => ({ nodes, links: [], groups: [] }),
+  };
+  const previous = wf({ changeTracker: { activeState: { nodes, links: [], groups: [] } } });
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      activeWorkflow: wf({}),
+      rootGraph,
+      others: [previous],
+    }),
+    true,
+  );
 });
 
 test("#1215: outline/query refuse the previous canvas after a switch that could not repaint", () => {
@@ -570,12 +618,25 @@ test("#1215: outline/query refuse the previous canvas after a switch that could 
       activeWorkflow,
       activeWorkflowUuid: "remove-bg-tab",
       liveNodeCount: 118,
+      switchRepaintUnproven: true,
       ...graphCommandBindingBar(cmd),
     });
     assert.equal(verdict?.reason, "root-state-unreadable", cmd);
     assert.equal(verdict.live, 118);
     assert.equal(verdict.expected, null);
   }
+  assert.equal(
+    resolveGraphBindingVerdict({
+      graph: rootGraph,
+      rootGraph,
+      activeWorkflow,
+      activeWorkflowUuid: "remove-bg-tab",
+      liveNodeCount: 118,
+      ...graphCommandBindingBar("graph_query"),
+    }),
+    null,
+    "without leftover switch proof, graph_query fixtures stay available",
+  );
 });
 
 test("#1215: a TARGET uuid on the leftover canvas is not ownership proof", () => {
@@ -590,6 +651,7 @@ test("#1215: a TARGET uuid on the leftover canvas is not ownership proof", () =>
     activeWorkflowUuid: "remove-bg-tab",
     liveNodeCount: 118,
     rootUuidMismatch: false,
+    switchRepaintUnproven: true,
     ...graphCommandBindingBar("graph_outline"),
   });
   assert.equal(
@@ -626,20 +688,27 @@ test("#1215: the refusal names the live count and says set_workflow_target is no
   assert.doesNotMatch(msg, /reports 0 node\(s\)/);
 });
 
-test("#1215: graph_outline and graph_query re-assert the binding bar in their executors", () => {
+test("#1215: graph_outline re-asserts the binding bar; graph_query stays dispatch-fenced", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  for (const cmd of ["graph_outline", "graph_query"]) {
-    const at = src.indexOf(`${cmd}({`);
-    assert.notEqual(at, -1, `${cmd} executor must remain`);
-    const slice = src.slice(at, at + 2200);
-    assert.match(slice, /assertGraphBoundToActiveWorkflow/, `${cmd} must re-assert before serving nodes`);
-    assert.match(
-      slice,
-      new RegExp(`graphCommandBindingBar\\("${cmd}"\\)`),
-      `${cmd} must keep the classified-read bar`,
-    );
-    assert.match(slice, /includeBaselineReadGuard: true/, `${cmd} must keep the #389 baseline guard on`);
-  }
+  const outlineAt = src.indexOf("graph_outline({");
+  assert.notEqual(outlineAt, -1);
+  const outline = src.slice(outlineAt, outlineAt + 2200);
+  assert.match(outline, /assertGraphBoundToActiveWorkflow/, "outline re-asserts before serving nodes");
+  assert.match(outline, /graphCommandBindingBar\("graph_outline"\)/);
+  assert.match(outline, /includeBaselineReadGuard: true/);
+  const queryAt = src.indexOf("graph_query({");
+  assert.notEqual(queryAt, -1);
+  const query = src.slice(queryAt, queryAt + 800);
+  assert.doesNotMatch(
+    query,
+    /assertGraphBoundToActiveWorkflow/,
+    "extracted graph_query budget tests re-run this method without the canvas fence",
+  );
+  assert.match(
+    src,
+    /assertGraphBoundToActiveWorkflow\(graph, rootGraph, graphCommandBindingBar\(msg\.cmd\)\)/,
+    "dispatch still fences graph_query through the classified-read bar",
+  );
 });
 
 test("missingNodeStateReportsNodes: only positive, shaped missing-node state is evidence", () => {
@@ -3773,8 +3842,8 @@ test("#618: a descended SUBGRAPH is exempt — an entered subgraph legitimately 
   assert.equal(verdict, null);
 });
 
-test("#618: no current-state evidence does not manufacture a mid-population verdict", () => {
-  for (const wf of [null, undefined]) {
+test("#618: no current-state evidence fails OPEN — an absent/malformed tracker read proves nothing", () => {
+  for (const wf of [midPopWorkflow(31, { withState: false }), null, undefined]) {
     const verdict = resolveGraphBindingVerdict({
       graph: midPopRoot(8),
       rootGraph: midPopRoot(8),
@@ -3782,21 +3851,9 @@ test("#618: no current-state evidence does not manufacture a mid-population verd
       liveNodeCount: 8,
       postReconnectWindow: true,
     });
-    assert.equal(verdict, null, "no workflow service stays legacy-available");
+    assert.equal(verdict, null, "unreadable current state must never manufacture a mid-population verdict");
+    assert.notEqual(verdict?.reason, "root-state-unreadable", "missing state without leftover switch proof stays available");
   }
-  const missingState = resolveGraphBindingVerdict({
-    graph: midPopRoot(8),
-    rootGraph: midPopRoot(8),
-    activeWorkflow: midPopWorkflow(31, { withState: false }),
-    liveNodeCount: 8,
-    postReconnectWindow: true,
-  });
-  assert.equal(
-    missingState?.reason,
-    "root-state-unreadable",
-    "a present workflow with no current state is the #1215 leftover-canvas refuse, not mid-population",
-  );
-  assert.notEqual(missingState?.reason, "root-mid-population");
 });
 
 test("#618: equal or AHEAD live counts do not fire — only a canvas BEHIND the workflow's own state is mid-restore evidence", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -709,6 +709,15 @@ test("#1215: graph_outline re-asserts the binding bar; graph_query stays dispatc
     /assertGraphBoundToActiveWorkflow\(graph, rootGraph, graphCommandBindingBar\(msg\.cmd\)\)/,
     "dispatch still fences graph_query through the classified-read bar",
   );
+  const fence = src.slice(
+    src.indexOf("function assertGraphBoundToActiveWorkflow("),
+    src.indexOf("function tryHealStaleRootWorkflowIdentity("),
+  );
+  assert.match(
+    fence,
+    /typeof switchRepaintUnproven !== "undefined"/,
+    "extracted #1477/#1233 fences must not throw on an unbound leftover flag",
+  );
 });
 
 test("missingNodeStateReportsNodes: only positive, shaped missing-node state is evidence", () => {

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -1825,7 +1825,7 @@ test("#1215 production workflow_open that cannot repaint does not let outline/qu
     },
     extensionManager: {
       workflow: {
-        openWorkflows: [target],
+        openWorkflows: [previous, target],
         workflows: [],
         getWorkflowByPath: () => target,
         openWorkflow: async () => {
@@ -1910,6 +1910,8 @@ test("#1215 production workflow_open that cannot repaint does not let outline/qu
       activeWorkflow: target,
       activeWorkflowUuid: targetUuid,
       liveNodeCount: root._nodes.length,
+      others: [previous],
+      switchRepaintUnproven: true,
       ...graphCommandBindingBar(cmd),
       includeBaselineReadGuard: true,
     });

--- a/browser_tests/unit/open-active-settle.test.mjs
+++ b/browser_tests/unit/open-active-settle.test.mjs
@@ -24,10 +24,12 @@ import {
   POINTER_WATCH_UNAVAILABLE_NOTICE,
 } from "../../web/js/lib/live-canvas-capture-gate.js";
 import {
+  graphCommandBindingBar,
   graphRootMatchesState,
   graphRootStructureExtendsActiveWorkflow,
   graphRootWorkflowUuidMatches,
   graphRootWorkflowUuidMismatches,
+  resolveGraphBindingVerdict,
 } from "../../web/js/lib/graph-binding.js";
 import {
   classifyOpenSwitchFailure,
@@ -1784,6 +1786,139 @@ test("#1215 production workflow_open refuses when the load leaves the previous t
   );
   assert.equal(root._nodes[0].widgets_values[0], "previous-value", "the leftover canvas is still SOURCE");
   assert.equal(panel.guard(), null, "the refused open still releases its reload guard");
+});
+
+test("#1215 production workflow_open that cannot repaint does not let outline/query serve the previous canvas", async () => {
+  const sourceUuid = "krea-118-0000-4000-8000-00000000000a";
+  const targetUuid = "remove-bg-0000-4000-8000-00000000000b";
+  const previousNodes = Array.from({ length: 118 }, (_, i) => ({ id: i + 1, type: "KSampler" }));
+  const root = {
+    _nodes: previousNodes.map((node) => ({ ...node })),
+    extra: {},
+  };
+  const previous = {
+    path: "workflows/image_krea.json",
+    changeTracker: { activeState: { nodes: previousNodes, links: [], groups: [] } },
+  };
+  const target = {
+    path: "workflows/remove_bg_workflow.json",
+    filename: "remove_bg_workflow.json",
+    isModified: false,
+  };
+  let active = previous;
+  const subscribers = [];
+  const workflowStore = {
+    $subscribe: (subscriber) => {
+      subscribers.push(subscriber);
+      return () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    },
+  };
+  const app = {
+    rootGraph: root,
+    graph: root,
+    canvas: { graph: root },
+    loadGraphData: async () => {
+      throw new Error("a target with no complete state must not reach loadGraphData");
+    },
+    extensionManager: {
+      workflow: {
+        openWorkflows: [target],
+        workflows: [],
+        getWorkflowByPath: () => target,
+        openWorkflow: async () => {
+          active = target;
+        },
+      },
+    },
+  };
+  const panel = productionExecutor("workflow_open", {
+    backendReconnectEpoch: 4,
+    activeWorkflowResyncEpoch: 4,
+    postReconnectBindingProofEpoch: 4,
+    app,
+    document: workflowPiniaDocument(workflowStore),
+    activeWorkflowRef: () => active,
+    sameWorkflowObject: (a, b) => a === b,
+    workflowTabId: (workflow) => `wf:${workflow.path}`,
+    WORKFLOW_META_NAMESPACE: "comfyui_mcp",
+    WORKFLOW_UUID_FIELD: "workflow_uuid",
+    WORKFLOW_PATH_FIELD: "workflow_path",
+    OPEN_PROOF_FIELD: "open_proof",
+    workflowObjectUuid: (workflow) => (workflow === previous ? sourceUuid : targetUuid),
+    workflowStableUuid: (workflow) => (workflow === previous ? sourceUuid : targetUuid),
+    workflowOwnsRootUuidTag: () => false,
+    workflowUuidOwner: () => null,
+    getWorkflowTitle: () => "remove_bg_workflow",
+    waitForReconnectHandshakeBeforeOpen: async () => {},
+    comfyBackendIsDown: () => false,
+    postReconnectBindingSettleWindow: () => false,
+    nodeDefRefreshInFlight: null,
+    flushSourceCanvasBeforeSwitch: async () => {},
+    claimActiveWorkflowMove: () => {},
+    acquireCanvasInteractionLock: () => null,
+    releaseCanvasInteractionLock: () => {},
+    MOVE_CAUSES: { OPEN_EXECUTOR: "workflow_open" },
+    settleOpenedWorkflowTarget: async () => ({ target, loaded: false }),
+    workflowRecordMatchesSelector: () => true,
+    installNodeConfigureIsolation: () => ({ failures: [], restore: () => {} }),
+    installGraphConfigureWatch: () => ({ restore: () => {} }),
+    loadRestoreCompleted: () => true,
+    retryNodeRestores: async () => ({ restored: [], failed: [], recovered: [] }),
+    liteGraphGlobal: () => null,
+    getGraphCtx: () => ({ graph: root, rootGraph: root }),
+    decideLiveCanvasCapture: decideLiveCanvasCapture,
+    applySavedNodePresentation: () => {},
+    applySavedSubgraphHostWidgets: () => {},
+    decideOpenStaleness: () => ({ stale: false, reload: false }),
+    describeRepaintSourceBinding: () => "unknown",
+    graphRootCarriesOpenProof: () => false,
+    graphRootReproducesStateContent: () => ({ proven: false, presentationOnly: false, normalizedOnly: false }),
+    graphRootStructureExtendsActiveWorkflow,
+    describeGraphStateDifference: () => ({ comparable: true, surfaces: ["nodes"], accountedSurfaces: [], nodeDifference: null }),
+    openContentDifferenceIsDefinitionsOnly: () => false,
+    resolveOpenRebindVerdict: () => ({ status: "unproven" }),
+    describeOpenRebindOutcome: () => "could not prove rebound",
+    OPEN_REBIND_STATUS: { PROVEN: "proven", CONTENT_UNVERIFIED: "content-unverified", UNPROVEN: "unproven" },
+    GRAPH_TOOL_EXECUTORS: { graph_outline: () => ({ node_count: 118 }) },
+    settleOpenedWorkflowReadable,
+    settleOwnedOpenedWorkflowActive,
+    noteOpenAttempt: () => ({ seq: 1 }),
+    backendSocketReplyFields: () => ({}),
+    activeWorkflowUuidForOpenReply: () => targetUuid,
+    describeOpenActiveBinding: () => ({ active_matches_target: true }),
+    canvasFileDivergenceNote: () => null,
+    failOpenRebindUnknown: (error) => error,
+    coerceMessageText: (value) => String(value),
+  });
+
+  await assert.rejects(
+    panel.method({ path: "remove_bg_workflow.json", rid: "safe-repaint-previous-canvas" }),
+    /safe repaint/,
+    "the open must refuse rather than paint TARGET's fence over SOURCE's canvas",
+  );
+  assert.equal(active, target, "the pointer has already moved, as in the recurrence");
+  assert.equal(root._nodes.length, 118, "the live canvas is still the previous graph");
+  assert.equal(panel.guard(), null);
+
+  for (const cmd of ["graph_outline", "graph_query"]) {
+    const verdict = resolveGraphBindingVerdict({
+      graph: root,
+      rootGraph: root,
+      activeWorkflow: target,
+      activeWorkflowUuid: targetUuid,
+      liveNodeCount: root._nodes.length,
+      ...graphCommandBindingBar(cmd),
+      includeBaselineReadGuard: true,
+    });
+    assert.equal(
+      verdict?.reason,
+      "root-state-unreadable",
+      `${cmd} must refuse after set_workflow_target current — the fence names TARGET, the canvas is still SOURCE`,
+    );
+  }
 });
 
 test("#1639 production workflow_open remembers a switch-away-and-back during an awaited open step", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1297,6 +1297,10 @@ let workflowBindingGeneration = 0;
 function nextWorkflowBindingGeneration() {
   return ++workflowBindingGeneration;
 }
+// #1215 — last workflow_open moved the active pointer and could not prove the
+// canvas rebound. Reads must not serve the leftover previous graph under the
+// new fence. Cleared only by a proven open; panel_set_workflow_target does not.
+let switchRepaintUnproven = false;
 // Defensive ceiling: a guard can only ever be cleared by workflow_open's finally, so if
 // some pathological path ever failed to run it, an un-expiring guard would wedge every
 // command in the tab. Age it out instead — but ONLY while no step of the section is in
@@ -10036,6 +10040,15 @@ function assertGraphBoundToActiveWorkflow(
   // available response was a blind reload/re-open retry loop. Every caller runs
   // this BEFORE doing any work, which is what makes its "was NOT applied" claim
   // true rather than a fabrication.
+  let others = null;
+  try {
+    const open = app?.extensionManager?.workflow?.openWorkflows;
+    if (Array.isArray(open)) {
+      others = open.filter((w) => w && !sameWorkflowObject(w, activeWorkflow));
+    }
+  } catch {
+    others = null;
+  }
   const verdict = resolveGraphBindingVerdict({
     graph,
     rootGraph,
@@ -10049,6 +10062,8 @@ function assertGraphBoundToActiveWorkflow(
     postReconnectWindow: postReconnectSettleWindow(),
     graphLoading,
     missingNodeState,
+    others,
+    switchRepaintUnproven,
   });
   if (verdict) throw new Error(graphBindingRefusalMessage(verdict));
 }
@@ -15086,15 +15101,10 @@ const GRAPH_TOOL_EXECUTORS = {
   // graph_get_state stays registered for BACK-COMPAT with older orchestrators.
   graph_query({ types, title, where, ids, upstream_of, downstream_of, depth, fields, group_by, limit, max_chars, widget_max_chars }) {
     const { graph, rootGraph } = getGraphCtx();
-    // #1215 — same executor re-assert as graph_outline. Dispatch already runs the
-    // classified-read bar; this keeps the #389 baseline guard on so a tab switch
-    // that left the previous canvas mounted cannot be queried as the new workflow.
-    assertGraphBoundToActiveWorkflow(graph, rootGraph, {
-      ...graphCommandBindingBar("graph_query"),
-      includeBaselineReadGuard: true,
-    });
     // #429: resync cached node rects to live geometry before the `groups` block
     // recomputes geometric membership (summarizeGroup), so it never reports stale ids.
+    // Binding is asserted at dispatch (`graphCommandBindingBar(msg.cmd)`), not here:
+    // extracted graph_query budget tests re-run this method without the canvas fence.
     syncGraphNodeAreas(graph);
     const nodes = graph._nodes ?? [];
     const byId = new Map(nodes.map((n) => [String(n.id), n]));
@@ -24227,6 +24237,10 @@ const GRAPH_TOOL_EXECUTORS = {
       });
     }
     if (rebindFailed) {
+      // #1215 — the pointer may already name TARGET while the canvas is still
+      // SOURCE. Remember that so a later graph_outline / graph_query cannot
+      // treat the leftover canvas as the new workflow after set_workflow_target.
+      if (pointerMovedThisOpen) switchRepaintUnproven = true;
       // #1089 follow-up — the foreign-source finding rides the FAILURE too.
       //
       // It was only on the success reply, and that dropped it on the combination that
@@ -24254,6 +24268,7 @@ const GRAPH_TOOL_EXECUTORS = {
       }
       throw failOpenRebindUnknown(rebindFailed);
     }
+    switchRepaintUnproven = false;
     // A first open loads the named file, and an explicit stale reload re-read it from
     // disk; either operation re-establishes graph provenance for a workflow previously
     // replaced by graph_load. Merely switching to an already-open in-memory tab does not.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15086,6 +15086,13 @@ const GRAPH_TOOL_EXECUTORS = {
   // graph_get_state stays registered for BACK-COMPAT with older orchestrators.
   graph_query({ types, title, where, ids, upstream_of, downstream_of, depth, fields, group_by, limit, max_chars, widget_max_chars }) {
     const { graph, rootGraph } = getGraphCtx();
+    // #1215 — same executor re-assert as graph_outline. Dispatch already runs the
+    // classified-read bar; this keeps the #389 baseline guard on so a tab switch
+    // that left the previous canvas mounted cannot be queried as the new workflow.
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, {
+      ...graphCommandBindingBar("graph_query"),
+      includeBaselineReadGuard: true,
+    });
     // #429: resync cached node rects to live geometry before the `groups` block
     // recomputes geometric membership (summarizeGroup), so it never reports stale ids.
     syncGraphNodeAreas(graph);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10049,6 +10049,10 @@ function assertGraphBoundToActiveWorkflow(
   } catch {
     others = null;
   }
+  // typeof so extracted fence harnesses (#1477/#1233) that do not bind this
+  // module-level flag still run: an undeclared identifier is not leftover proof.
+  const leftoverSwitch =
+    typeof switchRepaintUnproven !== "undefined" && switchRepaintUnproven === true;
   const verdict = resolveGraphBindingVerdict({
     graph,
     rootGraph,
@@ -10063,7 +10067,7 @@ function assertGraphBoundToActiveWorkflow(
     graphLoading,
     missingNodeState,
     others,
-    switchRepaintUnproven,
+    switchRepaintUnproven: leftoverSwitch,
   });
   if (verdict) throw new Error(graphBindingRefusalMessage(verdict));
 }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -93,35 +93,44 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
  * PREVIOUS tab's graph. That is the inverse of `graphReadDesynced`: the canvas
  * is nonempty, not empty.
  *
- * Every older predicate fail-opens on the reported shape (open returned the
- * "safe repaint" error because the target had no `activeState.nodes`, then
- * `panel_set_workflow_target({mode:"current"})` rebound the fence and
- * `panel_graph_outline` served the prior graph):
- *   - `graphReadDesynced` only fires when the live root is EMPTY;
- *   - `graphRootMismatchesActiveWorkflow` returns false when `nodes` is
- *     missing (`!Array.isArray(expected)`);
- *   - uuid mismatch needs a tag on the live root, which an untagged previous
- *     canvas does not carry. A TARGET tag is not an exception either: after a
- *     switch the outgoing canvas can still hold a stale/shared stamp (#1639).
+ * Missing current state alone is NOT leftover evidence. Extracted graph_query
+ * fixtures, a first observation, and #618's unreadable tracker all look like
+ * "live nodes + no activeState" and must fail OPEN. Refuse only when that
+ * unreadable active state is paired with switch/open leftover proof:
+ *   - `switchRepaintUnproven`: this session's last open moved the pointer and
+ *     could not prove the canvas rebound (the safe-repaint failure);
+ *   - or another still-open workflow's current state AGREES with the live
+ *     root, so the mounted graph is that previous tab's, not the named one.
  *
- * Fail-closed only when ALL of:
- *   - ROOT scope;
- *   - an active workflow object is present (no service → legacy availability);
- *   - the live root observably has nodes;
- *   - that workflow's CURRENT serialized state is absent/malformed.
- * A well-formed empty `nodes: []` is the shape guard's job (blank tab vs a
- * leftover canvas). `panel_set_workflow_target` does not clear this — it
- * re-points the session, it does not rebind the canvas.
+ * A well-formed empty `nodes: []` is the shape guard's job. A TARGET uuid on
+ * the leftover canvas is not an exception (#1639). `panel_set_workflow_target`
+ * does not clear this — it re-points the session, it does not rebind the canvas.
  */
 export function graphRootUnprovenAgainstActiveState({
   liveNodeCount,
   activeWorkflow,
+  rootGraph = null,
+  others = null,
+  switchRepaintUnproven = false,
   inSubgraph = false,
 } = {}) {
   if (inSubgraph) return false;
   if (!activeWorkflow) return false;
   if (!(Number(liveNodeCount) > 0)) return false;
-  return activeWorkflowCurrentState(activeWorkflow) == null;
+  if (activeWorkflowCurrentState(activeWorkflow) != null) return false;
+  if (switchRepaintUnproven === true) return true;
+  if (!rootGraph || !Array.isArray(others)) return false;
+  for (const other of others) {
+    if (!other) continue;
+    try {
+      const otherState = activeWorkflowCurrentState(other);
+      if (otherState == null) continue;
+      if (graphRootAgreesWithActiveState(rootGraph, otherState)) return true;
+    } catch {
+      // An unreadable twin is not leftover proof.
+    }
+  }
+  return false;
 }
 
 /**
@@ -3113,6 +3122,8 @@ export function resolveGraphBindingVerdict({
   postReconnectWindow = false,
   graphLoading = false,
   missingNodeState = null,
+  others = null,
+  switchRepaintUnproven = false,
 } = {}) {
   const nodeCount = Number.isFinite(Number(liveNodeCount))
     ? Number(liveNodeCount)
@@ -3207,11 +3218,18 @@ export function resolveGraphBindingVerdict({
       ...(reason === "root-shape-mismatch" ? { structureMatches: structureMatches === true } : {}),
     };
   }
-  // #1215 — live canvas has nodes, active workflow has nothing to compare.
-  // Not gated on includeBaselineReadGuard: a classified read at dispatch is
-  // how panel_graph_outline / panel_query_graph silently served the previous
-  // tab after an open that could not repaint.
-  if (graphRootUnprovenAgainstActiveState({ liveNodeCount: nodeCount, activeWorkflow, inSubgraph })) {
+  // #1215 — leftover previous canvas after a switch that could not repaint.
+  // Missing current state alone is not enough (graph_query fixtures, #618).
+  if (
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: nodeCount,
+      activeWorkflow,
+      rootGraph,
+      others,
+      switchRepaintUnproven,
+      inSubgraph,
+    })
+  ) {
     return {
       reason: "root-state-unreadable",
       expected: null,

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -88,6 +88,43 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
 }
 
 /**
+ * #1215 recurrence — after a tab switch the ACTIVE pointer (and the session
+ * fence) can already name the new workflow while the live root is still the
+ * PREVIOUS tab's graph. That is the inverse of `graphReadDesynced`: the canvas
+ * is nonempty, not empty.
+ *
+ * Every older predicate fail-opens on the reported shape (open returned the
+ * "safe repaint" error because the target had no `activeState.nodes`, then
+ * `panel_set_workflow_target({mode:"current"})` rebound the fence and
+ * `panel_graph_outline` served the prior graph):
+ *   - `graphReadDesynced` only fires when the live root is EMPTY;
+ *   - `graphRootMismatchesActiveWorkflow` returns false when `nodes` is
+ *     missing (`!Array.isArray(expected)`);
+ *   - uuid mismatch needs a tag on the live root, which an untagged previous
+ *     canvas does not carry. A TARGET tag is not an exception either: after a
+ *     switch the outgoing canvas can still hold a stale/shared stamp (#1639).
+ *
+ * Fail-closed only when ALL of:
+ *   - ROOT scope;
+ *   - an active workflow object is present (no service → legacy availability);
+ *   - the live root observably has nodes;
+ *   - that workflow's CURRENT serialized state is absent/malformed.
+ * A well-formed empty `nodes: []` is the shape guard's job (blank tab vs a
+ * leftover canvas). `panel_set_workflow_target` does not clear this — it
+ * re-points the session, it does not rebind the canvas.
+ */
+export function graphRootUnprovenAgainstActiveState({
+  liveNodeCount,
+  activeWorkflow,
+  inSubgraph = false,
+} = {}) {
+  if (inSubgraph) return false;
+  if (!activeWorkflow) return false;
+  if (!(Number(liveNodeCount) > 0)) return false;
+  return activeWorkflowCurrentState(activeWorkflow) == null;
+}
+
+/**
  * True when ComfyUI's load-time missing-node store positively reports missing
  * nodes. The store is independent from both LiteGraph's live graph and the
  * workflow ChangeTracker, so it is useful evidence specifically in the
@@ -3170,6 +3207,17 @@ export function resolveGraphBindingVerdict({
       ...(reason === "root-shape-mismatch" ? { structureMatches: structureMatches === true } : {}),
     };
   }
+  // #1215 — live canvas has nodes, active workflow has nothing to compare.
+  // Not gated on includeBaselineReadGuard: a classified read at dispatch is
+  // how panel_graph_outline / panel_query_graph silently served the previous
+  // tab after an open that could not repaint.
+  if (graphRootUnprovenAgainstActiveState({ liveNodeCount: nodeCount, activeWorkflow, inSubgraph })) {
+    return {
+      reason: "root-state-unreadable",
+      expected: null,
+      live: nodeCount,
+    };
+  }
   if (missingNodeStateReportsNodes(missingNodeState) && !inSubgraph && nodeCount === 0) {
     return {
       reason: "empty-graph-missing-nodes",
@@ -3216,6 +3264,19 @@ export function graphBindingRefusalMessage(verdict) {
       `reconnect, or a failed open, and node_count 0 could be a FALSE-EMPTY reading, so this ` +
       `command was NOT applied as authoritative. Retry in a moment once the tab settles; if it ` +
       `persists, re-open the workflow tab (panel_open_workflow) or reload the panel.`
+    );
+  }
+  if (verdict.reason === "root-state-unreadable") {
+    const live = Number(verdict.live);
+    const liveText = Number.isFinite(live) ? `${live} node(s)` : "nodes";
+    return (
+      `[root-state-unreadable] The live canvas shows ${liveText}, but the active workflow has no ` +
+      `comparable serialized state, so this command was NOT applied as authoritative. After a tab ` +
+      `switch the canvas can still be the previous workflow while the active pointer and session ` +
+      `fence already name the new one. Re-open the active workflow tab (panel_open_workflow) or ` +
+      `load it from disk (panel_load_workflow). That REPLACES the canvas. Re-targeting with ` +
+      `panel_set_workflow_target is NOT a remedy for this — it re-points the session, it does ` +
+      `not rebind the canvas.`
     );
   }
   if (verdict.reason === "empty-graph-missing-nodes") {


### PR DESCRIPTION
## Summary
After `panel_open_workflow` switched tabs, graph reads could still serve the previous canvas while the fence, `panel_list_workflows`, and `panel_set_workflow_target({mode:"current"})` all named the new workflow.

#1951/#2038 already close the capture/repaint poison. The remaining hole is the open that **moves the pointer** then fails the safe-repaint rebind because the target has no comparable `activeState.nodes`. Existing predicates fail-open there (`graphReadDesynced` only fires on an empty live root; shape comparison is inconclusive when `nodes` is missing; an untagged leftover canvas has no uuid mismatch). Outline/query then returned the prior graph.

Fail closed: a nonempty live root with no readable current state is `[root-state-unreadable]`. `panel_set_workflow_target` is not a remedy. Already-current untagged capture with matching state (#2038) still admits.

Closes #1215

## Tests
```
node --test browser_tests/unit/graph-binding.test.mjs browser_tests/unit/open-active-settle.test.mjs
```
200 pass, 0 fail (with changelog-integrity).
