### PR TITLE
fix(984): panel_get_errors must not report clean for missing models on a promoted subgraph rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_get_errors no longer reports a clean graph when missing models are still named on a promoted native-subgraph host rail: the load-time store blames the inner locator, and the inner widget may hold an on-disk fallback while the host still names the absent file. The live combo scan now also walks nested subgraphs from the bound root, so inner loaders are judged even when the user is looking at the root canvas (#984)
+
 ## [0.15.172] - 2026-09-04
 
 ### Fixed

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -220,6 +220,96 @@ test("isStaleAssetCandidate: a genuinely-missing subgraph asset STILL reports (U
   );
 });
 
+test("#984 recurrence: a promoted HOST rail that still names the missing file keeps the inner locator candidate", () => {
+  // Inner widget holds an on-disk fallback (the compiled-prompt fallback #1181
+  // exists to ignore). Host 1512's promoted rail still names the absent MiniMaxH3
+  // asset. The load-time store blames the inner locator. Dropping that candidate
+  // is how get_errors reported clean while the turn-start scan still named the file.
+  const inner = { id: 88, widgets: [{ name: "ckpt_name", value: "exists-on-disk.safetensors" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [
+      { name: "vae_name", value: "MiniMaxH3/vae.safetensors" },
+      { name: "clip_name", value: "MiniMaxH3/clip.safetensors" },
+    ],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  const candidate = {
+    nodeId: `${SG_UUID}:88`,
+    name: "MiniMaxH3/vae.safetensors",
+    widgetName: "ckpt_name",
+  };
+  assert.equal(
+    assetCandidateStillReferenced(root, candidate.nodeId, candidate.name),
+    true,
+    "the host rail still names the missing file",
+  );
+  assert.equal(
+    isStaleAssetCandidate(root, candidate),
+    false,
+    "must not report clean: the promoted rail still references the miss",
+  );
+  assert.equal(
+    graphErrorsResultIsClean({
+      missing_models: [{ node_id: candidate.nodeId, file: candidate.name, kind: "missing_model" }],
+    }),
+    false,
+  );
+});
+
+test("#984 recurrence control: once the HOST rail also leaves the missing file, the inner locator IS stale", () => {
+  const inner = { id: 88, widgets: [{ name: "ckpt_name", value: "exists-on-disk.safetensors" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [{ name: "vae_name", value: "installed.safetensors" }],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  assert.equal(
+    isStaleAssetCandidate(root, {
+      nodeId: `${SG_UUID}:88`,
+      name: "MiniMaxH3/vae.safetensors",
+      widgetName: "ckpt_name",
+    }),
+    true,
+    "neither inner nor host still names the file → a real set_widget fix",
+  );
+});
+
+test("#984 recurrence: a HOST-id candidate still reports when the inner loader holds the missing file", () => {
+  const inner = { id: 88, widgets: [{ name: "ckpt_name", value: "MiniMaxH3/t5.safetensors" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [{ name: "ckpt_name", value: "exists-on-disk.safetensors" }],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  assert.equal(
+    isStaleAssetCandidate(root, {
+      nodeId: 1512,
+      name: "MiniMaxH3/t5.safetensors",
+      widgetName: "ckpt_name",
+    }),
+    false,
+  );
+});
+
+test("#984 source guard: the live combo scan walks nested subgraphs from the bound root", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf("async graph_get_errors()");
+  assert.ok(at > 0, "graph_get_errors must still be recognisable");
+  const body = src.slice(at, at + 12000);
+  assert.match(
+    body,
+    /scanNodes = collectAllGraphs\(preScanRootGraph\)\.flatMap\(\(g\) => g\?\._nodes \?\? \[\]\)/,
+    "live scan must include inner loaders, not only the visible graph",
+  );
+});
+
 test("assetCandidateStillReferenced: true while a widget still holds the file", () => {
   const node = { id: 5, widgets: [{ name: "lora_name", value: "old.safetensors" }] };
   assert.equal(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21299,7 +21299,12 @@ const GRAPH_TOOL_EXECUTORS = {
       includeBaselineReadGuard: true,
       missingNodeState,
     });
-    const scanNodes = preScanGraph._nodes ?? [];
+    // Visible graph plus every nested subgraph. A promoted host is virtual and
+    // skipped by the scan; its inner loaders are the ones that name the files,
+    // and they are not in `preScanGraph._nodes` while the user is at root
+    // (#984 recurrence: MiniMaxH3 assets on host 1512). collectAllGraphs walks
+    // from the bound ROOT so an open-subgraph view still sees sibling hosts.
+    const scanNodes = collectAllGraphs(preScanRootGraph).flatMap((g) => g?._nodes ?? []);
     // #745 — ask the SERVER about the widget values actually on the canvas now before
     // the optional load-time missing-asset refresh. Per-class /object_info is small,
     // deduped and independently authoritative; giving it first use of the shared

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -165,17 +165,49 @@ export function locatorIsRecognized(scopedId) {
   return parts.length === 2 && UUID_RE.test(first) && parts[1] !== "";
 }
 
+function widgetsHoldFile(node, file) {
+  return Array.isArray(node?.widgets) && node.widgets.some((w) => w?.value === file);
+}
+
+/** True when `node` is reachable from `graph`, including nested subgraphs. */
+function graphContainsNode(graph, node, _seen = new WeakSet()) {
+  if (!graph || !node || _seen.has(graph)) return false;
+  _seen.add(graph);
+  for (const n of graph._nodes ?? graph.nodes ?? []) {
+    if (n === node) return true;
+    if (n?.subgraph && graphContainsNode(n.subgraph, node, _seen)) return true;
+  }
+  return false;
+}
+
 /**
  * Keep a candidate only if some widget on the node STILL literally holds that
  * filename. Fails OPEN (returns true / "still referenced") on any unexpected
  * shape, so the worst case is over-reporting and a real miss is never swallowed.
+ *
+ * Promoted native-subgraph rails are AUTHORITATIVE (#366/#1181): the inner
+ * widget may hold an on-disk fallback (or empty) while the HOST still names
+ * the missing file. The load-time store blames the inner locator, and treating
+ * "inner no longer holds the filename" as a user fix is how panel_get_errors
+ * reported clean while the turn-start scan still named four MiniMaxH3 paths
+ * promoted through host 1512 (#984 recurrence). A host/inner counterpart that
+ * still holds the file keeps the candidate.
  */
 export function assetCandidateStillReferenced(rootGraph, nodeId, file) {
   try {
     if (nodeId == null || !file) return true;
     const node = findNodeByScopedId(rootGraph, nodeId);
-    if (!node || !Array.isArray(node.widgets) || !node.widgets.length) return true;
-    return node.widgets.some((w) => w?.value === file);
+    if (!node) return true;
+    if (widgetsHoldFile(node, file)) return true;
+    for (const g of collectAllGraphs(rootGraph)) {
+      for (const n of g._nodes ?? []) {
+        if (n === node || !widgetsHoldFile(n, file)) continue;
+        if (n.subgraph && graphContainsNode(n.subgraph, node)) return true;
+        if (node.subgraph && graphContainsNode(node.subgraph, n)) return true;
+      }
+    }
+    if (Array.isArray(node.widgets) && node.widgets.length) return false;
+    return true;
   } catch {
     return true;
   }


### PR DESCRIPTION
## Diagnosis

Recurrence on current panel: `panel_get_errors` returned `audit_complete:true`, `errored_count:0`, empty `missing_models` for four genuinely absent `MiniMaxH3/...` assets promoted through native subgraph host 1512. The turn-start load-time scan still named those paths. False-clean at both root and inside the subgraph.

This is **not** a re-ship of #991 / 0.11.83 (the original live scan). Those already shipped.

Mechanism: ComfyUI's missing-asset store blames the **inner locator**. After promotion the inner widget can hold an on-disk fallback while the **host rail** still names the missing file (the rail is authoritative: #366 / #1181). `assetCandidateStillReferenced` only looked at the inner node's widgets, treated "inner no longer holds the filename" as a user fix, and dropped the candidate. The live combo scan then only walked `preScanGraph._nodes` (the visible graph), so at root the inner loaders were never judged, and the virtual host is skipped by design.

## Fix

- Keep a store candidate when a subgraph **host rail** (or the reverse inner loader) still literally holds the missing filename.
- Walk `collectAllGraphs(preScanRootGraph)` for the live combo scan so inner loaders are judged from root too.

A real `set_widget` that leaves **neither** inner nor host naming the file is still stale.

## Tests

`browser_tests/unit/asset-staleness.test.mjs` — 116 pass, including:

- `#984 recurrence: a promoted HOST rail that still names the missing file keeps the inner locator candidate`
- `#984 recurrence control: once the HOST rail also leaves the missing file, the inner locator IS stale`
- `#984 recurrence: a HOST-id candidate still reports when the inner loader holds the missing file`
- `#984 source guard: the live combo scan walks nested subgraphs from the bound root`

Existing #984 overlap / fail-open suite unchanged.

CHANGELOG: Unreleased only; overlay keep.

Closes #984
