### PR TITLE
fix(2264): generated-widget refresh uses serialized widgets_values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- panel_set_widget's generated custom-widget refresh no longer throws after a verified write on a migrated node whose serialized state has no `widgets_values`. The rebuild called `onConfigure()` with no arguments, so a pack that reads `info.widgets_values` (UnifiedResizeImageMask after the widget layout drifted from the current definition) reported `generated_widgets_refresh_failed` while the values had already landed. The refresh now serializes the live node, fills `widgets_values` from the live widget list when serialize omitted it, and skips `onConfigure` when those values are still missing (#2264)
+
 ## [0.15.178] - 2026-09-05
 
 ### Fixed

--- a/browser_tests/unit/custom-generated-widgets-refresh.test.mjs
+++ b/browser_tests/unit/custom-generated-widgets-refresh.test.mjs
@@ -34,6 +34,8 @@
  *   6. A rebuild that THROWS does not fail the verified write; the failure is
  *      disclosed (generated_widgets_refresh_failed).
  *   7. A rebuild that changes nothing is not claimed as a refresh.
+ *   8. #2264 — a migrated node whose serialize() omits widgets_values still
+ *      refreshes: onConfigure receives live widget values, never undefined.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -388,4 +390,110 @@ test("refreshCustomGeneratedWidgetsAfterWrite returns null when there is no patt
     out === null || typeof out.failed === "string",
     "hostile reads degrade to a disclosure, never a throw",
   );
