### PR TITLE
fix: resolve Autogrow display-label aliases in panel_connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_connect accepts an Autogrow display-label alias (`ref_image_0` → `ref_images.ref_image_0`) instead of refusing with a false "no input accepts type IMAGE"; the resolved live slot name still feeds #2008 dotted-name reconcile, and an unmatched name reports internal slot names rather than blaming the origin type (#2266)
+
 ## [0.15.179] - 2026-09-05
 
 ### Fixed
 - panel_set_widget combo refusals list the live options for generic enums (device/precision) instead of applying the private filename/path redaction to every combo (#2265, #2271)
-
 
 ## [0.15.178] - 2026-09-05
 

--- a/browser_tests/unit/connect-dynamic-prefix.test.mjs
+++ b/browser_tests/unit/connect-dynamic-prefix.test.mjs
@@ -67,6 +67,7 @@ import {
   findSlotIndexByName,
   reconcileDynamicPrefixSlots,
 } from "../../web/js/lib/dynamic-slot-reconcile.js";
+import { resolveExplicitSlot } from "../../web/js/lib/connect-match.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -96,9 +97,9 @@ function resolveSlot(slots, ref, kind) {
     if (ref < 0 || ref >= list.length) throw new Error(`no ${kind} slot ${ref}`);
     return ref;
   }
-  const i = list.findIndex((s) => s?.name === ref);
-  if (i === -1) throw new Error(`no ${kind} named ${ref}`);
-  return i;
+  const resolved = resolveExplicitSlot(list, ref);
+  if (Number.isInteger(resolved?.index)) return resolved.index;
+  throw new Error(`no ${kind} named ${ref}`);
 }
 
 const railIntent = () => null;
