### PR TITLE
fix(2263): refuse panel_get_errors leftover node ids after a switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_connect accepts an Autogrow display-label alias (`ref_image_0` → `ref_images.ref_image_0`) instead of refusing with a false "no input accepts type IMAGE"; the resolved live slot name still feeds #2008 dotted-name reconcile, and an unmatched name reports internal slot names rather than blaming the origin type (#2266)
+- panel_get_errors no longer reports previous-workflow node ids after a switch: a live combo scan whose ids are gone from the bound graph is refused as an instance mismatch rather than listing leftover ids (5599/5603), and load-time missing node types that do not appear on the live graph are dropped (#2263)
 
 ## [0.15.179] - 2026-09-05
 
@@ -18,7 +19,6 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - fetch_image no longer sends `/view` through ComfyUI `api.fetchApi`, which prefixes `/api` so local media became `/api/view` and failed with `Failed to fetch` after headless ECONNREFUSED. `/view` uses origin-validated `fileURL` + same-origin fetch (and `Comfy-User` when the API object has a user). History / system_stats keep `fetchApi` so cloud auth headers and 401 remint stay intact (comfyui-mcp#2884, #2261)
-
 
 ## [0.15.177] - 2026-09-05
 

--- a/browser_tests/unit/_graph-get-errors-harness.mjs
+++ b/browser_tests/unit/_graph-get-errors-harness.mjs
@@ -6,7 +6,9 @@ import {
   combineNodeErrorMaps,
   findNodeByScopedId,
   findVisibleNodeByScopedId,
+  graphGetErrorsLiveScanStale,
   pruneContradictedNodeErrorMaps,
+  recordedMissingTypesOnLiveGraph,
 } from "../../web/js/lib/asset-staleness.js";
 import { applyRuntimeExecFailure, boundExecFailurePayload } from "../../web/js/lib/exec-error-bounds.js";
 import { createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
@@ -68,8 +70,10 @@ const GRAPH_GET_ERRORS_DEPS = [
   "fetchSingleNodeInfo",
   "probeInputAssetPresence",
   "graphReadBindingChanged",
+  "graphGetErrorsLiveScanStale",
   "collectAllGraphs",
   "adjudicateRecordedMissingNodeTypes",
+  "recordedMissingTypesOnLiveGraph",
   "isRegisteredNodeType",
   "LiteGraph",
   "findVisibleNodeByScopedId",
@@ -124,6 +128,13 @@ export async function runProductionGraphGetErrors({
   objectInfoCache = createObjectInfoCache(),
   objectInfoSnapshot = createObjectInfoSnapshot(),
   verifiedNodeDefCache = createVerifiedNodeDefCache(),
+  collectAllGraphs = (value) => [value],
+  graphReadBindingChanged = () => false,
+  activeWorkflowRef = () => null,
+  graphGetErrorsLiveScanStale: graphGetErrorsLiveScanStaleOverride,
+  recordedMissingTypesOnLiveGraph: recordedMissingTypesOnLiveGraphOverride,
+  adjudicateRecordedMissingNodeTypes = (types) => ({ stillMissing: types, stalePlaceholders: [] }),
+  collectMissingNodeTypeReasons = () => [],
 }) {
   const deps = {
     monotonicNow,
@@ -142,16 +153,20 @@ export async function runProductionGraphGetErrors({
     assertGraphBoundToActiveWorkflow: () => {},
     graphCommandBindingBar: () => ({}),
     collectMissingAssets,
-    activeWorkflowRef: () => null,
+    activeWorkflowRef,
     GET_ERRORS_STEP_CAP_MS: 4000,
     filterServerConfirmedInputSubfolderMedia,
     inputAssetServerUsesWindowsPaths,
     scanComboAvailability: scan,
     fetchSingleNodeInfo,
     probeInputAssetPresence: () => {},
-    graphReadBindingChanged: () => false,
-    collectAllGraphs: (value) => [value],
-    adjudicateRecordedMissingNodeTypes: (types) => ({ stillMissing: types, stalePlaceholders: [] }),
+    graphReadBindingChanged,
+    graphGetErrorsLiveScanStale:
+      graphGetErrorsLiveScanStaleOverride ?? graphGetErrorsLiveScanStale,
+    collectAllGraphs,
+    adjudicateRecordedMissingNodeTypes,
+    recordedMissingTypesOnLiveGraph:
+      recordedMissingTypesOnLiveGraphOverride ?? recordedMissingTypesOnLiveGraph,
     isRegisteredNodeType: () => false,
     LiteGraph: {},
     findVisibleNodeByScopedId,
@@ -176,7 +191,7 @@ export async function runProductionGraphGetErrors({
     uncheckedNodesNote: () => "unchecked",
     stalePlaceholderNote: () => "placeholder",
     boundExecFailurePayload,
-    collectMissingNodeTypeReasons: () => [],
+    collectMissingNodeTypeReasons,
   };
   const executor = makeGraphGetErrors(...GRAPH_GET_ERRORS_DEPS.map((name) => deps[name]));
   return executor();

--- a/browser_tests/unit/_validation-banner-harness.mjs
+++ b/browser_tests/unit/_validation-banner-harness.mjs
@@ -7,7 +7,10 @@
 // function body, run with injected dependencies, so a test observes what SHIPS rather
 // than a re-implementation of it.
 import { PANEL_SRC } from "./_panel-constants.mjs";
-import { pruneContradictedNodeErrorMaps } from "../../web/js/lib/asset-staleness.js";
+import {
+  pruneContradictedNodeErrorMaps,
+  recordedMissingTypesOnLiveGraph,
+} from "../../web/js/lib/asset-staleness.js";
 
 function extractFunctionBody(source, signature) {
   const start = source.indexOf(signature);
@@ -61,6 +64,7 @@ const VALIDATION_BANNER_DEPS = [
   "filterServerConfirmedInputSubfolderMedia",
   "collectAllGraphs",
   "adjudicateRecordedMissingNodeTypes",
+  "recordedMissingTypesOnLiveGraph",
   "isRegisteredNodeType",
   "LiteGraph",
   "coerceMessageText",
@@ -103,6 +107,7 @@ export async function runProductionValidationBanner({
     filterServerConfirmedInputSubfolderMedia: async (media) => media,
     collectAllGraphs: (value) => [value],
     adjudicateRecordedMissingNodeTypes: (types) => ({ stillMissing: types, stalePlaceholders: [] }),
+    recordedMissingTypesOnLiveGraph,
     isRegisteredNodeType: () => false,
     LiteGraph: {},
     coerceMessageText: (value) => String(value ?? ""),

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -26,6 +26,9 @@ import {
   isWidgetInputSpec,
   reconcileUnknownWidgetNames,
   collectAllGraphs,
+  liveGraphNodeIdSet,
+  graphGetErrorsLiveScanStale,
+  recordedMissingTypesOnLiveGraph,
   reapplyDefsToLiveNodes,
   comboRebuildCovered,
   authoritativeComboValues,
@@ -713,6 +716,89 @@ test("collectAllGraphs walks nested subgraphs", () => {
   const graphs = collectAllGraphs(root);
   assert.ok(graphs.includes(root));
   assert.ok(graphs.includes(innerGraph));
+});
+
+test("#2263 liveGraphNodeIdSet includes nested subgraph ids", () => {
+  const inner = { id: 5603, widgets: [] };
+  const innerGraph = graphOf([inner]);
+  const host = { id: 12, subgraph: innerGraph };
+  const ids = liveGraphNodeIdSet(graphOf([host]));
+  assert.equal(ids.has("12"), true);
+  assert.equal(ids.has("5603"), true);
+});
+
+test("#2263 graphGetErrorsLiveScanStale: FALSE when scanned ids are still on the live graph", () => {
+  const n = { id: 12, type: "LoadImage", widgets: [] };
+  const graph = graphOf([n]);
+  assert.equal(
+    graphGetErrorsLiveScanStale({
+      scannedNodes: [n],
+      liveRootGraph: graph,
+      liveScan: { unknown: [{ id: 12, type: "LoadImage", reason: "node type not found in /object_info" }] },
+    }),
+    false,
+  );
+});
+
+test("#2263 graphGetErrorsLiveScanStale: TRUE after an in-place load replaces the node set", () => {
+  const previous = [
+    { id: 5599, type: "H3AdaLNLoRAFix", widgets: [] },
+    { id: 5603, type: "H3SLAAttention", widgets: [] },
+  ];
+  const live = graphOf([{ id: 1, type: "LoadImage", widgets: [] }]);
+  assert.equal(
+    graphGetErrorsLiveScanStale({
+      scannedNodes: previous,
+      liveRootGraph: live,
+      liveScan: {
+        unknown: [
+          { id: 5599, type: "H3AdaLNLoRAFix", reason: "node type not found in /object_info" },
+          { id: 5603, type: "H3SLAAttention", reason: "node type not found in /object_info" },
+        ],
+      },
+    }),
+    true,
+  );
+});
+
+test("#2263 graphGetErrorsLiveScanStale: TRUE when the live root is unreadable", () => {
+  assert.equal(
+    graphGetErrorsLiveScanStale({
+      scannedNodes: [{ id: 1 }],
+      liveRootGraph: null,
+      liveScan: { unknown: [{ id: 1 }] },
+    }),
+    true,
+  );
+});
+
+test("#2263 graphGetErrorsLiveScanStale: FALSE for nested inner ids of the CURRENT root", () => {
+  const inner = { id: 5599, type: "H3AdaLNLoRAFix", widgets: [] };
+  const host = { id: 12, type: "MiniMaxH3", subgraph: graphOf([inner]), widgets: [] };
+  const root = graphOf([host]);
+  assert.equal(
+    graphGetErrorsLiveScanStale({
+      scannedNodes: [host, inner],
+      liveRootGraph: root,
+      liveScan: { unknown: [{ id: 5599, type: "H3AdaLNLoRAFix", reason: "node type not found in /object_info" }] },
+    }),
+    false,
+  );
+});
+
+test("#2263 recordedMissingTypesOnLiveGraph drops previous-tab types absent from the live graph", () => {
+  const nodes = [{ id: 1, type: "LoadImage" }, { id: 2, type: "KSampler" }];
+  assert.deepEqual(
+    recordedMissingTypesOnLiveGraph(["H3AdaLNLoRAFix", "H3SLAAttention", "LoadImage"], nodes),
+    ["LoadImage"],
+  );
+});
+
+test("#2263 recordedMissingTypesOnLiveGraph fails open on an empty live type set", () => {
+  assert.deepEqual(
+    recordedMissingTypesOnLiveGraph(["H3AdaLNLoRAFix"], []),
+    ["H3AdaLNLoRAFix"],
+  );
 });
 
 test("reapplyDefsToLiveNodes repairs an ALREADY-LOADED node using fresh defs (finding #3)", () => {

--- a/browser_tests/unit/frontend-virtual-nodes.test.mjs
+++ b/browser_tests/unit/frontend-virtual-nodes.test.mjs
@@ -498,14 +498,14 @@ test("#1370 CONSUMER WIRING: both count-readers zero only on an ACTUAL removal",
   for (const holder of ["assets", "missing"]) {
     const at = PANEL.indexOf(`const recordedTypes = ${holder}.nodeTypes;`);
     assert.ok(at > 0, `${holder}: the pre-adjudication capture must exist`);
-    const after = PANEL.slice(at, at + 400);
+    const after = PANEL.slice(at, at + 700);
     assert.match(
       after,
       /adjudicateRecordedMissingNodeTypes\(\r?\n\s+recordedTypes,/,
       `${holder}: the captured list must be the one adjudicated`,
     );
     assert.ok(
-      after.indexOf(`${holder}.nodeTypes = adjudicated.stillMissing;`) >
+      after.indexOf(`${holder}.nodeTypes = recordedMissingTypesOnLiveGraph(adjudicated.stillMissing, allNodes);`) >
         after.indexOf("adjudicateRecordedMissingNodeTypes("),
       `${holder}: the capture must precede the narrowing assignment`,
     );

--- a/browser_tests/unit/get-errors-stale-ids.test.mjs
+++ b/browser_tests/unit/get-errors-stale-ids.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * #2263 — panel_get_errors reported previous-workflow node ids (H3AdaLNLoRAFix
+ * 5599, H3SLAAttention 5603) after a switch to a 17-node graph. ComfyUI can
+ * load the new workflow into the SAME graph object, so the instance-identity
+ * fence stays quiet while the live combo scan still names the old nodes.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { collectMissingNodeTypeReasons } from "../../web/js/lib/asset-staleness.js";
+import { runProductionGraphGetErrors } from "./_graph-get-errors-harness.mjs";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+test("#2263 wiring: graph_get_errors refuses a live scan whose ids left the bound graph", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf("async graph_get_errors()");
+  assert.ok(at > 0, "graph_get_errors must still be recognisable");
+  const body = src.slice(at, at + 16000);
+  assert.match(body, /graphGetErrorsLiveScanStale\(\{/, "must correlate the scan against the post-await live root");
+  assert.match(body, /scannedNodes: scanNodes/, "must pass the pre-await scan node list");
+  assert.match(body, /liveRootGraph: postProbeRootGraph/, "must use the post-await root, not the pre-scan one");
+  assert.match(body, /recordedMissingTypesOnLiveGraph\(adjudicated\.stillMissing, allNodes\)/, "must drop previous-tab missing types");
+});
+
+test("#2263 production graph_get_errors refuses leftover ids after an in-place workflow load", async () => {
+  const previous = [
+    { id: 5599, type: "H3AdaLNLoRAFix", widgets: [{ name: "lora_name", value: "x.safetensors" }] },
+    { id: 5603, type: "H3SLAAttention", widgets: [{ name: "model", value: "y.safetensors" }] },
+  ];
+  const current = Array.from({ length: 17 }, (_, i) => ({
+    id: i + 1,
+    type: "LoadImage",
+    widgets: [{ name: "image", value: "ok.png" }],
+  }));
+  const graph = {
+    _nodes: previous,
+    getNodeById: (id) => (graph._nodes.find((n) => String(n.id) === String(id)) ?? null),
+  };
+  await assert.rejects(
+    () =>
+      runProductionGraphGetErrors({
+        graph,
+        rootGraph: graph,
+        lastExecFailure: null,
+        scan: async (nodes) => {
+          graph._nodes = current;
+          return {
+            unavailable: [],
+            unknown: nodes.map((n) => ({
+              id: n.id,
+              type: n.type,
+              reason: "node type not found in /object_info",
+            })),
+          };
+        },
+      }),
+    (err) => {
+      assert.match(String(err?.message ?? err), /active workflow changed/i);
+      assert.match(String(err?.message ?? err), /Retry panel_get_errors/);
+      return true;
+    },
+  );
+});
+
+test("#2263 production graph_get_errors keeps nested inner ids of the CURRENT bound root", async () => {
+  const inner = {
+    id: 5599,
+    type: "H3AdaLNLoRAFix",
+    widgets: [{ name: "lora_name", value: "x.safetensors" }],
+  };
+  const innerGraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "5599" ? inner : null) };
+  const host = { id: 12, type: "MiniMaxH3", subgraph: innerGraph, widgets: [] };
+  const graph = {
+    _nodes: [host],
+    getNodeById: (id) => (String(id) === "12" ? host : null),
+  };
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    collectAllGraphs: (root) => [root, innerGraph],
+    scan: async () => ({
+      unavailable: [],
+      unknown: [{ id: 5599, type: "H3AdaLNLoRAFix", reason: "node type not found in /object_info" }],
+    }),
+  });
+  assert.equal(result.unchecked_nodes.length, 1);
+  assert.equal(result.unchecked_nodes[0].id, 5599);
+});
+
+test("#2263 production graph_get_errors drops load-time missing types the live graph does not carry", async () => {
+  const nodes = Array.from({ length: 17 }, (_, i) => ({
+    id: i + 1,
+    type: i === 0 ? "LoadImage" : "CLIPTextEncode",
+    widgets: [],
+  }));
+  const graph = {
+    _nodes: nodes,
+    getNodeById: (id) => nodes.find((n) => String(n.id) === String(id)) ?? null,
+  };
+  const result = await runProductionGraphGetErrors({
+    graph,
+    rootGraph: graph,
+    lastExecFailure: null,
+    collectMissingAssets: () => ({
+      models: [],
+      media: [],
+      nodeTypes: ["H3AdaLNLoRAFix", "H3SLAAttention"],
+      nodeCount: 2,
+    }),
+    collectMissingNodeTypeReasons,
+    scan: async () => ({ unavailable: [], unknown: [] }),
+  });
+  assert.equal(result.missing_node_types, undefined);
+  assert.equal(result.missing_node_count, undefined);
+  assert.equal(result.unchecked_nodes, undefined);
+  assert.equal(result.nodes.length, 0);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -230,6 +230,8 @@ import {
   emptyComboNote,
   refreshComboOptionsFromDefs,
   collectAllGraphs,
+  graphGetErrorsLiveScanStale,
+  recordedMissingTypesOnLiveGraph,
   collectMissingNodeTypeReasons,
   collectUnexplainedRedOutlines,
   combineNodeErrorMaps,
@@ -12652,10 +12654,11 @@ async function validationBanner() {
       allNodes,
       (type) => isRegisteredNodeType(LiteGraph?.registered_node_types, type),
     );
-    missing.nodeTypes = adjudicated.stillMissing;
+    missing.nodeTypes = recordedMissingTypesOnLiveGraph(adjudicated.stillMissing, allNodes);
     bannerStalePlaceholders = adjudicated.stalePlaceholders;
     // Same gate as graph_get_errors (panel#1370): an empty recorded list was never
     // narrowed by the adjudication, so its count is an unnamed miss, not a cleared one.
+    // #2263 — drop previous-tab type names the live graph does not carry.
     if (recordedTypes.length && !missing.nodeTypes.length) missing.nodeCount = 0;
   } catch {
     bannerStalePlaceholders = [];
@@ -21542,6 +21545,14 @@ const GRAPH_TOOL_EXECUTORS = {
         afterWorkflow: activeWorkflowRef(),
         beforeRootGraph: preProbeRootGraph,
         afterRootGraph: postProbeRootGraph,
+      }) ||
+      // #2263 — same-object in-place load: instance identity is unchanged but
+      // the scanned node ids are no longer on the bound graph. Refuse rather
+      // than emit the previous workflow's ids as if they were this canvas.
+      graphGetErrorsLiveScanStale({
+        scannedNodes: scanNodes,
+        liveRootGraph: postProbeRootGraph,
+        liveScan,
       })
     ) {
       throw new Error(
@@ -21566,7 +21577,7 @@ const GRAPH_TOOL_EXECUTORS = {
         allNodes,
         (type) => isRegisteredNodeType(LiteGraph?.registered_node_types, type),
       );
-      assets.nodeTypes = adjudicated.stillMissing;
+      assets.nodeTypes = recordedMissingTypesOnLiveGraph(adjudicated.stillMissing, allNodes);
       stalePlaceholders = adjudicated.stalePlaceholders;
       // #1332 drops the count when the adjudication removes every type the client can
       // now construct, so it cannot keep alarming for names that are no longer reported.
@@ -21574,6 +21585,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // empty recorded list means the store named nothing to begin with, and the count is
       // then the only evidence that anything is missing; zeroing it there turns "N
       // missing, names unknown" into "no errors recorded since the last execution start".
+      // #2263 — the same drop when the store still names a PREVIOUS tab's types.
       if (recordedTypes.length && !assets.nodeTypes.length) assets.nodeCount = 0;
     } catch {
       /* unreadable registry → keep the load-time list (fail closed) */

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -1091,6 +1091,96 @@ export function collectAllGraphs(rootGraph) {
 }
 
 /**
+ * Node ids reachable from `rootGraph`, including nested subgraphs. Empty when
+ * the graph is unreadable — callers that need fail-closed treat that as "no
+ * live ids", never as "everything is in scope".
+ */
+export function liveGraphNodeIdSet(rootGraph) {
+  const ids = new Set();
+  try {
+    for (const g of collectAllGraphs(rootGraph)) {
+      for (const n of g?._nodes ?? []) {
+        if (n?.id != null) ids.add(String(n.id));
+      }
+    }
+  } catch {
+    /* unreadable graph → empty set */
+  }
+  return ids;
+}
+
+function idsMissingFromLiveSet(ids, liveIds) {
+  if (!liveIds || typeof liveIds.has !== "function") return true;
+  try {
+    for (const id of ids ?? []) {
+      if (id == null) continue;
+      if (!liveIds.has(String(id))) return true;
+    }
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * #2263 — true when `panel_get_errors`' live combo scan no longer describes the
+ * bound graph. ComfyUI can load a new workflow into the SAME graph object, so
+ * `graphReadBindingChanged` (instance identity) stays false while `scanNodes`
+ * still names the previous tab's ids (5599 / 5603 after a switch to a 17-node
+ * graph). Returning those ids is the defect; refuse so the caller retries.
+ *
+ * Nested subgraph ids of the CURRENT root stay in-scope (`collectAllGraphs`).
+ * An unreadable live root fails closed (stale).
+ */
+export function graphGetErrorsLiveScanStale({ scannedNodes, liveRootGraph, liveScan } = {}) {
+  if (!liveRootGraph) return true;
+  const liveIds = liveGraphNodeIdSet(liveRootGraph);
+  const scanned = [];
+  try {
+    for (const n of Array.isArray(scannedNodes) ? scannedNodes : []) {
+      if (n?.id != null) scanned.push(n.id);
+    }
+  } catch {
+    return true;
+  }
+  if (idsMissingFromLiveSet(scanned, liveIds)) return true;
+  const findings = [];
+  try {
+    for (const list of [liveScan?.unavailable, liveScan?.unknown]) {
+      if (!Array.isArray(list)) continue;
+      for (const item of list) {
+        if (item?.id != null) findings.push(item.id);
+      }
+    }
+  } catch {
+    return true;
+  }
+  return idsMissingFromLiveSet(findings, liveIds);
+}
+
+/**
+ * #2263 — the missing-node-type Pinia store is a load-time snapshot and is not
+ * cleared on a tab switch (#316's model/media scoping does not cover it). Keep
+ * only types that still appear on the live graph. An empty live type set is not
+ * proof (empty canvas / unreadable nodes) — fail open and keep the record.
+ */
+export function recordedMissingTypesOnLiveGraph(recordedTypes, nodes) {
+  const recorded = Array.isArray(recordedTypes) ? recordedTypes : [];
+  if (!recorded.length) return recorded;
+  const liveTypes = new Set();
+  try {
+    for (const n of Array.isArray(nodes) ? nodes : []) {
+      const t = n?.type ?? n?.comfyClass;
+      if (t != null) liveTypes.add(t);
+    }
+  } catch {
+    return recorded;
+  }
+  if (!liveTypes.size) return recorded;
+  return recorded.filter((t) => liveTypes.has(t));
+}
+
+/**
  * After a node-def refresh, re-apply the fresh definitions to ALREADY-LOADED node
  * instances (finding #3): registerNodesFromDefs mints a NEW class per type, so
  * existing instances keep their old/generic constructor and would otherwise never


### PR DESCRIPTION
After switching workflows, `panel_get_errors` could still emit node ids from the previous graph (H3AdaLNLoRAFix 5599 / H3SLAAttention 5603) while `panel_graph_outline` / `panel_query_graph` listed only the live 17 nodes.

`graphReadBindingChanged` keys on workflow/root *object identity*. ComfyUI can load the new file into the same graph object, so that fence stays quiet while the live combo scan still names the old nodes.

## Fix
- After the existing mid-await identity check, refuse when scanned/finding ids are no longer on `collectAllGraphs` of the bound root (retry, do not return leftover ids).
- Nested inner ids of the *current* root stay in scope (#984).
- Drop load-time `missing_node_types` that do not appear on the live graph (the Pinia store is not cleared on tab switch).

Fixes #2263