### PR TITLE
fix(2262): panel_set_node_mode stamps rgthree repeater targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_set_node_mode on an rgthree Mute / Bypass Repeater (and a node that repeater owns) now stamps the repeater and its live targets together and refuses unless a fresh read of those modes matches, so a bypass receipt cannot disagree with panel_graph_outline still showing mute (#2262)
+
 ## [0.15.178] - 2026-09-05
 
 ### Fixed

--- a/browser_tests/unit/graph-edit-node.test.mjs
+++ b/browser_tests/unit/graph-edit-node.test.mjs
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { canonicalNodeId, isQualifiedNodeId } from "../../web/js/lib/node-id.js";
 import { writePoint, refreshNodeArea } from "../../web/js/lib/group-geometry.js";
+import { applyGraphNodeMode } from "../../web/js/lib/set-node-mode.js";
 import { fileURLToPath } from "node:url";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -117,8 +118,9 @@ function realLegacyMode(getGraphCtx, resolveNode, unsafeBypassMappings, normaliz
     "resolveNode",
     "unsafeBypassMappings",
     "normalizeLegacyNodeId",
+    "applyGraphNodeMode",
     `const executors = { ${legacyModeMatch[0]} }; return executors.graph_set_node_mode;`,
-  )(getGraphCtx, resolveNode, unsafeBypassMappings, normalizeLegacyNodeId);
+  )(getGraphCtx, resolveNode, unsafeBypassMappings, normalizeLegacyNodeId, applyGraphNodeMode);
 }
 
 function makeNode(id, { pos = [0, 0], size = [140, 60], collapsible = true } = {}) {

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -69,6 +69,7 @@ import {
 // that export is renamed or dropped, the completion frame and every video preview stop
 // linking — and neither has a syntax error to catch it.
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { applyGraphNodeMode } from "../../web/js/lib/set-node-mode.js";
 
 test("panel ↔ bundle-version.js module edge links (#584/#611)", () => {
   assert.equal(typeof resolveBundleStaleness, "function");
@@ -133,6 +134,10 @@ test("panel ↔ disconnect-verify.js module edge links (#668)", () => {
   assert.equal(typeof snapshotGraphState, "function");
   assert.equal(typeof describeInputLink, "function");
   assert.equal(typeof verifyDisconnect, "function");
+});
+
+test("panel ↔ set-node-mode.js module edge links (#2262)", () => {
+  assert.equal(typeof applyGraphNodeMode, "function");
 });
 
 test("panel ↔ settle-open-active.js tmp: reconnect edges link (#2022)", () => {

--- a/browser_tests/unit/set-node-mode-repeater.test.mjs
+++ b/browser_tests/unit/set-node-mode-repeater.test.mjs
@@ -1,0 +1,267 @@
+/**
+ * #2262 — panel_set_node_mode reports bypass on an rgthree Mute / Bypass Repeater
+ * (and its SaveVideo target) while a fresh outline still reads mute.
+ *
+ * The pack stamps connected inputs in `onModeChange`, which only runs when the
+ * `mode` ACCESSOR fires. A data-property write (`node.mode = 4`) sticks on the
+ * wrapper, so the receipt echoes bypass, but the targets never move — and a
+ * later repeater tick copies the wrapper's still-muted `this.mode` back onto
+ * them. These tests drive the shipped `applyGraphNodeMode` and the extracted
+ * `graph_set_node_mode` body against that fixture.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  applyGraphNodeMode,
+  NODE_MODE_REPEATER_TYPE,
+  NODE_MODE_RELAY_TYPE,
+  NodeModeWriteError,
+} from "../../web/js/lib/set-node-mode.js";
+
+const REPEATER = NODE_MODE_REPEATER_TYPE;
+const RELAY = NODE_MODE_RELAY_TYPE;
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+const legacyModeMatch = panelSrc.match(/graph_set_node_mode\(\{ node_id, mode, force \}\) \{[\s\S]*?\n  \},/);
+assert.ok(legacyModeMatch, "could not locate graph_set_node_mode in panel source");
+
+function normalizeLegacyNodeId(nodeId) {
+  if (typeof nodeId === "number" && Number.isInteger(nodeId)) return nodeId;
+  if (typeof nodeId === "string" && /^-?(?:0|[1-9]\d*)$/.test(nodeId)) {
+    const normalized = Number(nodeId);
+    if (Number.isSafeInteger(normalized)) return normalized;
+  }
+  throw new Error("node_id must be an integer");
+}
+
+function realSetNodeMode(getGraphCtx, resolveNode) {
+  return new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "unsafeBypassMappings",
+    "normalizeLegacyNodeId",
+    "applyGraphNodeMode",
+    `const executors = { ${legacyModeMatch[0]} }; return executors.graph_set_node_mode;`,
+  )(getGraphCtx, resolveNode, () => [], normalizeLegacyNodeId, applyGraphNodeMode);
+}
+
+function makeGraph() {
+  const byId = new Map();
+  const links = {};
+  const graph = {
+    links,
+    _nodes: [],
+    _groups: [],
+    getNodeById: (id) => byId.get(id) ?? null,
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+  const add = (node) => {
+    node.graph = graph;
+    byId.set(node.id, node);
+    graph._nodes.push(node);
+    return node;
+  };
+  return { graph, add, links };
+}
+
+/**
+ * Repeater whose `mode` is a DATA field. Assignment does not call onModeChange.
+ * That is the unfixed hole: the wrapper reads back bypass, the target stays mute.
+ */
+function makeDataRepeater(id, mode = 2) {
+  const node = {
+    id,
+    type: REPEATER,
+    title: REPEATER,
+    mode,
+    inputs: [],
+    onModeChange(_from, to) {
+      for (const slot of node.inputs ?? []) {
+        if (typeof slot?.link !== "number") continue;
+        const origin = node.graph.getNodeById(node.graph.links[slot.link]?.origin_id);
+        if (origin && origin.type !== RELAY) origin.mode = to;
+      }
+    },
+  };
+  return node;
+}
+
+/** Repeater with rgthree's accessor (stores rgthree_mode, fires onModeChange). */
+function makeAccessorRepeater(id, mode = 2) {
+  const node = {
+    id,
+    type: REPEATER,
+    title: REPEATER,
+    rgthree_mode: mode,
+    inputs: [],
+    onModeChange(_from, to) {
+      for (const slot of node.inputs ?? []) {
+        if (typeof slot?.link !== "number") continue;
+        const origin = node.graph.getNodeById(node.graph.links[slot.link]?.origin_id);
+        if (origin && origin.type !== RELAY) origin.mode = to;
+      }
+    },
+  };
+  Object.defineProperty(node, "mode", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return node.rgthree_mode;
+    },
+    set(value) {
+      if (node.rgthree_mode != value) {
+        const old = node.rgthree_mode;
+        node.rgthree_mode = value;
+        node.onModeChange(old, value);
+      }
+    },
+  });
+  return node;
+}
+
+function naiveAssign(node, target) {
+  node.mode = target;
+}
+
+test("#2262 unfixed: assigning mode on a data-field repeater does not move SaveVideo", () => {
+  const { graph, add } = makeGraph();
+  const save = add({ id: 11, type: "SaveVideo", title: "SaveVideo", mode: 2 });
+  const repeater = add(makeDataRepeater(17, 2));
+  graph.links[1] = { origin_id: 11, target_id: 17 };
+  repeater.inputs = [{ link: 1 }];
+
+  naiveAssign(repeater, 4);
+  assert.equal(repeater.mode, 4, "the wrapper assignment sticks");
+  assert.equal(save.mode, 2, "SaveVideo stays mute — the receipt would lie");
+});
+
+test("#2262: applyGraphNodeMode bypasses a data-field repeater AND its SaveVideo", () => {
+  const { graph, add } = makeGraph();
+  const save = add({ id: 11, type: "SaveVideo", title: "SaveVideo", mode: 2 });
+  const repeater = add(makeDataRepeater(17, 2));
+  graph.links[1] = { origin_id: 11, target_id: 17 };
+  repeater.inputs = [{ link: 1 }];
+
+  const result = applyGraphNodeMode(repeater, 4, graph);
+  assert.equal(repeater.mode, 4);
+  assert.equal(save.mode, 4);
+  assert.equal(result.actual, 4);
+  assert.equal(result.previous, 2);
+  assert.equal(result.propagated.length, 1);
+  assert.equal(result.propagated[0].node_id, 11);
+});
+
+test("#2262: setting SaveVideo also moves the owning mute repeater so a later tick cannot re-mute", () => {
+  const { graph, add } = makeGraph();
+  const save = add({ id: 11, type: "SaveVideo", title: "SaveVideo", mode: 2 });
+  const repeater = add(makeDataRepeater(17, 2));
+  graph.links[1] = { origin_id: 11, target_id: 17 };
+  repeater.inputs = [{ link: 1 }];
+
+  applyGraphNodeMode(save, 4, graph);
+  assert.equal(save.mode, 4);
+  assert.equal(repeater.mode, 4);
+
+  // Pack onConnectionsChange: changeModeOfNodes(inputNode, this.mode)
+  save.mode = repeater.mode;
+  assert.equal(save.mode, 4, "a later repeater tick must not copy mute back onto SaveVideo");
+});
+
+test("#2262: an accessor repeater still bypasses its wired target", () => {
+  const { graph, add } = makeGraph();
+  const save = add({ id: 11, type: "SaveVideo", title: "SaveVideo", mode: 2 });
+  const repeater = add(makeAccessorRepeater(18, 2));
+  graph.links[2] = { origin_id: 11, target_id: 18 };
+  repeater.inputs = [{ link: 2 }];
+
+  applyGraphNodeMode(repeater, 4, graph);
+  assert.equal(repeater.mode, 4);
+  assert.equal(repeater.rgthree_mode, 4);
+  assert.equal(save.mode, 4);
+});
+
+test("#2262: a group-mode repeater (no inputs) stamps the other group members", () => {
+  const { graph, add } = makeGraph();
+  const save = add({ id: 11, type: "SaveVideo", title: "SaveVideo", mode: 2 });
+  const repeater = add(makeDataRepeater(17, 2));
+  const group = { _children: new Set([save, repeater]), recomputeInsideNodes() {} };
+  graph._groups = [group];
+
+  applyGraphNodeMode(repeater, 4, graph);
+  assert.equal(repeater.mode, 4);
+  assert.equal(save.mode, 4);
+});
+
+test("#2262: ordinary nodes still change in isolation", () => {
+  const { graph, add } = makeGraph();
+  const ksampler = add({ id: 1, type: "KSampler", title: "KSampler", mode: 0 });
+  const other = add({ id: 2, type: "CLIPTextEncode", title: "CLIP", mode: 0 });
+  const result = applyGraphNodeMode(ksampler, 4, graph);
+  assert.equal(ksampler.mode, 4);
+  assert.equal(other.mode, 0);
+  assert.deepEqual(result.propagated, []);
+});
+
+test("#2262: a mismatched target is refused and the journal is restored", () => {
+  const { graph, add } = makeGraph();
+  const save = add({ id: 11, type: "SaveVideo", title: "SaveVideo", mode: 2 });
+  Object.defineProperty(save, "mode", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return 2;
+    },
+    set() {},
+  });
+  const repeater = add(makeDataRepeater(17, 2));
+  graph.links[1] = { origin_id: 11, target_id: 17 };
+  repeater.inputs = [{ link: 1 }];
+
+  assert.throws(
+    () => applyGraphNodeMode(repeater, 4, graph),
+    (error) =>
+      error instanceof NodeModeWriteError &&
+      /still reads "mute"/.test(error.message) &&
+      /Nothing is being reported as changed/.test(error.message),
+  );
+  assert.equal(repeater.mode, 2, "the repeater is restored");
+});
+
+test("#2262: shipped graph_set_node_mode bypasses repeater + SaveVideo together", () => {
+  const { graph, add } = makeGraph();
+  const save = add({ id: 11, type: "SaveVideo", title: "SaveVideo", mode: 2 });
+  const r17 = add(makeDataRepeater(17, 2));
+  const r18 = add(makeDataRepeater(18, 2));
+  graph.links[1] = { origin_id: 11, target_id: 17 };
+  graph.links[2] = { origin_id: 11, target_id: 18 };
+  r17.inputs = [{ link: 1 }];
+  r18.inputs = [{ link: 2 }];
+
+  const fn = realSetNodeMode(
+    () => ({ graph }),
+    (_graph, id) => {
+      const node = graph.getNodeById(id);
+      if (!node) throw new Error(`No node with id ${id}`);
+      return node;
+    },
+  );
+
+  const a = fn({ node_id: 17, mode: "bypass" });
+  assert.equal(a.mode, "bypass");
+  assert.equal(a.previous_mode, "mute");
+  assert.equal(r17.mode, 4);
+  assert.equal(save.mode, 4);
+  assert.equal(r18.mode, 4, "the sibling owning repeater is moved so it cannot re-mute SaveVideo");
+
+  const b = fn({ node_id: 11, mode: "bypass" });
+  assert.equal(b.mode, "bypass");
+  assert.equal(save.mode, 4);
+  assert.equal(r17.mode, 4);
+  assert.equal(r18.mode, 4);
+});

--- a/browser_tests/unit/set-node-mode-verify.test.mjs
+++ b/browser_tests/unit/set-node-mode-verify.test.mjs
@@ -34,9 +34,9 @@ function setNodeModeBody() {
 
 test("the mode is READ BACK after the write", () => {
   const body = setNodeModeBody();
-  const write = body.indexOf("node.mode = target;");
+  const write = body.indexOf("applyGraphNodeMode(node, target, graph)");
   const readBack = body.indexOf("const actualNum =");
-  assert.ok(write > -1, "the write must still be there");
+  assert.ok(write > -1, "the write must go through applyGraphNodeMode so repeater targets move");
   assert.ok(readBack > write, "the read-back must come AFTER the write, or it proves nothing");
 });
 
@@ -63,7 +63,7 @@ test("previous_mode is still sampled BEFORE the write", () => {
   // error in the other direction.
   const body = setNodeModeBody();
   const prev = body.indexOf("const previous_mode =");
-  const write = body.indexOf("node.mode = target;");
+  const write = body.indexOf("applyGraphNodeMode(node, target, graph)");
   assert.ok(prev > -1 && write > -1 && prev < write, "previous_mode must be read before the write");
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -396,6 +396,7 @@ import {
 } from "./lib/object-info-snapshot.js";
 import { fetchTypeScopedObjectInfo } from "./lib/scoped-object-info.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
+import { applyGraphNodeMode } from "./lib/set-node-mode.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import {
@@ -26842,8 +26843,15 @@ const GRAPH_TOOL_EXECUTORS = {
     const prevNum = typeof node.mode === "number" ? node.mode : 0;
     const previous_mode = NUM_TO_MODE[prevNum] ?? prevNum;
     graph.beforeChange?.();
+    let propagated = [];
     try {
-      node.mode = target;
+      // #2262 — a stock assignment is not enough for rgthree Mute / Bypass Repeater:
+      // the pack stores mode on an accessor and stamps connected inputs (or group
+      // members) in onModeChange. applyGraphNodeMode writes the wrapper, the
+      // owning repeaters, and their targets, then refuses unless every live mode
+      // matches. `node.mode = target` still happens inside that helper.
+      const applied = applyGraphNodeMode(node, target, graph);
+      propagated = applied.propagated;
     } finally {
       graph.afterChange?.();
     }
@@ -26869,6 +26877,7 @@ const GRAPH_TOOL_EXECUTORS = {
       node_id: node.id,
       mode: NUM_TO_MODE[actualNum],
       previous_mode,
+      ...(propagated.length ? { propagated } : {}),
       ...(bypassWarning ? { warning: bypassWarning } : {}),
     };
   },

--- a/web/js/lib/set-node-mode.js
+++ b/web/js/lib/set-node-mode.js
@@ -1,0 +1,313 @@
+/**
+ * Live LiteGraph mode writes for panel_set_node_mode.
+ *
+ * A stock LGraphNode stores `mode` as a data field, so `node.mode = 4` is the
+ * whole write. rgthree's Mute / Bypass Repeater is not stock: the pack shadows
+ * `mode` with an accessor that stores `rgthree_mode` and propagates in
+ * `onModeChange` to every connected input (or, with no inputs, every other
+ * node in its group). A plain assignment that never fires that setter reports
+ * success on the wrapper while SaveVideo / other targets stay mute — and a
+ * later repeater tick copies the wrapper's still-muted mode back onto them.
+ *
+ * This helper writes the requested node, walks owning repeaters and their
+ * targets, pins `rgthree_mode` when that field exists, and refuses unless
+ * every touched live mode matches. Fail-closed: a mismatch restores the
+ * journalled modes before throwing.
+ */
+
+export const MODE_TO_NUM = Object.assign(Object.create(null), {
+  active: 0,
+  bypass: 4,
+  mute: 2,
+});
+export const NUM_TO_MODE = { 0: "active", 2: "mute", 4: "bypass" };
+
+export const NODE_MODE_REPEATER_TYPE = "Mute / Bypass Repeater (rgthree)";
+export const NODE_MODE_RELAY_TYPE = "Mute / Bypass Relay (rgthree)";
+
+export class NodeModeWriteError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "NodeModeWriteError";
+  }
+}
+
+export function readLiveMode(node) {
+  try {
+    return typeof node?.mode === "number" ? node.mode : 0;
+  } catch {
+    // unknown-ok: an unreadable accessor is treated as active (LiteGraph default)
+    return 0;
+  }
+}
+
+export function modeName(num) {
+  return NUM_TO_MODE[num] ?? num;
+}
+
+function runtimeNodeType(node) {
+  try {
+    if (typeof node?.type === "string") return node.type;
+    if (typeof node?.constructor?.type === "string") return node.constructor.type;
+  } catch {
+    // unknown-ok: an unreadable third-party node is not a repeater
+  }
+  return "";
+}
+
+function isModePassThrough(node) {
+  const type = runtimeNodeType(node);
+  return type.includes("Reroute") || type.includes("Node Combiner") || type.includes("Node Collector");
+}
+
+function isRepeater(node) {
+  return runtimeNodeType(node) === NODE_MODE_REPEATER_TYPE;
+}
+
+function linkRecord(graph, linkId) {
+  try {
+    const links = graph?.links ?? graph?._links;
+    if (!links) return null;
+    if (typeof links.get === "function") return links.get(linkId) ?? null;
+    return links[linkId] ?? null;
+  } catch {
+    // unknown-ok: a hostile link store is treated as disconnected
+    return null;
+  }
+}
+
+function graphNodes(graph) {
+  try {
+    const nodes = graph?._nodes;
+    if (Array.isArray(nodes)) return nodes;
+    if (nodes && typeof nodes[Symbol.iterator] === "function") return [...nodes];
+  } catch {
+    // unknown-ok
+  }
+  return [];
+}
+
+function graphGroups(graph) {
+  try {
+    const groups = graph?._groups;
+    if (Array.isArray(groups)) return groups;
+    if (groups && typeof groups[Symbol.iterator] === "function") return [...groups];
+  } catch {
+    // unknown-ok
+  }
+  return [];
+}
+
+function groupMembers(group) {
+  try {
+    group?.recomputeInsideNodes?.();
+    const children = group?._children;
+    if (children == null) return [];
+    return [...children];
+  } catch {
+    // unknown-ok
+  }
+  return [];
+}
+
+function describeNode(node) {
+  return `${node?.id} (${node?.title ?? node?.type ?? "node"})`;
+}
+
+/**
+ * Connected input origins of `node`, matching rgthree's
+ * `getConnectedInputNodesAndFilterPassThroughs` walk: follow Reroute /
+ * Node Combiner / Node Collector, skip disconnected slots.
+ */
+export function connectedInputNodes(node, graph) {
+  const ordered = [];
+  const seen = new Set();
+  const walk = (current) => {
+    let slots;
+    try {
+      slots = current?.inputs;
+    } catch {
+      return;
+    }
+    if (!Array.isArray(slots)) return;
+    let g;
+    try {
+      g = current?.graph ?? graph;
+    } catch {
+      return;
+    }
+    for (const slot of slots) {
+      let origin = null;
+      try {
+        const linkId = slot?.link;
+        if (typeof linkId !== "number") continue;
+        origin = g?.getNodeById?.(linkRecord(g, linkId)?.origin_id);
+      } catch {
+        continue;
+      }
+      if (!origin || seen.has(origin)) continue;
+      seen.add(origin);
+      if (isModePassThrough(origin)) walk(origin);
+      else ordered.push(origin);
+    }
+  };
+  walk(node);
+  return ordered;
+}
+
+/**
+ * Nodes a Mute / Bypass Repeater will stamp on mode change: non-relay connected
+ * inputs, or (when none) the other members of any group that contains it.
+ */
+export function repeaterTargets(node, graph) {
+  const linked = connectedInputNodes(node, graph).filter(
+    (candidate) => runtimeNodeType(candidate) !== NODE_MODE_RELAY_TYPE,
+  );
+  if (linked.length) return linked;
+  const targets = [];
+  const seen = new Set();
+  for (const group of graphGroups(graph ?? node?.graph)) {
+    const members = groupMembers(group);
+    if (!members.includes(node)) continue;
+    for (const member of members) {
+      if (!member || member === node || seen.has(member)) continue;
+      seen.add(member);
+      targets.push(member);
+    }
+  }
+  return targets;
+}
+
+export function owningRepeaters(node, graph) {
+  const g = graph ?? node?.graph;
+  const owners = [];
+  for (const candidate of graphNodes(g)) {
+    if (!isRepeater(candidate) || candidate === node) continue;
+    if (repeaterTargets(candidate, g).includes(node)) owners.push(candidate);
+  }
+  return owners;
+}
+
+function modeSetter(node) {
+  try {
+    const own = Object.getOwnPropertyDescriptor(node, "mode");
+    if (typeof own?.set === "function") return own.set;
+    const proto = Object.getPrototypeOf(node);
+    if (proto && proto !== Object.prototype) {
+      const inherited = Object.getOwnPropertyDescriptor(proto, "mode");
+      if (typeof inherited?.set === "function") return inherited.set;
+    }
+  } catch {
+    // unknown-ok: treat as a data field and fire onModeChange below
+  }
+  return null;
+}
+
+function pinRgthreeMode(node, target) {
+  try {
+    if ("rgthree_mode" in node) node.rgthree_mode = target;
+  } catch {
+    // unknown-ok: pin is best-effort; live read-back is authoritative
+  }
+}
+
+function writeMode(node, target, previous) {
+  const setter = modeSetter(node);
+  node.mode = target;
+  pinRgthreeMode(node, target);
+  // A data-property write never runs rgthree's accessor, so onModeChange would
+  // not fire. Invoke the pack hook ourselves in that case only — calling it
+  // after a real setter would double-propagate, which is harmless but we
+  // already walk targets explicitly.
+  if (!setter && typeof node.onModeChange === "function") {
+    try {
+      node.onModeChange(previous, target);
+    } catch {
+      // unknown-ok: target walk + read-back report the live result
+    }
+  }
+}
+
+function restoreJournal(journal) {
+  for (let i = journal.length - 1; i >= 0; i--) {
+    const entry = journal[i];
+    try {
+      writeMode(entry.node, entry.previous, readLiveMode(entry.node));
+    } catch {
+      // unknown-ok: the throw below is the honest refusal
+    }
+  }
+}
+
+function collectFrontier(seed, graph) {
+  const visited = new Set();
+  const queue = [seed];
+  while (queue.length) {
+    const current = queue.shift();
+    if (!current || visited.has(current)) continue;
+    visited.add(current);
+    if (isRepeater(current)) {
+      for (const target of repeaterTargets(current, graph)) queue.push(target);
+    }
+    for (const owner of owningRepeaters(current, graph)) queue.push(owner);
+  }
+  return visited;
+}
+
+/**
+ * Write `target` (LiteGraph 0/2/4) onto `node` and every rgthree repeater
+ * that owns it (and those repeaters' other targets). Returns the observed
+ * previous/actual mode of `node`. Throws NodeModeWriteError after restoring
+ * the journal if any touched node does not hold `target`.
+ */
+export function applyGraphNodeMode(node, target, graph) {
+  const g = graph ?? node?.graph;
+  const previous = readLiveMode(node);
+  const journal = [];
+  const seen = new Set();
+
+  const stamp = (candidate) => {
+    if (!candidate || seen.has(candidate)) return;
+    seen.add(candidate);
+    const from = readLiveMode(candidate);
+    journal.push({ node: candidate, previous: from });
+    writeMode(candidate, target, from);
+  };
+
+  try {
+    for (const candidate of collectFrontier(node, g)) stamp(candidate);
+
+    const mismatched = journal.filter((entry) => readLiveMode(entry.node) !== target);
+    if (mismatched.length) {
+      restoreJournal(journal);
+      const first = mismatched[0];
+      if (first.node === node) {
+        throw new NodeModeWriteError(
+          `Node ${describeNode(node)} did not accept mode "${modeName(target)}": after the write it reads ` +
+            `"${modeName(readLiveMode(node))}". Nothing is being reported as changed. ` +
+            `Some node packs override \`mode\` to refuse or rewrite it — check the node on the ` +
+            `canvas (panel_screenshot) and set the mode from ComfyUI's own menu if it must hold.`,
+        );
+      }
+      throw new NodeModeWriteError(
+        `Node ${describeNode(node)} did not keep mode "${modeName(target)}" on the live canvas: ` +
+          `rgthree repeater target ${describeNode(first.node)} still reads "${modeName(readLiveMode(first.node))}". ` +
+          `Nothing is being reported as changed.`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof NodeModeWriteError) throw error;
+    restoreJournal(journal);
+    throw error;
+  }
+
+  const actual = readLiveMode(node);
+  const propagated = journal
+    .filter((entry) => entry.node !== node)
+    .map((entry) => ({
+      node_id: entry.node.id,
+      previous_mode: modeName(entry.previous),
+      mode: modeName(readLiveMode(entry.node)),
+    }));
+  return { previous, actual, propagated };
+}


### PR DESCRIPTION
Fixes #2262

## Problem
`panel_set_node_mode({ mode: "bypass" })` returned success with `mode: "bypass"` on rgthree Mute / Bypass Repeater nodes (and a SaveVideo they own) while a fresh `panel_graph_outline` / `panel_query_graph` still reported `mode=mute`. Ordinary nodes persisted as bypass. The receipt was lying.

## Root cause
rgthree Repeaters are frontend-only. They shadow `node.mode` with an accessor (`rgthree_mode`) and stamp connected inputs — or, with no inputs, the rest of their group — inside `onModeChange`. A stock `node.mode = 4` write on a data field never fires that hook, so the wrapper reads back bypass while SaveVideo stays mute. A later repeater tick then copies the wrapper's still-muted mode back onto the target.

## Fix
`applyGraphNodeMode` writes the requested node, every owning Repeater, and those Repeaters' live targets together, pins `rgthree_mode` when that field exists, and refuses (after restoring the journal) unless a fresh read of every touched mode matches.

## Tests
`browser_tests/unit/set-node-mode-repeater.test.mjs` drives the shipped helper and the extracted `graph_set_node_mode` body. The unfixed data-field assignment leaves SaveVideo mute; the helper and the panel executor bypass repeater + SaveVideo together. Full `npm run test:unit`: 8389 pass, 0 fail, 1 todo.

Not in 0.15.166–0.15.178.
