### PR TITLE
fix(2265): list non-path combo options in set_widget refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_widget combo refusals list the live options for generic enums (device/precision) instead of applying the private filename/path redaction to every combo (#2265)
+
 ## [0.15.178] - 2026-09-05
 
 ### Fixed

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -739,6 +739,53 @@ test("#2547: an invalid combo refusal keeps the verdict/count but never disclose
   assert.equal(node.widgets[0].value, privateOptions[0], "must not mutate on reject");
 });
 
+test("#2265: a generic enum combo refusal lists the live options so a stale guess can be corrected", () => {
+  const deviceOptions = ["cuda", "cpu", "mps"];
+  const node = {
+    id: 12,
+    type: "MinimaxH3LatentUpscaler3D",
+    widgets: [{ name: "device", options: { values: deviceOptions }, value: "cuda" }],
+  };
+
+  let refusal;
+  try {
+    applyWidgetWrite(node, "device", "auto", HOOKS);
+  } catch (err) {
+    refusal = err;
+  }
+
+  assert.ok(refusal instanceof WidgetWriteError);
+  assert.match(refusal.message, /not a valid option for combo widget "device"/);
+  assert.match(refusal.message, /holds 3 options/);
+  assert.match(refusal.message, /rejected VALUE, not an unreadable list/);
+  assert.match(refusal.message, /Valid options: "cuda", "cpu", "mps"/);
+  assert.equal(/intentionally omitted/.test(refusal.message), false);
+  assert.equal(node.widgets[0].value, "cuda", "must not mutate on reject");
+});
+
+test("#2265: a checkpoint combo still omits option values (path/model-file redaction)", () => {
+  const ckptOptions = ["private-project/v1.safetensors", "private-project/v2.ckpt"];
+  const node = {
+    id: 3,
+    type: "CheckpointLoaderSimple",
+    widgets: [{ name: "ckpt_name", options: { values: ckptOptions }, value: ckptOptions[0] }],
+  };
+
+  let refusal;
+  try {
+    applyWidgetWrite(node, "ckpt_name", "missing.safetensors", HOOKS);
+  } catch (err) {
+    refusal = err;
+  }
+
+  assert.ok(refusal instanceof WidgetWriteError);
+  assert.match(refusal.message, /holds 2 options/);
+  assert.match(refusal.message, /intentionally omitted/);
+  for (const privateValue of ckptOptions) {
+    assert.equal(refusal.message.includes(privateValue), false, `must not disclose ${privateValue}`);
+  }
+});
+
 test("combo: a numeric index is NOT reinterpreted as a dropdown position", () => {
   const node = { id: 1, type: "N", widgets: [{ name: "c", options: { values: ["alpha", "beta", "gamma"] }, value: "alpha" }] };
   assert.throws(() => applyWidgetWrite(node, "c", 1, HOOKS), WidgetWriteError);

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -763,6 +763,28 @@ test("#2265: a generic enum combo refusal lists the live options so a stale gues
   assert.equal(node.widgets[0].value, "cuda", "must not mutate on reject");
 });
 
+test("#2265: a mixed None/disabled/path combo still omits option values", () => {
+  const mixed = ["None", "disabled", "client/model.safetensors"];
+  const node = {
+    id: 4,
+    type: "OptionalLoader",
+    widgets: [{ name: "model", options: { values: mixed }, value: mixed[0] }],
+  };
+
+  let refusal;
+  try {
+    applyWidgetWrite(node, "model", "missing.safetensors", HOOKS);
+  } catch (err) {
+    refusal = err;
+  }
+
+  assert.ok(refusal instanceof WidgetWriteError);
+  assert.match(refusal.message, /holds 3 options/);
+  assert.match(refusal.message, /intentionally omitted/);
+  assert.equal(refusal.message.includes("client/model.safetensors"), false);
+  assert.equal(/Valid options:/.test(refusal.message), false);
+});
+
 test("#2265: a checkpoint combo still omits option values (path/model-file redaction)", () => {
   const ckptOptions = ["private-project/v1.safetensors", "private-project/v2.ckpt"];
   const node = {

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -79,6 +79,15 @@ export function optionsLookLikeFiles(options) {
   return strings.filter((s) => FILE_LIKE.test(s)).length * 2 >= strings.length;
 }
 
+/** True when any string option looks like a file path. Diagnostics that print
+ *  option values must use this, not majority `optionsLookLikeFiles` — a mixed
+ *  list like `None`/`disabled`/`client/model.safetensors` is not majority-file
+ *  but still contains a private path (#2265 Copilot). */
+export function optionsIncludeFileLike(options) {
+  if (!Array.isArray(options) || options.length === 0) return false;
+  return options.some((o) => typeof o === "string" && FILE_LIKE.test(o));
+}
+
 /**
  * Pull a class's combo inputs out of an /object_info/<class> body.
  *

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -9,6 +9,7 @@ import {
   boundPropertyState,
   boundPropertyUnverifiedNote,
 } from "./widget-bound-property.js";
+import { optionsLookLikeFiles } from "./live-combo-availability.js";
 
 // #976: captured at module load so invoking a widget's callback cannot read any
 // property off the callback itself (a poisoned `.call` getter or a Proxy trap would
@@ -218,6 +219,44 @@ export function readComboOptions(widget) {
  */
 export function comboOptions(widget) {
   return readComboOptions(widget).options;
+}
+
+/**
+ * #2265 / #2547 — the diagnostic half of an off-list combo refusal.
+ *
+ * #2547 omitted every option value because a LoadImage/checkpoint list can name
+ * private files. That rule was applied to EVERY combo, so a 3-value `device`
+ * enum refused "auto" while naming the count and none of the choices. Redact
+ * only when the live list looks like files on disk (same majority-extension
+ * rule as `optionsLookLikeFiles`); generic enums (device/precision/sampler)
+ * list the values so a stale guess can be corrected.
+ */
+function describeOffListCombo(name, value, options) {
+  const count = options.length;
+  const head =
+    `Value ${JSON.stringify(value)} is not a valid option for combo widget ` +
+    `"${name}". Its option list WAS read successfully and holds ${count} ` +
+    `option${count === 1 ? "" : "s"}, none of them this value — so this is a ` +
+    `rejected VALUE, not an unreadable list. `;
+  if (optionsLookLikeFiles(options)) {
+    return (
+      head +
+      `The valid option values are intentionally omitted from this diagnostic because ` +
+      `combo values may contain private filenames or paths. Choose a value from the ` +
+      `widget's current dropdown (refreshing its options first if needed) and retry.`
+    );
+  }
+  let listed = null;
+  try {
+    listed = options.map((o) => JSON.stringify(o)).join(", ");
+  } catch {
+    // unknown-ok: a hostile option must not replace the off-list refusal
+    listed = null;
+  }
+  if (!listed) {
+    return head + `Choose a value from the widget's current dropdown and retry.`;
+  }
+  return head + `Valid options: ${listed}.`;
 }
 
 /** #1126 — the human-readable half of a `readComboOptions` UNREADABLE outcome. */
@@ -1550,16 +1589,7 @@ export function coerceWidgetValue(
     // installed is caught here instead of failing 40 seconds into a run. The message says
     // which of the two happened, so an agent can tell "your value is wrong" apart from
     // "the panel could not look" and stop treating them as the same failure.
-    throw new WidgetWriteError(
-      `Value ${JSON.stringify(value)} is not a valid option for combo widget ` +
-        `"${name}". Its option list WAS read successfully and holds ${options.length} ` +
-        `option${options.length === 1 ? "" : "s"}, none of them this value — so this is a ` +
-        `rejected VALUE, not an unreadable list. The valid option values are intentionally ` +
-        `omitted from this diagnostic because combo values may contain private filenames ` +
-        `or paths. Choose a value from the widget's current dropdown (refreshing its ` +
-        `options first if needed) and retry.`,
-      { combo: true },
-    );
+    throw new WidgetWriteError(describeOffListCombo(name, value, options), { combo: true });
   }
 
   if (isNumericWidget(widget)) {

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -9,7 +9,7 @@ import {
   boundPropertyState,
   boundPropertyUnverifiedNote,
 } from "./widget-bound-property.js";
-import { optionsLookLikeFiles } from "./live-combo-availability.js";
+import { optionsIncludeFileLike } from "./live-combo-availability.js";
 
 // #976: captured at module load so invoking a widget's callback cannot read any
 // property off the callback itself (a poisoned `.call` getter or a Proxy trap would
@@ -227,9 +227,10 @@ export function comboOptions(widget) {
  * #2547 omitted every option value because a LoadImage/checkpoint list can name
  * private files. That rule was applied to EVERY combo, so a 3-value `device`
  * enum refused "auto" while naming the count and none of the choices. Redact
- * only when the live list looks like files on disk (same majority-extension
- * rule as `optionsLookLikeFiles`); generic enums (device/precision/sampler)
- * list the values so a stale guess can be corrected.
+ * only when ANY live option looks like a file (`optionsIncludeFileLike`);
+ * generic enums (device/precision/sampler) list the values so a stale guess
+ * can be corrected. Majority `optionsLookLikeFiles` is the missing-asset
+ * classifier, not a privacy gate — mixed None/disabled/path lists still leak.
  */
 function describeOffListCombo(name, value, options) {
   const count = options.length;
@@ -238,7 +239,7 @@ function describeOffListCombo(name, value, options) {
     `"${name}". Its option list WAS read successfully and holds ${count} ` +
     `option${count === 1 ? "" : "s"}, none of them this value — so this is a ` +
     `rejected VALUE, not an unreadable list. `;
-  if (optionsLookLikeFiles(options)) {
+  if (optionsIncludeFileLike(options)) {
     return (
       head +
       `The valid option values are intentionally omitted from this diagnostic because ` +


### PR DESCRIPTION
## User-visible failure

`panel_set_widget` rejected a stale `MinimaxH3LatentUpscaler3D` `device` value and confirmed the live list had 3 options, then omitted every choice because it applied the private filename/path redaction to a generic enum.

## Root cause

#2547 omitted combo option values from off-list refusals so LoadImage/checkpoint lists would not leak private paths. That redaction ran for every combo, including `device` / `precision` / sampler enums, so an agent could not correct a stale guess.

## Fix

Off-list combo diagnostics still refuse the write and still report the count. Option values are omitted only when the live list looks like files on disk (`optionsLookLikeFiles`). Generic enums include `Valid options: …` so the next write can pick a real choice.

## Test

- `browser_tests/unit/widget-write.test.mjs` — `#2265` lists `device` options; checkpoint/LoadImage refusals still omit private paths (`#2547`)

Fixes #2265