+});
+
+test("#2264 migrated serialize without widgets_values still refreshes; onConfigure sees live values", async () => {
+  const node = makeDenoNode({ count: 1 });
+  node.serialize = function () {
+    return { id: this.id, type: this.type };
+  };
+  let seen = null;
+  const orig = node.onConfigure;
+  node.onConfigure = function (info) {
+    seen = info.widgets_values;
+    return orig.call(this);
+  };
+
+  const res = await runSetWidget(node, "active_loras", 3, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+
+  assert.equal(res.set.value, 3, "the write itself still reports the value that landed");
+  assert.equal("generated_widgets_refresh_failed" in res.set, false);
+  assert.equal(res.set.generated_widgets_refreshed, true);
+  assert.ok(Array.isArray(seen), "onConfigure received widgets_values filled from live widgets");
+  assert.equal(seen[0], 3, "live active_loras is the first serialized value");
+  assert.deepEqual(generatedRowNames(node), [
+    "deno_multi_lora_row_1",
+    "deno_multi_lora_row_2",
+    "deno_multi_lora_row_3",
+  ]);
+});
+
+test("#2264 no serialize() still supplies widgets_values so a pack that reads info.widgets_values does not throw", async () => {
+  const node = makeDenoNode({ count: 1 });
+  const orig = node.onConfigure;
+  node.onConfigure = function (info) {
+    if (info.widgets_values.length < 1) throw new Error("empty widgets_values");
+    return orig.call(this);
+  };
+
+  const res = await runSetWidget(node, "active_loras", 2, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+
+  assert.equal(res.set.value, 2);
+  assert.equal("generated_widgets_refresh_failed" in res.set, false);
+  assert.equal(res.set.generated_widgets_refreshed, true);
+});
+
+test("#2264 missing widgets_values skips onConfigure instead of calling it with undefined", () => {
+  let called = 0;
+  const node = {
+    widgets: [
+      { name: "active_loras", hidden: true, type: "converted-widget", value: 1, options: { serialize: false } },
+      { name: "row_1", type: "custom", options: { serialize: false }, index: 1 },
+    ],
+    serialize() {
+      return { id: 7, type: "UnifiedResizeImageMask" };
+    },
+    onConfigure(info) {
+      called += 1;
+      return info.widgets_values.length;
+    },
+  };
+  const out = refreshCustomGeneratedWidgetsAfterWrite(node);
+  assert.equal(called, 0, "onConfigure is not invoked when widgets_values cannot be produced");
+  assert.equal(out, null);
+});
+
+test("#2264 UnifiedResize-shaped node: migrated serialize does not fail a verified scale_mode write", async () => {
+  const scale = {
+    name: "scale_mode",
+    type: "combo",
+    value: "Multiplier",
+    options: { values: ["Dimensions (W × H)", "Multiplier"] },
+  };
+  const width = { name: "width", type: "number", value: 1024, hidden: true };
+  const display = {
+    name: "resolution_display",
+    type: "custom",
+    options: { serialize: false },
+    value: "Resolution: (pending)",
+  };
+  const node = {
+    id: 9,
+    type: "UnifiedResizeImageMask",
+    widgets: [scale, width, display],
+    serialize() {
+      return { id: this.id, type: this.type };
+    },
+    onConfigure(info) {
+      this._fromValues = info.widgets_values[0];
+    },
+  };
+
+  const res = await runSetWidget(node, "scale_mode", "Dimensions (W × H)", {
+    registry: { UnifiedResizeImageMask: {} },
+    getFreshObjectInfo: async () => ({ UnifiedResizeImageMask: {} }),
+    canvas: CANVAS,
+  });
+
+  assert.equal(res.set.value, "Dimensions (W × H)");
+  assert.equal("generated_widgets_refresh_failed" in res.set, false);
+  assert.equal(node._fromValues, "Dimensions (W × H)");
 });

--- a/web/js/lib/custom-generated-widgets-refresh.js
+++ b/web/js/lib/custom-generated-widgets-refresh.js
@@ -33,8 +33,12 @@
  * hidden `active_loras` count, recompute size, and dirty the canvas. The
  * rebuild is the pack's own:
  *
- *   1. `onConfigure()` is the public re-entry the workaround already used
- *      (Deno queues `setupNode` from it). Invoked when present.
+ *   1. `onConfigure(info)` is the public re-entry (Deno queues `setupNode`
+ *      from it). `info` is the node's serialized state so a pack that reads
+ *      `info.widgets_values` — including after a widget-layout migrate that
+ *      dropped that field off the live node — does not throw. Invoked only
+ *      when `widgets_values` is present on that state (filled from the live
+ *      widget list when serialize() omitted it).
  *   2. Generated row widgets are then reconciled synchronously from an
  *      existing row's constructor (`new RowCtor(index)`), because Deno's
  *      `onConfigure` is a `queueMicrotask` and a caller that reads the node
@@ -379,6 +383,80 @@ function dirtyCanvas(node, setDirty) {
   }
 }
 
+function hasWidgetsValues(value) {
+  if (Array.isArray(value)) return value.length > 0;
+  return value != null && typeof value === "object";
+}
+
+function skipSerializedWidget(widget) {
+  try {
+    return widget?.options?.serialize === false;
+  } catch {
+    return false;
+  }
+}
+
+function widgetSerializedValue(widget, node, index) {
+  try {
+    if (typeof widget?.serializeValue === "function") {
+      return reflectApply(widget.serializeValue, widget, [node, index]);
+    }
+  } catch {
+    /* fall through to .value */
+  }
+  try {
+    return widget?.value;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Positional widgets_values matching LiteGraph: skip serialize:false rows. */
+function liveSerializedWidgetsValues(node) {
+  const widgets = readWidgets(node);
+  if (!widgets) return null;
+  const values = [];
+  for (let i = 0; i < widgets.length; i++) {
+    const widget = widgets[i];
+    if (skipSerializedWidget(widget)) continue;
+    values.push(widgetSerializedValue(widget, node, i));
+  }
+  return values;
+}
+
+/**
+ * Serialized node state for onConfigure. After a widget-layout migrate the
+ * live node often has no `widgets_values` of its own; serialize() may omit
+ * it too. Fill from the live widget list so packs that read
+ * `info.widgets_values` without optional chaining do not throw.
+ *
+ * @returns {object | null}
+ */
+function serializedConfigureInfo(node) {
+  let info = null;
+  try {
+    if (typeof node?.serialize === "function") {
+      const serialized = reflectApply(node.serialize, node, []);
+      if (serialized && typeof serialized === "object") info = serialized;
+    }
+  } catch {
+    // unknown-ok: a throwing serialize is treated as missing state
+    info = null;
+  }
+  if (info && hasWidgetsValues(info.widgets_values)) return info;
+  const live = liveSerializedWidgetsValues(node);
+  if (!hasWidgetsValues(live)) return null;
+  if (info) return { ...info, widgets_values: live };
+  return { widgets_values: live };
+}
+
+function invokeOnConfigure(node) {
+  if (typeof node.onConfigure !== "function") return;
+  const info = serializedConfigureInfo(node);
+  if (!info) return;
+  reflectApply(node.onConfigure, node, [info]);
+}
+
 /**
  * Rebuild generated custom-widget rows after a successful write.
  *
@@ -402,11 +480,11 @@ export function refreshCustomGeneratedWidgetsAfterWrite(node, { beforeChange, af
     try {
       // Pack-owned re-entry. Deno rebuilds generated rows from onConfigure →
       // setupNode → rebuildUi (the same path leaving and re-entering a subgraph
-      // takes). Arguments are not supplied: this is a refresh of widgets already
-      // on the node, not a deserialize.
-      if (typeof node.onConfigure === "function") {
-        reflectApply(node.onConfigure, node, []);
-      }
+      // takes). Pass serialized state: packs that read info.widgets_values
+      // (UnifiedResizeImageMask after a migrated layout) throw when the
+      // argument is missing. Skip the hook when widgets_values cannot be
+      // produced — never call onConfigure(undefined).
+      invokeOnConfigure(node);
     } catch (err) {
       threw = err;
     }


### PR DESCRIPTION
## Summary

`panel_set_widget` rebuilt generated custom widgets by calling `node.onConfigure()` with no arguments after a verified write. Packs that read `info.widgets_values` without a guard — including UnifiedResizeImageMask after the saved widget layout drifted from the current definition — threw `generated_widgets_refresh_failed: Cannot read properties of undefined (reading 'widgets_values')` even though the write had already landed.

The refresh now serializes the live node, fills `widgets_values` from the live widget list when serialize omitted it (the migrated-node case), and skips `onConfigure` when those values still cannot be produced. Deno Multi LoRA still rebuilds; a throwing pack hook is still disclosed rather than failing the write.

Fixes #2264

## Tests

- `node --test browser_tests/unit/custom-generated-widgets-refresh.test.mjs` — 17 pass
- `node --test browser_tests/unit/*.test.mjs` — 8385 pass, 1 todo, 0 fail
