### PR TITLE
fix(2031): keep DynamicCombo dotted FLOAT writes across the set_widget flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget wraps live COMFY_DYNAMICCOMBO_V3 parents before the write so a Vue/widget-store flush cannot rebuild dotted FLOAT children from spec defaults while the receipt still says applied:true; panel_query_graph then sees the value that was written (#2031)
+
 ## [0.15.176] - 2026-09-05
 
 ### Fixed

--- a/browser_tests/unit/set-widget-2031-dynamiccombo-child.test.mjs
+++ b/browser_tests/unit/set-widget-2031-dynamiccombo-child.test.mjs
@@ -154,12 +154,12 @@ function childValue(node, name) {
   return node.widgets.find((widget) => widget.name === name)?.value;
 }
 
-test("#2031 unfixed shape: FLOAT child write is accepted and readable, then lost at serialize", async () => {
+test("#2031 unfixed shape: a direct FLOAT child assign is readable, then lost at native serialize", () => {
   const { node, nativeGraphToPrompt } = makeUpscalerNode();
   assert.equal(childValue(node, "mode.scale"), 2);
 
-  const result = await runSetWidget(node, "mode.scale", 1.5, widgetOpts());
-  assert.equal(result.set.value, 1.5);
+  const child = node.widgets.find((widget) => widget.name === "mode.scale");
+  child.value = 1.5;
   assert.equal(childValue(node, "mode.scale"), 1.5, "query-style readback confirms the write");
 
   const queued = nativeGraphToPrompt();
@@ -167,6 +167,22 @@ test("#2031 unfixed shape: FLOAT child write is accepted and readable, then lost
     queued.output[186].inputs["mode.scale"],
     2,
     "native serialize rebuilds the combo from spec defaults and drops the FLOAT write",
+  );
+});
+
+test("#2031 a same-value parent flush after set_widget keeps the FLOAT child without waiting for graphToPrompt", async () => {
+  const { node } = makeUpscalerNode();
+
+  const result = await runSetWidget(node, "mode.scale", 1.5, widgetOpts());
+  assert.equal(result.set.value, 1.5);
+  assert.equal(childValue(node, "mode.scale"), 1.5);
+
+  const root = node.widgets.find((widget) => widget.name === "mode");
+  root.value = root.value;
+  assert.equal(
+    childValue(node, "mode.scale"),
+    1.5,
+    "Vue/widget-store flush after set must not revert the child before query_graph",
   );
 });
 

--- a/web/js/lib/dynamic-widget-reconcile.js
+++ b/web/js/lib/dynamic-widget-reconcile.js
@@ -256,7 +256,7 @@ function wrapDynamicComboSetter(node, widget) {
   widget[DYNAMIC_COMBO_PRESERVE_CHILDREN] = true;
 }
 
-function wrapGraphDynamicComboSetters(graph) {
+export function wrapGraphDynamicComboSetters(graph) {
   for (const node of graphNodes(graph)) {
     try {
       const required = nodeDef(node)?.input?.required;

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -1202,6 +1202,9 @@ async function runSetWidgetBody(
     // shared write path is not on offer, and pretending otherwise is what cost a round.
     const prepared = typeof prepareWriteTarget === "function" ? prepareWriteTarget() : null;
     try {
+      // After the object-info await, wrap the LIVE combo again so a Vue remount
+      // during the fetch cannot leave the parent setter unwrapped for this write.
+      preserveDynamicComboChildren();
       const set = applyWidgetWrite(node, widgetName, value, {
         resolveSource,
         canvas,

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -48,6 +48,7 @@ import {
 import { controlAfterGenerateWarning, controlEntryForWidget } from "./control-after-generate.js";
 import { isTypeScopedObjectInfo } from "./scoped-object-info.js";
 import { isPromotedContainer, linkDrivenWidgets, drivenTag } from "./graph-read.js";
+import { wrapGraphDynamicComboSetters } from "./dynamic-widget-reconcile.js";
 import { refreshDynamicInputsAfterWrite } from "./dynamic-inputs-refresh.js";
 import { refreshCustomGeneratedWidgetsAfterWrite } from "./custom-generated-widgets-refresh.js";
 import { REFRESH_JOIN_ABANDONED } from "./refresh-coalesce.js";
@@ -610,6 +611,19 @@ async function runSetWidgetBody(
   const assertNotAbandoned = () => {
     if (ackState?.abandoned) throw widgetWriteOutcomeUnknownError();
   };
+  // #2031 recurrence: graphToPrompt wrap is too late. Vue/widget-store flush
+  // after panel_set_widget re-assigns the DynamicCombo parent, rebuilds dotted
+  // children from spec defaults, then panel_query_graph reads the default
+  // while the receipt still says applied:true. Wrap before the write so a
+  // same-value parent assign restores the live children.
+  const preserveDynamicComboChildren = () => {
+    try {
+      wrapGraphDynamicComboSetters(node?.graph ?? { _nodes: [node] });
+    } catch {
+      /* a hostile node must not block the write */
+    }
+  };
+  preserveDynamicComboChildren();
   if (clear !== undefined && clear !== true && clear !== false) {
     throw new Error("panel_set_widget clear must be a boolean");
   }
@@ -1200,6 +1214,7 @@ async function runSetWidgetBody(
         out: writeOut,
         ...extra,
       });
+      preserveDynamicComboChildren();
       // #1282 — REFRESH DYNAMIC INPUT SLOTS after the write, on the node the write
       // landed on, inside the SAME synchronous stretch (no await since the fence, so
       // the press cannot interleave with a workflow switch or another command frame).


### PR DESCRIPTION
## User-visible failure

On panel 0.15.176 / frontend 1.51.9, `panel_set_widget` for `MinimaxH3LatentUpscaler3D` `mode.scale` `2 → 1.5` returns `applied:true`, then an immediate `panel_query_graph` still shows `mode.scale=2`. The next render uses scale 2 and OOMs. Recurrence of #2031 after v0.15.138 (#2096).

## Root cause

`COMFY_DYNAMICCOMBO_V3` destroys dotted children and recreates them from spec defaults whenever the parent combo is assigned, even to the same value. The #2096 wrap ran only at `graphToPrompt`. Vue/widget-store flush after `panel_set_widget` re-assigns the parent first, so query_graph already sees the default.

## Fix

Export `wrapGraphDynamicComboSetters` and install it before (and after) the write in `runSetWidget`. A same-value parent assign restores the live children. Changing the selected option still rebuilds from the new spec.

## Test

`browser_tests/unit/set-widget-2031-dynamiccombo-child.test.mjs` — after `runSetWidget`, `root.value = root.value` keeps `mode.scale=1.5` without waiting for graphToPrompt.

Fixes #2031