@@ -371,6 +372,25 @@ test("#2008 dotted-name helper is the Autogrow child shape, not positional packs
   assert.equal(isDynamicPrefixSlotName("input3"), false);
   assert.equal(isDynamicPrefixSlotName("prompt"), false);
   assert.equal(isDynamicPrefixSlotName(null), false);
+});
+
+test("#2266: Autogrow display alias still runs #2008 dotted-name reconcile", () => {
+  const { graph, mm } = minimaxFixture({ mode: "rebuild" });
+  const videoLink = nameLink(mm, "ref_videos.ref_video_0");
+  const audioLink = nameLink(mm, "ref_audios.ref_audio_0");
+  const graph_connect = buildConnect(graph);
+
+  const res = graph_connect({
+    from_node_id: 1,
+    from_output: 0,
+    to_node_id: 136,
+    to_input: "ref_image_4",
+  });
+
+  assert.equal(res.connected.to.input, "ref_images.ref_image_4");
+  assert.ok(nameLink(mm, "ref_images.ref_image_4") != null);
+  assert.equal(nameLink(mm, "ref_videos.ref_video_0"), videoLink, "alias must not skip Autogrow restore");
+  assert.equal(nameLink(mm, "ref_audios.ref_audio_0"), audioLink);
 });
 
 test("#2008 INSERT: connecting to ref_images.ref_image_4 keeps later names and stays silent", () => {

--- a/browser_tests/unit/connect-match.test.mjs
+++ b/browser_tests/unit/connect-match.test.mjs
@@ -26,6 +26,7 @@ import {
   isTypeCompatible,
   isWildcardSlotType,
   slotDiagnostic,
+  slotDisplayAlias,
   loopbackRefusalReason,
   unresolvedWildcardPairReason,
 } from "../../web/js/lib/connect-match.js";
@@ -507,4 +508,123 @@ test("#2028: with the reason override the diagnostic KEEPS the slot listing but 
   assert.doesNotMatch(msg, /No input on node 790 accepts type/);
   assert.match(msg, /unresolved wildcard-to-wildcard/);
   assert.match(msg, /INTConstant/);
+});
+
+// ---- #2266: Autogrow display-label alias resolves before type matching ------
+//
+// Reported: panel_connect IMAGE → MiniMaxH3ReferenceToVideo with
+// to_input "ref_image_0" (the canvas display label) was refused with
+// "No input on node N accepts type IMAGE" while the listing showed
+// [n] "ref_images.ref_image_0" (IMAGE). The full internal name worked.
+// A name-miss fell through to type-name matching, found zero slots typed
+// "ref_image_0", and blamed the origin IMAGE type. Unique display aliases
+// (label / localized_name / dotted suffix) now resolve first.
+
+function loadImageNode() {
+  return { id: 7, type: "LoadImage", outputs: [{ name: "IMAGE", type: "IMAGE" }] };
+}
+
+function miniMaxH3RefNode(extra = {}) {
+  return {
+    id: 12,
+    type: "MiniMaxH3ReferenceToVideo",
+    inputs: [
+      { name: "clip", type: "CLIP", link: null },
+      { name: "prompt", type: "STRING", link: null },
+      { name: "ref_images.ref_image_0", type: "IMAGE", link: null, ...extra },
+      { name: "ref_images.ref_image_1", type: "IMAGE", link: null },
+      { name: "ref_videos.ref_video_0", type: "IMAGE", link: null },
+    ],
+  };
+}
+
+test("#2266: slotDisplayAlias prefers label, then localized_name, then dotted suffix", () => {
+  assert.equal(
+    slotDisplayAlias({ name: "ref_images.ref_image_0", label: "first ref" }),
+    "first ref",
+  );
+  assert.equal(
+    slotDisplayAlias({ name: "ref_images.ref_image_0", localized_name: "ref_image_0" }),
+    "ref_image_0",
+  );
+  assert.equal(slotDisplayAlias({ name: "ref_images.ref_image_0" }), "ref_image_0");
+  assert.equal(slotDisplayAlias({ name: "prompt" }), null);
+  assert.equal(slotDisplayAlias({ name: "seed", label: "seed" }), null);
+});
+
+test("#2266: resolveExplicitSlot matches the Autogrow dotted suffix as a unique alias", () => {
+  const inputs = miniMaxH3RefNode().inputs;
+  assert.deepEqual(resolveExplicitSlot(inputs, "ref_image_0"), { index: 2 });
+  assert.deepEqual(resolveExplicitSlot(inputs, "ref_images.ref_image_0"), { index: 2 });
+  assert.deepEqual(resolveExplicitSlot(inputs, "ref_video_0"), { index: 4 });
+});
+
+test("#2266: a slot.label unique on the node is an address", () => {
+  const inputs = miniMaxH3RefNode({ label: "hero" }).inputs;
+  assert.deepEqual(resolveExplicitSlot(inputs, "hero"), { index: 2 });
+});
+
+test("#2266: localized_name unique on the node is an address", () => {
+  const inputs = miniMaxH3RefNode({ localized_name: "picture 1" }).inputs;
+  assert.deepEqual(resolveExplicitSlot(inputs, "picture 1"), { index: 2 });
+});
+
+test("#2266: the reported call (IMAGE → to_input ref_image_0) now connects", () => {
+  const m = autoMatchSlots(loadImageNode(), miniMaxH3RefNode(), "IMAGE", "ref_image_0");
+  assert.equal(m.outIdx, 0);
+  assert.equal(m.inIdx, 2);
+  assert.deepEqual(m.autoMatched, []);
+});
+
+test("#2266: the full dotted internal name still connects", () => {
+  const m = autoMatchSlots(loadImageNode(), miniMaxH3RefNode(), "IMAGE", "ref_images.ref_image_0");
+  assert.equal(m.inIdx, 2);
+});
+
+test("#2266: an exact NAME still outranks a sibling's display alias of the same token", () => {
+  const target = {
+    id: 2,
+    inputs: [
+      { name: "ref_image_0", type: "MASK", link: null },
+      { name: "ref_images.ref_image_0", type: "IMAGE", link: null },
+    ],
+  };
+  assert.deepEqual(resolveExplicitSlot(target.inputs, "ref_image_0"), { index: 0 });
+});
+
+test("#2266: two slots sharing a display alias are refused, not guessed", () => {
+  const origin = loadImageNode();
+  const target = {
+    id: 2,
+    type: "T",
+    inputs: [
+      { name: "a.foo", type: "IMAGE", link: null },
+      { name: "b.foo", type: "IMAGE", link: null },
+    ],
+  };
+  assert.throws(
+    () => autoMatchSlots(origin, target, "IMAGE", "foo"),
+    /ambiguous.*display alias "foo".*a\.foo.*b\.foo/is,
+  );
+});
+
+test("#2266: a leftover name miss no longer claims the IMAGE slot is missing", () => {
+  assert.throws(
+    () => autoMatchSlots(loadImageNode(), miniMaxH3RefNode(), "IMAGE", "ref_image_99"),
+    (err) => {
+      const msg = String(err?.message ?? err);
+      assert.match(msg, /No input named "ref_image_99"/);
+      assert.match(msg, /ref_images\.ref_image_0/);
+      assert.doesNotMatch(msg, /No input on node 12 accepts type IMAGE/);
+      return true;
+    },
+  );
+});
+
+test("#2266: slotDiagnostic lists the Autogrow display alias next to the internal name", () => {
+  const msg = slotDiagnostic(loadImageNode(), miniMaxH3RefNode(), {
+    from_output: "IMAGE",
+    to_input: "ref_image_99",
+  });
+  assert.match(msg, /"ref_images\.ref_image_0" as "ref_image_0"/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17574,8 +17574,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // name; an onConnectionsChange insert that shifts later families must not
     // steal those names' links or report them as rewrites.
     const namedSlotsBefore = captureNamedSlotLinks(target);
+    // Prefer the live programmatic name so an Autogrow display alias
+    // (`ref_image_0`) still feeds #2008 dotted-name reconcile
+    // (`ref_images.ref_image_0`). Raw to_input is only the fallback when the
+    // resolved slot has no name.
     const requestedSlotName =
-      typeof to_input === "string" ? to_input : target.inputs?.[inIdx]?.name ?? null;
+      target.inputs?.[inIdx]?.name ??
+      (typeof to_input === "string" ? to_input : null);
     const inputNamesBefore = snapshotInputSlotNames(graph);
     // #2380 — the whole-graph state, captured BEFORE the wire is made. Every other
     // check on this path is scoped to the two endpoints the command NAMED, so a

--- a/web/js/lib/connect-match.js
+++ b/web/js/lib/connect-match.js
@@ -20,6 +20,14 @@
 //          unresolvedWildcardPairReason replaces the computed
 //          "no input accepts type *" tail and tells the caller to land a
 //          concrete typed producer first.
+//   #2266 — to_input "ref_image_0" on MiniMaxH3ReferenceToVideo is the
+//          Autogrow DISPLAY alias of the dotted slot "ref_images.ref_image_0".
+//          A name-miss used to fall through to type-name matching, find zero
+//          slots typed "ref_image_0", and throw "no input accepts type IMAGE"
+//          while the listing already showed the IMAGE slot. Resolve a unique
+//          display alias (label / localized_name / dotted suffix) BEFORE the
+//          type-name pass; an ambiguous alias is refused with the internal
+//          names rather than guessed.
 
 export const SLOT_RANK_EXACT = 2;
 export const SLOT_RANK_WILD = 1;
@@ -130,8 +138,12 @@ function asIndexToken(ref) {
 export function slotDiagnostic(origin, target, requested = {}) {
   const refLabel = (ref) =>
     ref == null ? "auto" : typeof ref === "string" ? `"${ref}"` : String(ref);
+  const formatSlotName = (slot) => {
+    const alias = slotDisplayAlias(slot);
+    return alias ? `"${slot?.name ?? ""}" as "${alias}"` : `"${slot?.name ?? ""}"`;
+  };
   const outs = (origin.outputs ?? [])
-    .map((o, i) => `[${i}] "${o?.name ?? ""}" (${renderSlotType(o?.type)})`)
+    .map((o, i) => `[${i}] ${formatSlotName(o)} (${renderSlotType(o?.type)})`)
     .join(", ");
   const ins = (target.inputs ?? [])
     .map((inp, i) => {
@@ -139,7 +151,7 @@ export function slotDiagnostic(origin, target, requested = {}) {
         ? `${baseSlotType(inp?.type)}/widget`
         : renderSlotType(inp?.type);
       const connected = inp?.link != null ? " [connected]" : "";
-      return `[${i}] "${inp?.name ?? ""}" (${typeStr})${connected}`;
+      return `[${i}] ${formatSlotName(inp)} (${typeStr})${connected}`;
     })
     .join(", ");
 
@@ -240,11 +252,87 @@ export function unresolvedWildcardPairReason(origin, target, outIdx, inIdx) {
   );
 }
 
+/** Distinct display alias a slot carries, or null.
+ *  Order: `label`, then `localized_name`, then the suffix after the last `.`
+ *  on a dotted Autogrow name (`ref_images.ref_image_0` → `ref_image_0`).
+ *  A token identical to the programmatic name is not an alias. */
+export function slotDisplayAlias(slot) {
+  const name = typeof slot?.name === "string" ? slot.name.trim() : "";
+  const candidates = [slot?.label, slot?.localized_name];
+  if (name.includes(".")) candidates.push(name.slice(name.lastIndexOf(".") + 1));
+  for (const raw of candidates) {
+    if (typeof raw !== "string") continue;
+    const token = raw.trim();
+    if (token && token !== name) return token;
+  }
+  return null;
+}
+
+/** Lowercased distinct aliases a slot can be addressed by (not including `name`). */
+function slotAliasTokens(slot) {
+  const tokens = [];
+  const seen = new Set();
+  const add = (raw) => {
+    if (typeof raw !== "string") return;
+    const token = raw.trim().toLowerCase();
+    if (!token || seen.has(token)) return;
+    seen.add(token);
+    tokens.push(token);
+  };
+  const name = typeof slot?.name === "string" ? slot.name.trim() : "";
+  add(slot?.label);
+  add(slot?.localized_name);
+  if (name.includes(".")) add(name.slice(name.lastIndexOf(".") + 1));
+  // The programmatic name is already handled by the exact-name pass; drop it
+  // so a redundant `label === name` cannot double-count this slot as an alias.
+  const nameLower = name.toLowerCase();
+  return tokens.filter((t) => t !== nameLower);
+}
+
+/** Resolve `ref` against unique display aliases. Returns { index },
+ *  { error: "ambiguous", names } when several slots share it, or null when
+ *  none do. Called only after an exact NAME miss. */
+function resolveDisplayAliasSlot(slots, ref) {
+  if (ref == null || typeof ref === "number") return null;
+  const want = String(ref).trim().toLowerCase();
+  if (!want) return null;
+  const list = slots ?? [];
+  const hits = [];
+  list.forEach((s, i) => {
+    if (slotAliasTokens(s).includes(want)) hits.push(i);
+  });
+  if (hits.length === 1) return { index: hits[0] };
+  if (hits.length > 1) {
+    const names = hits.map((i) => list[i]?.name).filter(Boolean);
+    return { error: "ambiguous", names };
+  }
+  return null;
+}
+
+function unresolvedNameReason(slots, ref, side) {
+  const list = slots ?? [];
+  const names = list.map((s) => s?.name).filter(Boolean);
+  const aliasHints = [];
+  for (const s of list) {
+    const alias = slotDisplayAlias(s);
+    if (alias && s?.name) aliasHints.push(`"${alias}" → ${s.name}`);
+  }
+  return (
+    `No ${side} named "${ref}"` +
+    (aliasHints.length ? `; display aliases: ${aliasHints.join(", ")}` : "") +
+    `. Use a slot name or index` +
+    (names.length ? ` (available: ${names.join(", ")})` : "") +
+    "."
+  );
+}
+
 /** Resolve one explicit slot ref to an index, or null when omitted (auto).
  *  A bare integer token (real number OR numeric string such as "0") is an INDEX
  *  and is range-checked; any other string is a case-insensitive/trimmed NAME
- *  lookup with NO silent fallback. Returns
- *  { index } | { error: "range"|"name" } | null (omitted). */
+ *  lookup with NO silent fallback. A unique display alias (label /
+ *  localized_name / Autogrow dotted suffix) is accepted after a name miss and
+ *  the numeric-string index fallback (#2266). Returns
+ *  { index } | { error: "range"|"name"|"ambiguous", names? } | null (omitted). */
 export function resolveExplicitSlot(slots, ref) {
   if (ref == null) return null;
   const list = slots ?? [];
@@ -268,6 +356,10 @@ export function resolveExplicitSlot(slots, ref) {
     if (idxToken < 0 || idxToken >= list.length) return { error: "range" };
     return { index: idxToken };
   }
+  // #2266: unique display alias AFTER name and numeric-index, BEFORE the type-name
+  // pass in autoMatchSlots, so "ref_image_0" is not read as a TYPE.
+  const byAlias = resolveDisplayAliasSlot(list, ref);
+  if (byAlias) return byAlias;
   return { error: "name" };
 }
 
@@ -324,7 +416,17 @@ export function typeMatchedIndices(slots, ref) {
 function resolveTypeRef(slots, ref, origin, target, requested, side) {
   const ti = typeMatchedIndices(slots, ref);
   if (ti.length === 1) return { index: ti[0] };
-  if (ti.length === 0) throw new Error(slotDiagnostic(origin, target, requested));
+  if (ti.length === 0) {
+    // #2266 — a leftover NAME miss is not a type incompatibility. The computed
+    // "no input accepts type IMAGE" tail is what made `to_input:"ref_image_0"`
+    // look like the IMAGE autogrow slot was missing when it was listed.
+    throw new Error(
+      slotDiagnostic(origin, target, {
+        ...requested,
+        reason: unresolvedNameReason(slots, ref, side),
+      }),
+    );
+  }
   const names = ti.map((i) => slots[i]?.name).filter(Boolean);
   const reason =
     `ambiguous: ${ti.length} ${renderSlotType(slots[ti[0]]?.type)} ${side}s` +
@@ -348,6 +450,20 @@ export function autoMatchSlots(origin, target, fromRef, toRef) {
     throw new Error(`output slot index ${fromRef} out of range (node has ${outputs.length})`);
   if (inp?.error === "range")
     throw new Error(`input slot index ${toRef} out of range (node has ${inputs.length})`);
+  if (out?.error === "ambiguous") {
+    const names = out.names ?? [];
+    const reason =
+      `ambiguous: ${names.length} outputs share display alias "${fromRef}"` +
+      `${names.length ? ` (${names.join(", ")})` : ""} — name one by slot name or index`;
+    throw new Error(slotDiagnostic(origin, target, { ...requested, reason }));
+  }
+  if (inp?.error === "ambiguous") {
+    const names = inp.names ?? [];
+    const reason =
+      `ambiguous: ${names.length} inputs share display alias "${toRef}"` +
+      `${names.length ? ` (${names.join(", ")})` : ""} — name one by slot name or index`;
+    throw new Error(slotDiagnostic(origin, target, { ...requested, reason }));
+  }
 
   // #406: a string ref that matched no slot NAME may instead name a slot's TYPE —
   // the caller addressed the port by its displayed type ("IMAGE") rather than its


### PR DESCRIPTION
Fixes #2266.

## Root cause

`panel_connect` resolves `to_input` by exact slot name, then treats a miss as a **type name**. Autogrow children on MiniMaxH3ReferenceToVideo are internally `ref_images.ref_image_0` while the canvas display alias is `ref_image_0`. That alias matched no name and no type, so the diagnostic blamed the origin (`No input on node N accepts type IMAGE`) even though the listing already showed the IMAGE slot. The dotted internal name worked.

## Fix

In shipped `autoMatchSlots` / `resolveExplicitSlot` (`web/js/lib/connect-match.js`):

- After name and numeric-index lookup, resolve a **unique** display alias: `label`, `localized_name`, or the suffix after the last `.` on a dotted Autogrow name.
- Several slots sharing the alias are refused with the internal names (no guess).
- A leftover name miss reports available internal names / aliases instead of a false type incompatibility.
- Failure listings now show `"ref_images.ref_image_0" as "ref_image_0"`.

## Tests

`browser_tests/unit/connect-match.test.mjs` drives the shipped matchers (the reported `IMAGE` → `to_input: "ref_image_0"` call, dotted name, label, localized_name, ambiguous alias, leftover miss).

`npm run test:unit`: 8391 pass, 0 fail, 1 todo.
