### PR TITLE
fix(984): panel_get_errors must not report clean for missing models on a promoted subgraph rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_get_errors no longer reports a clean graph when missing models are still named on a promoted native-subgraph host rail: the load-time store blames the inner locator, and the inner widget may hold an on-disk fallback while the host still names the absent file. The live combo scan now also walks nested subgraphs from the bound root, so inner loaders are judged even when the user is looking at the root canvas (#984)
+
 ## [0.15.172] - 2026-09-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
-- panel_get_errors no longer reports a clean graph when missing models are still named on a promoted native-subgraph host rail: the load-time store blames the inner locator, and the inner widget may hold an on-disk fallback while the host still names the absent file. The live combo scan now also walks nested subgraphs from the bound root, so inner loaders are judged even when the user is looking at the root canvas (#984)
+- panel_get_errors no longer reports a clean graph when missing models are still named on a promoted native-subgraph host rail: the load-time store may blame the inner locator or the host id, the inner widget may hold an on-disk fallback, and the host-rail combo can still list the absent file (or be empty) after a trusted refresh. The live combo scan now walks nested subgraphs from the bound root and judges promoted host rails against the inner loader's /object_info, so MiniMaxH3 paths on host 1512 stay in missing_models and/or unavailable_widget_values (#984)
 
 ## [0.15.172] - 2026-09-04
 

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -310,6 +310,104 @@ test("#984 source guard: the live combo scan walks nested subgraphs from the bou
   );
 });
 
