### PR TITLE
fix(2249): age out switch fence after delivered workflow_open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- After a delivered panel_open_workflow, the switch fence no longer latches panel_list_workflows / panel_set_workflow_target({mode:"current"}) / panel_graph_outline for minutes while a later settle or safe-repaint is still pending. workflow_list stays the recovery probe; leftover previous-tab graph is still refused (#2249, #1215)
+
 ## [0.15.173] - 2026-09-04
 
 ### Fixed

--- a/browser_tests/unit/open-node-difference.test.mjs
+++ b/browser_tests/unit/open-node-difference.test.mjs
@@ -375,6 +375,11 @@ test("the pin guard also skips the recovery probe, or the wedge just moves", () 
     /pinnedPath\.trim\(\) && !commandIsCanvasTargetless\(msg\.cmd\)/,
     "both guards must consult the same predicate",
   );
+  assert.match(
+    PANEL,
+    /switchFenceRefusesCommand\(/,
+    "#2249 — the switch token must consult the same targetless exemption, or the wedge moves there",
+  );
 });
 
 test("an ordinary graph read stays fenced — the exemption is not a hole", () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -726,6 +726,7 @@ test("#442 codex R9: the switch+reload holds a critical section that REFUSES con
   assert.notEqual(guardAt, -1, "the command dispatcher must consult the section");
   assert.ok(guardAt < execAt, "…BEFORE running the executor");
   const refusal = src.slice(guardAt, execAt);
+  assert.match(refusal, /switchFenceRefusesCommand\(/);
   assert.match(refusal, /was NOT applied — nothing changed\. Retry in a moment\./);
   // A stuck guard must age out rather than wedge the tab forever.
   assert.match(src, /Date\.now\(\) - workflowReloadGuard\.since > WORKFLOW_RELOAD_GUARD_MAX_MS/);

--- a/browser_tests/unit/switch-fence-timeout.test.mjs
+++ b/browser_tests/unit/switch-fence-timeout.test.mjs
@@ -1,0 +1,220 @@
+// comfyui-mcp-panel#2249 — switch fence latched after a delivered workflow_open.
+//
+// MCP already acks delivery and keeps the instance fence fail-closed. The remaining
+// hole is panel `activeWorkflowReloadGuard`: a settle/safe-repaint step in flight is
+// immune to the 30s age-out, so graph_outline / workflow_list / mode:current were
+// refused for 86s–2m+ after the open had already applied, with no correlated reply.
+// #1264 bounded the post-open rAF; that did not unlatch a later pending settle.
+//
+// These tests drive the SHIPPED predicate (not a mock of it) and the wiring in the
+// bundle. Fail on the unfixed latch; leftover previous-tab graph stays refused.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  frontendActiveMatchesAppliedOpen,
+  switchFenceRefusesCommand,
+} from "../../web/js/lib/switch-fence.js";
+import {
+  commandIsCanvasTargetless,
+  commandTargetsActiveWorkflow,
+} from "../../web/js/lib/workflow-chat-identity.js";
+import {
+  graphCommandBindingBar,
+  graphRootUnprovenAgainstActiveState,
+  resolveGraphBindingVerdict,
+} from "../../web/js/lib/graph-binding.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const PENDING_GUARD = { token: 1, key: "wf:target.json", since: 1_000_000, pending: 1 };
+
+test("#2249 workflow_list is exempt from the switch fence the same way it is from the instance fence", () => {
+  assert.equal(commandIsCanvasTargetless("workflow_list"), true);
+  assert.equal(
+    switchFenceRefusesCommand({ cmd: "workflow_list", guard: PENDING_GUARD }),
+    false,
+    "the recovery probe must run while a settle step is still pending",
+  );
+  assert.equal(
+    commandTargetsActiveWorkflow({
+      cmd: "workflow_list",
+      commandUuid: "stale-uuid",
+      activeUuid: "live-uuid",
+    }),
+    true,
+  );
+});
+
+test("#2249 UNFIXED LATCH: graph_outline / graph_query stay refused until the open is delivered", () => {
+  for (const cmd of ["graph_outline", "graph_query", "graph_set_widget", "workflow_save"]) {
+    assert.equal(
+      switchFenceRefusesCommand({ cmd, guard: PENDING_GUARD }),
+      true,
+      `${cmd} must not run mid-switch before the open receipt is applied`,
+    );
+  }
+});
+
+test("#2249 a delivered open whose frontend already names the target unlatches dispatch", () => {
+  for (const cmd of ["graph_outline", "graph_query", "graph_set_widget"]) {
+    assert.equal(
+      switchFenceRefusesCommand({
+        cmd,
+        guard: PENDING_GUARD,
+        openReceiptApplied: true,
+        frontendActiveMatchesAppliedOpen: true,
+      }),
+      false,
+      `${cmd} must not stay latched through later settle/safe-repaint`,
+    );
+  }
+});
+
+test("#2249 a receipt for a different workflow, or an unapplied one, stays fail-closed", () => {
+  assert.equal(
+    switchFenceRefusesCommand({
+      cmd: "graph_outline",
+      guard: PENDING_GUARD,
+      openReceiptApplied: true,
+      frontendActiveMatchesAppliedOpen: false,
+    }),
+    true,
+  );
+  assert.equal(
+    switchFenceRefusesCommand({
+      cmd: "graph_outline",
+      guard: PENDING_GUARD,
+      openReceiptApplied: false,
+      frontendActiveMatchesAppliedOpen: true,
+    }),
+    true,
+    "frontend active matching without an applied receipt is the #433 restore shape",
+  );
+});
+
+test("#2249 frontendActiveMatchesAppliedOpen correlates path/routing key, never filename", () => {
+  const receipt = {
+    applied: true,
+    requested: "target.json",
+    resolved: { path: "user/target.json", filename: "Unsaved Workflow", routing_key: "wf:user/target.json" },
+  };
+  assert.equal(
+    frontendActiveMatchesAppliedOpen({
+      receipt,
+      activePath: "user/target.json",
+      activeRoutingKey: "wf:user/target.json",
+    }),
+    true,
+  );
+  assert.equal(
+    frontendActiveMatchesAppliedOpen({
+      receipt,
+      activePath: "user/other.json",
+      activeRoutingKey: "wf:user/other.json",
+    }),
+    false,
+  );
+  assert.equal(
+    frontendActiveMatchesAppliedOpen({
+      receipt: { ...receipt, applied: false },
+      activePath: "user/target.json",
+      activeRoutingKey: "wf:user/target.json",
+    }),
+    false,
+  );
+  assert.equal(
+    frontendActiveMatchesAppliedOpen({
+      receipt: {
+        applied: true,
+        requested: "Unsaved Workflow",
+        resolved: { path: null, filename: "Unsaved Workflow", routing_key: "tmp:aaa" },
+      },
+      activePath: null,
+      activeRoutingKey: "tmp:bbb",
+    }),
+    false,
+    "shared unsaved filename must not unlatch a different instance",
+  );
+});
+
+test("#2249 leftover previous-tab graph is still refused after the switch token unlatches", () => {
+  const nodes = Array.from({ length: 118 }, (_, i) => ({ id: i + 1, type: "KSampler" }));
+  const rootGraph = { _nodes: nodes };
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 118,
+      activeWorkflow: { changeTracker: { activeState: { nodes: "bad" } } },
+      switchRepaintUnproven: true,
+    }),
+    true,
+  );
+  const verdict = resolveGraphBindingVerdict({
+    graph: rootGraph,
+    rootGraph,
+    activeWorkflow: {},
+    activeWorkflowUuid: "remove-bg-tab",
+    liveNodeCount: 118,
+    switchRepaintUnproven: true,
+    ...graphCommandBindingBar("graph_outline"),
+  });
+  assert.equal(verdict?.reason, "root-state-unreadable");
+});
+
+test("#2249 dispatch consults the shipped predicate; ownership still ignores age-out while pending", () => {
+  const guardAt = SRC.indexOf("const reloadGuard = activeWorkflowReloadGuard();");
+  const execAt = SRC.indexOf("result = await executor(msg);");
+  assert.ok(guardAt !== -1 && guardAt < execAt);
+  const refusal = SRC.slice(guardAt, execAt);
+  assert.match(refusal, /switchFenceRefusesCommand\(/);
+  assert.match(refusal, /commandIsCanvasTargetless|frontendActiveMatchesAppliedOpen/);
+  assert.match(refusal, /openReceiptApplied:/);
+  assert.match(refusal, /was NOT applied — nothing changed\. Retry in a moment\./);
+  assert.match(
+    SRC,
+    /typeof switchRepaintUnproven !== "undefined"/,
+    "extracted leftover fences must still typeof-check the flag",
+  );
+
+  const reloadGuardMatch = SRC.match(
+    /let workflowReloadGuard = null;[\s\S]*?function activeWorkflowReloadGuard\(\) \{[\s\S]*?\n\}/,
+  );
+  assert.ok(reloadGuardMatch, "could not locate the workflow reload guard block");
+  const factory = new Function(
+    "Date",
+    `${reloadGuardMatch[0]}\nreturn { acquireWorkflowReloadGuard, beginWorkflowReloadStep, activeWorkflowReloadGuard };`,
+  );
+  const now = { t: 1_000_000 };
+  const g = factory({ now: () => now.t });
+  const token = g.acquireWorkflowReloadGuard("wf:target.json");
+  assert.equal(g.beginWorkflowReloadStep(token), true);
+  now.t += 120_000;
+  const held = g.activeWorkflowReloadGuard();
+  assert.ok(held, "ownership must still suspend age-out while a genuine step is in flight");
+  assert.equal(held.token, token);
+});
+
+test("#2249 workflow_open journals the applied receipt before the safe-repaint await", () => {
+  const openAt = SRC.indexOf("async workflow_open({ path, rid }) {");
+  assert.ok(openAt > 0);
+  const openBody = SRC.slice(openAt, SRC.indexOf("async workflow_close(", openAt));
+  const settleAt = openBody.indexOf("if (openSettled.target && openSettled.target !== target) target = openSettled.target;");
+  const earlyJournalAt = openBody.indexOf("applied: true,", settleAt);
+  const leftoverAt = openBody.indexOf("if (pointerMovedThisOpen) switchRepaintUnproven = true;", settleAt);
+  const repaintAt = openBody.indexOf("await app.loadGraphData(repaintState, true, true, target);");
+  assert.ok(settleAt !== -1 && earlyJournalAt !== -1 && leftoverAt !== -1 && repaintAt !== -1);
+  assert.ok(
+    settleAt < leftoverAt && leftoverAt < earlyJournalAt && earlyJournalAt < repaintAt,
+    "delivered open must be journaled (and leftover marked) before the hangable repaint",
+  );
+  assert.match(
+    openBody.slice(settleAt, repaintAt),
+    /sameWorkflowObject\(activeAfterSwitch, target\) === true/,
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -822,6 +822,10 @@ import {
   createSingleFlight,
 } from "./lib/open-outcome.js";
 import {
+  frontendActiveMatchesAppliedOpen,
+  switchFenceRefusesCommand,
+} from "./lib/switch-fence.js";
+import {
   classifyUndeliveredReply,
   describeUndeliveredReply,
   createLostReplyJournal,
@@ -1393,6 +1397,13 @@ function activeWorkflowReloadGuard() {
 /** Journal one open attempt and return its receipt. `applied:false` (with the error) is
  *  recorded too — a genuine negative is as load-bearing as a positive here. */
 function noteOpenAttempt({ cmd, rid, requested, resolved, applied, error }) {
+  // #2249 — a delivered switch journals applied as soon as the frontend names
+  // TARGET, so a later settle hang cannot withhold the receipt. The success
+  // path journals the same rid again; keep one applied record per command.
+  if (applied === true && rid) {
+    const latest = latestOpenReceipt(openReceipts);
+    if (latest && latest.rid === rid && latest.applied === true) return latest;
+  }
   const receipt = makeOpenReceipt({
     seq: ++openReceiptSeq,
     cmd,
@@ -23048,6 +23059,31 @@ const GRAPH_TOOL_EXECUTORS = {
           endWorkflowReloadStep(reloadGuardToken);
         }
         if (openSettled.target && openSettled.target !== target) target = openSettled.target;
+        // #2249 — the switch is delivered once the frontend already names TARGET.
+        // Journal applied NOW so a later settle/repaint hang cannot withhold the
+        // receipt from workflow_list, and mark leftover-canvas so graph_outline
+        // still refuses the previous tab (#1215). The token stays owned for this
+        // open's remaining steps; dispatch unlatches via switchFenceRefusesCommand.
+        try {
+          const activeAfterSwitch = activeWorkflowRef();
+          if (sameWorkflowObject(activeAfterSwitch, target) === true) {
+            pointerMovedThisOpen = !sameWorkflowObject(activeBefore, target);
+            if (pointerMovedThisOpen) switchRepaintUnproven = true;
+            noteOpenAttempt({
+              cmd: "workflow_open",
+              rid,
+              requested: path,
+              resolved: {
+                path: target.path,
+                filename: target.filename,
+                routing_key: workflowTabId(target),
+              },
+              applied: true,
+            });
+          }
+        } catch {
+          /* switch observation is best-effort — a missed early receipt keeps the fence */
+        }
       // We deliberately do NOT auto-reload the canvas from disk here: switching to an
       // already-open tab must not silently discard the user's in-memory graph, and a
       // re-read could race a concurrent canvas edit and clobber it. Instead the staleness
@@ -29496,7 +29532,26 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // (nothing applied, safe to retry) rather than queue: refusing cannot reorder
             // or double-apply, and the section lasts a fraction of a second.
             const reloadGuard = activeWorkflowReloadGuard();
-            if (reloadGuard) {
+            const appliedOpenReceipt = latestOpenReceipt(openReceipts);
+            let switchFenceActive = null;
+            try {
+              switchFenceActive = activeWorkflowRef();
+            // unknown-ok:
+            } catch {
+              switchFenceActive = null;
+            }
+            if (
+              switchFenceRefusesCommand({
+                cmd: msg.cmd,
+                guard: reloadGuard,
+                openReceiptApplied: appliedOpenReceipt?.applied === true,
+                frontendActiveMatchesAppliedOpen: frontendActiveMatchesAppliedOpen({
+                  receipt: appliedOpenReceipt,
+                  activePath: typeof switchFenceActive?.path === "string" ? switchFenceActive.path : null,
+                  activeRoutingKey: switchFenceActive ? workflowTabId(switchFenceActive) : null,
+                }),
+              })
+            ) {
               throw new Error(
                 `the panel is switching/refreshing "${reloadGuard.key}" right now, so "${msg.cmd}" ` +
                   `was NOT applied — nothing changed. Retry in a moment.`,

--- a/web/js/lib/switch-fence.js
+++ b/web/js/lib/switch-fence.js
@@ -1,0 +1,71 @@
+/**
+ * #2249 — the workflow-switch token must not latch recovery after a delivered open.
+ *
+ * `activeWorkflowReloadGuard` is a critical section so a graph command cannot land
+ * mid-switch and be overwritten or re-baselined as CLEAN (#442). A step in flight
+ * is deliberately immune to the 30s age-out. That immunity is what latches
+ * `workflow_list` / `graph_outline` / `panel_set_workflow_target({mode:"current"})`
+ * for minutes after MCP has already acked `workflow_open` delivery, while a later
+ * settle or safe-repaint is still pending (#1264 recurrence).
+ *
+ * Dispatch and ownership are different questions. The open keeps the token for its
+ * own remaining steps (abort a late load). Dispatch must not refuse the recovery
+ * probe, and must unlatch once the correlated open receipt is applied and the
+ * frontend already names that workflow. Leftover previous-tab graph is
+ * `switchRepaintUnproven`'s job (#1215), not this token.
+ *
+ * Dependency-free so unit tests drive the shipped predicate.
+ */
+
+import { commandIsCanvasTargetless } from "./workflow-chat-identity.js";
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value ? value : null;
+}
+
+/**
+ * Does the frontend's live active workflow already name the workflow a correlated
+ * `applied:true` open receipt resolved to?
+ *
+ * Path and routing key only — filename is shared by every unsaved tab (#186) and
+ * must not unlatch a switch onto a different instance.
+ */
+export function frontendActiveMatchesAppliedOpen({
+  receipt,
+  activePath = null,
+  activeRoutingKey = null,
+} = {}) {
+  if (!receipt || receipt.applied !== true) return false;
+  const resolved = receipt.resolved && typeof receipt.resolved === "object" ? receipt.resolved : {};
+  const want = [
+    nonEmptyString(resolved.routing_key ?? resolved.routingKey),
+    nonEmptyString(resolved.path),
+    nonEmptyString(receipt.requested),
+  ].filter(Boolean);
+  const have = [nonEmptyString(activeRoutingKey), nonEmptyString(activePath)].filter(Boolean);
+  if (!want.length || !have.length) return false;
+  return have.some((id) => want.includes(id));
+}
+
+/**
+ * Should dispatch refuse this command because the switch/reload section is held?
+ *
+ * `workflow_list` (and other canvas-targetless commands) are exempt the same way
+ * they are exempt from the instance fence: the list is the recovery probe, and
+ * fencing it makes the repair require the thing it repairs.
+ *
+ * When `openReceiptApplied` and the frontend already reports that workflow, later
+ * settle/repaint must not keep refusing `graph_outline`. A receipt for a different
+ * workflow, or an unapplied one, stays fail-closed.
+ */
+export function switchFenceRefusesCommand({
+  cmd,
+  guard,
+  openReceiptApplied = false,
+  frontendActiveMatchesAppliedOpen: activeMatchesAppliedOpen = false,
+} = {}) {
+  if (commandIsCanvasTargetless(cmd)) return false;
+  if (!guard) return false;
+  if (openReceiptApplied === true && activeMatchesAppliedOpen === true) return false;
+  return true;
+}

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -417,18 +417,19 @@ export function commandIsCanvasIndependent(cmd) {
  *  `workflow_list`, which DOES observe the canvas (it reports which tab is active)
  *  and so cannot honestly join that set, but which targets none.
  *
- *  Both guards this feeds exist to stop an operation landing on the WRONG workflow —
- *  the uuid fence (#570) and the pinned-target guard (#349/#186). `workflow_list`
- *  lands on nothing: it mutates no graph, selects no target (it enumerates every open
- *  tab), and returns tab metadata rather than graph content.
+ *  The guards this feeds exist to stop an operation landing on the WRONG workflow —
+ *  the uuid fence (#570), the pinned-target guard (#349/#186), and the switch/reload
+ *  token (#442/#2249). `workflow_list` lands on nothing: it mutates no graph, selects
+ *  no target (it enumerates every open tab), and returns tab metadata rather than
+ *  graph content.
  *
  *  It is also the ONLY probe the recovery path has. `rebindWorkflowFence()` re-derives
- *  a session's target from `workflow_list`'s active record, so gating it behind either
- *  guard makes the repair require the thing it repairs to be already-correct. That
- *  circularity is what made #932/#607/#688 permanent: every command refused, and the
- *  refusal text advertising a recovery that was itself refused for the same reason.
- *  Both guards must consult THIS predicate, or the wedge simply moves to whichever one
- *  was left behind. */
+ *  a session's target from `workflow_list`'s active record, so gating it behind any of
+ *  those guards makes the repair require the thing it repairs to be already-correct.
+ *  That circularity is what made #932/#607/#688/#2249 permanent: every command refused,
+ *  and the refusal text advertising a recovery that was itself refused for the same
+ *  reason. Every one of those guards must consult THIS predicate, or the wedge simply
+ *  moves to whichever one was left behind. */
 export function commandIsCanvasTargetless(cmd) {
   return commandIsCanvasIndependent(cmd) || cmd === 'workflow_list';
 }


### PR DESCRIPTION
## Problem

After MCP delivered `workflow_open`, panel `activeWorkflowReloadGuard` still refused `graph_outline`, `workflow_list`, and `panel_set_workflow_target({mode:"current"})` for 86s–2m+. A later settle / safe-repaint step left `pending > 0`, which is immune to the 30s age-out (#442). #1264 bounded the post-open rAF; that did not unlatch this hang.

## Fix

- Dispatch consults `switchFenceRefusesCommand` instead of treating any live switch token as a blanket refuse.
- `workflow_list` is exempt the same way it is from the instance fence (`commandIsCanvasTargetless`) — it is the recovery probe, including `mode:current`.
- Once the frontend already names TARGET, journal `applied:true` before the hangable repaint. Dispatch then unlatches when that correlated receipt matches the live active path/routing key, even if a later settle step is still pending.
- Ownership of the token is unchanged: a genuine in-flight step still cannot age out, so a late load cannot clobber an acknowledged edit.
- Leftover previous-tab graph still fails closed via `switchRepaintUnproven` (#1215). `typeof switchRepaintUnproven !== "undefined"` is unchanged for extracted fences.

## Tests

`npm run test:unit` — 8360 pass, 1 todo.

New `browser_tests/unit/switch-fence-timeout.test.mjs` drives the shipped predicate (fail on the unfixed latch, pass after) and pins leftover-graph refusal plus dispatcher wiring.

## Changelog

```
## [Unreleased]

### Fixed

- After a delivered panel_open_workflow, the switch fence no longer latches panel_list_workflows / panel_set_workflow_target({mode:"current"}) / panel_graph_outline for minutes while a later settle or safe-repaint is still pending. workflow_list stays the recovery probe; leftover previous-tab graph is still refused (#2249, #1215)
```
