### PR TITLE
fix(1181): copy promoted subgraph values into the compiled prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_run copies promoted subgraph rails and linked primitive values into the compiled prompt so a Krea2-style width/height and external prompt execute instead of stored inner defaults; GetNode/SetNode bus relays are no longer reported as dropped value sources (#1181)
+
 ## [0.15.171] - 2026-09-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
-- panel_run copies promoted subgraph rails and linked primitive values into the compiled prompt so a Krea2-style width/height and external prompt execute instead of stored inner defaults; GetNode/SetNode bus relays are no longer reported as dropped value sources (#1181)
+- panel_run compiles promoted host-rail width/height and linked PrimitiveNode/GetNode primitive values into the flattened subgraph prompt so inner stored fallbacks do not execute; GetNode/SetNode tensor buses are not reported as dropped value sources (#1181)
 
 ## [0.15.171] - 2026-09-04
 

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -72,7 +72,11 @@ import {
   scopedBatchDriveNote,
   rgthreeFixedSeedNote,
 } from "../../web/js/lib/scoped-batch-seed.js";
-import { collectVirtualSourceFeeds, virtualSourceNote } from "../../web/js/lib/virtual-source-promotion.js";
+import {
+  collectVirtualSourceFeeds,
+  installGraphToPromptVirtualSourceApply,
+  virtualSourceNote,
+} from "../../web/js/lib/virtual-source-promotion.js";
 import { collectDisabledAncestorOutputs, disabledOutputsNote } from "../../web/js/lib/muted-subgraph-outputs.js";
 import { prunedRetryNote } from "../../web/js/lib/partial-run-prune.js";
 import {
@@ -745,6 +749,7 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
     installGraphToPromptNullSafety,
     installGraphToPromptSnapshotBarrier,
     installGraphToPromptDynamicReconcile,
+    installGraphToPromptVirtualSourceApply,
     queuePromptWithGraphToPromptSnapshot,
     reserveGraphToPromptSnapshot,
     releaseGraphToPromptSnapshot,

--- a/browser_tests/unit/virtual-source-promotion.test.mjs
+++ b/browser_tests/unit/virtual-source-promotion.test.mjs
@@ -27,6 +27,9 @@ import {
   collectVirtualSourceFeeds,
   virtualSourceNote,
   virtualSourceTag,
+  linkedSourcePayload,
+  applyLinkedSubgraphValuesToPrompt,
+  installGraphToPromptVirtualSourceApply,
 } from "../../web/js/lib/virtual-source-promotion.js";
 
 // ---- fixtures ---------------------------------------------------------------
@@ -93,6 +96,40 @@ test("#1181 a virtual node with a CONNECTED input can relay a real value — not
 
 test("#1181 a bare virtual node with nothing to forward IS flagged", () => {
   assert.equal(isNonSerializingValueSource({ id: 2, isVirtualNode: true, inputs: [] }), true);
+});
+
+test("#1181 GetNode is a bus relay graphToPrompt resolves, not a dropped value source", () => {
+  // Krea2 wires Get_VAE / Get_CLIP into the subgraph. Clause 2 used to flag any
+  // virtual node with no connected input, so panel_run claimed GetNode was the
+  // non-source PrimitiveNode is. The widget is the bus NAME, not a payload.
+  assert.equal(
+    isNonSerializingValueSource({
+      id: 59,
+      type: "GetNode",
+      isVirtualNode: true,
+      inputs: [],
+      widgets: [{ name: "value", value: "VAE" }],
+    }),
+    false,
+  );
+  assert.equal(
+    isNonSerializingValueSource({
+      id: 32,
+      type: "SetNode",
+      isVirtualNode: true,
+      inputs: [{ name: "VAE", link: 1 }],
+    }),
+    false,
+  );
+  assert.equal(
+    linkedSourcePayload({
+      id: 59,
+      type: "GetNode",
+      isVirtualNode: true,
+      widgets: [{ name: "value", value: "VAE" }],
+    }),
+    undefined,
+  );
 });
 
 test("#1181 malformed/missing nodes fail safe: not a source, never a throw", () => {
@@ -210,9 +247,9 @@ test("#1181 the queue-time note names the source and says the STORED value execu
   assert.match(note, /PrimitiveNode #85/);
   assert.match(note, /subgraph #10/);
   assert.match(note, /"text"/);
-  assert.match(note, /STORED/i, "says the inner stored value is what executes");
-  assert.match(note, /does NOT reach the prompt|dropped from the prompt/i);
-  // The remedy the reporter verified: a BACKEND primitive carries the value.
+  assert.match(note, /STORED/i, "names the inner stored fallback ComfyUI would serialize");
+  assert.match(note, /DROPS that source|dropped from the prompt/i);
+  assert.match(note, /compiles the linked/i, "says panel_run compiles the linked value into the prompt");
   assert.match(note, /backend/i);
 });
 
@@ -226,7 +263,8 @@ test("#1181 no findings, no note", () => {
 test("#1181 the outline/compact tag says the link value is NOT what executes", () => {
   const tag = virtualSourceTag({ node_id: 85, output_slot: 0 });
   assert.match(tag, /#85\.0/);
-  assert.match(tag, /NOT what executes|not serialized|stored value/i);
+  assert.match(tag, /not serialized/i);
+  assert.match(tag, /compiles the linked value into the prompt/i);
   assert.equal(virtualSourceTag(null), "");
 });
 
@@ -273,4 +311,185 @@ test("#1181 the promoted-write refusal names the real repairs when the outer fee
   assert.match(src, /does NOT cross the subgraph boundary/, "the corrected refusal says what happens");
   // The generic #366 refusal must still exist for real-source / nested-promotion cases.
   assert.match(src, /parent rail widget could not be identified/, "the generic refusal is kept");
+});
+
+// ---- compiled-prompt apply (Krea2 recurrence) --------------------------------
+
+function krea2LikeGraph() {
+  const latent = {
+    id: 76,
+    type: "EmptyLatentImage",
+    widgets: [
+      { name: "width", value: 1920 },
+      { name: "height", value: 1080 },
+      { name: "batch_size", value: 1 },
+    ],
+    inputs: [],
+  };
+  const encode = {
+    id: 15,
+    type: "CLIPTextEncode",
+    widgets: [{ name: "text", value: "" }],
+    inputs: [
+      { name: "clip", type: "CLIP", link: 42 },
+      { name: "text", type: "STRING", link: 83, widget: { name: "text" } },
+    ],
+  };
+  const anySwitch = {
+    id: 72,
+    type: "Any Switch (rgthree)",
+    isVirtualNode: true,
+    widgets: [],
+    inputs: [
+      { name: "any_01", type: "*", link: 97 },
+      { name: "any_02", type: "*", link: null },
+    ],
+    outputs: [{ name: "*", type: "*", links: [83] }],
+  };
+  const inner = {
+    _nodes: [latent, encode, anySwitch],
+    inputNode: { id: -10 },
+    links: [
+      { id: 97, origin_id: -10, origin_slot: 4, target_id: 72, target_slot: 0, type: "*" },
+      { id: 83, origin_id: 72, origin_slot: 0, target_id: 15, target_slot: 1, type: "STRING" },
+      { id: 42, origin_id: -10, origin_slot: 1, target_id: 15, target_slot: 0, type: "CLIP" },
+    ],
+  };
+  const promptNode = {
+    id: 143,
+    type: "PrimitiveStringMultiline",
+    constructor: { nodeData: {} },
+    outputs: [{ name: "STRING", type: "STRING", links: [153] }],
+    widgets: [{ name: "value", value: "a lantern at dusk" }],
+  };
+  const getVae = {
+    id: 59,
+    type: "GetNode",
+    isVirtualNode: true,
+    inputs: [],
+    outputs: [{ name: "VAE", type: "VAE", links: [84] }],
+    widgets: [{ name: "value", value: "VAE" }],
+  };
+  const host = {
+    id: 78,
+    type: "21ffbd86-8db8-4fab-954b-2cd8ab0662da",
+    subgraph: inner,
+    properties: { proxyWidgets: [["76", "width"], ["76", "height"]] },
+    widgets: [
+      { name: "width", value: 1024 },
+      { name: "height", value: 768 },
+    ],
+    inputs: [
+      { name: "vae", type: "VAE", link: 84 },
+      { name: "clip", type: "CLIP", link: 85 },
+      { name: "model", type: "MODEL", link: 156 },
+      { name: "positive", type: "CONDITIONING", link: 238 },
+      { name: "any_01", type: "STRING", link: 153 },
+      { name: "any_02", type: "STRING", link: null },
+    ],
+  };
+  const g = graphOf(
+    [getVae, promptNode, host],
+    {
+      84: { origin_id: 59, origin_slot: 0 },
+      153: { origin_id: 143, origin_slot: 0 },
+    },
+  );
+  host.graph = g;
+  return g;
+}
+
+function staleKrea2Prompt() {
+  return {
+    output: {
+      "78:76": {
+        class_type: "EmptyLatentImage",
+        inputs: { width: 1920, height: 1080, batch_size: 1 },
+      },
+      "78:15": {
+        class_type: "CLIPTextEncode",
+        inputs: { clip: ["1", 0], text: "" },
+      },
+    },
+  };
+}
+
+test("#1181 GetNode feeding a subgraph is not a virtual-source feed", () => {
+  const found = collectVirtualSourceFeeds(krea2LikeGraph());
+  assert.equal(found.some((f) => f.origin_type === "GetNode"), false);
+});
+
+test("#1181 Krea2-like compiled prompt carries promoted width/height and the linked prompt", () => {
+  const g = krea2LikeGraph();
+  const prompt = staleKrea2Prompt();
+  const n = applyLinkedSubgraphValuesToPrompt(g, prompt);
+  assert.ok(n >= 3, `expected width, height, and text patches, got ${n}`);
+  assert.equal(prompt.output["78:76"].inputs.width, 1024);
+  assert.equal(prompt.output["78:76"].inputs.height, 768);
+  assert.equal(prompt.output["78:15"].inputs.text, "a lantern at dusk");
+  assert.equal(prompt.output["78:15"].inputs.clip[0], "1", "tensor links are left alone");
+});
+
+test("#1181 PrimitiveNode coverage is not weakened: it is still a non-serializing source", () => {
+  assert.equal(isNonSerializingValueSource(primitive(85, "a lantern")), true);
+  const g = primitiveFeed();
+  const prompt = {
+    output: {
+      "10:3": { class_type: "CLIPTextEncode", inputs: { text: "OLD stored text" } },
+    },
+  };
+  // primitiveFeed's container has no inner CLIPTextEncode — pin the detector still fires.
+  const found = collectVirtualSourceFeeds(g);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].origin_type, "PrimitiveNode");
+  applyLinkedSubgraphValuesToPrompt(g, prompt);
+});
+
+test("#1181 PrimitiveNode linked into a subgraph STRING input is copied onto the inner prompt node", () => {
+  const innerNode = {
+    id: 3,
+    type: "CLIPTextEncode",
+    widgets: [{ name: "text", value: "OLD stored text" }],
+    inputs: [{ name: "text", type: "STRING", link: 1, widget: { name: "text" } }],
+  };
+  const innerGraph = {
+    _nodes: [innerNode],
+    inputNode: { id: -10 },
+    links: [{ id: 1, origin_id: -10, origin_slot: 0, target_id: 3, target_slot: 0, type: "STRING" }],
+  };
+  const host = container(10);
+  host.subgraph = innerGraph;
+  host.inputs = [{ name: "text", type: "STRING", link: 7, _widget: { name: "text" } }];
+  const g = graphOf([primitive(85, "a lantern at dusk"), host], { 7: { origin_id: 85, origin_slot: 0 } });
+  host.graph = g;
+  const prompt = {
+    output: { "10:3": { class_type: "CLIPTextEncode", inputs: { text: "OLD stored text" } } },
+  };
+  applyLinkedSubgraphValuesToPrompt(g, prompt);
+  assert.equal(prompt.output["10:3"].inputs.text, "a lantern at dusk");
+});
+
+test("#1181 graphToPrompt wrap patches the compiled prompt and does not mutate live inner widgets", async () => {
+  const g = krea2LikeGraph();
+  const inner = g._nodes[2].subgraph._nodes[0];
+  const app = {
+    graph: g,
+    graphToPrompt: () => staleKrea2Prompt(),
+  };
+  assert.equal(installGraphToPromptVirtualSourceApply(app), true);
+  assert.equal(installGraphToPromptVirtualSourceApply(app), true, "idempotent");
+  const prompt = await app.graphToPrompt();
+  assert.equal(prompt.output["78:76"].inputs.width, 1024);
+  assert.equal(prompt.output["78:15"].inputs.text, "a lantern at dusk");
+  assert.equal(inner.widgets[0].value, 1920, "live inner stored value is untouched");
+});
+
+test("#1181 graph_run installs the virtual-source prompt apply before the snapshot barrier", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const apply = src.indexOf("installGraphToPromptVirtualSourceApply(app)");
+  const snapshot = src.indexOf("installGraphToPromptSnapshotBarrier(app)");
+  const preflight = src.indexOf("const preflightBuild = await withTimeout(");
+  assert.ok(apply > 0, "graph_run must install the virtual-source prompt apply");
+  assert.ok(snapshot > apply, "snapshot barrier stays outermost");
+  assert.ok(preflight > snapshot, "apply is installed before pre-flight serialize");
 });

--- a/browser_tests/unit/virtual-source-promotion.test.mjs
+++ b/browser_tests/unit/virtual-source-promotion.test.mjs
@@ -430,6 +430,56 @@ test("#1181 Krea2-like compiled prompt carries promoted width/height and the lin
   assert.equal(prompt.output["78:15"].inputs.clip[0], "1", "tensor links are left alone");
 });
 
+test("#1181 GetNode primitive bus compiles through SetNode, never the Constant key", () => {
+  const latent = {
+    id: 4,
+    type: "EmptyLatentImage",
+    widgets: [{ name: "width", value: 512 }],
+    inputs: [{ name: "width", type: "INT", link: 1, widget: { name: "width" } }],
+  };
+  const inner = {
+    _nodes: [latent],
+    inputNode: { id: -10 },
+    links: [{ id: 1, origin_id: -10, origin_slot: 0, target_id: 4, target_slot: 0, type: "INT" }],
+  };
+  const source = primitive(1, 1280);
+  const setNode = {
+    id: 2,
+    type: "SetNode",
+    isVirtualNode: true,
+    widgets: [{ name: "Constant", value: "width" }],
+    inputs: [{ name: "*", link: 8 }],
+  };
+  const getNode = {
+    id: 3,
+    type: "GetNode",
+    isVirtualNode: true,
+    inputs: [],
+    outputs: [{ name: "INT", type: "INT" }],
+    widgets: [{ name: "Constant", value: "width" }],
+  };
+  const host = {
+    id: 10,
+    subgraph: inner,
+    widgets: [{ name: "width", value: 512 }],
+    inputs: [{ name: "width", type: "INT", link: 7, widget: { name: "width" } }],
+  };
+  const g = graphOf(
+    [source, setNode, getNode, host],
+    {
+      8: { origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 },
+      7: { origin_id: 3, origin_slot: 0, target_id: 10, target_slot: 0 },
+    },
+  );
+  for (const node of g._nodes) node.graph = g;
+  assert.equal(linkedSourcePayload(getNode, g), 1280);
+  const prompt = { output: { "10:4": { class_type: "EmptyLatentImage", inputs: { width: 512 } } } };
+  applyLinkedSubgraphValuesToPrompt(g, prompt);
+  assert.equal(prompt.output["10:4"].inputs.width, 1280);
+  assert.equal(getNode.widgets[0].value, "width");
+  assert.equal(latent.widgets[0].value, 512, "live inner widget is untouched");
+});
+
 test("#1181 PrimitiveNode coverage is not weakened: it is still a non-serializing source", () => {
   assert.equal(isNonSerializingValueSource(primitive(85, "a lantern")), true);
   const g = primitiveFeed();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -277,6 +277,7 @@ import {
 } from "./lib/muted-subgraph-outputs.js";
 import {
   collectVirtualSourceFeeds,
+  installGraphToPromptVirtualSourceApply,
   virtualFedInputs,
   virtualSourceNote,
   virtualSourceTag,
@@ -20246,6 +20247,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // and the deferred queue-loop serialize see the same nested set. Installed before
     // the snapshot barrier so a cancelled queue item still throws synchronously.
     installGraphToPromptDynamicReconcile(app);
+    // #1181 recurrence — copy promoted rails and linked primitive payloads into
+    // the compiled prompt (Krea2 width/height + external prompt). After reconcile,
+    // before the snapshot barrier so cancel still throws synchronously.
+    installGraphToPromptVirtualSourceApply(app);
     installGraphToPromptSnapshotBarrier(app);
     try {
       // Inspect the SERIALIZED prompt, not the canvas. graphToPrompt has already
@@ -21208,12 +21213,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // execution disagreed, reused cached conditioning and all). Measured on ComfyUI
     // 0.32.0 / frontend 1.48.7.
     //
-    // Same posture as #985 above: the panel does not build this prompt and cannot
-    // carry the value across the boundary, but it can stop queueing in silence.
-    // Reported at QUEUE time so an agent can interrupt rather than learn it from
-    // the render. Scoped runs are NOT exempt — unlike #985 this is not about
-    // execution roots: a dropped source feeds nothing no matter how the run is
-    // scoped. The note states the read-from-graph caveat itself.
+    // The serializer wrap copies those payloads into the compiled prompt. This
+    // scan still names leftover PrimitiveNode feeds at QUEUE time so an agent
+    // can interrupt (GetNode/SetNode bus relays are not feeds). Scoped runs are
+    // NOT exempt — unlike #985 this is not about execution roots. The note
+    // states the read-from-graph caveat itself.
     try {
       const virtualFeeds = collectVirtualSourceFeeds(rootGraph);
       if (virtualFeeds.length) {

--- a/web/js/lib/virtual-source-promotion.js
+++ b/web/js/lib/virtual-source-promotion.js
@@ -295,6 +295,8 @@ export function linkedSourcePayload(node, graph = node?.graph, seen = new Set())
   nextSeen.add(node);
   if (node.subgraph) return undefined;
   if (node.type === "GetNode") {
+    const outType = node.outputs?.[0]?.type;
+    if (typeof outType === "string" && outType && !PRIMITIVE_OUTPUT_TYPES.has(outType)) return undefined;
     try {
       if (typeof node.getInputLink === "function") {
         const link = node.getInputLink(0);

--- a/web/js/lib/virtual-source-promotion.js
+++ b/web/js/lib/virtual-source-promotion.js
@@ -12,14 +12,11 @@
  * reporter verified the counterpart too — a BACKEND PrimitiveStringMultiline
  * wired the same way appears in the execution graph and drives the value.
  *
- * A whole-graph `panel_run` hands prompt construction to ComfyUI's own
- * `app.queuePrompt`, so the panel does not build this prompt and cannot carry
- * the value across the boundary itself. What it CAN do is stop being silent —
- * and stop asserting the opposite of the truth, which is what the read path did
- * before this issue: `linkDrivenWidgets` flags any link-connected widget as
- * "OVERRIDDEN by a link at run time — the stored value is stale, NOT what
- * executes", which is exactly backwards when the link's origin is a virtual
- * node the prompt compiler drops.
+ * Native graphToPrompt still drops the virtual origin. panel_run now copies
+ * promoted host-rail values and linked primitive payloads into the flattened
+ * prompt so the inner stored widget is not what executes. This module is still
+ * the detector for leftover PrimitiveNode feeds: stop asserting `driven_by_link`
+ * (the stored value is stale) when the origin is virtual.
  *
  * WHY THE TARGET IS A SUBGRAPH CONTAINER: a top-level PrimitiveNode feeding an
  * ORDINARY node works — graphToPrompt resolves the primitive's value into the
@@ -30,8 +27,7 @@
  * Read-only and dependency-free, like graph-read.js / muted-subgraph-outputs.js,
  * so it can be unit-tested in isolation
  * (browser_tests/unit/virtual-source-promotion.test.mjs). Nothing here mutates
- * the graph: pushing the primitive's value into the inner widget during a read
- * or a run is exactly the silent-mutation class #979/#233 forbid.
+ * the graph: the compile path patches the prompt object, not live widgets.
  */
 
 /**
@@ -44,7 +40,9 @@
  *      FRONTEND_ONLY_NODE_TYPES allowlist is NOT reused wholesale: Note has no
  *      outputs, a Reroute relays whatever is upstream (fine when the upstream
  *      is real), and KJNodes' Get/Set bus is resolved BY graphToPrompt — calling
- *      any of those "carries nothing" would be a false claim.
+ *      any of those "carries nothing" would be a false claim. GetNode/SetNode
+ *      are therefore excluded by type even though a GetNode is virtual and has
+ *      no connected input (its "value" widget is the bus NAME, not a payload).
  *   2. any OTHER litegraph virtual node (`isVirtualNode === true`) that is not a
  *      subgraph container and has NO connected input to forward — whatever it
  *      displays lives only in the frontend. A subgraph container is excluded
@@ -53,6 +51,7 @@
  */
 export function isNonSerializingValueSource(node) {
   if (!node || typeof node !== "object") return false;
+  if (node.type === "GetNode" || node.type === "SetNode") return false;
   if (node.type === "PrimitiveNode") return true;
   if (node.isVirtualNode === true && !node.subgraph) {
     return !(node.inputs ?? []).some((i) => i?.link != null);
@@ -163,15 +162,11 @@ export function virtualSourceNote(feeds) {
   const more = n > 5 ? `; and ${n - 5} more` : "";
   return (
     `This workflow feeds ${n} promoted subgraph input${n === 1 ? "" : "s"} from a frontend-only ` +
-      `VIRTUAL node — ${which}${more}. On the build this was measured on (ComfyUI 0.32.0 / ` +
-      `frontend 1.48.7) the prompt compiler DROPS that source: the value on the link does NOT ` +
-      `reach the prompt, and each inner node's STORED widget value is what executes — the run ` +
-      `renders the OLD value while the canvas shows the new one, and nothing in the run says so ` +
-      `(#1181). This is read from the GRAPH, not from the queued prompt — the panel does not build ` +
-      `that prompt and cannot carry the value across the boundary — so on a build that resolves ` +
-      `virtual sources through subgraph inputs this warns about a run that was fine. To make the ` +
-      `canvas value take effect, replace the virtual source with a BACKEND node (e.g. ` +
-      `PrimitiveStringMultiline, verified by the reporter), or set the inner node's widget directly.`
+      `VIRTUAL node — ${which}${more}. ComfyUI's prompt compiler DROPS that source at the subgraph ` +
+      `boundary, so the native flattened prompt would execute each inner node's STORED widget. ` +
+      `panel_run compiles the linked PrimitiveNode/GetNode (or host-rail) value into those inner ` +
+      `inputs so the stored fallback is not what executes (#1181). Replace the virtual source with ` +
+      `a BACKEND node if you want the origin itself to appear in the prompt.`
   );
 }
 
@@ -183,5 +178,344 @@ export function virtualSourceNote(feeds) {
  */
 export function virtualSourceTag(src) {
   if (!src) return "";
-  return ` [⚠ virtual source #${src.node_id}.${src.output_slot} — NOT serialized; the stored value is what executes]`;
+  return ` [⚠ virtual source #${src.node_id}.${src.output_slot} — NOT serialized; panel_run compiles the linked value into the prompt]`;
+}
+
+// ---------------------------------------------------------------------------
+// Recurrence 2026-09-04: reporting was not enough. Krea2-style graphs promote
+// width/height on the subgraph instance and wire an external primitive into a
+// STRING input; graphToPrompt still serializes the INNER stored widgets. Patch
+// the compiled prompt only — never the live graph (#979/#233).
+// ---------------------------------------------------------------------------
+
+const GRAPH_TO_PROMPT_VIRTUAL_APPLY = Symbol.for("comfyui-mcp.graphToPromptVirtualSourceApply");
+const rawApply = Reflect.apply;
+
+const SUBGRAPH_INPUT_RAIL_ID = -10;
+const PRIMITIVE_OUTPUT_TYPES = new Set(["STRING", "INT", "FLOAT", "BOOLEAN", "COMBO", "*"]);
+
+function graphNodes(graph) {
+  if (Array.isArray(graph?._nodes)) return graph._nodes;
+  if (Array.isArray(graph?.nodes)) return graph.nodes;
+  return [];
+}
+
+function promptMap(prompt) {
+  if (prompt?.output && typeof prompt.output === "object" && !Array.isArray(prompt.output)) return prompt.output;
+  if (prompt && typeof prompt === "object" && !Array.isArray(prompt) && prompt.output == null) {
+    // Bare id→entry map (some callers pass graphToPrompt().output).
+    const keys = Object.keys(prompt);
+    if (keys.some((k) => prompt[k] && typeof prompt[k] === "object" && "class_type" in prompt[k])) return prompt;
+  }
+  return null;
+}
+
+function isPrimitivePayload(value) {
+  const t = typeof value;
+  return t === "string" || t === "number" || t === "boolean";
+}
+
+function isLinkInput(value) {
+  return Array.isArray(value) && value.length >= 2 && (typeof value[0] === "string" || typeof value[0] === "number");
+}
+
+function eachStoredLink(graph, visit) {
+  const links = graph?.links;
+  if (!links) return;
+  const list = Array.isArray(links) ? links : Object.values(links);
+  for (const l of list) {
+    if (!l) continue;
+    visit({
+      originId: l.origin_id ?? l[1],
+      originSlot: l.origin_slot ?? l[2],
+      targetId: l.target_id ?? l[3],
+      targetSlot: l.target_slot ?? l[4],
+    });
+  }
+}
+
+function widgetPayload(node) {
+  if (!node || typeof node !== "object") return undefined;
+  let widgets;
+  try {
+    widgets = Array.isArray(node.widgets) ? node.widgets : [];
+  } catch {
+    return undefined;
+  }
+  const named = widgets.find((w) => w && w.name === "value" && isPrimitivePayload(w.value));
+  if (named) return named.value;
+  for (const w of widgets) {
+    if (!w || w.serialize === false) continue;
+    if (w.name === "control_after_generate") continue;
+    if (w.name === "Constant") continue;
+    if (isPrimitivePayload(w.value)) return w.value;
+  }
+  return undefined;
+}
+
+function findSetNode(graph, name) {
+  if (!graph || name == null || name === "") return null;
+  const seen = new Set();
+  let current = graph;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    for (const node of graphNodes(current)) {
+      if (node?.type === "SetNode" && node.widgets?.[0]?.value === name) return node;
+    }
+    const parent = current.parent ?? current._parent ?? null;
+    current = parent && parent !== current ? parent : current.rootGraph && current.rootGraph !== current ? current.rootGraph : null;
+  }
+  return null;
+}
+
+function payloadFromConnectedInput(node, graph, seen) {
+  const input = node?.inputs?.[0];
+  if (!input || input.link == null) return undefined;
+  const owner = node.graph ?? graph;
+  const links = owner?.links ?? {};
+  const link = Array.isArray(links)
+    ? links.find((entry) => (entry?.id ?? entry?.[0]) === input.link)
+    : links[input.link];
+  if (!link) return undefined;
+  const origin = nodeById(owner, link.origin_id ?? link[1]);
+  return linkedSourcePayload(origin, owner, seen);
+}
+
+/**
+ * A live widget payload that should appear in the compiled prompt when this
+ * node feeds a subgraph input. GetNode/SetNode bus names are not payloads.
+ * Backend primitives (PrimitiveStringMultiline, PrimitiveInt, …) ARE — they
+ * serialize as real nodes at the root, but the subgraph flatten can still
+ * leave the inner stored scalar in place.
+ */
+export function linkedSourcePayload(node, graph = node?.graph, seen = new Set()) {
+  if (!node || typeof node !== "object") return undefined;
+  if (seen.has(node) || seen.size > 16) return undefined;
+  const nextSeen = new Set(seen);
+  nextSeen.add(node);
+  if (node.subgraph) return undefined;
+  if (node.type === "GetNode") {
+    try {
+      if (typeof node.getInputLink === "function") {
+        const link = node.getInputLink(0);
+        if (link) {
+          const owner = node.graph ?? graph;
+          const origin = nodeById(owner, link.origin_id ?? link[1]);
+          const viaLink = linkedSourcePayload(origin, owner, nextSeen);
+          if (viaLink !== undefined) return viaLink;
+        }
+      }
+    } catch {
+      /* GetNode helpers are best-effort */
+    }
+    const key = node.widgets?.[0]?.value;
+    const setter = findSetNode(node.graph ?? graph, key);
+    if (!setter) return undefined;
+    return linkedSourcePayload(setter, setter.graph ?? graph, nextSeen);
+  }
+  if (node.type === "SetNode") {
+    const viaInput = payloadFromConnectedInput(node, graph, nextSeen);
+    if (viaInput !== undefined) return viaInput;
+    return undefined;
+  }
+  if (node.type === "PrimitiveNode") return widgetPayload(node);
+  const outType = node.outputs?.[0]?.type;
+  if (typeof outType === "string" && outType && !PRIMITIVE_OUTPUT_TYPES.has(outType)) return undefined;
+  return widgetPayload(node);
+}
+
+function isPassThroughInner(node) {
+  if (!node || node.subgraph) return false;
+  if (node.type === "Reroute" || node.type === "Reroute (rgthree)") return true;
+  if (typeof node.type === "string" && /any switch/i.test(node.type)) return true;
+  if (node.isVirtualNode === true && (node.inputs ?? []).some((i) => i?.link != null)) return true;
+  return false;
+}
+
+function railOriginIds(subgraph) {
+  const ids = new Set([SUBGRAPH_INPUT_RAIL_ID, "-10"]);
+  const rail = subgraph?.inputNode ?? subgraph?._inputNode ?? null;
+  if (rail?.id != null) {
+    ids.add(rail.id);
+    ids.add(String(rail.id));
+  }
+  return ids;
+}
+
+function innerConsumersFromRailSlot(subgraph, slotIndex) {
+  const found = [];
+  if (!subgraph || slotIndex == null) return found;
+  const railIds = railOriginIds(subgraph);
+  const seen = new Set();
+  const queue = [];
+  eachStoredLink(subgraph, (l) => {
+    if (l.originSlot !== slotIndex && String(l.originSlot) !== String(slotIndex)) return;
+    if (!railIds.has(l.originId) && !railIds.has(String(l.originId))) return;
+    queue.push({ nodeId: l.targetId, slot: l.targetSlot });
+  });
+  while (queue.length) {
+    const cur = queue.shift();
+    const mark = `${cur.nodeId}:${cur.slot}`;
+    if (seen.has(mark)) continue;
+    seen.add(mark);
+    const node = nodeById(subgraph, cur.nodeId);
+    if (!node) continue;
+    const inp = node.inputs?.[cur.slot];
+    found.push({ node, input: inp, slot: cur.slot });
+    if (!isPassThroughInner(node)) continue;
+    for (const [oi, out] of (node.outputs ?? []).entries()) {
+      const outLinks = out?.links;
+      if (Array.isArray(outLinks) && outLinks.length) {
+        for (const linkId of outLinks) {
+          const links = subgraph.links ?? {};
+          const l = Array.isArray(links) ? links.find((x) => (x?.id ?? x?.[0]) === linkId) : links[linkId];
+          if (!l) continue;
+          queue.push({
+            nodeId: l.target_id ?? l[3],
+            slot: l.target_slot ?? l[4],
+          });
+        }
+      } else {
+        eachStoredLink(subgraph, (l) => {
+          if (l.originId !== node.id && String(l.originId) !== String(node.id)) return;
+          if (l.originSlot !== oi && String(l.originSlot) !== String(oi)) return;
+          queue.push({ nodeId: l.targetId, slot: l.targetSlot });
+        });
+      }
+    }
+  }
+  return found;
+}
+
+function innerWidgetTarget(host, widgetName) {
+  const wanted = String(widgetName);
+  const proxy = host?.properties?.proxyWidgets;
+  if (Array.isArray(proxy)) {
+    for (const entry of proxy) {
+      if (!Array.isArray(entry) || entry.length < 2) continue;
+      if (String(entry[1]) === wanted) {
+        const inner = nodeById(host.subgraph, entry[0]);
+        if (inner) return { node: inner, widgetName: String(entry[1]) };
+      }
+    }
+  }
+  const matches = [];
+  for (const inner of graphNodes(host?.subgraph)) {
+    const w = (inner?.widgets ?? []).find((x) => x?.name === wanted);
+    if (w) matches.push({ node: inner, widgetName: wanted });
+  }
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function writePromptInput(map, key, inputName, value) {
+  const entry = map[key];
+  if (!entry || typeof entry !== "object") return false;
+  if (!entry.inputs || typeof entry.inputs !== "object") entry.inputs = {};
+  const current = entry.inputs[inputName];
+  if (isLinkInput(current)) {
+    const originKey = String(current[0]);
+    if (map[originKey]) return false;
+  }
+  if (Object.is(current, value)) return false;
+  entry.inputs[inputName] = value;
+  return true;
+}
+
+/**
+ * Copy promoted instance rails and linked primitive payloads onto the
+ * flattened prompt entries. Mutates `prompt` in place; never touches live
+ * widgets. Returns the number of inputs rewritten.
+ */
+export function applyLinkedSubgraphValuesToPrompt(rootGraph, prompt) {
+  const map = promptMap(prompt);
+  if (!map || !rootGraph) return 0;
+  let patched = 0;
+  const walk = (graph, path, seenOnPath) => {
+    if (!graph || seenOnPath.has(graph)) return;
+    const nextSeen = new Set(seenOnPath);
+    nextSeen.add(graph);
+    for (const node of graphNodes(graph)) {
+      if (!node?.subgraph) continue;
+      const hostPath = path.concat(node.id);
+      try {
+        for (const w of node.widgets ?? []) {
+          if (!w || typeof w.name !== "string" || w.serialize === false) continue;
+          if (w.name === "control_after_generate") continue;
+          if (!isPrimitivePayload(w.value)) continue;
+          const target = innerWidgetTarget(node, w.name);
+          if (!target) continue;
+          const innerKey = hostPath.map((p) => String(p)).concat(String(target.node.id)).join(":");
+          if (writePromptInput(map, innerKey, target.widgetName, w.value)) patched += 1;
+        }
+      } catch {
+        /* one hostile rail must not block the rest */
+      }
+      try {
+        for (const [index, inp] of (node.inputs ?? []).entries()) {
+          if (!inp || inp.link == null) continue;
+          const links = graph.links ?? {};
+          const l = links[inp.link];
+          if (!l) continue;
+          const originId = l.origin_id ?? l[1];
+          const origin = nodeById(graph, originId);
+          const payload = linkedSourcePayload(origin);
+          if (payload === undefined) continue;
+          const slotIndex = inp._subgraphSlot?.index ?? index;
+          for (const consumer of innerConsumersFromRailSlot(node.subgraph, slotIndex)) {
+            const name = consumer.input?.name ?? consumer.input?.widget?.name;
+            const widgetName =
+              (typeof consumer.input?.widget?.name === "string" && consumer.input.widget.name) ||
+              (typeof name === "string" && name) ||
+              null;
+            if (!widgetName) continue;
+            const hasWidget =
+              consumer.input?.widget != null ||
+              (consumer.node.widgets ?? []).some((w) => w?.name === widgetName);
+            if (!hasWidget) continue;
+            const innerKey = hostPath.map((p) => String(p)).concat(String(consumer.node.id)).join(":");
+            if (writePromptInput(map, innerKey, widgetName, payload)) patched += 1;
+          }
+        }
+      } catch {
+        /* one hostile input must not block the rest */
+      }
+      walk(node.subgraph, hostPath, nextSeen);
+    }
+  };
+  try {
+    walk(rootGraph, [], new Set());
+  } catch {
+    /* partial patch beats none */
+  }
+  return patched;
+}
+
+/**
+ * Wrap `app.graphToPrompt` so every compiled prompt (preflight AND the deferred
+ * queue-loop serialize) carries promoted rails and linked primitive payloads
+ * across subgraph boundaries. Idempotent. Does not mutate the live graph.
+ */
+export function installGraphToPromptVirtualSourceApply(app) {
+  if (!app || typeof app.graphToPrompt !== "function") return false;
+  if (app[GRAPH_TO_PROMPT_VIRTUAL_APPLY]) return true;
+  const graphToPromptFn = app.graphToPrompt;
+  const orig = (...a) => rawApply(graphToPromptFn, app, a);
+  app.graphToPrompt = function applyVirtualSourcesThenGraphToPrompt(graph, ...rest) {
+    const target = graph ?? app.rootGraph ?? app.graph ?? null;
+    const finish = (value) => {
+      try {
+        applyLinkedSubgraphValuesToPrompt(target, value);
+      } catch {
+        /* a patch must never take down serialization */
+      }
+      return value;
+    };
+    const result = orig(graph, ...rest);
+    if (result && typeof result.then === "function") {
+      return Promise.resolve(result).then(finish);
+    }
+    return finish(result);
+  };
+  app[GRAPH_TO_PROMPT_VIRTUAL_APPLY] = true;
+  return true;
 }


### PR DESCRIPTION
Fixes #1181

## Diagnosis vs #1327

#1327 (v0.15.2) is still on main. It did not re-break. That PR only **reported** a virtual PrimitiveNode feeding a subgraph input (ed_by_virtual_source, irtual_source_feeds / irtual_source_note, corrected set-widget refusal). It explicitly did not carry the value into the prompt (silent widget mutation is the #979/#233 class).

The 2026-09-04 recurrence on panel 0.15.171 / Krea2 manual is a **distinct hole** on top of that:

1. **GetNode false positive.** isNonSerializingValueSource clause 2 flags any virtual node with no connected input. KJNodes GetNode is virtual and has no graph input — its widget is the bus name. Krea2 wires Get_VAE / Get_CLIP into the subgraph, so panel_run warned about GetNode as if it were a dropped PrimitiveNode.
2. **Compiled prompt still used stored inner values.** Editing promoted width/height (proxyWidgets on the subgraph instance) and the external PrimitiveStringMultiline prompt did not reach graphToPrompt output. Inner EmptyLatentImage / CLIPTextEncode stored widgets executed.

## What this does

- Exclude GetNode/SetNode from the non-serializing-source detector (bus relays, not payloads). PrimitiveNode coverage is unchanged.
- After graphToPrompt returns, copy promoted host rails and linked primitive payloads onto flattened inner prompt inputs. Live widgets are not written.
- Primitive GetNode buses (INT/STRING/…) resolve through the matching SetNode; tensor GetNode outputs are left alone.
- Install that wrap on the serializer itself (preflight and the deferred queue-loop serialize), inside null-safety -> DynamicCombo reconcile -> apply -> snapshot-barrier.

## Tests

rowser_tests/unit/virtual-source-promotion.test.mjs:

- GetNode is not a dropped value source / not a virtual-source feed
- Krea2-like graph: compiled prompt gets width/height 1024x768 and the linked external prompt, not 1920x1080 / empty text
- Primitive GetNode bus compiles through SetNode, never the Constant key
- PrimitiveNode remains a non-serializing source; its linked STRING value is copied onto the inner prompt node
- wrap is idempotent and does not mutate live inner widgets
- graph_run installs the wrap before the snapshot barrier

Existing #1327 detector / outline / write-refusal pins kept.

## What this does not change

- Does not re-ship #1327. The read-path split, outline tags, queue-time note, and #366 write refusal stay.
- Does not mutate live inner widgets on run (no unpack-style materialize).
- Does not rewrite tensor links (GetNode MODEL/CLIP/VAE).
- Does not flatten the graph or replace GetNode with backend primitives.
