### PR TITLE
fix(2252): refuse panel_run on a stale live bundle instead of silent drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- panel_run refuses a stale live browser bundle with a Ctrl+Shift+R hard-refresh requirement instead of silently dropping dispatch; unverified scoped pending items are still removed fail-closed (#2252)
+
+
 ## [0.15.174] - 2026-09-04
 
 ### Fixed

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -36,7 +36,7 @@ import { commandIsCanvasIndependent } from "../../web/js/lib/workflow-chat-ident
 import { sealProvenRootBinding } from "../../web/js/lib/graph-binding.js";
 import { composeShowMediaReply } from "../../web/js/lib/media-preview.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
-import { describeNodeDefRefresh, describeStaleBundleRefresh } from "../../web/js/lib/node-def-refresh.js";
+import { describeNodeDefRefresh, describeStaleBundleRefresh, describeStaleBundleRun } from "../../web/js/lib/node-def-refresh.js";
 import { confirmCanvasNavigation } from "../../web/js/lib/canvas-navigation.js";
 import {
   watchPostReconnectSettle,
@@ -112,6 +112,7 @@ test("panel ↔ media-preview.js / run-completion-frame.js ↔ bounded-step.js e
 test("panel ↔ node-def-refresh.js / canvas-navigation.js / reconnect-recovery.js edges link (#635/#619/#663/#646/#1641/#1914)", () => {
   assert.equal(typeof describeNodeDefRefresh, "function");
   assert.equal(typeof describeStaleBundleRefresh, "function");
+  assert.equal(typeof describeStaleBundleRun, "function");
   assert.equal(typeof confirmCanvasNavigation, "function");
   assert.equal(typeof watchPostReconnectSettle, "function");
   assert.equal(typeof waitForReconnectHandshakeBeforeOpen, "function");

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -37,6 +37,8 @@ import { sealProvenRootBinding } from "../../web/js/lib/graph-binding.js";
 import { composeShowMediaReply } from "../../web/js/lib/media-preview.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 import { describeNodeDefRefresh, describeStaleBundleRefresh, describeStaleBundleRun } from "../../web/js/lib/node-def-refresh.js";
+// describeStaleBundleRun is a lib export for tests; the panel maps the refresh
+// verdict in-root so a mixed cache (new panel.js + old node-def-refresh.js) still links.
 import { confirmCanvasNavigation } from "../../web/js/lib/canvas-navigation.js";
 import {
   watchPostReconnectSettle,

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -2971,3 +2971,113 @@ test("#1861: a scoped batch with repeating controls attaches the note to partial
     stop();
   }
 });
+
+// ---------------------------------------------------------------------------
+// #2252 — a stale live bundle must refuse panel_run BEFORE dispatch.
+// Unfixed: graph_run accepted the request and dispatch returned queued_unknown
+// with no prompt_id; ComfyUI never logged got prompt. Fixed: hard-refresh
+// refusal, no queuePrompt, no dispatchScopedRun, no pending item.
+// ---------------------------------------------------------------------------
+
+function stale173vs174() {
+  return describeStaleBundleRun({ running: "0.15.173", installed: "0.15.174" });
+}
+
+test("#2252 UNFIXED silent drop: without the stale-bundle gate, scoped graph_run still reaches dispatch", async () => {
+  const gateAt = runMatch[0].indexOf("refuseStaleBundleRun");
+  const dispatchAt = runMatch[0].indexOf("dispatchScopedRun");
+  const beginAt = runMatch[0].indexOf("beginPanelRun");
+  assert.notEqual(dispatchAt, -1, "shipped graph_run still dispatches scoped runs");
+  assert.notEqual(beginAt, -1, "shipped graph_run still marks beginPanelRun");
+  // Characterise the defect: if the gate is missing, dispatch is reachable while stale.
+  // The SHIPPED body must place the probe before either effect.
+  assert.notEqual(gateAt, -1, "unfixed graph_run accepted a stale tab and dropped dispatch silently");
+  assert.ok(gateAt < dispatchAt, "stale-bundle refusal must run before dispatchScopedRun");
+  assert.ok(gateAt < beginAt, "stale-bundle refusal must run before beginPanelRun");
+});
+
+test("#2252 SHIPPED: stale 0.15.173 vs installed 0.15.174 refuses scoped and full panel_run before dispatch", async () => {
+  const stop = keepAlive();
+  try {
+    const stale = stale173vs174();
+    let dispatched = 0;
+    let begun = 0;
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, drainMs: 5 });
+    app.graph = { _nodes: [] };
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 2000,
+      serializeMs: 500,
+      dispatch: () => {
+        dispatched += 1;
+        return {
+          outcome: "unverified",
+          queueMark: 1,
+          verified: 0,
+          error: "frontend deferred or silently dropped the request",
+        };
+      },
+      runCompletionRef: {
+        beginPanelRun() {
+          begun += 1;
+          return Symbol("run");
+        },
+        endPanelRun() {},
+        onQueued() {},
+      },
+      refuseStaleBundleRun: async () => stale,
+    });
+
+    const scoped = await built.graph_run({ to_node_id: 9 });
+    assert.equal(scoped.queued, false, "a stale tab must not claim a queue");
+    assert.equal(scoped.queued_unknown, undefined, "must not report the silent-drop queued_unknown shape");
+    assert.equal(scoped.reason, "stale_bundle");
+    assert.equal(scoped.running, "0.15.173");
+    assert.equal(scoped.installed, "0.15.174");
+    assert.match(scoped.error, /Ctrl\+Shift\+R/);
+    assert.match(scoped.remedy, /Hard-refresh/);
+    assert.equal(dispatched, 0, "dispatchScopedRun must not run on a stale bundle");
+    assert.equal(begun, 0, "beginPanelRun must not arm on a stale bundle");
+    assert.equal(promptCallCount(apiTarget.fetchApi), 0, "nothing may POST /prompt");
+    assert.equal(app.queueItems.length, 0, "no pending queue item may be created");
+
+    const full = await built.graph_run({});
+    assert.equal(full.queued, false);
+    assert.equal(full.queued_unknown, undefined);
+    assert.equal(full.reason, "stale_bundle");
+    assert.equal(dispatched, 0);
+    assert.equal(begun, 0);
+    assert.equal(promptCallCount(apiTarget.fetchApi), 0);
+    assert.equal(app.queueItems.length, 0);
+  } finally {
+    stop();
+  }
+});
+
+test("#2252 SHIPPED: a current / unknown probe still reaches dispatch (fail-open)", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, drainMs: 5 });
+    app.graph = { _nodes: [] };
+    let dispatched = 0;
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 2000,
+      serializeMs: 500,
+      dispatch: () => {
+        dispatched += 1;
+        return { outcome: "dispatched", verified: 1, promptIds: ["p1"], queueMark: 1 };
+      },
+      refuseStaleBundleRun: async () => null,
+    });
+    const res = await built.graph_run({ to_node_id: 9 });
+    assert.equal(dispatched, 1, "a readable current/unknown probe must not block a run");
+    assert.notEqual(res.reason, "stale_bundle");
+  } finally {
+    stop();
+  }
+});

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -99,6 +99,7 @@ import {
   compareRunDispatchIdentity,
   downgradeUnstableRunResult,
 } from "../../web/js/lib/run-dispatch-identity.js";
