### PR TITLE
fix(2257): keep Save-As identity after refresh_nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_set_widget wraps live COMFY_DYNAMICCOMBO_V3 parents before the write so a Vue/widget-store flush cannot rebuild dotted FLOAT children from spec defaults while the receipt still says applied:true; panel_query_graph then sees the value that was written (#2031)
+- A failed Save-As restore now passes `{ workflow }` to the canvas fence, so cleanup can repaint the source instead of always returning false and leaving the next graph read on a partial canvas (#2257)
 
 ## [0.15.176] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_set_widget wraps live COMFY_DYNAMICCOMBO_V3 parents before the write so a Vue/widget-store flush cannot rebuild dotted FLOAT children from spec defaults while the receipt still says applied:true; panel_query_graph then sees the value that was written (#2031)
-- A failed Save-As restore now passes `{ workflow }` to the canvas fence, so cleanup can repaint the source instead of always returning false and leaving the next graph read on a partial canvas (#2257)
+- Save-As after panel_refresh_nodes proves destination canvas identity before refusing, recaptures the active tracker (and reseals a missing root uuid) so refresh does not invalidate content identity, and a failed copy's source restore actually runs then recaptures so the next graph read is not root-shape-mismatch (#2257)
 
 ## [0.15.176] - 2026-09-05
 

--- a/browser_tests/unit/refresh-nodes-identity.test.mjs
+++ b/browser_tests/unit/refresh-nodes-identity.test.mjs
@@ -246,3 +246,13 @@ test("#2026 production refresh_nodes snapshots identity, gates the route on that
   );
   assert.match(refreshBody, /viewing: boundIdentity/);
 });
+
+test("#2257 production refresh_nodes recaptures the active tracker after a successful refresh", () => {
+  const refreshBody = refreshNodesMatch[0];
+  assert.match(
+    refreshBody,
+    /captureCanvasIntoTracker\(wf\)/,
+    "refresh must recapture content identity so the next Save-As / graph read is not root-shape-mismatch",
+  );
+  assert.match(refreshBody, /sealProvenRootBinding\(/);
+});

--- a/browser_tests/unit/save-as-canvas-disclosure.test.mjs
+++ b/browser_tests/unit/save-as-canvas-disclosure.test.mjs
@@ -78,6 +78,16 @@ test("#939 the production adapter repaints before it captures and persists the c
     /if \(!canvasFence\(\{ workflow \}\)\) return false;/,
     "#2257 restoreCanvas must pass { workflow } — the record itself always fails the fence",
   );
+  assert.match(
+    panel,
+    /destIdentityProven/,
+    "#2257 must verify destination identity before declaring a Save-As restore failure",
+  );
+  assert.match(
+    panel,
+    /captureCanvasIntoTracker\(workflow\)/,
+    "#2257 source restore must recapture the tracker after a proven canvas restore",
+  );
   assert.match(panel, /\[WORKFLOW_PATH_FIELD\]: destinationPath/);
   assert.match(panel, /loadGraphDataWithCompletionProof\(\{/);
   assert.ok(

--- a/browser_tests/unit/save-as-canvas-disclosure.test.mjs
+++ b/browser_tests/unit/save-as-canvas-disclosure.test.mjs
@@ -73,6 +73,11 @@ test("#939 the production adapter repaints before it captures and persists the c
   assert.match(panel, /const canvasFence = \(\{ workflow \} = \{\}\)/);
   assert.match(panel, /saveAsCanvasGeneration/);
   assert.match(panel, /restoreCanvas: async \(\{ workflow \}\)/);
+  assert.match(
+    panel,
+    /if \(!canvasFence\(\{ workflow \}\)\) return false;/,
+    "#2257 restoreCanvas must pass { workflow } — the record itself always fails the fence",
+  );
   assert.match(panel, /\[WORKFLOW_PATH_FIELD\]: destinationPath/);
   assert.match(panel, /loadGraphDataWithCompletionProof\(\{/);
   assert.ok(

--- a/browser_tests/unit/save-as-reconciliation-bound.test.mjs
+++ b/browser_tests/unit/save-as-reconciliation-bound.test.mjs
@@ -147,3 +147,55 @@ test('#939 a continuously changing active tab gets a bounded neutral canvas befo
     delete globalThis.app
   }
 })
+
+test('#2257 destination identity on the canvas proves Save-As even when load completion is incomplete', async () => {
+  const fn = namedFunctionSource(PANEL, 'repaintSaveAsCanvas')
+  const repaintSaveAsCanvas = new Function(`
+    const MAX_SAVE_AS_CANVAS_RECONCILIATIONS = 3
+    const WORKFLOW_META_NAMESPACE = 'comfyui_mcp'
+    const WORKFLOW_UUID_FIELD = 'workflow_uuid'
+    const WORKFLOW_PATH_FIELD = 'workflow_path'
+    const workflowStableUuid = (workflow) => workflow.uuid
+    const workflowObjectUuid = (workflow) => workflow.uuid
+    const sameWorkflowObject = (a, b) => a === b
+    const normalizedWorkflowPath = (path) => path
+    const activeWorkflowRef = () => globalThis.__cmcp2257Active
+    const liteGraphGlobal = () => null
+    const loadGraphDataWithCompletionProof = async ({ load }) => {
+      await load()
+      return { completed: false }
+    }
+    ${fn}
+    return repaintSaveAsCanvas
+  `)()
+
+  const copy = {
+    path: 'workflows/copy-after-refresh.json',
+    uuid: 'copy-after-refresh',
+    changeTracker: { activeState: { nodes: [{ id: 1, type: 'KSampler' }], extra: {} } }
+  }
+  globalThis.__cmcp2257Active = copy
+  globalThis.app = {
+    graph: { _nodes: copy.changeTracker.activeState.nodes, extra: {} },
+    canvas: null,
+    loadGraphData: async (payload) => {
+      globalThis.app.graph.extra = payload.extra
+      globalThis.app.graph._nodes = payload.nodes ?? []
+    }
+  }
+
+  try {
+    assert.equal(
+      await repaintSaveAsCanvas(copy, copy.path, {
+        canvasFence: (workflow) => globalThis.__cmcp2257Active === workflow
+      }),
+      true,
+      'destination uuid+path on the live root is the persist proof, not configure completion',
+    )
+    assert.equal(globalThis.app.graph.extra.comfyui_mcp.workflow_uuid, copy.uuid)
+    assert.equal(globalThis.app.graph.extra.comfyui_mcp.workflow_path, copy.path)
+  } finally {
+    delete globalThis.__cmcp2257Active
+    delete globalThis.app
+  }
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7727,19 +7727,27 @@ async function repaintSaveAsCanvas(copy, targetPath, { canvasFence } = {}) {
       // active workflow record and this Save-As operation's monotonic generation.
       const ownerChanged = !ownsWorkflow(workflow, "repaint-after");
       if (ownerChanged) return { ok: false, ownerChanged: true };
-      if (restore.completed !== true) return { ok: false, ownerChanged: false };
       const rootGraph = app?.graph;
       const rootMeta = rootGraph?.extra?.[WORKFLOW_META_NAMESPACE];
       const canvasIsRoot = app?.canvas?.graph == null || app.canvas.graph === rootGraph;
-      return {
-        ok:
-          ownsWorkflow(workflow, "repaint-verify") &&
-          sameWorkflowObject(activeWorkflowRef(), workflow) &&
-          canvasIsRoot &&
-          rootMeta?.[WORKFLOW_UUID_FIELD] === targetUuid &&
-          normalizedWorkflowPath(rootMeta?.[WORKFLOW_PATH_FIELD]) === normalizedWorkflowPath(destinationPath),
-        ownerChanged: false,
-      };
+      // keepInstance may restamp extra onto the live object uuid. Verify the
+      // identity that actually landed, not only the pre-load mint (#2257).
+      const attachedUuid =
+        (typeof workflowObjectUuid === "function" ? workflowObjectUuid(workflow) : null) || targetUuid;
+      const destIdentityProven =
+        ownsWorkflow(workflow, "repaint-verify") &&
+        sameWorkflowObject(activeWorkflowRef(), workflow) &&
+        canvasIsRoot &&
+        typeof attachedUuid === "string" &&
+        attachedUuid &&
+        rootMeta?.[WORKFLOW_UUID_FIELD] === attachedUuid &&
+        normalizedWorkflowPath(rootMeta?.[WORKFLOW_PATH_FIELD]) === normalizedWorkflowPath(destinationPath);
+      // Destination identity is the #939 persist gate. A node-configure miss
+      // after panel_refresh_nodes must not hide a canvas that already carries
+      // the copy's uuid and path (#2257).
+      if (destIdentityProven) return { ok: true, ownerChanged: false };
+      if (restore.completed !== true) return { ok: false, ownerChanged: false };
+      return { ok: false, ownerChanged: false };
     } catch {
       // A throw is recoverable only when the awaited load also lost ownership. If
       // the same owner remains active, preserve the existing fail-closed refusal.
@@ -7942,9 +7950,19 @@ async function programmaticSave(name) {
       // every failed Save-As then reported "source canvas restore returned false"
       // and left the next graph read on a partial canvas (#2257).
       if (!canvasFence({ workflow })) return false;
-      return repaintSaveAsCanvas(workflow, workflow.path, {
+      const restored = await repaintSaveAsCanvas(workflow, workflow.path, {
         canvasFence: (current, phase) => canvasFence({ workflow: current, phase }),
       });
+      if (restored !== true) return false;
+      // The restore already proved source identity on the canvas. Recapture the
+      // tracker in the same turn so the next graph read cannot see dest-stamped
+      // extra against a source snapshot as root-shape-mismatch (#2257).
+      try {
+        captureCanvasIntoTracker(workflow);
+      } catch {
+        /* proven restore still stands; recapture is identity bookkeeping */
+      }
+      return true;
     },
     canvasFence,
     operationFence,
@@ -14295,6 +14313,28 @@ const GRAPH_TOOL_EXECUTORS = {
         rebindLoadedPromotedMappings(app?.graph);
       } catch {
         /* mapping rebind is best-effort; the witness still recomputes on the next read */
+      }
+      // Combo reapply mutates live widgets. Recapture the active tracker and
+      // reseal a missing root uuid so the next Save-As / graph read still
+      // sees this workflow's content identity (#2257).
+      try {
+        const wf = typeof activeWorkflowRef === "function" ? activeWorkflowRef() : null;
+        if (wf) {
+          captureCanvasIntoTracker(wf);
+          const uuid =
+            (typeof workflowObjectUuid === "function" && workflowObjectUuid(wf)) ||
+            (typeof workflowStableUuid === "function" && workflowStableUuid(wf, { commit: false })) ||
+            null;
+          if (typeof uuid === "string" && uuid && typeof sealProvenRootBinding === "function") {
+            sealProvenRootBinding({
+              rootGraph: app?.graph,
+              activeWorkflow: wf,
+              activeWorkflowUuid: uuid,
+            });
+          }
+        }
+      } catch {
+        /* identity recapture must never fail a completed node-def refresh */
       }
     }
     // #981: the stale-placeholder disclosure has to survive BOTH paths. The producer

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7937,7 +7937,11 @@ async function programmaticSave(name) {
       // The adapter restores the record before calling this hook. Repaint only when
       // that record is still the active instance; a concurrent tab switch must not
       // load the source graph over the user's other canvas.
-      if (!canvasFence(workflow)) return false;
+      // canvasFence takes `{ workflow }` — passing the record itself always
+      // destructures `workflow.workflow` (undefined) and returns false, so
+      // every failed Save-As then reported "source canvas restore returned false"
+      // and left the next graph read on a partial canvas (#2257).
+      if (!canvasFence({ workflow })) return false;
       return repaintSaveAsCanvas(workflow, workflow.path, {
         canvasFence: (current, phase) => canvasFence({ workflow: current, phase }),
       });


### PR DESCRIPTION
## User-visible failure

`panel_save_workflow` Save-As after `panel_refresh_nodes` fail-closed with #939 ("the Save-As copy could not be proven active on the canvas with destination metadata"). Cleanup then said "source canvas restore returned false", and the next `panel_graph_outline` reported `root-shape-mismatch` even though node counts matched. Original file untouched; blocked creating an optimized copy.

## Root cause

1. Destination proof short-circuited on incomplete `loadGraphData` completion after a node-def refresh, without checking whether dest uuid+path had already landed on the live root.
2. `panel_refresh_nodes` mutated live widgets and did not recapture the active tracker / reseal a missing root uuid, so content identity drifted.
3. Failed-copy cleanup called `canvasFence(workflow)` instead of `canvasFence({ workflow })`, so source restore always returned false and left dest-stamped extra against the source snapshot.

## Fix

- Prove destination identity (active record + root uuid + dest path) before refusing persist. Incomplete node configure is not a veto when that identity is live. Unproven identity still fail-closes; nothing is written (#939, #226).
- Recapture the active tracker after a successful `panel_refresh_nodes`, and reseal a missing root uuid.
- Pass `{ workflow }` into the restore fence, then recapture after a proven source restore so the next graph read is not `root-shape-mismatch`.

## Test

- `browser_tests/unit/save-as-reconciliation-bound.test.mjs` — dest identity proves Save-As when completion is incomplete
- `browser_tests/unit/save-as-canvas-disclosure.test.mjs` — fence `{ workflow }` + destIdentityProven + source recapture
- `browser_tests/unit/refresh-nodes-identity.test.mjs` — refresh recaptures tracker / reseals uuid
- `browser_tests/unit/workflow-save.test.mjs` — existing #939 fail-closed cases still hold

Fixes #2257