+test("#984 recurrence: a stale HOST-rail combo must not combo-clear a still-missing promoted file", () => {
+  // get_errors sets trustCombo after refreshComboOptionsFromDefs. That sweep keys
+  // off node.type, so a virtual GraphNode host is never rebuilt and its rail
+  // options.values can still list the absent MiniMaxH3 path. Combo-clearing from
+  // that list is how missing_models went empty while the turn-start scan named it.
+  const inner = {
+    id: 88,
+    widgets: [
+      {
+        name: "vae_name",
+        value: "exists-on-disk.safetensors",
+        options: { values: ["exists-on-disk.safetensors"] },
+      },
+    ],
+  };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [
+      {
+        name: "vae_name",
+        value: "MiniMaxH3/vae.safetensors",
+        options: { values: ["MiniMaxH3/vae.safetensors", "exists-on-disk.safetensors"] },
+      },
+    ],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  const candidate = { nodeId: 1512, name: "MiniMaxH3/vae.safetensors", widgetName: "vae_name" };
+  assert.equal(
+    assetCandidateResolvesLive(root, candidate.nodeId, candidate.name, candidate.widgetName),
+    false,
+    "a host-rail combo is not /object_info of the inner loader",
+  );
+  assert.equal(
+    isStaleAssetCandidate(root, candidate, { trustCombo: true }),
+    false,
+    "trustCombo after get_errors' refresh must not drop a genuine promoted miss",
+  );
+});
+
+test("#984 recurrence: an empty HOST-rail combo is not proof the file exists", () => {
+  const inner = { id: 88, widgets: [{ name: "vae_name", value: "exists-on-disk.safetensors", options: { values: [] } }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [{ name: "vae_name", value: "MiniMaxH3/vae.safetensors", options: { values: [] } }],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  const candidate = { nodeId: 1512, name: "MiniMaxH3/vae.safetensors", widgetName: "vae_name" };
+  assert.equal(assetCandidateResolvesLive(root, candidate.nodeId, candidate.name, candidate.widgetName), false);
+  assert.equal(isStaleAssetCandidate(root, candidate, { trustCombo: true }), false);
+});
+
+test("#984 recurrence: locator + trustCombo still reports when only the HOST rail names the miss", () => {
+  const inner = {
+    id: 88,
+    widgets: [
+      {
+        name: "vae_name",
+        value: "exists-on-disk.safetensors",
+        options: { values: ["exists-on-disk.safetensors"] },
+      },
+    ],
+  };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [{ name: "vae_name", value: "MiniMaxH3/vae.safetensors" }],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  const candidate = {
+    nodeId: `${SG_UUID}:88`,
+    name: "MiniMaxH3/vae.safetensors",
+    widgetName: "vae_name",
+  };
+  assert.equal(isStaleAssetCandidate(root, candidate, { trustCombo: true }), false);
+});
+
+test("#984 recurrence: the two halves naming the same promoted miss count once and are not clean", () => {
+  const file = "MiniMaxH3/vae.safetensors";
+  const result = {
+    errored_count: 0,
+    node_errors: null,
+    last_execution_error: null,
+    missing_models: [{ node_id: 1512, file, widget: "vae_name" }],
+    unavailable_widget_values: [
+      { id: 1512, type: "VAELoader", widget: "vae_name", value: file, kind: "missing_asset" },
+    ],
+  };
+  assert.equal(graphErrorsResultIsClean(result), false);
+  const counts = graphErrorsFindingCounts(result);
+  assert.equal(counts.missingAssets, 1);
+  assert.equal(counts.unavailable, 0, "same (node, widget, file) is one finding, not two");
+});
+
 test("assetCandidateStillReferenced: true while a widget still holds the file", () => {
   const node = { id: 5, widgets: [{ name: "lora_name", value: "old.safetensors" }] };
   assert.equal(

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -220,6 +220,96 @@ test("isStaleAssetCandidate: a genuinely-missing subgraph asset STILL reports (U
   );
 });
 
+test("#984 recurrence: a promoted HOST rail that still names the missing file keeps the inner locator candidate", () => {
+  // Inner widget holds an on-disk fallback (the compiled-prompt fallback #1181
+  // exists to ignore). Host 1512's promoted rail still names the absent MiniMaxH3
+  // asset. The load-time store blames the inner locator. Dropping that candidate
+  // is how get_errors reported clean while the turn-start scan still named the file.
+  const inner = { id: 88, widgets: [{ name: "ckpt_name", value: "exists-on-disk.safetensors" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [
+      { name: "vae_name", value: "MiniMaxH3/vae.safetensors" },
+      { name: "clip_name", value: "MiniMaxH3/clip.safetensors" },
+    ],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  const candidate = {
+    nodeId: `${SG_UUID}:88`,
+    name: "MiniMaxH3/vae.safetensors",
+    widgetName: "ckpt_name",
+  };
+  assert.equal(
+    assetCandidateStillReferenced(root, candidate.nodeId, candidate.name),
+    true,
+    "the host rail still names the missing file",
+  );
+  assert.equal(
+    isStaleAssetCandidate(root, candidate),
+    false,
+    "must not report clean: the promoted rail still references the miss",
+  );
+  assert.equal(
+    graphErrorsResultIsClean({
+      missing_models: [{ node_id: candidate.nodeId, file: candidate.name, kind: "missing_model" }],
+    }),
+    false,
+  );
+});
+
+test("#984 recurrence control: once the HOST rail also leaves the missing file, the inner locator IS stale", () => {
+  const inner = { id: 88, widgets: [{ name: "ckpt_name", value: "exists-on-disk.safetensors" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [{ name: "vae_name", value: "installed.safetensors" }],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  assert.equal(
+    isStaleAssetCandidate(root, {
+      nodeId: `${SG_UUID}:88`,
+      name: "MiniMaxH3/vae.safetensors",
+      widgetName: "ckpt_name",
+    }),
+    true,
+    "neither inner nor host still names the file → a real set_widget fix",
+  );
+});
+
+test("#984 recurrence: a HOST-id candidate still reports when the inner loader holds the missing file", () => {
+  const inner = { id: 88, widgets: [{ name: "ckpt_name", value: "MiniMaxH3/t5.safetensors" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = {
+    id: 1512,
+    subgraph: sub,
+    widgets: [{ name: "ckpt_name", value: "exists-on-disk.safetensors" }],
+  };
+  const root = rootWithSubgraphs([host], [sub]);
+  assert.equal(
+    isStaleAssetCandidate(root, {
+      nodeId: 1512,
+      name: "MiniMaxH3/t5.safetensors",
+      widgetName: "ckpt_name",
+    }),
+    false,
+  );
+});
+
+test("#984 source guard: the live combo scan walks nested subgraphs from the bound root", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf("async graph_get_errors()");
+  assert.ok(at > 0, "graph_get_errors must still be recognisable");
+  const body = src.slice(at, at + 12000);
+  assert.match(
+    body,
+    /scanNodes = collectAllGraphs\(preScanRootGraph\)\.flatMap\(\(g\) => g\?\._nodes \?\? \[\]\)/,
+    "live scan must include inner loaders, not only the visible graph",
+  );
+});
+
 test("assetCandidateStillReferenced: true while a widget still holds the file", () => {
   const node = { id: 5, widgets: [{ name: "lora_name", value: "old.safetensors" }] };
   assert.equal(

--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -26,6 +26,8 @@ import {
   optionsLookLikeFiles,
   comboAvailabilityNote,
   linkDrivenWidgetNames,
+  promotedComboScanTargets,
+  expandPromotedHostScanNodes,
 } from "../../web/js/lib/live-combo-availability.js";
 import { SINGLE_NODE_INFO_OUTCOME } from "../../web/js/lib/single-node-def.js";
 
@@ -714,4 +716,75 @@ test("#1634 Windows: a genuinely different nested model is still reported", asyn
 test("#1634 Windows separator equivalence never collapses string vs number", () => {
   assert.equal(comboOffers([10], "10", { backslashIsSeparator: true }), false);
   assert.equal(comboOffers(["10"], 10, { backslashIsSeparator: true }), false);
+});
+
+const VAE = classBody("VAELoader", {
+  vae_name: [["exists-on-disk.safetensors"], {}],
+});
+
+function promotedHost(file = "MiniMaxH3/vae.safetensors") {
+  const inner = {
+    id: 88,
+    type: "VAELoader",
+    widgets: [{ name: "vae_name", value: "exists-on-disk.safetensors" }],
+    inputs: [{ name: "vae_name", link: 1, widget: { name: "vae_name" } }],
+  };
+  const host = {
+    id: 1512,
+    type: "MiniMaxH3",
+    isVirtualNode: true,
+    subgraph: { _nodes: [inner] },
+    properties: { proxyWidgets: [["88", "vae_name"]] },
+    widgets: [{ name: "vae_name", value: file }],
+  };
+  return { host, inner };
+}
+
+test("#984 recurrence: a virtual subgraph HOST still reports a promoted missing model", async () => {
+  const { host, inner } = promotedHost();
+  const r = await scanComboAvailability([host, inner], async (cls) =>
+    cls === "VAELoader" ? VAE : {},
+  );
+  assert.equal(r.unavailable.length, 1, "the host rail names a file the inner combo does not offer");
+  assert.equal(r.unavailable[0].id, 1512);
+  assert.equal(r.unavailable[0].type, "VAELoader");
+  assert.equal(r.unavailable[0].widget, "vae_name");
+  assert.equal(r.unavailable[0].value, "MiniMaxH3/vae.safetensors");
+  assert.equal(r.unavailable[0].kind, "missing_asset");
+});
+
+test("#984 recurrence: a promoted host rail whose value IS offered is not reported", async () => {
+  const { host, inner } = promotedHost("exists-on-disk.safetensors");
+  const r = await scanComboAvailability([host, inner], async (cls) =>
+    cls === "VAELoader" ? VAE : {},
+  );
+  assert.deepEqual(r.unavailable, []);
+});
+
+test("#984 recurrence: an inner link-driven leftover is still skipped (host rail is the live value)", async () => {
+  const { host, inner } = promotedHost();
+  inner.widgets[0].value = "MiniMaxH3/stale-inner-leftover.safetensors";
+  const r = await scanComboAvailability([host, inner], async (cls) =>
+    cls === "VAELoader" ? VAE : {},
+  );
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].value, "MiniMaxH3/vae.safetensors", "judge the host rail, not the inner leftover");
+});
+
+test("#984 promotedComboScanTargets maps proxyWidgets onto the inner class", () => {
+  const { host, inner } = promotedHost();
+  assert.deepEqual(
+    promotedComboScanTargets(host).map((t) => ({ name: t.widgetName, type: t.className, inner: t.inner })),
+    [{ name: "vae_name", type: "VAELoader", inner }],
+  );
+  assert.deepEqual(promotedComboScanTargets({ isVirtualNode: true, widgets: [] }), []);
+});
+
+test("#984 expandPromotedHostScanNodes synthesises an inner-typed host-id node", () => {
+  const { host } = promotedHost();
+  const expanded = expandPromotedHostScanNodes([host]);
+  assert.equal(expanded.length, 2);
+  assert.equal(expanded[1].id, 1512);
+  assert.equal(expanded[1].type, "VAELoader");
+  assert.equal(expanded[1].widgets[0].value, "MiniMaxH3/vae.safetensors");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21299,7 +21299,12 @@ const GRAPH_TOOL_EXECUTORS = {
       includeBaselineReadGuard: true,
       missingNodeState,
     });
-    const scanNodes = preScanGraph._nodes ?? [];
+    // Visible graph plus every nested subgraph. A promoted host is virtual and
+    // skipped by the scan; its inner loaders are the ones that name the files,
+    // and they are not in `preScanGraph._nodes` while the user is at root
+    // (#984 recurrence: MiniMaxH3 assets on host 1512). collectAllGraphs walks
+    // from the bound ROOT so an open-subgraph view still sees sibling hosts.
+    const scanNodes = collectAllGraphs(preScanRootGraph).flatMap((g) => g?._nodes ?? []);
     // #745 — ask the SERVER about the widget values actually on the canvas now before
     // the optional load-time missing-asset refresh. Per-class /object_info is small,
     // deduped and independently authoritative; giving it first use of the shared

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -165,17 +165,49 @@ export function locatorIsRecognized(scopedId) {
   return parts.length === 2 && UUID_RE.test(first) && parts[1] !== "";
 }
 
+function widgetsHoldFile(node, file) {
+  return Array.isArray(node?.widgets) && node.widgets.some((w) => w?.value === file);
+}
+
+/** True when `node` is reachable from `graph`, including nested subgraphs. */
+function graphContainsNode(graph, node, _seen = new WeakSet()) {
+  if (!graph || !node || _seen.has(graph)) return false;
+  _seen.add(graph);
+  for (const n of graph._nodes ?? graph.nodes ?? []) {
+    if (n === node) return true;
+    if (n?.subgraph && graphContainsNode(n.subgraph, node, _seen)) return true;
+  }
+  return false;
+}
+
 /**
  * Keep a candidate only if some widget on the node STILL literally holds that
  * filename. Fails OPEN (returns true / "still referenced") on any unexpected
  * shape, so the worst case is over-reporting and a real miss is never swallowed.
+ *
+ * Promoted native-subgraph rails are AUTHORITATIVE (#366/#1181): the inner
+ * widget may hold an on-disk fallback (or empty) while the HOST still names
+ * the missing file. The load-time store blames the inner locator, and treating
+ * "inner no longer holds the filename" as a user fix is how panel_get_errors
+ * reported clean while the turn-start scan still named four MiniMaxH3 paths
+ * promoted through host 1512 (#984 recurrence). A host/inner counterpart that
+ * still holds the file keeps the candidate.
  */
 export function assetCandidateStillReferenced(rootGraph, nodeId, file) {
   try {
     if (nodeId == null || !file) return true;
     const node = findNodeByScopedId(rootGraph, nodeId);
-    if (!node || !Array.isArray(node.widgets) || !node.widgets.length) return true;
-    return node.widgets.some((w) => w?.value === file);
+    if (!node) return true;
+    if (widgetsHoldFile(node, file)) return true;
+    for (const g of collectAllGraphs(rootGraph)) {
+      for (const n of g._nodes ?? []) {
+        if (n === node || !widgetsHoldFile(n, file)) continue;
+        if (n.subgraph && graphContainsNode(n.subgraph, node)) return true;
+        if (node.subgraph && graphContainsNode(node.subgraph, n)) return true;
+      }
+    }
+    if (Array.isArray(node.widgets) && node.widgets.length) return false;
+    return true;
   } catch {
     return true;
   }

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -240,11 +240,24 @@ export function assetCandidateStillReferenced(rootGraph, nodeId, file) {
  * `[input]`-annotated one (its stripped bare name) may be combo-cleared: both
  * resolve against the very input root the combo enumerates.
  */
+/**
+ * Combo lists on a native-subgraph HOST are not /object_info of the inner loader
+ * (#984 recurrence). `refreshComboOptionsFromDefs` keys off `node.type`, so a
+ * virtual GraphNode's promoted rails keep whatever they had at load — including
+ * the absent MiniMaxH3 path, or an empty list. Neither is proof the file exists.
+ * Only an inner node that currently holds the filename may combo-clear it.
+ */
+function comboAuthorityNodes(node, file) {
+  if (!node) return [];
+  if (!node.subgraph) return [node];
+  return (node.subgraph._nodes ?? []).filter((n) => widgetsHoldFile(n, file));
+}
+
 export function assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName) {
   try {
     if (nodeId == null || !file) return false;
     const node = findNodeByScopedId(rootGraph, nodeId);
-    if (!node || !Array.isArray(node.widgets)) return false;
+    if (!node) return false;
     // Annotation classification comes FIRST (codex P1): a value that parses as
     // [output]/[temp]-annotated resolves as its STRIPPED name in the output/temp
     // root via folder_paths.annotated_filepath. A combo entry that literally
@@ -264,24 +277,31 @@ export function assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName) 
     // input root the combo enumerates — and the RAW annotated string is NOT
     // checked: a literal `foo.png [input]` combo entry is a weird filename, not
     // proof that `foo.png` exists.
-    const comboHasFile = (w) => {
-      if (!w) return false;
+    const comboHasFile = (n, w) => {
+      if (!w || !n) return false;
       const raw = w.options?.values;
-      const list = typeof raw === "function" ? raw(w, node) : raw;
+      const list = typeof raw === "function" ? raw(w, n) : raw;
       return Array.isArray(list) && list.includes(parsed.name);
     };
-    const named = widgetName
-      ? node.widgets.find((x) => x?.name === widgetName)
-      : node.widgets.find((x) => Array.isArray(x?.options?.values));
-    if (comboHasFile(named)) return true;
-    // Widget-shift repair (#569): the blamed widget's own combo can never hold
-    // the file, so also consult the widgets whose CURRENT value literally carries
-    // it — exactly the widgets assetCandidateStillReferenced's node-wide scan
-    // keeps this candidate alive for. A widget still referencing a genuinely
-    // missing file is NOT offered by its fresh combo, so it still flags.
-    for (const w of node.widgets) {
-      if (w === named) continue;
-      if (w?.value === file && comboHasFile(w)) return true;
+    const nodeResolves = (n) => {
+      if (!n || !Array.isArray(n.widgets)) return false;
+      const named = widgetName
+        ? n.widgets.find((x) => x?.name === widgetName)
+        : n.widgets.find((x) => Array.isArray(x?.options?.values));
+      if (comboHasFile(n, named)) return true;
+      // Widget-shift repair (#569): the blamed widget's own combo can never hold
+      // the file, so also consult the widgets whose CURRENT value literally carries
+      // it — exactly the widgets assetCandidateStillReferenced's node-wide scan
+      // keeps this candidate alive for. A widget still referencing a genuinely
+      // missing file is NOT offered by its fresh combo, so it still flags.
+      for (const w of n.widgets) {
+        if (w === named) continue;
+        if (w?.value === file && comboHasFile(n, w)) return true;
+      }
+      return false;
+    };
+    for (const n of comboAuthorityNodes(node, file)) {
+      if (nodeResolves(n)) return true;
     }
     return false;
   } catch {

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -185,6 +185,81 @@ function parseClassCombos(body, className) {
  * no `inputs` array, an unconnected input, a malformed entry — yields nothing, so the
  * widget stays judged. Skipping is the only thing this can do, and only on evidence.
  */
+/**
+ * Promoted native-subgraph HOST rails are `isVirtualNode` and absent from
+ * /object_info, so the live scan used to skip the whole wrapper. The inner
+ * loader that owns the combo is usually converted-to-input (link-driven) and
+ * skipped too — leaving MiniMaxH3 paths on host 1512 with no live finding
+ * (#984 recurrence). Map each host rail onto its inner class via proxyWidgets
+ * (or a unique inner widget of the same name) so the scan can fetch THAT
+ * class's /object_info and judge the host value.
+ *
+ * Unresolvable rails yield nothing: the load-time store still has to keep the
+ * candidate, and inventing a class would be a false positive.
+ */
+export function promotedComboScanTargets(node) {
+  const out = [];
+  try {
+    if (!node?.subgraph || !Array.isArray(node.widgets) || !node.widgets.length) return out;
+    const inners = node.subgraph._nodes ?? [];
+    const byId = new Map();
+    for (const inner of inners) {
+      if (inner?.id != null) byId.set(String(inner.id), inner);
+    }
+    const pairs = Array.isArray(node.properties?.proxyWidgets) ? node.properties.proxyWidgets : [];
+    const innerForWidget = (widgetName) => {
+      for (const pair of pairs) {
+        if (!Array.isArray(pair) || pair.length < 2) continue;
+        if (String(pair[1]) !== widgetName) continue;
+        const hit = byId.get(String(pair[0]));
+        if (hit) return hit;
+      }
+      const matches = inners.filter((inner) =>
+        (inner?.widgets ?? []).some((w) => w?.name === widgetName),
+      );
+      return matches.length === 1 ? matches[0] : null;
+    };
+    for (const widget of node.widgets) {
+      const widgetName = typeof widget?.name === "string" ? widget.name : null;
+      if (!widgetName) continue;
+      const inner = innerForWidget(widgetName);
+      const className =
+        typeof inner?.type === "string"
+          ? inner.type
+          : typeof inner?.comfyClass === "string"
+            ? inner.comfyClass
+            : null;
+      if (!inner || !className || isFrontendVirtualNode(inner)) continue;
+      out.push({ widget, widgetName, className, inner });
+    }
+  } catch {
+    return out;
+  }
+  return out;
+}
+
+/**
+ * Virtual subgraph hosts contribute synthetic scan nodes typed as the INNER
+ * loader so /object_info is the real combo, while `id` stays the host (the
+ * visible rail). Original nodes are kept: a non-promoted virtual node still
+ * skips later, and an inner loader is still judged on its own widgets.
+ */
+export function expandPromotedHostScanNodes(nodes) {
+  if (!Array.isArray(nodes)) return nodes;
+  const extra = [];
+  for (const node of nodes) {
+    if (!isFrontendVirtualNode(node) || !node.subgraph) continue;
+    for (const t of promotedComboScanTargets(node)) {
+      extra.push({
+        id: node.id,
+        type: t.className,
+        widgets: [{ name: t.widgetName, value: t.widget?.value }],
+      });
+    }
+  }
+  return extra.length ? [...nodes, ...extra] : nodes;
+}
+
 export function linkDrivenWidgetNames(node) {
   const names = new Set();
   try {
@@ -309,6 +384,7 @@ export async function scanComboAvailability(
   if (!Array.isArray(nodes) || typeof fetchClassInfo !== "function") {
     return { unavailable, unknown };
   }
+  nodes = expandPromotedHostScanNodes(nodes);
   // get_errors shares ONE budget across every elective server wait it makes, and
   // overrunning it is not a slow answer — it is a "did not reply" that strands the
   // agent with NO error surface at all (#589). That is strictly worse than the


### PR DESCRIPTION
## Diagnosis

Recurrence of #984 on current main (0.15.172): turn-start still named four absent `MiniMaxH3/...` assets promoted through native subgraph host 1512, but `panel_get_errors` returned `audit_complete:true`, `errored_count:0`, empty `missing_models`. Same false-clean at root and inside the subgraph.

This is **not** the original load-time-store-empty hole. PR #991 / v0.11.83 already shipped the live `/object_info` scan. The new hole is the live **cross-check** that **subtracts** from Pinia `missingModel`:

1. The store blames the inner locator **or** host id 1512. After promotion the inner widget often holds an on-disk fallback while the **host rail** still names the missing file. Treating “inner no longer holds the filename” as a user fix dropped the candidate.
2. `get_errors` then sets `trustCombo` after refresh. `refreshComboOptionsFromDefs` keys off `node.type`, so a virtual GraphNode host is never rebuilt. A stale (or empty) host-rail combo that still **lists** the MiniMaxH3 path was treated as proof the file exists, so `missing_models` went empty.
3. The live scan skipped the virtual host entirely, and skipped inner loaders whose widgets are link-driven from the subgraph input, so `unavailable_widget_values` did not put the four files back. Both halves empty → `clean`.

## What this does **not** re-ship

- PR #991 / v0.11.83 live-scan introduction
- The original “stores empty at load” path

## Fix

- `assetCandidateStillReferenced` also looks at the promoted host rail (and the reverse).
- `assetCandidateResolvesLive` combo-clears only from **inner** nodes that currently hold the file — never from a host-rail combo list.
- `graph_get_errors` scans nested subgraphs from the bound root, and maps promoted host rails onto the inner loader class so `/object_info` can judge the **host** value.

Fail-closed: a genuine miss stays reported. An empty/stale combo on a host rail or inner node is not proof the file exists.

## Tests

- `#984 recurrence: a promoted HOST rail that still names the missing file keeps the inner locator candidate`
- `#984 recurrence: a stale HOST-rail combo must not combo-clear a still-missing promoted file`
- `#984 recurrence: an empty HOST-rail combo is not proof the file exists`
- `#984 recurrence: locator + trustCombo still reports when only the HOST rail names the miss`
- `#984 recurrence: the two halves naming the same promoted miss count once and are not clean`
- `#984 recurrence: a virtual subgraph HOST still reports a promoted missing model`
- Existing #984 suite in `browser_tests/unit/asset-staleness.test.mjs` still passes

## Notes

Do not merge. Do not cut a release. Parent overlay-merges after CI CLEAN.

Closes nothing yet — tracking #984.