### PR TITLE
fix(1215): refuse archived canvas when already-open file is larger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- After an already-open panel_open_workflow applies last_open, panel_graph_outline / panel_query_graph refuse a leftover previous-tab or archived canvas when the live graph is smaller than the named file — failed switch repaint and another open tab matching the live root stay fail-closed; fixtures without leftover proof stay available (#1215)
+
+
 ## [0.15.175] - 2026-09-05
 
 ### Fixed

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -676,6 +676,104 @@ test("#1215: already-current untagged canvas with matching state still admits (#
   assert.equal(verdict, null);
 });
 
+test("#1215: a failed switch repaint is leftover even when the TARGET tracker still serializes", () => {
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 4,
+      activeWorkflow: wf({ changeTracker: { activeState: state(4) } }),
+      switchRepaintUnproven: true,
+    }),
+    true,
+    "poisoned already-open state matching the leftover canvas is not ownership proof",
+  );
+});
+
+test("#1215: a clean already-open file larger than the live canvas is leftover archive", () => {
+  const live = state(4);
+  const file = state(69);
+  const rootGraph = {
+    _nodes: live.nodes,
+    serialize: () => ({ nodes: live.nodes, links: [], groups: [] }),
+  };
+  const activeWorkflow = wf({
+    isModified: false,
+    path: "workflows/3d_pixal3d_trellis2_image_to_model.json",
+    originalContent: JSON.stringify({ ...file, links: [], groups: [] }),
+    changeTracker: { activeState: { ...live, links: [], groups: [] } },
+  });
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 4,
+      activeWorkflow,
+      rootGraph,
+    }),
+    true,
+    "last-open named the 69-node file while the canvas still holds a 4-node archive",
+  );
+  for (const cmd of ["graph_outline", "graph_query"]) {
+    const verdict = resolveGraphBindingVerdict({
+      graph: rootGraph,
+      rootGraph,
+      activeWorkflow,
+      activeWorkflowUuid: "already-open-trellis2",
+      liveNodeCount: 4,
+      ...graphCommandBindingBar(cmd),
+      includeBaselineReadGuard: true,
+    });
+    assert.equal(verdict?.reason, "root-state-unreadable", cmd);
+    assert.equal(verdict.live, 4);
+  }
+});
+
+test("#1215: a dirty tab smaller than its file is not leftover (user deletions fail OPEN)", () => {
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 4,
+      activeWorkflow: wf({
+        isModified: true,
+        originalContent: JSON.stringify(state(69)),
+        changeTracker: { activeState: state(4) },
+      }),
+    }),
+    false,
+  );
+});
+
+test("#1215: missing or unreadable originalContent is not leftover (fixtures fail OPEN)", () => {
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 4,
+      activeWorkflow: wf({ isModified: false, changeTracker: { activeState: state(4) } }),
+    }),
+    false,
+    "no file bytes",
+  );
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 4,
+      activeWorkflow: wf({
+        isModified: false,
+        originalContent: "{not-json",
+        changeTracker: { activeState: state(4) },
+      }),
+    }),
+    false,
+    "unreadable file bytes",
+  );
+  assert.equal(
+    graphRootUnprovenAgainstActiveState({
+      liveNodeCount: 69,
+      activeWorkflow: wf({
+        isModified: false,
+        originalContent: JSON.stringify(state(69)),
+        changeTracker: { activeState: state(69) },
+      }),
+    }),
+    false,
+    "live canvas matches the already-open file",
+  );
+});
+
 test("#1215: the refusal names the live count and says set_workflow_target is not a remedy", () => {
   const msg = graphBindingRefusalMessage({ reason: "root-state-unreadable", live: 118, expected: null });
   assert.match(msg, /^\[root-state-unreadable\]/);

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -87,6 +87,24 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
   return activeWorkflowNodeCount(activeWorkflow) > 0;
 }
 
+function workflowLoadedFileNodeCount(activeWorkflow) {
+  try {
+    const raw = activeWorkflow?.originalContent;
+    if (typeof raw !== "string" || !raw) return 0;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed?.nodes) ? parsed.nodes.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function leftoverArchivedCanvasAgainstOpenFile({ liveNodeCount, activeWorkflow }) {
+  if (activeWorkflow?.isModified === true) return false;
+  const fileCount = workflowLoadedFileNodeCount(activeWorkflow);
+  if (!(fileCount > 0)) return false;
+  return Number(liveNodeCount) < fileCount;
+}
+
 /**
  * #1215 recurrence — after a tab switch the ACTIVE pointer (and the session
  * fence) can already name the new workflow while the live root is still the
@@ -95,12 +113,19 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
  *
  * Missing current state alone is NOT leftover evidence. Extracted graph_query
  * fixtures, a first observation, and #618's unreadable tracker all look like
- * "live nodes + no activeState" and must fail OPEN. Refuse only when that
- * unreadable active state is paired with switch/open leftover proof:
+ * "live nodes + no activeState" and must fail OPEN. Refuse when last-open
+ * leftover proof is present:
  *   - `switchRepaintUnproven`: this session's last open moved the pointer and
- *     could not prove the canvas rebound (the safe-repaint failure);
- *   - or another still-open workflow's current state AGREES with the live
- *     root, so the mounted graph is that previous tab's, not the named one.
+ *     could not prove the canvas rebound (the safe-repaint failure). A TARGET
+ *     tracker that still serializes is not an exception — that is the poisoned
+ *     already-open tab;
+ *   - another still-open workflow's current state AGREES with the live root
+ *     while THIS tab has no comparable current state, so the mounted graph is
+ *     that previous tab's, not the named one;
+ *   - or a CLEAN already-open tab whose loaded file (`originalContent`) is
+ *     LARGER than the live canvas: the tracker can agree with a leftover
+ *     4-node archive while last-open names the 69-node file. Dirty tabs fail
+ *     OPEN (a user can delete nodes). Missing/unreadable file bytes fail OPEN.
  *
  * A well-formed empty `nodes: []` is the shape guard's job. A TARGET uuid on
  * the leftover canvas is not an exception (#1639). `panel_set_workflow_target`
@@ -117,8 +142,9 @@ export function graphRootUnprovenAgainstActiveState({
   if (inSubgraph) return false;
   if (!activeWorkflow) return false;
   if (!(Number(liveNodeCount) > 0)) return false;
-  if (activeWorkflowCurrentState(activeWorkflow) != null) return false;
   if (switchRepaintUnproven === true) return true;
+  if (leftoverArchivedCanvasAgainstOpenFile({ liveNodeCount, activeWorkflow })) return true;
+  if (activeWorkflowCurrentState(activeWorkflow) != null) return false;
   if (!rootGraph || !Array.isArray(others)) return false;
   for (const other of others) {
     if (!other) continue;


### PR DESCRIPTION
## Summary

v0.15.170 #2238 refuses leftover previous-tab graph when the last open could not prove a repaint **and** TARGET has no comparable current state. The 04:48Z recurrence still served a **4-node archived Pixal3D canvas** after an already-open `panel_open_workflow` of the 69-node Trellis2 file: `active_matches_target:true`, `modified:false`, applied `last_open`, then `panel_graph_outline` read the leftover graph.

The hole is a poisoned already-open tracker: live canvas and `activeState` both hold the 4-node archive, so the shape guard agrees, `switchRepaintUnproven` is cleared (or never set, already-current), and outline succeeds under the named file.

Fail closed on last-open leftover evidence:

- failed switch repaint, even when TARGET still serializes
- another open tab whose state matches the live root (unchanged; still requires this tab's current state to be missing so fixtures stay available)
- a **clean** already-open tab whose loaded file (`originalContent`) is **larger** than the live canvas

Dirty tabs and missing/unreadable file bytes fail open. `switchRepaintUnproven` typeof-check in extracted fences is unchanged. `panel_set_workflow_target` is still not a remedy.

Does not merge or cut a release.

## Tests

```
node --test browser_tests/unit/graph-binding.test.mjs browser_tests/unit/switch-fence-timeout.test.mjs browser_tests/unit/open-active-settle.test.mjs
```

203 pass, 0 fail.