+import { describeStaleBundleRun } from "../../web/js/lib/node-def-refresh.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -709,7 +710,7 @@ test("#1565 P0: a run abandoned at its bound still FENCES its own late post, wit
  * technique add-node-command-budget.test.mjs uses) so the wiring can be exercised in
  * milliseconds; the shipped VALUES are pinned separately below.
  */
-function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef, runReceiptSender, runReceiptRouteRef, runReceiptSessionRef, panelRunOwnerRef, runDispatchIdentityRef, resolveRunToNodeTargetRef }) {
+function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runCompletionRef, armRunReconcileSweepRef, runReceiptSender, runReceiptRouteRef, runReceiptSessionRef, panelRunOwnerRef, runDispatchIdentityRef, resolveRunToNodeTargetRef, refuseStaleBundleRun }) {
   const seen = { dispatchArgs: null };
   const localRunToken = Symbol("test local graph run");
   const deps = {
@@ -795,6 +796,8 @@ function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch, runComp
         targetId,
       })),
     panelRunOwnerRef: panelRunOwnerRef ?? { current: {} },
+    // #2252 — fail-open default so budget/dispatch tests still exercise a current bundle.
+    refuseStaleBundleRun: refuseStaleBundleRun ?? (async () => null),
   };
   const names = Object.keys(deps);
   const factory = new Function(

--- a/browser_tests/unit/run-stale-bundle.test.mjs
+++ b/browser_tests/unit/run-stale-bundle.test.mjs
@@ -171,25 +171,53 @@ test("#2252 a version mismatch is queued:false stale_bundle with a Ctrl+Shift+R 
 // ---------------------------------------------------------------------------
 
 test("#2252 SHIPPED refuseStaleBundleRun maps the installed-pack probe onto a run refusal", async () => {
-  const body = extractFunction("async function refuseStaleBundleRun(");
+  const refreshBody = extractFunction("async function refuseStaleBundleRefresh(");
+  const runBody = extractFunction("async function refuseStaleBundleRun(");
   const factory = new Function(
-    "refuseStaleBundleRefresh",
+    "api",
+    "PANEL_VERSION",
+    "describeStaleBundleRefresh",
     "describeStaleBundleRun",
-    `${body}; return refuseStaleBundleRun;`,
+    `${refreshBody}; ${runBody}; return refuseStaleBundleRun;`,
   );
+  let versionRoute = 0;
   const stale = await factory(
-    async () => describeStaleBundleRefresh({ running: "0.15.173", installed: "0.15.174" }),
+    {
+      fetchApi: async (route, init) => {
+        versionRoute += 1;
+        assert.equal(route, "/comfyui_mcp_panel/version");
+        assert.equal(init?.cache, "no-store");
+        return { ok: true, json: async () => ({ version: "0.15.174" }) };
+      },
+    },
+    "0.15.173",
+    describeStaleBundleRefresh,
     describeStaleBundleRun,
   )();
+  assert.equal(versionRoute, 1);
   assert.equal(stale.queued, false);
   assert.equal(stale.reason, "stale_bundle");
   assert.equal(stale.running, "0.15.173");
   assert.equal(stale.installed, "0.15.174");
   assert.match(stale.error, /Ctrl\+Shift\+R/);
   assert.match(stale.error, /Nothing was queued/);
+  assert.equal("queued_unknown" in stale, false);
 
-  const current = await factory(async () => null, describeStaleBundleRun)();
-  assert.equal(current, null, "equal/unknown probes fail open into the run");
+  const current = await factory(
+    { fetchApi: async () => ({ ok: true, json: async () => ({ version: "0.15.174" }) }) },
+    "0.15.174",
+    describeStaleBundleRefresh,
+    describeStaleBundleRun,
+  )();
+  assert.equal(current, null, "equal versions fail open into the run");
+
+  const unknown = await factory(
+    { fetchApi: async () => ({ ok: false }) },
+    "0.15.173",
+    describeStaleBundleRefresh,
+    describeStaleBundleRun,
+  )();
+  assert.equal(unknown, null, "an unreadable probe must not invent stale_bundle");
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/run-stale-bundle.test.mjs
+++ b/browser_tests/unit/run-stale-bundle.test.mjs
@@ -1,0 +1,287 @@
+/**
+ * #2252 — panel_run must not accept a run on a stale live bundle.
+ *
+ * Reported: a tab running panel 0.15.173 while 0.15.174 was installed accepted
+ * panel_run, then silently dropped dispatch. Scoped and full runs produced no
+ * prompt_id; ComfyUI never logged got prompt. One scoped attempt created a
+ * pending item that the guard correctly removed after no dispatch was observed.
+ *
+ * Unfixed: graph_run proceeds into queuePrompt / dispatchScopedRun and the
+ * agent sees queued_unknown with no hard-refresh requirement.
+ * Fixed: stale_bundle + Ctrl+Shift+R before any dispatch; pending-item removal
+ * on an unverified scoped run is unchanged.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  describeStaleBundleRefresh,
+  describeStaleBundleRun,
+  NODE_DEF_REFRESH_REASONS,
+} from "../../web/js/lib/node-def-refresh.js";
+import { cancelPendingScopedQueueItem, QUEUE_ITEM_TAG } from "../../web/js/lib/run-scope-guard.js";
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+const SCOPE_SRC = readFileSync(join(HERE, "../../web/js/lib/run-scope-guard.js"), "utf8").replace(/\r\n/g, "\n");
+
+const runMatch = SRC.match(/\n {2}async graph_run\(\{ batch_count, to_node_id \}\) \{[\s\S]*?\n {2}\},/);
+assert.ok(runMatch, "could not locate graph_run in panel source");
+
+function extractFunction(marker) {
+  const start = SRC.indexOf(marker);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = SRC.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") {
+      i = SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && SRC[i + 1] === "*") {
+      i = SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < SRC.length; i += 1) {
+        if (SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function: ${marker}`);
+}
+
+function buildGraphRun(overrides = {}) {
+  let begun = 0;
+  let dispatchCalls = 0;
+  let queueCalls = 0;
+  let ctxCalls = 0;
+  const stats = {
+    get begun() {
+      return begun;
+    },
+    get dispatchCalls() {
+      return dispatchCalls;
+    },
+    get queueCalls() {
+      return queueCalls;
+    },
+    get ctxCalls() {
+      return ctxCalls;
+    },
+  };
+  const graph = { _nodes: [] };
+  const app = {
+    graph,
+    queuePrompt: async () => {
+      queueCalls += 1;
+      return true;
+    },
+  };
+  const deps = {
+    RUN_COMMAND_BUDGET_MS: 2000,
+    RUN_SERIALIZE_TIMEOUT_MS: 500,
+    makeCommandBudget,
+    monotonicNow: () => 0,
+    LOCAL_GRAPH_RUN_TOKEN: Symbol("local"),
+    runReceiptSender: null,
+    runReceiptRouteRef: () => null,
+    runReceiptSessionRef: () => null,
+    panelRunOwnerRef: { current: {} },
+    runCompletionRef: {
+      beginPanelRun() {
+        begun += 1;
+        return "tok";
+      },
+      endPanelRun() {},
+    },
+    armRunReconcileSweepRef: () => {},
+    runDispatchIdentityRef: () => ({ routeReady: true }),
+    captureRunDispatchIdentity: (x) => x,
+    refuseStaleBundleRun: async () => null,
+    getGraphCtx() {
+      ctxCalls += 1;
+      return { app, graph, rootGraph: graph };
+    },
+    assertGraphBoundToActiveWorkflow() {},
+    dispatchScopedRun: async () => {
+      dispatchCalls += 1;
+      return { outcome: "unverified", error: "stub" };
+    },
+    ...overrides,
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${runMatch[0]}};
+     return executors.graph_run;`,
+  );
+  return { graph_run: factory(...names.map((n) => deps[n])), stats, app };
+}
+
+// ---------------------------------------------------------------------------
+// Pure verdict
+// ---------------------------------------------------------------------------
+
+test("#2252 equal versions are not a stale-bundle run refusal", () => {
+  assert.equal(describeStaleBundleRun({ running: "0.15.174", installed: "0.15.174" }), null);
+});
+
+test("#2252 a missing probe is unknown — fail open, never invent stale_bundle for panel_run", () => {
+  assert.equal(describeStaleBundleRun({ running: "0.15.173", installed: null }), null);
+  assert.equal(describeStaleBundleRun({ running: "0.15.173", installed: "" }), null);
+  assert.equal(describeStaleBundleRun({ running: "", installed: "0.15.174" }), null);
+  assert.equal(describeStaleBundleRun({}), null);
+});
+
+test("#2252 a version mismatch is queued:false stale_bundle with a Ctrl+Shift+R remedy", () => {
+  const v = describeStaleBundleRun({ running: "0.15.173", installed: "0.15.174" });
+  assert.equal(v.queued, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.STALE_BUNDLE);
+  assert.equal(v.reason, "stale_bundle");
+  assert.equal(v.running, "0.15.173");
+  assert.equal(v.installed, "0.15.174");
+  assert.match(v.remedy, /Ctrl\+Shift\+R/);
+  assert.match(v.remedy, /0\.15\.173/);
+  assert.match(v.remedy, /0\.15\.174/);
+  assert.match(v.remedy, /Nothing was queued/);
+  assert.match(v.remedy, /panel_run/);
+  assert.equal(v.error, v.remedy);
+  assert.equal("queued_unknown" in v, false, "must not reuse the silent-drop acknowledgement");
+});
+
+// ---------------------------------------------------------------------------
+// SHIPPED refuseStaleBundleRun
+// ---------------------------------------------------------------------------
+
+test("#2252 SHIPPED refuseStaleBundleRun maps the installed-pack probe onto a run refusal", async () => {
+  const body = extractFunction("async function refuseStaleBundleRun(");
+  const factory = new Function(
+    "refuseStaleBundleRefresh",
+    "describeStaleBundleRun",
+    `${body}; return refuseStaleBundleRun;`,
+  );
+  const stale = await factory(
+    async () => describeStaleBundleRefresh({ running: "0.15.173", installed: "0.15.174" }),
+    describeStaleBundleRun,
+  )();
+  assert.equal(stale.queued, false);
+  assert.equal(stale.reason, "stale_bundle");
+  assert.equal(stale.running, "0.15.173");
+  assert.equal(stale.installed, "0.15.174");
+  assert.match(stale.error, /Ctrl\+Shift\+R/);
+  assert.match(stale.error, /Nothing was queued/);
+
+  const current = await factory(async () => null, describeStaleBundleRun)();
+  assert.equal(current, null, "equal/unknown probes fail open into the run");
+});
+
+// ---------------------------------------------------------------------------
+// SHIPPED graph_run — the command that was silently dropping dispatch
+// ---------------------------------------------------------------------------
+
+test("#2252 SHIPPED: a stale bundle refuses panel_run before dispatch", async () => {
+  const staleVerdict = describeStaleBundleRun({ running: "0.15.173", installed: "0.15.174" });
+  const { graph_run, stats } = buildGraphRun({
+    refuseStaleBundleRun: async () => staleVerdict,
+    getGraphCtx() {
+      throw new Error("getGraphCtx must not run on a stale bundle");
+    },
+    dispatchScopedRun: async () => {
+      throw new Error("dispatchScopedRun must not run on a stale bundle");
+    },
+  });
+
+  const scoped = await graph_run({ to_node_id: 9 });
+  assert.equal(scoped.queued, false);
+  assert.equal(scoped.reason, "stale_bundle");
+  assert.match(scoped.error, /Ctrl\+Shift\+R/);
+  assert.match(scoped.error, /0\.15\.173/);
+  assert.match(scoped.error, /0\.15\.174/);
+  assert.equal(stats.begun, 0, "must not begin a panel_run hold");
+  assert.equal(stats.dispatchCalls, 0, "must not enter scoped dispatch");
+  assert.equal(stats.queueCalls, 0, "must not call queuePrompt");
+  assert.equal(stats.ctxCalls, 0, "must not construct a prompt on a stale tab");
+
+  const full = await graph_run({});
+  assert.equal(full.queued, false);
+  assert.equal(full.reason, "stale_bundle");
+  assert.equal(stats.begun, 0);
+  assert.equal(stats.queueCalls, 0);
+});
+
+test("#2252 SHIPPED: a current bundle still reaches the graph (fail-open on match)", async () => {
+  let ctxCalls = 0;
+  const { graph_run } = buildGraphRun({
+    refuseStaleBundleRun: async () => null,
+    getGraphCtx() {
+      ctxCalls += 1;
+      throw new Error("stop-after-ctx");
+    },
+  });
+  await assert.rejects(() => graph_run({}), /stop-after-ctx/);
+  assert.equal(ctxCalls, 1, "a current bundle must still enter the run path");
+});
+
+test("#2252 wiring: graph_run asks the stale-bundle gate before beginPanelRun and dispatch", () => {
+  const body = runMatch[0];
+  const gateAt = body.indexOf("refuseStaleBundleRun");
+  const beginAt = body.indexOf("dispatchRunCompletion?.beginPanelRun");
+  const queueAt = body.indexOf("app.queuePrompt");
+  const dispatchAt = body.indexOf("dispatchScopedRun");
+  assert.notEqual(gateAt, -1, "graph_run must consult refuseStaleBundleRun");
+  assert.notEqual(beginAt, -1, "the panel_run hold is still taken for a live dispatch");
+  assert.notEqual(queueAt, -1, "the full-run queue call is still present");
+  assert.notEqual(dispatchAt, -1, "scoped dispatch is still present");
+  assert.ok(gateAt < beginAt, "stale-bundle detection must run before beginPanelRun");
+  assert.ok(gateAt < queueAt, "stale-bundle detection must run before queuePrompt");
+  assert.ok(gateAt < dispatchAt, "stale-bundle detection must run before dispatchScopedRun");
+});
+
+// ---------------------------------------------------------------------------
+// Pending-item removal must stay fail-closed (the report's correct half)
+// ---------------------------------------------------------------------------
+
+test("#2252 wiring: dispatchScopedRun still fail-closed-removes an unverified pending item", () => {
+  const timeoutCancel = SCOPE_SRC.indexOf("const cancel = cancelPendingScopedQueueItem(app, { runTag, queueMark: mark });");
+  assert.notEqual(
+    timeoutCancel,
+    -1,
+    "the scoped timeout path must still splice THIS run's tagged pending item",
+  );
+  const graphRun = runMatch[0];
+  assert.match(
+    graphRun,
+    /dispatchScopedRun\(/,
+    "graph_run must still hand scoped runs to dispatchScopedRun (where the removal lives)",
+  );
+});
+
+test("#2252 cancelPendingScopedQueueItem still removes only the tagged pending item", () => {
+  const runTag = Symbol("ours");
+  const ours = { number: 7, batchCount: 1, queueNodeIds: ["9"] };
+  ours.queueNodeIds[QUEUE_ITEM_TAG] = runTag;
+  const foreign = { number: 7, batchCount: 1, queueNodeIds: ["9"] };
+  const app = { queueItems: [foreign, ours] };
+  const res = cancelPendingScopedQueueItem(app, { runTag, queueMark: 7 });
+  assert.equal(res.accessible, true);
+  assert.equal(res.removed, 1);
+  assert.equal(app.queueItems.length, 1);
+  assert.equal(app.queueItems[0], foreign);
+});

--- a/browser_tests/unit/run-stale-bundle.test.mjs
+++ b/browser_tests/unit/run-stale-bundle.test.mjs
@@ -173,11 +173,15 @@ test("#2252 a version mismatch is queued:false stale_bundle with a Ctrl+Shift+R 
 test("#2252 SHIPPED refuseStaleBundleRun maps the installed-pack probe onto a run refusal", async () => {
   const refreshBody = extractFunction("async function refuseStaleBundleRefresh(");
   const runBody = extractFunction("async function refuseStaleBundleRun(");
+  assert.doesNotMatch(
+    runBody,
+    /describeStaleBundleRun/,
+    "the root must map the refresh verdict itself — a static new export breaks mixed cache",
+  );
   const factory = new Function(
     "api",
     "PANEL_VERSION",
     "describeStaleBundleRefresh",
-    "describeStaleBundleRun",
     `${refreshBody}; ${runBody}; return refuseStaleBundleRun;`,
   );
   let versionRoute = 0;
@@ -192,7 +196,6 @@ test("#2252 SHIPPED refuseStaleBundleRun maps the installed-pack probe onto a ru
     },
     "0.15.173",
     describeStaleBundleRefresh,
-    describeStaleBundleRun,
   )();
   assert.equal(versionRoute, 1);
   assert.equal(stale.queued, false);
@@ -207,7 +210,6 @@ test("#2252 SHIPPED refuseStaleBundleRun maps the installed-pack probe onto a ru
     { fetchApi: async () => ({ ok: true, json: async () => ({ version: "0.15.174" }) }) },
     "0.15.174",
     describeStaleBundleRefresh,
-    describeStaleBundleRun,
   )();
   assert.equal(current, null, "equal versions fail open into the run");
 
@@ -215,9 +217,18 @@ test("#2252 SHIPPED refuseStaleBundleRun maps the installed-pack probe onto a ru
     { fetchApi: async () => ({ ok: false }) },
     "0.15.173",
     describeStaleBundleRefresh,
-    describeStaleBundleRun,
   )();
   assert.equal(unknown, null, "an unreadable probe must not invent stale_bundle");
+});
+
+test("#2252 mixed-cache: a fresh root still links against an older node-def-refresh.js", () => {
+  const named = SRC.match(/import \{([^}]+)\} from "\.\/lib\/node-def-refresh\.js";/);
+  assert.ok(named, "node-def-refresh named import not found");
+  assert.doesNotMatch(
+    named[1],
+    /describeStaleBundleRun/,
+    "must not statically import a new child export the cached module may lack",
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -342,6 +342,7 @@ import {
   NODE_DEF_REFRESH_REASONS,
   describeNodeDefRefresh,
   describeStaleBundleRefresh,
+  describeStaleBundleRun,
   describeRefreshGraphLoss,
   restoredLiveNodesNote,
 } from "./lib/node-def-refresh.js";
@@ -1807,6 +1808,16 @@ async function refuseStaleBundleRefresh() {
   } catch {
     return null;
   }
+}
+
+/**
+ * #2252 — same installed-pack probe as refuseStaleBundleRefresh, mapped onto a
+ * panel_run refusal. A stale tab must not reach queuePrompt or dispatchScopedRun.
+ */
+async function refuseStaleBundleRun() {
+  const stale = await refuseStaleBundleRefresh();
+  if (!stale) return null;
+  return describeStaleBundleRun({ running: stale.running, installed: stale.installed });
 }
 
 async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {
@@ -20103,6 +20114,13 @@ const GRAPH_TOOL_EXECUTORS = {
         targetId,
       });
     };
+    // #2252 — a stale live bundle must not accept a run. 0.15.173 vs installed
+    // 0.15.174 silently dropped dispatch (queued_unknown, no prompt_id, ComfyUI
+    // never logged got prompt). Refuse with a hard-refresh requirement BEFORE
+    // the panel_run hold, prompt construction, queuePrompt, or scoped dispatch.
+    // An unreadable version probe fails open (same rule as #2027).
+    const staleBundle = await refuseStaleBundleRun();
+    if (staleBundle) return staleBundle;
     // Mark the dispatch before queuePrompt can produce a fast execution_success.
     // The tracker holds that completion until the delayed /prompt response gives
     // it a prompt-scoped key, then replays the exact batch keyed.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -342,7 +342,6 @@ import {
   NODE_DEF_REFRESH_REASONS,
   describeNodeDefRefresh,
   describeStaleBundleRefresh,
-  describeStaleBundleRun,
   describeRefreshGraphLoss,
   restoredLiveNodesNote,
 } from "./lib/node-def-refresh.js";
@@ -1813,11 +1812,29 @@ async function refuseStaleBundleRefresh() {
 /**
  * #2252 — same installed-pack probe as refuseStaleBundleRefresh, mapped onto a
  * panel_run refusal. A stale tab must not reach queuePrompt or dispatchScopedRun.
+ *
+ * Map the refresh verdict in this root module. A static import of
+ * describeStaleBundleRun would fail ESM linking if a fresh root met a cached
+ * older node-def-refresh.js that does not export it — the mixed-cache state
+ * this gate exists to handle.
  */
 async function refuseStaleBundleRun() {
   const stale = await refuseStaleBundleRefresh();
   if (!stale) return null;
-  return describeStaleBundleRun({ running: stale.running, installed: stale.installed });
+  const running = stale.running;
+  const installed = stale.installed;
+  const remedy =
+    `This tab is running panel ${running} while the installed pack is ${installed}. ` +
+    `Hard-refresh this tab (Ctrl+Shift+R) to load panel ${installed} before panel_run. ` +
+    `Nothing was queued.`;
+  return {
+    queued: false,
+    reason: stale.reason,
+    running,
+    installed,
+    remedy,
+    error: remedy,
+  };
 }
 
 async function registerComfyNodeDefs(preloadedDefs, runOpts, runControl) {

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -80,6 +80,35 @@ export function describeStaleBundleRefresh({ running, installed } = {}) {
   };
 }
 
+/**
+ * #2252 — refuse panel_run when the running browser bundle is STALE.
+ *
+ * A one-patch live/installed mismatch (0.15.173 vs 0.15.174) accepted the run
+ * and then silently dropped dispatch: queued_unknown, no prompt_id, ComfyUI
+ * never logged got prompt. Fail-closed here, before queuePrompt / scoped
+ * dispatch, so the caller gets a hard-refresh requirement instead of an idle
+ * queue. Fail-open on an unreadable probe — same rule as describeStaleBundleRefresh.
+ *
+ * @returns {null|{queued:false, reason:string, running:string, installed:string, remedy:string, error:string}}
+ */
+export function describeStaleBundleRun({ running, installed } = {}) {
+  if (resolveBundleStaleness({ running, installed }) !== "stale") return null;
+  const run = String(running).trim();
+  const inst = String(installed).trim();
+  const remedy =
+    `This tab is running panel ${run} while the installed pack is ${inst}. ` +
+    `Hard-refresh this tab (Ctrl+Shift+R) to load panel ${inst} before panel_run. ` +
+    `Nothing was queued.`;
+  return {
+    queued: false,
+    reason: NODE_DEF_REFRESH_REASONS.STALE_BUNDLE,
+    running: run,
+    installed: inst,
+    remedy,
+    error: remedy,
+  };
+}
+
 function detailSuffix(thrown) {
   const text = String(thrown?.message ?? thrown ?? "").trim();
   return text ? `(${text})` : "";


### PR DESCRIPTION
## Problem

On a live tab running panel 0.15.173 while 0.15.174 is installed, `panel_run` accepted the request and then silently dropped dispatch. Scoped and full runs produced no `prompt_id`; ComfyUI never logged `got prompt`; the queue stayed idle. One scoped attempt created a pending item that the guard correctly removed after no dispatch was observed.

This is not #2248 / comfyui-mcp#2854: those refuse loudly with `backend socket down`. This path returned `queued_unknown` with no reason and no hard-refresh requirement.

## Fix

Fail-closed: compare the running `PANEL_VERSION` to the installed pack (`/comfyui_mcp_panel/version`) **before** `beginPanelRun` / `graphToPrompt` / `queuePrompt` / `dispatchScopedRun`. A proven mismatch returns `queued: false`, `reason: "stale_bundle"`, and a Ctrl+Shift+R remedy. An unreadable probe still fails open (same rule as #2027).

Unverified scoped pending-item removal is unchanged (`cancelPendingScopedQueueItem` on the dispatch timeout path).

## Tests

`node --test browser_tests/unit/*.test.mjs` — 8369 pass, 1 todo.

New `browser_tests/unit/run-stale-bundle.test.mjs` fails without the gate (graph_run proceeds into dispatch) and passes with it. Also pins fail-open on a missing probe and that tagged pending-item removal still splices only this run's item.

## Changelog

```
## [Unreleased]

### Fixed

- panel_run refuses a stale live browser bundle with a Ctrl+Shift+R hard-refresh requirement instead of silently dropping dispatch; unverified scoped pending items are still removed fail-closed (#2252)
```
