### PR TITLE
fix(2267): recover lost panel_create_subgraph conversion outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - panel_connect accepts an Autogrow display-label alias (`ref_image_0` → `ref_images.ref_image_0`) instead of refusing with a false "no input accepts type IMAGE"; the resolved live slot name still feeds #2008 dotted-name reconcile, and an unmatched name reports internal slot names rather than blaming the origin type (#2266)
+- panel_create_subgraph recovers a conversion whose reply was lost: a retry of the same node_ids returns the existing subgraph instead of wrapping leftovers or reporting unknown, a partial leftover set is refused rather than converted, and the landed receipt is replayable via retry_of (#2267)
 
 ## [0.15.179] - 2026-09-05
 

--- a/browser_tests/unit/create-subgraph-recovery.test.mjs
+++ b/browser_tests/unit/create-subgraph-recovery.test.mjs
@@ -1,0 +1,301 @@
+/**
+ * #2267 — panel_create_subgraph whose HTTP reply is lost must be recoverable.
+ *
+ * convertToSubgraph moves the named nodes into the wrapper. A retry of the same
+ * ids must return that wrapper (and must not convert leftover siblings). These
+ * drive the shipped recoverConvertedSubgraph / graph_create_subgraph / mutation
+ * receipt functions.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  danglingInputLinks,
+  disconnectedBoundaryInputs,
+  brokenConversionRefusal,
+  brokenConversionWarning,
+  detachedConversionNodes,
+  detachedConversionRefusal,
+  conversionSnapshot,
+  conversionThrowReport,
+} from "../../web/js/lib/subgraph-conversion-integrity.js";
+import {
+  normalizeCreateSubgraphNodeIds,
+  recoverConvertedSubgraph,
+  recoveredCreateSubgraphResult,
+  unresolvedCreateSubgraphNodesRefusal,
+} from "../../web/js/lib/subgraph-conversion-recovery.js";
+import {
+  createMutationReceiptStore,
+  resolveLateMutationReply,
+} from "../../web/js/lib/mutation-receipt.js";
+import { commandFingerprint } from "../../web/js/lib/command-dedupe.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+
+test("#2267 normalizeCreateSubgraphNodeIds drops rails, dupes, and junk", () => {
+  assert.deepEqual(normalizeCreateSubgraphNodeIds([10, "11", 10, -10, -20, "x", null]), [10, 11]);
+  assert.deepEqual(normalizeCreateSubgraphNodeIds("not-an-array"), []);
+  assert.deepEqual(normalizeCreateSubgraphNodeIds([]), []);
+});
+
+function hostWithInner(id, innerIds, extra = {}) {
+  return {
+    id,
+    title: extra.title ?? "New Subgraph",
+    subgraph: {
+      name: extra.name ?? "New Subgraph",
+      _nodes: [
+        { id: -10 },
+        { id: -20 },
+        ...innerIds.map((nid) => ({ id: nid })),
+      ],
+    },
+  };
+}
+
+test("#2267 recoverConvertedSubgraph returns the unique host that holds every named id", () => {
+  const host = hostWithInner(302, [1, 2, 3]);
+  const graph = {
+    _nodes: [{ id: 4 }, host],
+    getNodeById: (id) => (id === 4 ? graph._nodes[0] : null),
+  };
+  const recovered = recoverConvertedSubgraph({ graph, nodeIds: [1, 2, 3] });
+  assert.equal(recovered, host);
+  assert.equal(recoveredCreateSubgraphResult(recovered, [1, 2, 3]).subgraph.recovered, true);
+  assert.equal(recoveredCreateSubgraphResult(recovered, [1, 2, 3]).subgraph.node_id, 302);
+});
+
+test("#2267 recoverConvertedSubgraph misses when any named node is still on this graph", () => {
+  const host = hostWithInner(302, [1, 2, 3]);
+  const live = { id: 1 };
+  const graph = {
+    _nodes: [live, host],
+    getNodeById: (id) => (id === 1 ? live : null),
+  };
+  assert.equal(recoverConvertedSubgraph({ graph, nodeIds: [1, 2, 3] }), null);
+});
+
+test("#2267 recoverConvertedSubgraph misses when two hosts contain the set", () => {
+  const a = hostWithInner(301, [1, 2, 3], { name: "A" });
+  const b = hostWithInner(302, [1, 2, 3, 9], { name: "B" });
+  const graph = { _nodes: [a, b], getNodeById: () => null };
+  assert.equal(recoverConvertedSubgraph({ graph, nodeIds: [1, 2, 3] }), null);
+});
+
+test("#2267 recoverConvertedSubgraph misses when no host contains every id", () => {
+  const host = hostWithInner(302, [1, 2]);
+  const graph = { _nodes: [host], getNodeById: () => null };
+  assert.equal(recoverConvertedSubgraph({ graph, nodeIds: [1, 2, 3] }), null);
+});
+
+test("#2267 unresolvedCreateSubgraphNodesRefusal names a lost-reply recovery path", () => {
+  const missing = unresolvedCreateSubgraphNodesRefusal({
+    what: "panel_create_subgraph",
+    requested: [1, 2, 3],
+    foundIds: [],
+  });
+  assert.match(missing, /none of the named nodes/);
+  assert.match(missing, /panel_graph_outline/);
+  const partial = unresolvedCreateSubgraphNodesRefusal({
+    what: "panel_create_subgraph",
+    requested: [1, 2, 3],
+    foundIds: [1],
+  });
+  assert.match(partial, /only 1 of 3/);
+  assert.match(partial, /wrap a different set/);
+  assert.match(partial, /missing: 2, 3/);
+});
+
+function methodSource(name, args) {
+  const match = PANEL_SRC.match(new RegExp(`${name}\\(${args}\\) \\{[\\s\\S]*?\\n  \\},`));
+  assert.ok(match, `could not locate ${name} in panel source`);
+  return match[0];
+}
+
+const createSource = methodSource("graph_create_subgraph", "\\{ node_ids \\}");
+const runnerMatch = PANEL_SRC.match(
+  /function convertSelectionToSubgraph\(\{ graph, canvas, nodes, what \}\) \{[\s\S]*?\r?\n\}/,
+);
+assert.ok(runnerMatch, "could not locate convertSelectionToSubgraph");
+const landedMatch = PANEL_SRC.match(
+  /function assertSubgraphNodeLanded\(res, graph, what\) \{[\s\S]*?\r?\n\}/,
+);
+const serializableMatch = PANEL_SRC.match(
+  /function assertSubgraphConversionSerializable\(res, node, what\) \{[\s\S]*?\r?\n\}/,
+);
+const advisoriesMatch = PANEL_SRC.match(
+  /function subgraphConversionAdvisories\(\{ disconnected, dangling, warning \}\) \{[\s\S]*?\r?\n\}/,
+);
+
+function shippedCreate(getGraphCtx) {
+  const convertSelectionToSubgraph = new Function(
+    "detachedConversionNodes",
+    "detachedConversionRefusal",
+    "conversionSnapshot",
+    "conversionThrowReport",
+    `return ${runnerMatch[0]};`,
+  )(detachedConversionNodes, detachedConversionRefusal, conversionSnapshot, conversionThrowReport);
+  return new Function(
+    "getGraphCtx",
+    "clearStaleRedFlagsAfterSubgraphConversion",
+    "convertSelectionToSubgraph",
+    "assertSubgraphNodeLanded",
+    "assertSubgraphConversionSerializable",
+    "subgraphConversionAdvisories",
+    "normalizeCreateSubgraphNodeIds",
+    "recoverConvertedSubgraph",
+    "recoveredCreateSubgraphResult",
+    "unresolvedCreateSubgraphNodesRefusal",
+    `const executors = { ${createSource} }; return executors.graph_create_subgraph;`,
+  )(
+    getGraphCtx,
+    () => {},
+    convertSelectionToSubgraph,
+    new Function(`return ${landedMatch[0]};`)(),
+    new Function(
+      "danglingInputLinks",
+      "disconnectedBoundaryInputs",
+      "brokenConversionRefusal",
+      "brokenConversionWarning",
+      `return ${serializableMatch[0]};`,
+    )(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal, brokenConversionWarning),
+    new Function(`return ${advisoriesMatch[0]};`)(),
+    normalizeCreateSubgraphNodeIds,
+    recoverConvertedSubgraph,
+    recoveredCreateSubgraphResult,
+    unresolvedCreateSubgraphNodesRefusal,
+  );
+}
+
+test("#2267 shipped graph_create_subgraph returns the existing wrapper without converting again", () => {
+  const host = hostWithInner(302, [7, 8, 9]);
+  host.subgraph._nodes.push(host); // landing check uses graph._nodes.includes(node)
+  let converted = 0;
+  const graph = {
+    _nodes: [host],
+    getNodeById: () => null,
+    convertToSubgraph: () => {
+      converted += 1;
+      return { node: host, subgraph: host.subgraph };
+    },
+    setDirtyCanvas: () => {},
+    beforeChange: () => {},
+    afterChange: () => {},
+  };
+  const create = shippedCreate(() => ({
+    app: {},
+    graph,
+    canvas: { selectItems() {}, selectedItems: [] },
+    rootGraph: graph,
+  }));
+  const out = create({ node_ids: [7, 8, 9] });
+  assert.equal(converted, 0, "a recovered conversion must not run convertToSubgraph");
+  assert.equal(out.subgraph.node_id, 302);
+  assert.equal(out.subgraph.recovered, true);
+  assert.deepEqual(out.subgraph.from_nodes, [7, 8, 9]);
+});
+
+test("#2267 shipped graph_create_subgraph still converts when every named node is live", () => {
+  const n7 = { id: 7 };
+  const n8 = { id: 8 };
+  const wrapper = { id: 100, subgraph: { name: "converted" } };
+  let converted = 0;
+  const graph = {
+    _nodes: [wrapper],
+    getNodeById: (id) => (id === 7 ? n7 : id === 8 ? n8 : null),
+    convertToSubgraph: () => {
+      converted += 1;
+      return { node: wrapper, subgraph: wrapper.subgraph };
+    },
+    setDirtyCanvas: () => {},
+    beforeChange: () => {},
+    afterChange: () => {},
+  };
+  const create = shippedCreate(() => ({
+    app: {},
+    graph,
+    canvas: {
+      selectedItems: [],
+      selectItems(items) {
+        graph.canvasSelected = items;
+        this.selectedItems = items;
+      },
+    },
+    rootGraph: graph,
+  }));
+  const out = create({ node_ids: [7, 8] });
+  assert.equal(converted, 1);
+  assert.equal(out.subgraph.node_id, 100);
+  assert.equal(out.subgraph.recovered, undefined);
+});
+
+test("#2267 shipped graph_create_subgraph refuses a partial leftover set instead of converting it", () => {
+  const leftover = { id: 7 };
+  const host = hostWithInner(302, [8, 9]);
+  let converted = 0;
+  const graph = {
+    _nodes: [leftover, host],
+    getNodeById: (id) => (id === 7 ? leftover : null),
+    convertToSubgraph: () => {
+      converted += 1;
+      return { node: host, subgraph: host.subgraph };
+    },
+  };
+  const create = shippedCreate(() => ({
+    app: {},
+    graph,
+    canvas: { selectItems() {}, selectedItems: [] },
+    rootGraph: graph,
+  }));
+  assert.throws(
+    () => create({ node_ids: [7, 8, 9] }),
+    /only 1 of 3 named nodes/,
+  );
+  assert.equal(converted, 0, "a partial leftover must not be wrapped");
+});
+
+test("#2267 mutation receipts persist a landed create_subgraph and retry_of replays it", () => {
+  const store = createMutationReceiptStore();
+  const result = {
+    subgraph: { node_id: 302, name: "New Subgraph", from_nodes: [1, 2, 3], recovered: true },
+  };
+  const fingerprint = commandFingerprint({
+    cmd: "graph_create_subgraph",
+    node_ids: [1, 2, 3],
+  });
+  store.remember("r1", result, { cmd: "graph_create_subgraph", fingerprint });
+  const hit = store.lookup("r1", fingerprint);
+  assert.equal(hit.cmd, "graph_create_subgraph");
+  assert.equal(hit.result.subgraph.node_id, 302);
+  const resolved = resolveLateMutationReply(
+    store,
+    { rid: "r2", retry_of: "r1", cmd: "graph_create_subgraph" },
+    fingerprint,
+  );
+  assert.equal(resolved.retryOfHit, true);
+  assert.equal(resolved.reply.rid, "r2");
+  assert.equal(resolved.reply.result.subgraph.node_id, 302);
+});
+
+test("#2267 wiring: create_subgraph recovers from graph state and stores a receipt", () => {
+  const start = PANEL_SRC.indexOf("graph_create_subgraph({ node_ids })");
+  assert.ok(start >= 0, "graph_create_subgraph handler not found");
+  const handler = PANEL_SRC.slice(start, PANEL_SRC.indexOf("\n  graph_subgraph_group", start));
+  assert.match(handler, /recoverConvertedSubgraph\(\{ graph, nodeIds: requested \}\)/);
+  assert.match(handler, /recoveredCreateSubgraphResult\(recovered, requested\)/);
+  assert.match(handler, /unresolvedCreateSubgraphNodesRefusal/);
+  assert.match(PANEL_SRC, /from "\.\/lib\/subgraph-conversion-recovery\.js"/);
+  assert.match(
+    PANEL_SRC,
+    /msg\.cmd === "graph_create_subgraph"/,
+  );
+  assert.match(
+    PANEL_SRC,
+    /lateMutationReceipts\.remember\(msg\.rid, reply\.result/,
+  );
+});

--- a/browser_tests/unit/mutation-receipt.test.mjs
+++ b/browser_tests/unit/mutation-receipt.test.mjs
@@ -248,4 +248,21 @@ test("#2116 wiring: graph_set_widget persists late receipts and retry_of replays
     /lateMutationReceipts\.remember\(msg\.rid, reply\.result/,
   );
   assert.match(PANEL_SRC, /from "\.\/lib\/mutation-receipt\.js"/);
+  assert.match(PANEL_SRC, /msg\.cmd === "graph_create_subgraph"/);
+});
+
+test("#2267 store: a landed subgraph conversion is replayable by request id", () => {
+  const store = createMutationReceiptStore();
+  const fingerprint = commandFingerprint({
+    cmd: "graph_create_subgraph",
+    node_ids: [1, 2, 3],
+  });
+  store.remember(
+    "r-sub",
+    { subgraph: { node_id: 302, from_nodes: [1, 2, 3] } },
+    { cmd: "graph_create_subgraph", fingerprint },
+  );
+  const hit = store.lookup("r-sub", fingerprint);
+  assert.equal(hit.cmd, "graph_create_subgraph");
+  assert.equal(hit.result.subgraph.node_id, 302);
 });

--- a/browser_tests/unit/subgraph-conversion-integrity.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-integrity.test.mjs
@@ -46,6 +46,12 @@ import {
   conversionSnapshot,
   conversionThrowReport,
 } from "../../web/js/lib/subgraph-conversion-integrity.js";
+import {
+  normalizeCreateSubgraphNodeIds,
+  recoverConvertedSubgraph,
+  recoveredCreateSubgraphResult,
+  unresolvedCreateSubgraphNodesRefusal,
+} from "../../web/js/lib/subgraph-conversion-recovery.js";
 
 const src = () =>
   readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
@@ -507,6 +513,10 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
     "assertSubgraphNodeLanded",
     "assertSubgraphConversionSerializable",
     "subgraphConversionAdvisories",
+    "normalizeCreateSubgraphNodeIds",
+    "recoverConvertedSubgraph",
+    "recoveredCreateSubgraphResult",
+    "unresolvedCreateSubgraphNodesRefusal",
     `const executors = { ${body[0]} }; return executors.${name.replace(/^async /, "")};`,
   )(
     () => ({ app: {}, graph, canvas, rootGraph: graph }),
@@ -530,6 +540,10 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
       `return ${serializable[0]};`,
     )(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal, brokenConversionWarning),
     new Function(`return ${advisories[0]};`)(),
+    normalizeCreateSubgraphNodeIds,
+    recoverConvertedSubgraph,
+    recoveredCreateSubgraphResult,
+    unresolvedCreateSubgraphNodesRefusal,
   );
 }
 

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -19,6 +19,12 @@ import {
   conversionSnapshot,
   conversionThrowReport,
 } from "../../web/js/lib/subgraph-conversion-integrity.js";
+import {
+  normalizeCreateSubgraphNodeIds,
+  recoverConvertedSubgraph,
+  recoveredCreateSubgraphResult,
+  unresolvedCreateSubgraphNodesRefusal,
+} from "../../web/js/lib/subgraph-conversion-recovery.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -101,6 +107,10 @@ function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
     "assertSubgraphNodeLanded",
     "assertSubgraphConversionSerializable",
     "subgraphConversionAdvisories",
+    "normalizeCreateSubgraphNodeIds",
+    "recoverConvertedSubgraph",
+    "recoveredCreateSubgraphResult",
+    "unresolvedCreateSubgraphNodesRefusal",
     `const executors = { ${createSource} }; return executors.graph_create_subgraph;`,
   )(
     getGraphCtx,
@@ -109,6 +119,10 @@ function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
     assertSubgraphNodeLanded,
     assertSubgraphConversionSerializable,
     subgraphConversionAdvisories,
+    normalizeCreateSubgraphNodeIds,
+    recoverConvertedSubgraph,
+    recoveredCreateSubgraphResult,
+    unresolvedCreateSubgraphNodesRefusal,
   );
 }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -549,6 +549,12 @@ import {
   conversionThrowReport,
 } from "./lib/subgraph-conversion-integrity.js";
 import {
+  normalizeCreateSubgraphNodeIds,
+  recoverConvertedSubgraph,
+  recoveredCreateSubgraphResult,
+  unresolvedCreateSubgraphNodesRefusal,
+} from "./lib/subgraph-conversion-recovery.js";
+import {
   classifyWorkflowRefresh,
   knownSelectorSample,
   openWorkflowNotFoundMessage,
@@ -25008,10 +25014,23 @@ const GRAPH_TOOL_EXECUTORS = {
     if (typeof graph.convertToSubgraph !== "function") {
       throw new Error("convertToSubgraph unavailable on this frontend");
     }
-    const ns = (Array.isArray(node_ids) ? node_ids : [])
-      .map((id) => graph.getNodeById(Number(id)))
-      .filter(Boolean);
-    if (!ns.length) throw new Error("provide node_ids to group into a subgraph");
+    const requested = normalizeCreateSubgraphNodeIds(node_ids);
+    if (!requested.length) throw new Error("provide node_ids to group into a subgraph");
+    const ns = requested.map((id) => graph.getNodeById(id)).filter(Boolean);
+    // #2267 — a lost reply after convertToSubgraph leaves the named nodes inside
+    // the wrapper. Retrying the same ids must return that wrapper, not wrap a
+    // leftover set or report the outcome as unknown.
+    if (ns.length !== requested.length) {
+      const recovered = recoverConvertedSubgraph({ graph, nodeIds: requested });
+      if (recovered) return recoveredCreateSubgraphResult(recovered, requested);
+      throw new Error(
+        unresolvedCreateSubgraphNodesRefusal({
+          what: "panel_create_subgraph",
+          requested,
+          foundIds: ns.map((n) => n.id),
+        }),
+      );
+    }
     // #1463 — selects, refuses a detached selection, and reports a THROW with a
     // mutation verdict instead of the frontend's bare exception.
     const res = convertSelectionToSubgraph({
@@ -28629,8 +28648,9 @@ function awaitDuplicateReply(prior, rid, callerTimeoutMs) {
   ]);
 }
 const commandRidLedger = createCommandDedupeLedger(200, (m) => console.warn(m));
-// #2116 — rid-correlated receipts for graph_set_widget mutations that applied
-// after the caller timeout. retry_of reads these instead of executing again.
+// #2116 / #2267 — rid-correlated receipts for mutations that applied after the
+// caller timeout (widget writes and subgraph conversions). retry_of reads these
+// instead of executing again.
 const lateMutationReceipts = createMutationReceiptStore();
 
 // #968 — WHAT last moved the active workflow. A stale binding and a fresh one are the same
@@ -29967,7 +29987,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // the same rid on a fresh socket learns the true outcome instead of
         // re-executing the command.
         settleRid(reply);
-        if (msg.cmd === "graph_set_widget" && reply?.ok) {
+        if (
+          (msg.cmd === "graph_set_widget" ||
+            msg.cmd === "graph_create_subgraph" ||
+            msg.cmd === "graph_subgraph_group") &&
+          reply?.ok
+        ) {
           lateMutationReceipts.remember(msg.rid, reply.result, {
             cmd: msg.cmd,
             fingerprint,

--- a/web/js/lib/mutation-receipt.js
+++ b/web/js/lib/mutation-receipt.js
@@ -1,22 +1,28 @@
-// #2116 — persist graph_set_widget acknowledgements by request id.
+// #2116 / #2267 — persist applied mutation acknowledgements by request id.
 //
 // A timed-out mutation can still apply after the caller has given up. The
 // command rid is the transaction identity: retry_of must replay that receipt
 // instead of executing a second write, and panel_list_workflows advertises
 // the same rid-correlated list the save path uses for late_save_receipts.
+// graph_set_widget writes and subgraph conversions that landed are both
+// receipts — a lost panel_create_subgraph reply is how #2267 retried blind.
 
 export const LATE_MUTATION_RECEIPT_TTL_MS = 10 * 60 * 1000;
 export const MAX_LATE_MUTATION_RECEIPTS = 32;
 
-function appliedWidgetResult(result) {
+function appliedMutationResult(result) {
   if (!result || typeof result !== "object" || Array.isArray(result)) return false;
   if (result.applied === true) return true;
   const set = result.set;
-  return !!(set && typeof set === "object" && Object.prototype.hasOwnProperty.call(set, "value"));
+  if (set && typeof set === "object" && Object.prototype.hasOwnProperty.call(set, "value")) {
+    return true;
+  }
+  const subgraph = result.subgraph;
+  return !!(subgraph && typeof subgraph === "object" && subgraph.node_id != null);
 }
 
 /**
- * Bounded rid-keyed store for applied widget-write receipts.
+ * Bounded rid-keyed store for applied mutation receipts.
  *
  * @param {{
  *   ttlMs?: number,
@@ -47,7 +53,7 @@ export function createMutationReceiptStore({
   return {
     remember(rid, result, { cmd = "graph_set_widget", fingerprint } = {}) {
       if (typeof rid !== "string" || !rid) return;
-      if (!appliedWidgetResult(result)) return;
+      if (!appliedMutationResult(result)) return;
       prune();
       receipts.set(rid, {
         rid,

--- a/web/js/lib/subgraph-conversion-recovery.js
+++ b/web/js/lib/subgraph-conversion-recovery.js
@@ -1,0 +1,124 @@
+// #2267 — recover a panel_create_subgraph whose conversion applied but whose
+// reply never reached the caller (HTTP send error / dropped orchestrator
+// transport). convertToSubgraph moves the selected nodes INTO the new wrapper,
+// so a blind retry of the same node_ids either throws "provide node_ids" or
+// wraps whatever leftover siblings still sit on the parent.
+//
+// Graph state is the source of truth: if EVERY named id is gone from this graph
+// and lives inside exactly one subgraph node here, the conversion already
+// landed. A retry returns that wrapper. A partial leftover set is refused —
+// converting it would wrap a different set. Dependency-light so unit tests can
+// drive the same functions the executor calls.
+
+import { isPromotedContainer } from "./graph-read.js";
+
+const RAIL_IDS = new Set([-10, -20]);
+
+/** Unique numeric node ids, dropping rails and non-finite values. */
+export function normalizeCreateSubgraphNodeIds(nodeIds) {
+  if (!Array.isArray(nodeIds)) return [];
+  const out = [];
+  const seen = new Set();
+  for (const raw of nodeIds) {
+    if (raw == null || raw === "") continue;
+    const id = Number(raw);
+    if (!Number.isFinite(id) || RAIL_IDS.has(id)) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+function subgraphContainsAll(subgraph, wanted) {
+  if (!subgraph || typeof subgraph !== "object" || !wanted.length) return false;
+  const nodes = Array.isArray(subgraph._nodes)
+    ? subgraph._nodes
+    : Array.isArray(subgraph.nodes)
+      ? subgraph.nodes
+      : null;
+  if (nodes) {
+    const inner = new Set();
+    for (const node of nodes) {
+      const id = Number(node?.id);
+      if (!Number.isFinite(id) || RAIL_IDS.has(id)) continue;
+      inner.add(id);
+    }
+    return wanted.every((id) => inner.has(id));
+  }
+  if (typeof subgraph.getNodeById === "function") {
+    return wanted.every((id) => {
+      const node = subgraph.getNodeById(id);
+      if (!node) return false;
+      const liveId = Number(node.id);
+      return Number.isFinite(liveId) && !RAIL_IDS.has(liveId);
+    });
+  }
+  return false;
+}
+
+/**
+ * The subgraph node that already holds every named id, or null.
+ *
+ * Returns null when any named node is still on THIS graph (conversion has not
+ * consumed them), when no host contains all of them, or when more than one host
+ * does (ambiguous — fail closed rather than pick).
+ *
+ * @param {{ graph?: object, nodeIds?: unknown[] }} args
+ * @returns {object | null}
+ */
+export function recoverConvertedSubgraph({ graph, nodeIds } = {}) {
+  const wanted = normalizeCreateSubgraphNodeIds(nodeIds);
+  if (!wanted.length || !graph || typeof graph !== "object") return null;
+  if (typeof graph.getNodeById === "function") {
+    for (const id of wanted) {
+      if (graph.getNodeById(id)) return null;
+    }
+  }
+  const list = Array.isArray(graph._nodes) ? graph._nodes : [];
+  const hosts = [];
+  for (const node of list) {
+    if (!isPromotedContainer(node)) continue;
+    if (subgraphContainsAll(node.subgraph, wanted)) hosts.push(node);
+  }
+  return hosts.length === 1 ? hosts[0] : null;
+}
+
+/** Success payload for a conversion that already landed. */
+export function recoveredCreateSubgraphResult(host, fromNodes) {
+  return {
+    subgraph: {
+      node_id: host?.id ?? null,
+      name: host?.subgraph?.name ?? host?.title ?? null,
+      from_nodes: Array.isArray(fromNodes) ? fromNodes : [],
+      recovered: true,
+    },
+  };
+}
+
+/**
+ * Refusal when the named nodes are not a complete live selection and cannot be
+ * recovered as an already-converted subgraph.
+ */
+export function unresolvedCreateSubgraphNodesRefusal({ what, requested, foundIds } = {}) {
+  const wanted = normalizeCreateSubgraphNodeIds(requested);
+  const found = normalizeCreateSubgraphNodeIds(foundIds);
+  const tool = typeof what === "string" && what ? what : "panel_create_subgraph";
+  if (!wanted.length) return "provide node_ids to group into a subgraph";
+  const foundSet = new Set(found);
+  const missing = wanted.filter((id) => !foundSet.has(id));
+  if (!found.length) {
+    return (
+      `${tool} was NOT run — none of the named nodes (${wanted.join(", ")}) are on this ` +
+      `graph, and no existing subgraph contains all of them. A prior convertToSubgraph ` +
+      `whose reply was lost would have moved them inside a wrapper; this retry could not ` +
+      `find that wrapper. Re-read the graph (panel_graph_outline) before grouping again.`
+    );
+  }
+  return (
+    `${tool} was NOT retried because only ${found.length} of ${wanted.length} named nodes ` +
+    `are still on this graph (missing: ${missing.join(", ")}). A lost reply after ` +
+    `convertToSubgraph can leave the rest inside a subgraph already. Converting the leftover ` +
+    `nodes would wrap a different set. Re-read the graph (panel_graph_outline) before grouping again.`
+  );
+}


### PR DESCRIPTION
## User-visible failure

`panel_create_subgraph` for a 29-node selection failed with an HTTP transport send error to the local orchestrator. `panel_graph_outline` then showed no mutation, and retrying the identical create succeeded. The client could not tell whether the conversion had landed, so a retry after a lost reply is outcome-unknown: convertToSubgraph may already have moved those nodes into a wrapper, and grouping whatever is left would wrap a different set.

## Root cause

`graph_create_subgraph` is not idempotent. convertToSubgraph removes the named nodes from the parent graph. A dropped reply (HTTP send error / timed-out rid) leaves the caller with no receipt. The next call with the same `node_ids` either throws `provide node_ids` (nodes already inside the wrapper) or converts leftover siblings. `retry_of` receipts only covered `graph_set_widget`, so an orchestrator retry of create_subgraph could not replay a landed conversion.

## Fix

If every named id is gone from this graph and lives inside exactly one subgraph node, return that wrapper with `recovered: true` and do not convert again. A partial leftover set is refused rather than wrapped. Landed create_subgraph / subgraph_group results are stored as rid-correlated mutation receipts so `retry_of` replays them.

## Test

- `browser_tests/unit/create-subgraph-recovery.test.mjs` — shipped `graph_create_subgraph` recovers, still converts when nodes are live, refuses a partial leftover, stores a receipt
- `browser_tests/unit/mutation-receipt.test.mjs` — subgraph results are replayable by rid

`npm run test:unit` — 8393 pass, 0 fail, 1 todo

Fixes #2267
