### PR TITLE
fix(2887): reseat unpack links by dynamic slot identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- panel_unpack_subgraph reseats and verifies restored links by boundary-slot identity (dynamic namespace + child name + type) instead of trusting LiteGraph's post-rebuild slot indices, and rolls back if that identity is not unique. An IMAGE feed landing on MiniMaxH3ReferenceToVideo `ref_videos` after unpack is a refusal, not a silent graph (comfyui-mcp#2887)
 - panel_set_widget combo refusals list the live options for generic enums (device/precision) instead of applying the private filename/path redaction to every combo (#2265)
 
 ## [0.15.178] - 2026-09-05

--- a/browser_tests/unit/unpack-duplicate-linkids.test.mjs
+++ b/browser_tests/unit/unpack-duplicate-linkids.test.mjs
@@ -26,6 +26,7 @@ import { fileURLToPath } from "node:url";
 import {
   snapshotExternalLinks,
   verifyExternalLinks,
+  reseatExternalLinksByIdentity,
 } from "../../web/js/lib/unpack-link-verify.js";
 import {
   materializePromotedValues,
@@ -175,6 +176,7 @@ function buildUnpack(graph, { app, canvas, rootGraph, methodSrc = unpackSrc } = 
     "resolveLoadGraphArgs",
     "snapshotExternalLinks",
     "verifyExternalLinks",
+    "reseatExternalLinksByIdentity",
     "materializedValuesNote",
     `return ({
 ${methodSrc}
@@ -199,6 +201,7 @@ ${methodSrc}
     resolveLoadGraphArgs,
     snapshotExternalLinks,
     verifyExternalLinks,
+    reseatExternalLinksByIdentity,
     materializedValuesNote,
   );
 }
@@ -306,4 +309,8 @@ test("#1938 the shipped method still owns the dedupe, before snapshot and unpack
   assert.ok(dedupeAt < snapshotAt, "dedupe must precede the snapshot");
   assert.ok(dedupeAt < unpackAt, "dedupe must precede the unpack");
   assert.match(unpackSrc, /graph\.unpackSubgraph\(node[\s\S]{0,400}?\} catch \(err\)/);
+  const reseatAt = unpackSrc.indexOf("reseatExternalLinksByIdentity(graph, externalLinks)");
+  const verifyAt = unpackSrc.indexOf("verifyExternalLinks(graph, externalLinks)");
+  assert.ok(reseatAt > unpackAt, "identity reseat must follow unpack");
+  assert.ok(verifyAt > reseatAt, "identity verify must follow reseat");
 });

--- a/browser_tests/unit/unpack-link-verify.test.mjs
+++ b/browser_tests/unit/unpack-link-verify.test.mjs
@@ -16,6 +16,7 @@ import assert from "node:assert/strict";
 import {
   snapshotExternalLinks,
   verifyExternalLinks,
+  reseatExternalLinksByIdentity,
 } from "../../web/js/lib/unpack-link-verify.js";
 
 const mkLink = (id, origin_id, origin_slot, target_id, target_slot) => ({
@@ -68,12 +69,16 @@ test("#1665 snapshot names external endpoints on BOTH sides of the wrapper", () 
   assert.equal(snap.unverifiable.length, 0);
   assert.equal(snap.links.length, 2);
   const inbound = snap.links.find((l) => l.kind === "in");
-  assert.deepEqual(inbound.source, { node_id: 131, slot: 0, name: "INT" });
+  assert.deepEqual(inbound.source, { node_id: 131, slot: 0, name: "INT", type: null });
+  assert.deepEqual(inbound.interior, []);
+  assert.equal(inbound.identity_unresolved, false);
   assert.equal(inbound.rail, "int_in");
   assert.equal(inbound.consumers, 1);
   assert.equal(inbound.baseline, 1);
   const outbound = snap.links.find((l) => l.kind === "out");
-  assert.deepEqual(outbound.target, { node_id: 136, slot: 2, name: "length" });
+  assert.deepEqual(outbound.target, { node_id: 136, slot: 2, name: "length", type: null });
+  assert.equal(outbound.producer, null);
+  assert.equal(outbound.identity_unresolved, false);
   assert.equal(outbound.rail, "int_out");
 });
 
@@ -243,3 +248,143 @@ test("#1665 object-keyed link tables (older LiteGraph) verify the same", () => {
   assert.equal(res.restored, 1);
   assert.deepEqual(res.dropped, []);
 });
+
+const inputT = (name, link, type) => ({ name, link, type });
+const outputT = (name, links, type) => ({ name, links, type });
+
+/** Reporter's MiniMaxH3 shape: dotted autogrow children plus shared INT rails. */
+function minimaxUnpackFixture() {
+  const load = { id: 10, outputs: [outputT("IMAGE", [50], "IMAGE")], inputs: [] };
+  const res = { id: 11, outputs: [outputT("INT", [51], "INT")], inputs: [] };
+  const inner = {
+    id: 136,
+    inputs: [
+      inputT("prompt", null, "STRING"),
+      inputT("ref_images.ref_image_0", 900, "IMAGE"),
+      inputT("ref_videos.ref_video_0", null, "VIDEO"),
+      inputT("width", 901, "INT"),
+    ],
+    outputs: [],
+  };
+  const interiorLinks = [mkLink(900, -10, 0, 136, 1), mkLink(901, -10, 1, 136, 3)];
+  const subgraphNode = {
+    id: 6350,
+    inputs: [inputT("ref_images", 50, "IMAGE"), inputT("width", 51, "INT")],
+    outputs: [],
+    subgraph: {
+      inputs: [
+        { name: "ref_images", type: "IMAGE", linkIds: [900] },
+        { name: "width", type: "INT", linkIds: [901] },
+      ],
+      _links: new Map(interiorLinks.map((l) => [l.id, l])),
+      _nodes: [inner],
+      getNodeById(id) {
+        return this._nodes.find((n) => String(n.id) === String(id)) ?? null;
+      },
+    },
+  };
+  return {
+    graph: mkGraph([load, res, subgraphNode], [mkLink(50, 10, 0, 6350, 0), mkLink(51, 11, 0, 6350, 1)]),
+    inner,
+    subgraphNode,
+  };
+}
+
+function scrambledMinimaxGraph(inner) {
+  inner.inputs = [
+    inputT("prompt", null, "STRING"),
+    inputT("ref_images.ref_image_0", null, "IMAGE"),
+    inputT("ref_videos.ref_video_0", 60, "VIDEO"),
+    inputT("width", 61, "INT"),
+  ];
+  return mkGraph(
+    [
+      { id: 10, outputs: [outputT("IMAGE", [60], "IMAGE")], inputs: [] },
+      { id: 11, outputs: [outputT("INT", [61], "INT")], inputs: [] },
+      inner,
+    ],
+    [mkLink(60, 10, 0, 136, 2), mkLink(61, 11, 0, 136, 3)],
+  );
+}
+
+test("#2887 snapshot names interior autogrow children, not just the rail", () => {
+  const { graph, subgraphNode } = minimaxUnpackFixture();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  assert.equal(snap.unverifiable.length, 0);
+  const imageIn = snap.links.find((l) => l.rail === "ref_images");
+  assert.deepEqual(imageIn.interior, [{ node_id: 136, name: "ref_images.ref_image_0", type: "IMAGE" }]);
+  assert.equal(imageIn.identity_unresolved, false);
+  const widthIn = snap.links.find((l) => l.rail === "width");
+  assert.deepEqual(widthIn.interior, [{ node_id: 136, name: "width", type: "INT" }]);
+});
+
+test("#2887 a count-matching scramble onto ref_videos is DROPPED, not restored", () => {
+  const { graph, inner, subgraphNode } = minimaxUnpackFixture();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  const graph2 = scrambledMinimaxGraph(inner);
+  const res = verifyExternalLinks(graph2, snap);
+  assert.equal(res.restored, 1, "the INT width rail still sits on width");
+  assert.equal(res.dropped.length, 1);
+  assert.match(res.dropped[0], /ref_images\.ref_image_0/);
+  assert.match(res.dropped[0], /10\.IMAGE/);
+});
+
+test("#2887 reseat moves the IMAGE off ref_videos onto the unique named child", () => {
+  const { graph, inner, subgraphNode } = minimaxUnpackFixture();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  const graph2 = scrambledMinimaxGraph(inner);
+  const moved = reseatExternalLinksByIdentity(graph2, snap);
+  assert.ok(moved >= 1);
+  assert.equal(inner.inputs[1].link, 60, "ref_images.ref_image_0 holds the IMAGE");
+  assert.equal(inner.inputs[2].link, null, "ref_videos is empty again");
+  const res = verifyExternalLinks(graph2, snap);
+  assert.equal(res.restored, 2);
+  assert.deepEqual(res.dropped, []);
+});
+
+test("#2887 duplicate child names fail closed instead of reseating onto a guess", () => {
+  const { graph, inner, subgraphNode } = minimaxUnpackFixture();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  inner.inputs = [
+    inputT("ref_images.ref_image_0", 60, "IMAGE"),
+    inputT("ref_images.ref_image_0", null, "IMAGE"),
+    inputT("ref_videos.ref_video_0", null, "VIDEO"),
+    inputT("width", 61, "INT"),
+  ];
+  const graph2 = mkGraph(
+    [
+      { id: 10, outputs: [outputT("IMAGE", [60], "IMAGE")], inputs: [] },
+      { id: 11, outputs: [outputT("INT", [61], "INT")], inputs: [] },
+      inner,
+    ],
+    [mkLink(60, 10, 0, 136, 0), mkLink(61, 11, 0, 136, 3)],
+  );
+  assert.equal(reseatExternalLinksByIdentity(graph2, snap), 0);
+  const res = verifyExternalLinks(graph2, snap);
+  assert.match(res.dropped.join("\n"), /ref_images\.ref_image_0/);
+});
+
+test("#2887 an unreadable interior store with a live linkId is unresolved identity", () => {
+  const load = { id: 10, outputs: [outputT("IMAGE", [50], "IMAGE")], inputs: [] };
+  const subgraphNode = {
+    id: 6350,
+    inputs: [inputT("ref_images", 50, "IMAGE")],
+    outputs: [],
+    subgraph: {
+      inputs: [{ name: "ref_images", type: "IMAGE", linkIds: [900] }],
+      _links: new Map(),
+      _nodes: [],
+    },
+  };
+  const graph = mkGraph([load, subgraphNode], [mkLink(50, 10, 0, 6350, 0)]);
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  assert.equal(snap.links[0].identity_unresolved, true);
+  assert.deepEqual(snap.links[0].interior, []);
+  const after = mkGraph(
+    [load, { id: 136, inputs: [inputT("ref_images.ref_image_0", 60, "IMAGE")], outputs: [] }],
+    [mkLink(60, 10, 0, 136, 0)],
+  );
+  const res = verifyExternalLinks(after, snap);
+  assert.equal(res.dropped.length, 1);
+});
+

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -314,6 +314,7 @@ import {
 import {
   snapshotExternalLinks,
   verifyExternalLinks,
+  reseatExternalLinksByIdentity,
 } from "./lib/unpack-link-verify.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { isGenericManagerUpdateError, readUpdateTraceback } from "./lib/manager-update-traceback.js";
@@ -25603,6 +25604,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // expected link by NAME against the live link table; if any cannot be proven
     // present, roll back and refuse with exactly what would have been lost rather
     // than report a success over a graph that would render wrong.
+    //
+    // comfyui-mcp#2887 — #1665 only counted surviving wires. After a MiniMax-style
+    // autogrow rebuild, litegraph can still attach those wires to the WRONG named
+    // child (`IMAGE` on `ref_videos.ref_video_0`). Reseat by the snapshotted
+    // boundary identity (namespace + child + type) before verifying; a slot that
+    // is not unique is left for the refusal below rather than guessed.
+    const reseated = reseatExternalLinksByIdentity(graph, externalLinks);
     const linkCheck = verifyExternalLinks(graph, externalLinks);
     if (linkCheck.dropped.length) {
       let rolledBack = false;
@@ -25619,8 +25627,9 @@ const GRAPH_TOOL_EXECUTORS = {
       throw new Error(
         `unpack_subgraph refused: the unpack did not restore ${linkCheck.dropped.length} ` +
           `external link(s):\n${lost}\n` +
-          `These are links litegraph's unpackSubgraph rewires by slot index and silently loses ` +
-          `when the target is a widget-converted or dynamic input (comfyui-mcp#1665). ` +
+          `These are links litegraph's unpackSubgraph rewires by slot index: it can DROP them ` +
+          `on widget-converted/dynamic targets (#1665) or RESTORE them onto the wrong named ` +
+          `child after a dynamic-input rebuild (#2887). ` +
           (rolledBack
             ? `The workflow was reloaded from its pre-unpack snapshot, so the subgraph and all ` +
               `its links are intact — nothing was lost. Unpack in the ComfyUI canvas and re-add ` +
@@ -25644,8 +25653,9 @@ const GRAPH_TOOL_EXECUTORS = {
         // pre-unpack state could not even be read (pre-existing corruption the unpack
         // did not cause, disclosed rather than silently inherited).
         ...(externalLinks.links.length
-          ? { external_links_verified: linkCheck.restored }
+          ? { external_links_verified: linkCheck.restored, external_links_identity_ok: true }
           : {}),
+        ...(reseated ? { external_links_reseated: reseated } : {}),
         ...(linkCheck.unverifiable.length ? { external_links_unverifiable: linkCheck.unverifiable } : {}),
         // #979 — disclose what was carried inward. An unpack cannot be undone from
         // this result, so a caller checking values afterwards needs to know which

--- a/web/js/lib/unpack-link-verify.js
+++ b/web/js/lib/unpack-link-verify.js
@@ -7,23 +7,37 @@
  * returned a plain success payload, so nothing told the caller the graph it just
  * mutated would render wrong.
  *
+ * comfyui-mcp#2887 — the #1665 check only COUNTED surviving live wires from the
+ * external source. litegraph still rewires by slot INDEX, and after MiniMax-style
+ * autogrow rebuilds (`ref_images.ref_image_0`, `ref_videos.ref_video_0`) that
+ * index no longer names the same child. An IMAGE feed can land on `ref_videos`
+ * while the count still matches — a silent scramble, not a drop. This module now
+ * snapshots interior consumers/producers by NAME + TYPE (the dynamic namespace
+ * and child), reseats a misplaced live wire onto that unique identity, and treats
+ * a non-unique or type-mismatched landing as dropped so the unpack rolls back.
+ *
  * WHY IT HAPPENS: litegraph's `unpackSubgraph` rewires the rails' external links by
  * slot INDEX. Slot indices shift during the unpack (the measured report: node 136
  * gained a new dynamic `ref_audio_1` slot), and widget-backed / dynamic inputs are
  * re-slotted or skipped entirely — the link is never re-created on the target, but
- * the id lingers on the source output's link list.
+ * the id lingers on the source output's link list. When the link IS recreated, it
+ * may be attached to whichever slot currently occupies that index.
  *
  * WHAT THIS MODULE DOES: snapshots the subgraph node's EXTERNAL link set BEFORE the
  * unpack (endpoints resolved to slot NAMES, not indices, because indices shift), and
  * after the unpack re-resolves every expected link against the LIVE link table. A
  * link counts as restored only when the stored link AND the target input's
  * back-reference agree (the ghost above fails exactly that check — same test as
- * connect-verify's isLinkPersisted). What cannot be proven present is reported as
- * dropped so the caller can refuse loudly instead of reporting a corrupt success.
+ * connect-verify's isLinkPersisted) AND, when the interior identity was readable,
+ * the wire sits on that named slot with a compatible type. What cannot be proven
+ * present (or uniquely identified) is reported as dropped so the caller can refuse
+ * loudly instead of reporting a corrupt success.
  *
  * Pure (no DOM / no ComfyUI globals — graph + nodes are passed in) so the SAME check
  * runs under unit test and in production. Fully defensive; never throws — an
  * unreadable piece lands in `unverifiable` rather than breaking the unpack report.
+ * A readable-but-ambiguous interior identity is DROPPED, not unverifiable: guessing
+ * the child would be the scramble this exists to stop.
  */
 
 /** All stored link objects on `graph` — `graph.links` is a Map in current LiteGraph
@@ -73,21 +87,206 @@ function slotIndexByName(slots, name) {
 }
 
 /**
+ * Slot index of `name` only when that name is UNIQUE on `slots`. Duplicates are
+ * unpairable — returning the first hit would reseat onto a coin-flip child.
+ */
+function uniqueSlotIndexByName(slots, name) {
+  if (typeof name !== "string" || !Array.isArray(slots)) return -1;
+  const lower = name.toLowerCase();
+  let found = -1;
+  for (let i = 0; i < slots.length; i++) {
+    if (slots[i]?.name?.toLowerCase() !== lower) continue;
+    if (found !== -1) return -1;
+    found = i;
+  }
+  return found;
+}
+
+function slotTypeOf(slot, fallback) {
+  const t = slot?.type ?? fallback;
+  if (typeof t === "string") return t;
+  if (t == null) return null;
+  return String(t);
+}
+
+/** Compatible when either side is missing/wildcard, equal, or shares a union member. */
+function typesCompatible(a, b) {
+  if (a == null || b == null) return true;
+  const left = String(a).toUpperCase();
+  const right = String(b).toUpperCase();
+  if (left === right) return true;
+  if (left === "*" || right === "*" || left === "0" || right === "0") return true;
+  const as = left.split(",").map((s) => s.trim()).filter(Boolean);
+  const bs = right.split(",").map((s) => s.trim()).filter(Boolean);
+  return as.some((x) => bs.includes(x));
+}
+
+function writeTargetSlot(stored, nodeId, index) {
+  if (!stored || typeof stored !== "object") return;
+  try {
+    if (Array.isArray(stored)) {
+      stored[3] = nodeId;
+      stored[4] = index;
+      return;
+    }
+    stored.target_id = nodeId;
+    stored.target_slot = index;
+  } catch {
+    /* best-effort retarget */
+  }
+}
+
+function interiorLinkStoreKind(subgraph) {
+  if (!subgraph || typeof subgraph !== "object") return null;
+  try {
+    if (typeof subgraph.getLink === "function") return "getLink";
+  } catch {
+    /* fall through */
+  }
+  try {
+    if (subgraph._links) return "_links";
+  } catch {
+    /* fall through */
+  }
+  try {
+    if (subgraph.links) return "links";
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+function readInteriorLink(subgraph, id) {
+  if (!subgraph || id == null) return null;
+  try {
+    if (typeof subgraph.getLink === "function") {
+      const stored = subgraph.getLink(id);
+      if (stored != null) return stored;
+    }
+  } catch {
+    /* try maps */
+  }
+  try {
+    for (const links of [subgraph._links, subgraph.links]) {
+      if (!links) continue;
+      const stored = typeof links.get === "function" ? links.get(id) : links[id];
+      if (stored != null) return stored;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function getSubgraphNode(subgraph, id) {
+  try {
+    if (id != null && typeof subgraph?.getNodeById === "function") {
+      const node = subgraph.getNodeById(id);
+      if (node) return node;
+    }
+  } catch {
+    /* fall through */
+  }
+  try {
+    const nodes = subgraph?._nodes ?? subgraph?.nodes;
+    if (Array.isArray(nodes)) {
+      return nodes.find((n) => String(n.id) === String(id)) ?? null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function namedEndpoint(node, slots, slotIndex, fallbackType) {
+  const slot = slots?.[slotIndex];
+  const name = typeof slot?.name === "string" ? slot.name : null;
+  if (!node || name == null) return null;
+  return { node_id: node.id, name, type: slotTypeOf(slot, fallbackType) };
+}
+
+/**
  * Count LIVE links out of (`nodeId`, `outIdx`) — live means the stored link exists
  * AND its target input back-references the same link id. The one-sided ghost of
  * #1665 (stored + on the origin's list, but the target input is `link: null`) is
  * NOT live, which is exactly what makes it detectable here.
  */
-function liveLinkCountFrom(graph, nodeId, outIdx) {
-  let count = 0;
+function liveLinksFrom(graph, nodeId, outIdx) {
+  const live = [];
   for (const stored of storedLinks(graph)) {
     if (stored == null) continue;
     if (String(linkOriginId(stored)) !== String(nodeId)) continue;
     if (Number(linkOriginSlot(stored)) !== Number(outIdx)) continue;
     const target = getNode(graph, linkTargetId(stored));
-    if (target?.inputs?.[linkTargetSlot(stored)]?.link === linkId(stored)) count += 1;
+    if (target?.inputs?.[linkTargetSlot(stored)]?.link === linkId(stored)) live.push(stored);
   }
-  return count;
+  return live;
+}
+
+function liveLinkCountFrom(graph, nodeId, outIdx) {
+  return liveLinksFrom(graph, nodeId, outIdx).length;
+}
+
+/**
+ * Interior consumers of a host input rail, named by the child slot (including a
+ * dotted autogrow path). Only runs when the subgraph actually exposes a link
+ * store — fixtures/frontends without one keep the count-only #1665 path.
+ *
+ * `unresolved` is true when the store exists but a consumer cannot be named
+ * uniquely (missing record, unnamed slot). That is a refusal, not unverifiable.
+ */
+function snapshotInteriorConsumers(subgraphNode, railIndex) {
+  const subgraph = subgraphNode?.subgraph;
+  const railSlot = subgraph?.inputs?.[railIndex];
+  const ids = Array.isArray(railSlot?.linkIds) ? railSlot.linkIds : [];
+  const consumers = [];
+  if (!ids.length || !interiorLinkStoreKind(subgraph)) {
+    return { consumers, unresolved: false };
+  }
+  let unresolved = false;
+  const seen = new Map();
+  for (const lid of ids) {
+    const stored = readInteriorLink(subgraph, lid);
+    const targetId = stored ? linkTargetId(stored) : null;
+    const targetSlot = stored ? linkTargetSlot(stored) : null;
+    const target = getSubgraphNode(subgraph, targetId);
+    const endpoint = namedEndpoint(target, target?.inputs, targetSlot, railSlot?.type);
+    if (!endpoint) {
+      unresolved = true;
+      continue;
+    }
+    const key = `${String(endpoint.node_id)}\0${endpoint.name.toLowerCase()}`;
+    if (seen.has(key)) {
+      unresolved = true;
+      continue;
+    }
+    seen.set(key, true);
+    consumers.push(endpoint);
+  }
+  return { consumers, unresolved };
+}
+
+function snapshotInteriorProducer(subgraphNode, railIndex) {
+  const subgraph = subgraphNode?.subgraph;
+  const railSlot = subgraph?.outputs?.[railIndex];
+  const ids = Array.isArray(railSlot?.linkIds) ? railSlot.linkIds : [];
+  if (!ids.length || !interiorLinkStoreKind(subgraph)) {
+    return { producer: null, unresolved: false };
+  }
+  let producer = null;
+  for (const lid of ids) {
+    const stored = readInteriorLink(subgraph, lid);
+    const originId = stored ? linkOriginId(stored) : null;
+    const originSlot = stored ? linkOriginSlot(stored) : null;
+    const origin = getSubgraphNode(subgraph, originId);
+    const endpoint = namedEndpoint(origin, origin?.outputs, originSlot, railSlot?.type);
+    if (!endpoint) return { producer: null, unresolved: true };
+    if (producer && (String(producer.node_id) !== String(endpoint.node_id) || producer.name.toLowerCase() !== endpoint.name.toLowerCase())) {
+      return { producer: null, unresolved: true };
+    }
+    producer = endpoint;
+  }
+  return { producer, unresolved: false };
 }
 
 /**
@@ -128,11 +327,20 @@ export function snapshotExternalLinks(graph, subgraphNode) {
       let consumers = 1;
       const railSlot = subgraphNode.subgraph?.inputs?.[i];
       if (railSlot && Array.isArray(railSlot.linkIds)) consumers = railSlot.linkIds.length;
+      const interior = snapshotInteriorConsumers(subgraphNode, i);
       links.push({
         kind: "in",
         rail,
-        source: { node_id: originId, slot: originSlot, name },
+        rail_type: slotTypeOf(slot, railSlot?.type),
+        source: {
+          node_id: originId,
+          slot: originSlot,
+          name,
+          type: slotTypeOf(origin.outputs?.[originSlot]),
+        },
         consumers,
+        interior: interior.consumers,
+        identity_unresolved: interior.unresolved,
         baseline: liveLinkCountFrom(graph, originId, originSlot),
       });
     }
@@ -154,7 +362,19 @@ export function snapshotExternalLinks(graph, subgraphNode) {
           });
           continue;
         }
-        links.push({ kind: "out", rail, target: { node_id: targetId, slot: targetSlot, name } });
+        const producerSnap = snapshotInteriorProducer(subgraphNode, i);
+        links.push({
+          kind: "out",
+          rail,
+          target: {
+            node_id: targetId,
+            slot: targetSlot,
+            name,
+            type: slotTypeOf(target.inputs?.[targetSlot]),
+          },
+          producer: producerSnap.producer,
+          identity_unresolved: producerSnap.unresolved,
+        });
       }
     }
   } catch {
@@ -169,9 +389,18 @@ export function snapshotExternalLinks(graph, subgraphNode) {
 function describeExpected(e) {
   const srcName = e.source?.name ?? `slot ${e.source?.slot}`;
   const tgtName = e.target?.name ?? `slot ${e.target?.slot}`;
-  return e.kind === "in"
-    ? `${e.source?.node_id}.${srcName} → subgraph input "${e.rail}" (fed ${e.consumers} interior node(s))`
-    : `subgraph output "${e.rail}" → ${e.target?.node_id}.${tgtName}`;
+  if (e.kind === "in") {
+    const interior = Array.isArray(e.interior) ? e.interior : [];
+    if (interior.length) {
+      const dest = interior.map((c) => `${c.node_id}.${c.name}`).join(", ");
+      return `${e.source?.node_id}.${srcName} → ${dest} (via subgraph input "${e.rail}")`;
+    }
+    return `${e.source?.node_id}.${srcName} → subgraph input "${e.rail}" (fed ${e.consumers} interior node(s))`;
+  }
+  if (e.producer?.name) {
+    return `${e.producer.node_id}.${e.producer.name} → ${e.target?.node_id}.${tgtName} (via subgraph output "${e.rail}")`;
+  }
+  return `subgraph output "${e.rail}" → ${e.target?.node_id}.${tgtName}`;
 }
 
 /**
@@ -201,33 +430,199 @@ export function verifyExternalLinks(graph, snapshot) {
   return { restored, dropped, unverifiable };
 }
 
-/** External SOURCE → rail → interior consumer(s): the unpack should leave
- *  `baseline - 1 + consumers` live links from the source slot (the rail link itself
- *  is gone, one new live link per interior consumer). */
-function inboundRestored(graph, e) {
+function originOutIndex(graph, e) {
   const origin = getNode(graph, e.source?.node_id);
-  if (!origin) return false;
+  if (!origin) return null;
   let outIdx = slotIndexByName(origin.outputs, e.source?.name);
   if (outIdx === -1) outIdx = e.source?.slot;
+  return outIdx == null ? null : outIdx;
+}
+
+function inboundConsumerRestored(graph, e, consumer, outIdx) {
+  const target = getNode(graph, consumer.node_id);
+  if (!target) return false;
+  const inIdx = uniqueSlotIndexByName(target.inputs, consumer.name);
+  if (inIdx === -1) return false;
+  const slot = target.inputs[inIdx];
+  if (!typesCompatible(slot?.type, consumer.type ?? e.rail_type ?? e.source?.type)) return false;
+  const id = slot?.link;
+  if (id == null) return false;
+  const stored = readLink(graph, id);
+  if (!stored) return false;
+  return (
+    String(linkOriginId(stored)) === String(e.source.node_id) &&
+    Number(linkOriginSlot(stored)) === Number(outIdx) &&
+    String(linkTargetId(stored)) === String(consumer.node_id) &&
+    Number(linkTargetSlot(stored)) === Number(inIdx) &&
+    slot.link === linkId(stored)
+  );
+}
+
+function inboundHasScrambledSibling(graph, e, outIdx) {
+  const expected = new Map();
+  for (const consumer of e.interior ?? []) {
+    const key = String(consumer.node_id);
+    if (!expected.has(key)) expected.set(key, new Set());
+    expected.get(key).add(String(consumer.name).toLowerCase());
+  }
+  for (const stored of liveLinksFrom(graph, e.source.node_id, outIdx)) {
+    const tid = String(linkTargetId(stored));
+    if (!expected.has(tid)) continue;
+    const target = getNode(graph, linkTargetId(stored));
+    const name = target?.inputs?.[linkTargetSlot(stored)]?.name;
+    if (typeof name !== "string" || !expected.get(tid).has(name.toLowerCase())) return true;
+  }
+  return false;
+}
+
+/** External SOURCE → rail → interior consumer(s): the unpack should leave
+ *  `baseline - 1 + consumers` live links from the source slot (the rail link itself
+ *  is gone, one new live link per interior consumer). When interior identity was
+ *  readable, each named child must hold that wire — a count match on the wrong
+ *  dynamic slot is #2887, not a restore. */
+function inboundRestored(graph, e) {
+  if (e.identity_unresolved) return false;
+  const outIdx = originOutIndex(graph, e);
   if (outIdx == null) return false;
+  const interior = Array.isArray(e.interior) ? e.interior : [];
+  if (interior.length) {
+    return (
+      interior.every((consumer) => inboundConsumerRestored(graph, e, consumer, outIdx)) &&
+      !inboundHasScrambledSibling(graph, e, outIdx)
+    );
+  }
   const expected = Math.max(0, (e.baseline ?? 1) - 1) + (e.consumers ?? 1);
   return liveLinkCountFrom(graph, e.source.node_id, outIdx) >= expected;
 }
 
 /** Rail → external TARGET: the target node survives the unpack, so the check is
  *  name-based on its CURRENT inputs (indices may have shifted — that is the bug).
- *  The input must reference a stored link that agrees it targets this node/slot. */
+ *  The input must reference a stored link that agrees it targets this node/slot.
+ *  When the interior producer was named, that origin must be the live source. */
 function outboundRestored(graph, e) {
+  if (e.identity_unresolved) return false;
   const target = getNode(graph, e.target?.node_id);
   if (!target) return false;
-  const inIdx = slotIndexByName(target.inputs, e.target?.name);
-  if (inIdx === -1) return false; // name gone — cannot prove survival, fail closed
+  const inIdx = uniqueSlotIndexByName(target.inputs, e.target?.name);
+  if (inIdx === -1) return false; // name gone or duplicated — cannot prove survival
   const id = target.inputs?.[inIdx]?.link;
   if (id == null) return false;
   const stored = readLink(graph, id);
   if (!stored) return false;
+  if (
+    String(linkTargetId(stored)) !== String(e.target.node_id) ||
+    Number(linkTargetSlot(stored)) !== Number(inIdx)
+  ) {
+    return false;
+  }
+  if (!typesCompatible(target.inputs[inIdx]?.type, e.target?.type)) return false;
+  if (!e.producer) return true;
+  const origin = getNode(graph, e.producer.node_id);
+  if (!origin) return false;
+  const outIdx = uniqueSlotIndexByName(origin.outputs, e.producer.name);
+  if (outIdx === -1) return false;
   return (
-    String(linkTargetId(stored)) === String(e.target.node_id) &&
-    Number(linkTargetSlot(stored)) === Number(inIdx)
+    String(linkOriginId(stored)) === String(e.producer.node_id) &&
+    Number(linkOriginSlot(stored)) === Number(outIdx) &&
+    typesCompatible(origin.outputs?.[outIdx]?.type, e.producer.type)
   );
+}
+
+function clearSlotIfHolds(node, index, id) {
+  try {
+    const slot = node?.inputs?.[index];
+    if (slot && slot.link === id) slot.link = null;
+  } catch {
+    /* skip a hostile slot */
+  }
+}
+
+function reseatInbound(graph, e) {
+  if (e.identity_unresolved) return 0;
+  const interior = Array.isArray(e.interior) ? e.interior : [];
+  if (!interior.length) return 0;
+  const outIdx = originOutIndex(graph, e);
+  if (outIdx == null) return 0;
+  const live = liveLinksFrom(graph, e.source.node_id, outIdx);
+  const used = new Set();
+  let reseated = 0;
+  for (const consumer of interior) {
+    const target = getNode(graph, consumer.node_id);
+    if (!target) continue;
+    const inIdx = uniqueSlotIndexByName(target.inputs, consumer.name);
+    if (inIdx === -1) continue;
+    const dest = target.inputs[inIdx];
+    if (!dest || !typesCompatible(dest.type, consumer.type ?? e.rail_type ?? e.source?.type)) continue;
+    if (inboundConsumerRestored(graph, e, consumer, outIdx)) {
+      const keep = dest.link;
+      if (keep != null) used.add(String(keep));
+      continue;
+    }
+    const candidate = live.find((stored) => {
+      const id = linkId(stored);
+      if (id == null || used.has(String(id))) return false;
+      return String(linkTargetId(stored)) === String(consumer.node_id);
+    });
+    if (!candidate) continue;
+    const candidateId = linkId(candidate);
+    if (dest.link != null && dest.link !== candidateId) {
+      const occupying = readLink(graph, dest.link);
+      if (occupying && dest.link === linkId(occupying)) continue;
+    }
+    const fromIdx = Number(linkTargetSlot(candidate));
+    if (fromIdx !== inIdx) clearSlotIfHolds(target, fromIdx, candidateId);
+    dest.link = candidateId;
+    writeTargetSlot(candidate, consumer.node_id, inIdx);
+    used.add(String(candidateId));
+    reseated += 1;
+  }
+  return reseated;
+}
+
+function reseatOutbound(graph, e) {
+  if (e.identity_unresolved || !e.producer) return 0;
+  const target = getNode(graph, e.target?.node_id);
+  const origin = getNode(graph, e.producer.node_id);
+  if (!target || !origin) return 0;
+  const inIdx = uniqueSlotIndexByName(target.inputs, e.target.name);
+  const outIdx = uniqueSlotIndexByName(origin.outputs, e.producer.name);
+  if (inIdx === -1 || outIdx === -1) return 0;
+  const dest = target.inputs[inIdx];
+  if (!dest || !typesCompatible(dest.type, e.target.type ?? e.producer.type)) return 0;
+  if (outboundRestored(graph, e)) return 0;
+  const candidate = liveLinksFrom(graph, e.producer.node_id, outIdx).find(
+    (stored) => String(linkTargetId(stored)) === String(e.target.node_id),
+  );
+  if (!candidate) return 0;
+  const candidateId = linkId(candidate);
+  if (dest.link != null && dest.link !== candidateId) {
+    const occupying = readLink(graph, dest.link);
+    if (occupying && dest.link === linkId(occupying)) return 0;
+  }
+  const fromIdx = Number(linkTargetSlot(candidate));
+  if (fromIdx !== inIdx) clearSlotIfHolds(target, fromIdx, candidateId);
+  dest.link = candidateId;
+  writeTargetSlot(candidate, e.target.node_id, inIdx);
+  return 1;
+}
+
+/**
+ * Move live unpack wires that landed on the wrong index onto the unique named
+ * identity snapshotted before the unpack. Never throws. Returns how many
+ * endpoints were rewritten; verifyExternalLinks is still the verdict.
+ */
+export function reseatExternalLinksByIdentity(graph, snapshot) {
+  let reseated = 0;
+  try {
+    for (const e of snapshot?.links ?? []) {
+      try {
+        reseated += e.kind === "in" ? reseatInbound(graph, e) : reseatOutbound(graph, e);
+      } catch {
+        /* one bad expected link must not abort the rest */
+      }
+    }
+  } catch {
+    return reseated;
+  }
+  return reseated;
 }


### PR DESCRIPTION
Related to artokun/comfyui-mcp#2887

## What
`panel_unpack_subgraph` could report success while restoring MiniMaxH3ReferenceToVideo dynamic inputs onto the wrong children. LiteGraph rewires by slot index; after an autogrow rebuild that index is a different named slot, so an IMAGE feed could land on `ref_videos.ref_video_0`. #1665 only counted surviving live wires, so the scramble was invisible.

## Fix
Snapshot interior consumers/producers by unique named identity (dynamic namespace + child + type) before unpack. After litegraph returns, reseat any misplaced live wire onto that identity, then verify. Duplicate names, type mismatch, or an unreadable interior identity fail closed and roll the workflow back.

## Evidence
`browser_tests/unit/unpack-link-verify.test.mjs` (#2887): count-matching scramble onto `ref_videos` is dropped; reseat moves IMAGE onto `ref_images.ref_image_0`; duplicate child names are not guessed. Existing #1665 and #1938 unpack tests still pass (21 unpack-link/duplicate tests).

Not merged. No release.