### PR TITLE
fix(panel): preserve ask_user cards across same-session reconnect (#2218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- interactive ask/question cards now retain their URL+epoch correlation across a same-session reconnect, replay the pending answer only to that proven session, and withdraw mismatched cards without painting duplicates (#2218)
+
 ## [0.15.181] - 2026-09-07
 
 ### Fixed

--- a/browser_tests/unit/adult-consent-wait.test.mjs
+++ b/browser_tests/unit/adult-consent-wait.test.mjs
@@ -167,7 +167,8 @@ function makeQuestionPainter({
     "tr",
     "INTERACTIVE_ABANDONED",
     "waitForAdultConsentAnswer",
-    `${namedFunctionSource(source, "paintQuestion")}; return paintQuestion;`,
+    `${namedFunctionSource(source, "normalizeInteractiveCardScope")};
+     ${namedFunctionSource(source, "paintQuestion")}; return paintQuestion;`,
   )(
     document,
     log,
@@ -272,7 +273,7 @@ test("#390 the painter imports and returns the shipped consent wait", () => {
   assert.match(paint, /return handedToCaller;/);
   assert.match(
     namedFunctionSource(source, "createBridgeClient"),
-    /result = await onAsk\(msg, thisSock\.__cmcpSocketId \?\? null\)/,
+    /result = await onAsk\(msg, \{[\s\S]*?socketId: thisSock\.__cmcpSocketId \?\? null,[\s\S]*?url: thisSock\.__cmcpBridgeUrl \?\? socketUrl,[\s\S]*?epoch: thisSock\.__cmcpBridgeEpoch,/,
     "the executor still awaits the painter's promise — that is the command duration",
   );
 });

--- a/browser_tests/unit/bridge-disconnect.test.mjs
+++ b/browser_tests/unit/bridge-disconnect.test.mjs
@@ -12,7 +12,7 @@ const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", imp
 
 function bridgeStatusHandler() {
   const source = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
-  const start = source.indexOf("const client = createBridgeClient({\n    onStatus(state, socketId) {");
+  const start = source.indexOf("const client = createBridgeClient({\n    onStatus(state, socketId, bridgeScope) {");
   assert.notEqual(start, -1, "could not locate the bridge status callback");
   const end = source.indexOf("\n    onSay(", start);
   assert.notEqual(end, -1, "could not locate the callback following onStatus");

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -177,7 +177,7 @@ test("codex R8: replay never crosses a bridge change — entries for another bri
   const body = src.slice(start, src.indexOf("\n  }", start));
   assert.match(
     body,
-    /if \(!isReplayable\(entry, \{ now, targetUrl, targetEpoch \}\)\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
+    /if \(!lostReplies\.canReplay\(entry, \{ now, targetUrl, targetEpoch \}\)\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
     "an outcome belonging to a previous bridge, session, or too old must never be volunteered",
   );
   assert.match(body, /lostReplies\.replayReply\(entry, \{ now, targetUrl, targetEpoch \}\)/, "same-session sensitive frames use the guarded selector");
@@ -272,6 +272,22 @@ test("#2218: sensitive replies correlate once and replay raw only to the proven 
     assert.deepEqual(j.summaries({ now, targetUrl: URL_A, targetEpoch: "e2" }), [], `${cmd}: mismatch is withdrawn, not advertised`);
     assert.equal(j.replayReply(entry, { now, targetUrl: URL_A }), entry.reply, `${cmd}: an unknown epoch fails closed`);
   }
+});
+
+test("#2218: an epoch-less sensitive reply is never replayable across a same-URL replacement", () => {
+  const URL_A = "ws://127.0.0.1:9199";
+  const now = 1_000_000;
+  const j = createLostReplyJournal();
+  const reply = { rid: "legacy-secret", ok: true, result: "user-private-value" };
+  const entry = j.record({ reply, cmd: "ask_user", at: now - 1000, url: URL_A });
+
+  assert.equal(j.canReplay(entry, { now, targetUrl: URL_A }), false);
+  assert.equal(j.replayReply(entry, { now, targetUrl: URL_A }).result, undefined);
+  assert.deepEqual(
+    j.summaries({ now, targetUrl: URL_A }),
+    [],
+    "an unproven replacement must not even advertise the sensitive outcome",
+  );
 });
 
 test("#694: the journal records the session epoch and summaries filter by it identically", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -288,6 +288,20 @@ test("#2218: an epoch-less sensitive reply is never replayable across a same-URL
     [],
     "an unproven replacement must not even advertise the sensitive outcome",
   );
+
+  const failureJournal = createLostReplyJournal();
+  const failure = failureJournal.record({
+    reply: { rid: "safe-failure", ok: false, error: "question withdrawn" },
+    cmd: "request_secret",
+    at: now - 1000,
+    url: URL_A,
+  });
+  assert.equal(
+    failureJournal.canReplay(failure, { now, targetUrl: URL_A }),
+    false,
+    "even a payload-free sensitive failure needs a proven session",
+  );
+  assert.deepEqual(failureJournal.summaries({ now, targetUrl: URL_A }), []);
 });
 
 test("#694: the journal records the session epoch and summaries filter by it identically", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -32,6 +32,7 @@ import {
   describeUndeliveredReply,
   createLostReplyJournal,
   isReplayable,
+  sameBridgeSession,
   REPLAY_MAX_AGE_MS,
   SENSITIVE_RESULT_CMDS,
   redactSensitiveReply,
@@ -133,10 +134,10 @@ test("the journal keeps the EXACT reply frame (replayable verbatim) but omits it
   assert.deepEqual(j.summaries(), [{ rid: "abc", cmd: "workflow_open", ok: true, reason: "socket_closed", at: 7 }]);
 });
 
-test("codex R8: a SENSITIVE result is never journaled in the clear (it must not survive to a replay)", () => {
+test("codex R8: a SENSITIVE result is never exposed in the public journal", () => {
   // request_secret's result IS the pasted secret; ask_user's is whatever the user typed.
-  // A journaled raw frame is replayed on whatever socket is current later — which can be a
-  // DIFFERENT orchestrator after a backend switch — so the payload must not be kept at all.
+  // The public entry is replayed on whatever socket is current later — which can be a
+  // DIFFERENT orchestrator after a backend switch — so it must never contain the payload.
   for (const cmd of ["request_secret", "ask_user"]) {
     assert.ok(SENSITIVE_RESULT_CMDS.has(cmd), `${cmd} must be classified sensitive`);
     const j = createLostReplyJournal();
@@ -179,6 +180,7 @@ test("codex R8: replay never crosses a bridge change — entries for another bri
     /if \(!isReplayable\(entry, \{ now, targetUrl, targetEpoch \}\)\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
     "an outcome belonging to a previous bridge, session, or too old must never be volunteered",
   );
+  assert.match(body, /lostReplies\.replayReply\(entry, \{ now, targetUrl, targetEpoch \}\)/, "same-session sensitive frames use the guarded selector");
   assert.match(body, /lostReplies\.replace\(keep\)/, "only undeliverable-but-still-ours entries are retried");
   assert.match(body, /Discarded \$\{dropped\}/, "the user must be told what was discarded");
   // codex R9 — the comparison must use the SOCKET's own bridge, not the mutable current
@@ -242,6 +244,34 @@ test("#694: isReplayable demands the SAME session epoch — match replays, misma
     false,
     "an epoch-less entry must not replay to an epoch'd target",
   );
+});
+
+test("#2218: sensitive replies correlate once and replay raw only to the proven same session", () => {
+  const URL_A = "ws://127.0.0.1:9199";
+  const now = 1_000_000;
+  assert.equal(sameBridgeSession({ sourceUrl: URL_A, sourceEpoch: "e1", targetUrl: URL_A, targetEpoch: "e1" }), true);
+  assert.equal(sameBridgeSession({ sourceUrl: URL_A, sourceEpoch: 0, targetUrl: URL_A, targetEpoch: 0 }), true);
+  assert.equal(sameBridgeSession({ sourceUrl: URL_A, sourceEpoch: "e1", targetUrl: URL_A, targetEpoch: "e2" }), false);
+  assert.equal(sameBridgeSession({ sourceUrl: URL_A, sourceEpoch: "e1", targetUrl: "ws://other", targetEpoch: "e1" }), false);
+  assert.equal(sameBridgeSession({ sourceUrl: URL_A, sourceEpoch: "e1", targetUrl: URL_A }), false);
+  assert.equal(sameBridgeSession({ sourceUrl: URL_A, targetUrl: URL_A }), false);
+  assert.equal(sameBridgeSession({ sourceUrl: URL_A, sourceEpoch: NaN, targetUrl: URL_A, targetEpoch: NaN }), false);
+
+  for (const cmd of ["ask_user", "request_secret"]) {
+    const j = createLostReplyJournal();
+    const reply = { rid: `${cmd}-rid`, ok: true, result: "user-private-value" };
+    const entry = j.record({ reply, cmd, at: now - 1000, url: URL_A, epoch: "e1" });
+    const sameSession = j.replayReply(entry, { now, targetUrl: URL_A, targetEpoch: "e1" });
+    assert.deepEqual(sameSession, reply, `${cmd}: same-session replay preserves correlation and result`);
+    assert.equal(j.summaries({ now, targetUrl: URL_A, targetEpoch: "e1" })[0].ok, true, `${cmd}: status is not falsely pending`);
+
+    const mismatch = j.replayReply(entry, { now, targetUrl: URL_A, targetEpoch: "e2" });
+    assert.equal(mismatch.ok, false, `${cmd}: a restarted orchestrator gets a failure`);
+    assert.equal(mismatch.result, undefined, `${cmd}: the mismatch gets no private result`);
+    assert.equal(JSON.stringify(mismatch).includes("user-private-value"), false, `${cmd}: no value crosses the session fence`);
+    assert.deepEqual(j.summaries({ now, targetUrl: URL_A, targetEpoch: "e2" }), [], `${cmd}: mismatch is withdrawn, not advertised`);
+    assert.equal(j.replayReply(entry, { now, targetUrl: URL_A }), entry.reply, `${cmd}: an unknown epoch fails closed`);
+  }
 });
 
 test("#694: the journal records the session epoch and summaries filter by it identically", () => {

--- a/browser_tests/unit/i18n.test.mjs
+++ b/browser_tests/unit/i18n.test.mjs
@@ -739,7 +739,7 @@ test("every connection status token has a translated label", () => {
   // Scoped to the onStatus handler, not the whole file, for two reasons: a whole-file
   // doesNotMatch dumps 1.6MB into the failure output, and a COMMENT explaining the rejected
   // shape would trip it — which is exactly what happened on the first run.
-  const onStatusAt = src.indexOf("onStatus(state, socketId)");
+  const onStatusAt = src.indexOf("onStatus(state, socketId, bridgeScope)");
   assert.notEqual(onStatusAt, -1, "onStatus handler must exist");
   const handler = src.slice(onStatusAt, onStatusAt + 1400).replace(/^\s*\/\/.*$/gm, "");
   assert.doesNotMatch(handler, /tr\(\s*`/, "status keys must be literal, not assembled at runtime");

--- a/browser_tests/unit/interactive-abandon.test.mjs
+++ b/browser_tests/unit/interactive-abandon.test.mjs
@@ -11,11 +11,10 @@
  *
  * What is real is underneath it. `ask_user` / `request_secret` are the only commands whose
  * executor blocks on a human, and retirement (0.13.0) deliberately does not resolve the
- * card's promise. So the executor stays suspended forever, `settleRid` never runs, and the
- * ledger keeps an IN-FLIGHT entry — which is never evicted, by design, because dropping an
- * unsettled command would let its replay double-apply. Two consequences, both tested here:
- * the entry is unreclaimable, and a redelivery of that rid awaits a promise that can never
- * resolve, so the panel answers NOTHING at all.
+ * card's promise. On a different or unproven bridge session the panel therefore abandons
+ * the card, settles the command with a payload-free sentinel failure, and never forwards
+ * the user's input. A same URL + epoch reconnect is the narrow exception: its private
+ * journal entry may replay once to the proven same session, without painting a second card.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -191,19 +190,17 @@ test("#952 (codex ×2) the claim is the LEDGER — not a caller-visible recovery
   }
 });
 
-test("#952 (codex r4) the trigger is a REPLACEMENT connection, not a bare disconnect", () => {
-  // The header used to say the card is retired "when the connection that asked drops".
-  // The sweep runs from a `connected` status carrying a different socket id — so a socket
-  // that simply drops retires nothing, and the card stays live until something replaces
-  // it. Documenting the wrong trigger would have a reader expect an abandonment reply at
-  // a moment when none is produced.
+test("#2218: the trigger is a replacement session, not a bare disconnect", () => {
+  // A socket drop alone does not prove that the orchestrator session changed. The sweep
+  // runs only from a connected handshake and compares the URL + epoch pair, so a same-
+  // session reconnect keeps its card while a different or unproven session withdraws it.
   const src = readFileSync(new URL("../../web/js/lib/interactive-abandon.js", import.meta.url), "utf8");
   assert.match(src, /a bare disconnect retires nothing/, "the trigger is stated correctly");
   const panel = readFileSync(PANEL, "utf8");
   assert.match(
     panel,
-    /if \(state === "connected"\) retireInteractiveCardsFromPreviousSockets\(\);/,
-    "and that is what the wiring does",
+    /if \(state === "connected"\) \{[\s\S]*?retireInteractiveCardsFromPreviousSessions\(connectedScope\);/,
+    "the wiring sweeps only after a connected session handshake",
   );
 });
 
@@ -220,7 +217,7 @@ test("#952 (codex r3) the note does not claim a card that may not be on screen",
 
 test("#952 source: retirement disables the card AND ends its command, in that order", () => {
   const src = readFileSync(PANEL, "utf8");
-  const start = src.indexOf("function retireInteractiveCardsFromPreviousSockets()");
+  const start = src.indexOf("function retireInteractiveCardsFromPreviousSessions(");
   assert.ok(start > 0, "the sweep exists");
   const body = src.slice(start, src.indexOf("\n  }", start));
   const retireAt = body.indexOf("record.retire?.()");
@@ -254,7 +251,7 @@ test("#952 source: the abandon flag is NOT the answered flag", () => {
 
 test("#952 source: both interactive executors recognize the sentinel and throw", () => {
   const src = readFileSync(PANEL, "utf8");
-  for (const call of ["onAsk(msg, thisSock.__cmcpSocketId", "onSecret(msg, thisSock.__cmcpSocketId"]) {
+  for (const call of ["onAsk(msg, {", "onSecret(msg, {"]) {
     const at = src.indexOf(call);
     assert.ok(at > 0, call);
     const after = src.slice(at, at + 900);

--- a/browser_tests/unit/interactive-card-fence.test.mjs
+++ b/browser_tests/unit/interactive-card-fence.test.mjs
@@ -425,6 +425,9 @@ function buildHandlers() {
     let lastMintedThreadId = null;
     let thread = null;
     let pendingSecretRequest = null;
+    // This harness extracts the fence and host callbacks without the full card registry;
+    // the registry's duplicate guard is covered by stale-interactive-card.test.mjs.
+    const interactiveCardWouldDuplicate = () => false;
     ${fenceMatch[0]}
     const host = {
       ${onAskSrc}
@@ -574,6 +577,9 @@ function buildLifecycle() {
     let thread = null;
     let localEndAt = 0;
     let pendingSecretRequest = null;
+    // This harness extracts the fence and host callbacks without the full card registry;
+    // the registry's duplicate guard is covered by stale-interactive-card.test.mjs.
+    const interactiveCardWouldDuplicate = () => false;
     let lastAgentGraph = null, lastAgentGraphKey = null, lastAgentGraphEpoch = null, sessionEpoch = 0;
     const completeDedicatedWorkflowSessionSwap = () => {};
     const settlePendingDedicatedWorkflowSwapAfterCancellation = () => {};

--- a/browser_tests/unit/pi-readiness-ordering.test.mjs
+++ b/browser_tests/unit/pi-readiness-ordering.test.mjs
@@ -26,7 +26,7 @@ test("#505 panel wiring records the backends frame before allowing Pi ack promot
   assert.ok(backendsStart >= 0 && ackStart > backendsStart, "could not locate bridge callbacks");
   const backends = source.slice(backendsStart, ackStart);
   const ack = source.slice(ackStart, source.indexOf("    getResume:", ackStart));
-  const statusStart = source.indexOf("    onStatus(state, socketId) {");
+  const statusStart = source.indexOf("    onStatus(state, socketId, bridgeScope) {");
   const status = source.slice(statusStart, source.indexOf("    onSay(", statusStart));
 
   assert.match(backends, /piBackendsReadinessReceived = true/, "backends frame must unlock Pi ack promotion");

--- a/browser_tests/unit/restart-confirmation-transport.test.mjs
+++ b/browser_tests/unit/restart-confirmation-transport.test.mjs
@@ -109,7 +109,8 @@ function makeQuestionPainter({ record = () => {}, onReveal = () => {} } = {}) {
     "tr",
     "INTERACTIVE_ABANDONED",
     "waitForAdultConsentAnswer",
-    `${namedFunctionSource(source, "paintQuestion")}; return paintQuestion;`,
+    `${namedFunctionSource(source, "normalizeInteractiveCardScope")};
+     ${namedFunctionSource(source, "paintQuestion")}; return paintQuestion;`,
   )(
     document,
     log,
@@ -159,7 +160,11 @@ test("#1764 the real question painter settles the command before history persist
 
 test("#1764 production caller path keeps the original ask rid on the answer", () => {
   const bridge = namedFunctionSource(source, "createBridgeClient");
-  assert.match(bridge, /result = await onAsk\(msg, thisSock\.__cmcpSocketId \?\? null\)/);
+  assert.match(
+    bridge,
+    /result = await onAsk\(msg, \{[\s\S]*?socketId: thisSock\.__cmcpSocketId \?\? null,[\s\S]*?url: thisSock\.__cmcpBridgeUrl \?\? socketUrl,[\s\S]*?epoch: thisSock\.__cmcpBridgeEpoch,/,
+    "the answer remains tied to the command's bridge scope",
+  );
   assert.match(bridge, /reply = \{ rid: msg\.rid, ok: true, result: withViewingWitness\(result\) \}/);
   assert.match(bridge, /thisSock\["send"\]\(JSON\.stringify\(reply\)\)/);
   assert.match(bridge, /settleRid\(reply\)/);

--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -181,6 +181,7 @@ function cardRegistryHarness(src) {
     "sameBridgeSession",
     `const liveInteractiveCards = new Set();
      ${namedFunctionSource(src, "registerInteractiveCard")}
+     ${namedFunctionSource(src, "interactiveCardWouldDuplicate")}
      ${namedFunctionSource(src, "bindInteractiveCardsToHandshake")}
      ${namedFunctionSource(src, "retireInteractiveCardsFromPreviousSessions")}
      function onStatus(state, socketId, bridgeScope) {
@@ -189,7 +190,7 @@ function cardRegistryHarness(src) {
          retireInteractiveCardsFromPreviousSessions(bridgeScope);
        }
      }
-     return { registerInteractiveCard, onStatus, size: () => liveInteractiveCards.size };`,
+     return { registerInteractiveCard, interactiveCardWouldDuplicate, onStatus, size: () => liveInteractiveCards.size };`,
   )(sameBridgeSession);
 }
 
@@ -239,6 +240,38 @@ test("#2218: epoch/URL mismatch withdraws, while a pre-handshake card binds to i
   });
   make.onStatus("connected", 3, { url: "ws://other-agent", epoch: "session-2" });
   assert.deepEqual(urlRetired, ["retire", "abandon"], "the URL mismatch also withdraws");
+});
+
+test("#2218: an unproven same-URL retry cannot create a second interactive card", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const make = cardRegistryHarness(src);
+  make.onStatus("connected", 1, { url: "ws://agent", epoch: "session-1" });
+  make.registerInteractiveCard({
+    paintedOnSocketId: 1,
+    paintedOnScope: { url: "ws://agent", epoch: "session-1" },
+    retire: () => {},
+    abandon: () => {},
+  });
+
+  assert.equal(
+    make.interactiveCardWouldDuplicate({ url: "ws://agent" }),
+    true,
+    "an unknown epoch cannot prove that a same-URL replacement is a new interaction",
+  );
+  assert.equal(
+    make.interactiveCardWouldDuplicate({ url: "ws://other-agent" }),
+    false,
+    "a different endpoint is left for its own handshake fence",
+  );
+  assert.equal(
+    make.interactiveCardWouldDuplicate({ url: "ws://agent", epoch: "session-1" }),
+    false,
+    "a proven session may continue through its normal card path",
+  );
+
+  const panel = readFileSync(PANEL_JS, "utf8");
+  assert.match(panel, /fenceInteractiveCard\("ask_user"\);\r?\n\s*if \(interactiveCardWouldDuplicate\(cardScope\)\)/);
+  assert.match(panel, /fenceInteractiveCard\("request_secret"\);\r?\n\s*if \(interactiveCardWouldDuplicate\(cardScope\)/);
 });
 
 test("#2218: repeated handshakes in one bridge session retire nothing", () => {

--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -1,20 +1,12 @@
 /**
- * #952 — a `panel_ask` whose tab disconnects mid-command returns an unknown outcome, and
- * the orchestrator's own message (comfyui-mcp 0.50.88) has to warn:
+ * #2218 — an interactive `panel_ask` card must survive a replacement WebSocket when the
+ * replacement proves the same bridge URL + server-issued session epoch. The old socket id
+ * fence disabled the card and dropped the user's pick even though the orchestrator process
+ * was still the same.
  *
- *   "Expect the stale card to remain on screen: retry suppression is keyed to the socket
- *    that dropped, so this counts as a new command and the user may see two. Tell them
- *    which one to answer."
- *
- * The panel is the side that can just say it. A card painted on a connection that has since
- * been replaced cannot deliver an answer to anyone — the panel deliberately does not replay
- * a reply of this kind across a reconnect — yet it looks exactly as clickable as the newer
- * card beside it.
- *
- * DELIBERATELY NOT TOUCHED, because they are design questions this issue records and leaves
- * to its owner: whether interactive cards should dedupe on a scope that survives a
- * reconnect, and what a retry should return while the original is unanswered. Retiring a
- * dead card needs neither — no new scope, no retry semantics, no ledger change.
+ * The negative side remains load-bearing: an unknown, different URL, or different session
+ * epoch must retire the card and abandon its command. A retry must never paint a second card
+ * merely because the original socket disappeared.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -27,6 +19,7 @@ import { dirname, join } from "node:path";
 // with `{holes}` filled. So the wording assertions below still read the English the panel
 // renders, and they still fail if that English changes.
 import { tr } from "../../web/js/lib/i18n.js";
+import { sameBridgeSession } from "../../web/js/lib/command-liveness.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -111,39 +104,37 @@ test("#952 retirement is presentation only — a hostile card cannot break a rec
   assert.doesNotThrow(() => retire(fakeCard(), { alreadyAnswered: () => { throw new Error("boom"); } }));
 });
 
-test("#952 (codex) source guard: a DIFFERENT SOCKET retires cards, and nothing resolves their promise", () => {
+test("#2218 source guard: cards use a proven bridge session, not a socket", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  // `"connected"` re-fires on every re-handshake — each `models` frame calls markConnected,
-  // and a workflow change re-hellos the LIVE socket — so keying on the status string would
-  // retire cards that are still perfectly answerable. The socket's identity can tell them
-  // apart; the string cannot.
-  assert.match(src, /socketId != null && socketId !== liveSocketId/, "a DIFFERENT socket");
-  assert.match(src, /retireInteractiveCardsFromPreviousSockets\(\);/);
-  assert.ok(!/bridgeConnectSeq/.test(src), "the status-counting trigger must not come back");
-  assert.match(src, /thisSock\.__cmcpSocketId = \+\+socketSeq;/, "minted once per WebSocket");
-  assert.match(src, /onStatus\(s, sock\?\.__cmcpSocketId \?\? null\)/, "and handed to the UI");
-  const sweep = namedFunctionSource(src, "retireInteractiveCardsFromPreviousSockets");
-  assert.match(sweep, /if \(record\.paintedOnSocket === liveSocketId\) continue;/, "only cards from another socket");
-  // Resolving would send an answer to a socket that is gone, and the panel's own rule is
-  // that a reply of this kind does not cross a reconnect.
+  assert.match(src, /sameBridgeSession\(/, "the session identity helper is the retirement gate");
+  assert.match(src, /function bindInteractiveCardsToHandshake\(/, "pre-handshake cards are bound at handshake");
+  assert.match(src, /function retireInteractiveCardsFromPreviousSessions\(/);
+  assert.match(src, /onStatus\(state, socketId, bridgeScope\)/);
+  assert.match(src, /url: sock\?\.__cmcpBridgeUrl \?\? null/);
+  assert.match(src, /epoch: sock\?\.__cmcpBridgeEpoch/);
+  assert.ok(!/let liveSocketId/.test(src), "a socket-only live identity must not return");
+  const sweep = namedFunctionSource(src, "retireInteractiveCardsFromPreviousSessions");
+  assert.match(sweep, /sameBridgeSession\(/, "retirement compares URL + epoch");
   assert.ok(!/resolveFn|resolve\(/.test(sweep), "the sweep must not answer anything");
   const retireSrc = namedFunctionSource(src, "retireInteractiveCard");
   assert.ok(!/resolveFn|resolve\(/.test(retireSrc), "nor may the retirement itself");
 });
 
-test("#952 source guard: a question card registers itself and unregisters when answered", () => {
+test("#2218: a question card registers its bridge scope and unregisters when answered", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const paint = namedFunctionSource(src, "paintQuestion");
   assert.match(
     paint,
-    /const unregister = paintedOnSocket == null \? \(\) => \{\} : registerInteractiveCard\(\{/,
-    "registered at paint, and ONLY when a command painted it",
+    /const cardScope = normalizeInteractiveCardScope\(paintedOnScope\);/,
+    "the command's scope is normalized at paint",
   );
+  assert.match(paint, /paintedOnSocketId: cardScope\.socketId/);
+  assert.match(paint, /paintedOnScope: cardScope/);
   assert.match(paint, /alreadyAnswered: \(\) => done,/, "so an answered card is skipped");
   assert.match(paint, /handedToCaller\.then\(unregister, unregister\)/, "and dropped once the caller-facing wait settles, either way");
 });
 
-test("#952 (codex) a SECRET card is retired too, with secret-safe wording", () => {
+test("#2218: a SECRET card carries the same session scope and remains secret-safe", () => {
   // It matters more here than for a question: a live password field whose reply has
   // nowhere to go can still display "Token saved", telling a user their token was stored
   // when nothing received it.
@@ -151,9 +142,11 @@ test("#952 (codex) a SECRET card is retired too, with secret-safe wording", () =
   const paint = namedFunctionSource(src, "paintSecret");
   assert.match(
     paint,
-    /const unregisterSecret = paintedOnSocket == null \? \(\) => \{\} : registerInteractiveCard\(\{/,
-    "registered at paint, and ONLY when a command painted it",
+    /const cardScope = normalizeInteractiveCardScope\(paintedOnScope\);/,
+    "the command's scope is normalized at paint",
   );
+  assert.match(paint, /paintedOnSocketId: cardScope\.socketId/);
+  assert.match(paint, /paintedOnScope: cardScope/);
   // Either the bare literal or the translated form — but if it is translated, the KEY is
   // pinned too, not just the English. A wildcard key would let `tr("panel.question",
   // "secret request")` pass while every non-English locale renders the secret card with the
@@ -183,133 +176,120 @@ test("#952 (codex) the retirement note takes the caller's detail, and defaults f
   assert.match(q._children[0].textContent, /If it asked again, answer the newer card\./, "the default stands");
 });
 
-test("#952 (codex r2) a card painted BEFORE its socket handshakes is not retired by that handshake", () => {
-  // A command frame is accepted before the handshake, so an interactive card can be painted
-  // on socket B while the UI still believes A is live. Retiring on B's `connected` would
-  // then kill a card that is perfectly answerable — worse than the duplicate this fixes.
-  // The sandbox runs the SHIPPED registry functions with the shipped handler's two lines,
-  // which the source guard below pins.
-  const src = readFileSync(PANEL_JS, "utf8");
-  const register = namedFunctionSource(src, "registerInteractiveCard");
-  const sweep = namedFunctionSource(src, "retireInteractiveCardsFromPreviousSockets");
-  const make = new Function(
-    `let liveSocketId = null;
-     const liveInteractiveCards = new Set();
-     ${register}
-     ${sweep}
-     function onStatus(state, socketId) {
-       if (socketId != null && socketId !== liveSocketId) liveSocketId = socketId;
-       if (state === "connected") retireInteractiveCardsFromPreviousSockets();
+function cardRegistryHarness(src) {
+  return new Function(
+    "sameBridgeSession",
+    `const liveInteractiveCards = new Set();
+     ${namedFunctionSource(src, "registerInteractiveCard")}
+     ${namedFunctionSource(src, "bindInteractiveCardsToHandshake")}
+     ${namedFunctionSource(src, "retireInteractiveCardsFromPreviousSessions")}
+     function onStatus(state, socketId, bridgeScope) {
+       if (state === "connected") {
+         bindInteractiveCardsToHandshake(socketId, bridgeScope);
+         retireInteractiveCardsFromPreviousSessions(bridgeScope);
+       }
      }
-     return { registerInteractiveCard, onStatus, liveCount: () => liveInteractiveCards.size };`,
-  );
-  const s = make();
+     return { registerInteractiveCard, onStatus, size: () => liveInteractiveCards.size };`,
+  )(sameBridgeSession);
+}
 
-  // Socket A connects; a card is painted and answered normally.
-  s.onStatus("connected", 1);
-  const retiredA = [];
-  s.registerInteractiveCard({ paintedOnSocket: 1, retire: () => retiredA.push("A") });
-
-  // A drops, B opens ("connecting" carries B's id) and receives ask_user BEFORE its models
-  // frame — the window this test exists for.
-  s.onStatus("connecting", 2);
-  const retiredB = [];
-  s.registerInteractiveCard({ paintedOnSocket: 2, retire: () => retiredB.push("B") });
-
-  // B handshakes.
-  s.onStatus("connected", 2);
-  assert.deepEqual(retiredA, ["A"], "the card from the previous socket IS retired");
-  assert.deepEqual(retiredB, [], "the card painted on B, before B handshaked, is NOT");
-  assert.equal(s.liveCount(), 1, "and B's card is still tracked");
+test("#2218: same-session reconnect keeps the live approval exactly once", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const make = cardRegistryHarness(src);
+  make.onStatus("connected", 1, { url: "ws://agent", epoch: "session-1" });
+  const retired = [];
+  make.registerInteractiveCard({
+    paintedOnSocketId: 1,
+    paintedOnScope: { url: "ws://agent", epoch: "session-1" },
+    retire: () => retired.push("retire"),
+    abandon: () => retired.push("abandon"),
+  });
+  make.onStatus("connected", 2, { url: "ws://agent", epoch: "session-1" });
+  assert.deepEqual(retired, [], "a new socket in the same session does not withdraw the pick");
+  assert.equal(make.size(), 1, "the reconnect does not create a duplicate card");
 });
 
-test("#952 (codex r2) a RE-HANDSHAKE on the same socket retires nothing", () => {
+test("#2218: epoch/URL mismatch withdraws, while a pre-handshake card binds to its own session", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  const make = new Function(
-    `let liveSocketId = null;
-     const liveInteractiveCards = new Set();
-     ${namedFunctionSource(src, "registerInteractiveCard")}
-     ${namedFunctionSource(src, "retireInteractiveCardsFromPreviousSockets")}
-     function onStatus(state, socketId) {
-       if (socketId != null && socketId !== liveSocketId) liveSocketId = socketId;
-       if (state === "connected") retireInteractiveCardsFromPreviousSockets();
-     }
-     return { registerInteractiveCard, onStatus };`,
-  )();
-  make.onStatus("connected", 7);
+  const make = cardRegistryHarness(src);
+  make.onStatus("connected", 1, { url: "ws://agent", epoch: "session-1" });
   const retired = [];
-  make.registerInteractiveCard({ paintedOnSocket: 7, retire: () => retired.push("x") });
-  // Every models frame re-emits "connected" on the SAME socket; a workflow change re-hellos it.
-  make.onStatus("connected", 7);
-  make.onStatus("connected", 7);
+  make.registerInteractiveCard({
+    paintedOnSocketId: 1,
+    paintedOnScope: { url: "ws://agent", epoch: "session-1" },
+    retire: () => retired.push("old-retire"),
+    abandon: () => retired.push("old-abandon"),
+  });
+  make.registerInteractiveCard({
+    paintedOnSocketId: 2,
+    paintedOnScope: { url: "ws://agent", epoch: undefined },
+    retire: () => retired.push("new-retire"),
+    abandon: () => retired.push("new-abandon"),
+  });
+  make.onStatus("connected", 2, { url: "ws://agent", epoch: "session-2" });
+  assert.deepEqual(retired, ["old-retire", "old-abandon"], "the epoch mismatch withdraws the old card");
+  assert.equal(make.size(), 1, "the card painted before the new handshake remains once");
+
+  const urlRetired = [];
+  make.registerInteractiveCard({
+    paintedOnSocketId: 2,
+    paintedOnScope: { url: "ws://agent", epoch: "session-2" },
+    retire: () => urlRetired.push("retire"),
+    abandon: () => urlRetired.push("abandon"),
+  });
+  make.onStatus("connected", 3, { url: "ws://other-agent", epoch: "session-2" });
+  assert.deepEqual(urlRetired, ["retire", "abandon"], "the URL mismatch also withdraws");
+});
+
+test("#2218: repeated handshakes in one bridge session retire nothing", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const make = cardRegistryHarness(src);
+  make.onStatus("connected", 7, { url: "ws://agent", epoch: "session-1" });
+  const retired = [];
+  make.registerInteractiveCard({
+    paintedOnSocketId: 7,
+    paintedOnScope: { url: "ws://agent", epoch: "session-1" },
+    retire: () => retired.push("x"),
+  });
+  // Every models frame re-emits "connected"; a workflow change can re-hello the live socket.
+  make.onStatus("connected", 7, { url: "ws://agent", epoch: "session-1" });
+  make.onStatus("connected", 7, { url: "ws://agent", epoch: "session-1" });
   assert.deepEqual(retired, [], "a live card survives any number of re-handshakes");
 });
 
-test("#952 (codex r2) source guard: adoption is unconditional, retirement waits for the handshake", () => {
+test("#2218 source guard: session scope is stamped before replay and handed to the panel", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   assert.match(
     src,
-    /if \(socketId != null && socketId !== liveSocketId\) liveSocketId = socketId;\r?\n\s*if \(state === "connected"\) retireInteractiveCardsFromPreviousSockets\(\);/,
-    "adopt on any status carrying a new id; sweep only on connected",
+    /if \(state === "connected"\) \{\r?\n\s*bindInteractiveCardsToHandshake\(socketId, connectedScope\);\r?\n\s*retireInteractiveCardsFromPreviousSessions\(connectedScope\);/,
+    "bind and sweep only after a connected handshake",
   );
-  // The open path must actually emit a status carrying the new socket's id, or a card
-  // painted pre-handshake would still record the previous one.
   assert.match(src, /thisSock\.__cmcpSocketId = \+\+socketSeq;/);
-  assert.match(src, /onStatus\(s, sock\?\.__cmcpSocketId \?\? null\)/);
+  assert.match(src, /onStatus\(s, sock\?\.__cmcpSocketId \?\? null, \{[\s\S]*?url: sock\?\.__cmcpBridgeUrl/);
+  assert.match(src, /epoch: sock\?\.__cmcpBridgeEpoch/);
 });
 
-test("#952 (codex r2) the card records the socket that ASKED, not the UI's belief", () => {
-  // The open status that would tell the UI about a new socket is suppressed once the
-  // patience window has been given up on (`if (!gaveUp) emitStatus("connecting")`), so a
-  // UI-side belief can be stale exactly when a pre-handshake command arrives. Taking the
-  // id from the command's own socket removes the dependency entirely.
+test("#2218: the card records the command's URL+epoch scope, not the UI's belief", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  assert.match(src, /result = await onAsk\(msg, thisSock\.__cmcpSocketId \?\? null\);/, "ask carries its socket");
-  assert.match(src, /result = await onSecret\(msg, thisSock\.__cmcpSocketId \?\? null\);/, "so does the secret request");
-  assert.match(src, /onAsk\(msg, socketId\) \{/, "the UI takes it");
-  assert.match(src, /onSecret\(msg, socketId\) \{/);
-  assert.match(src, /const p = paintQuestion\(msg, socketId\);/, "and threads it to the painter");
-  assert.match(src, /const p = paintSecret\(msg, socketId\);/);
-  assert.match(src, /function paintQuestion\(msg, paintedOnSocket = null\) \{/);
-  assert.match(src, /function paintSecret\(msg, paintedOnSocket = null\) \{/);
-  // The registry entry prefers the painter's own id and falls back to the UI's belief.
-  // BOTH painters, COUNTED. Matching once passed while one of the two had lost it — a
-  // guard that cannot tell "both do this" from "at least one does" is not guarding much.
+  for (const cmd of ["onAsk", "onSecret"]) {
+    const at = src.indexOf(`result = await ${cmd === "onAsk" ? "onAsk" : "onSecret"}(msg, {`);
+    assert.ok(at > 0, `${cmd} carries a bridge scope`);
+    const frame = src.slice(at, at + 260);
+    assert.match(frame, /socketId: thisSock\.__cmcpSocketId/);
+    assert.match(frame, /url: thisSock\.__cmcpBridgeUrl \?\? socketUrl/);
+    assert.match(frame, /epoch: thisSock\.__cmcpBridgeEpoch/);
+  }
+  assert.match(src, /onAsk\(msg, cardScope\) \{/);
+  assert.match(src, /onSecret\(msg, cardScope\) \{/);
+  assert.match(src, /const p = paintQuestion\(msg, cardScope\);/);
+  assert.match(src, /const p = paintSecret\(msg, cardScope\);/);
+  assert.match(src, /function paintQuestion\(msg, paintedOnScope = null\) \{/);
+  assert.match(src, /function paintSecret\(msg, paintedOnScope = null\) \{/);
   assert.equal(
-    (src.match(/paintedOnSocket == null \? \(\) => \{\} : registerInteractiveCard\(\{/g) ?? []).length,
+    (src.match(/cardScope == null \? \(\) => \{\} : registerInteractiveCard\(\{/g) ?? []).length,
     2,
-    "the question card AND the secret card each register only when a command painted them",
+    "both interactive card types register only when a command painted them",
   );
-});
-
-test("#952 (codex r2) a card painted on a socket the UI never adopted is still tied to it", () => {
-  // The behavioural half: with the id coming from the COMMAND, a card painted while
-  // `liveSocketId` is stale still records the socket that asked, so that socket
-  // handshaking does not retire it — and the older one still does. This matters because
-  // the open status carrying a new socket's id is suppressed once the patience window has
-  // been given up on, so the UI's belief can be stale exactly when it counts.
-  const src = readFileSync(PANEL_JS, "utf8");
-  const make = new Function(
-    `let liveSocketId = null;
-     const liveInteractiveCards = new Set();
-     ${namedFunctionSource(src, "registerInteractiveCard")}
-     ${namedFunctionSource(src, "retireInteractiveCardsFromPreviousSockets")}
-     function onStatus(state, socketId) {
-       if (socketId != null && socketId !== liveSocketId) liveSocketId = socketId;
-       if (state === "connected") retireInteractiveCardsFromPreviousSockets();
-     }
-     return { registerInteractiveCard, onStatus };`,
-  )();
-  make.onStatus("connected", 1); // socket A is live
-  const retiredA = [];
-  make.registerInteractiveCard({ paintedOnSocket: 1, retire: () => retiredA.push("A") });
-  // Socket B opens with NO status reaching the UI, and an ask_user arrives on it: the
-  // painter names B explicitly.
-  const retiredB = [];
-  make.registerInteractiveCard({ paintedOnSocket: 2, retire: () => retiredB.push("B") });
-  make.onStatus("connected", 2); // B finally handshakes
-  assert.deepEqual(retiredA, ["A"], "the card from A is retired");
-  assert.deepEqual(retiredB, [], "the card that named B survives B handshaking");
 });
 
 test("#952 (codex r3) a SETTINGS token card is never registered — it is agent-free", () => {
@@ -323,8 +303,7 @@ test("#952 (codex r3) a SETTINGS token card is never registered — it is agent-
   assert.ok(!/socketId/.test(settingsCall), "it passes no socket id");
   // …and with none passed, the painter does not register it at all.
   const make = new Function(
-    `let liveSocketId = 9;
-     const liveInteractiveCards = new Set();
+    `const liveInteractiveCards = new Set();
      ${namedFunctionSource(src, "registerInteractiveCard")}
      return { registerInteractiveCard, size: () => liveInteractiveCards.size };`,
   )();
@@ -335,7 +314,7 @@ test("#952 (codex r3) a SETTINGS token card is never registered — it is agent-
   off();
   assert.match(
     namedFunctionSource(src, "registerInteractiveCard"),
-    /const record = \{ paintedOnSocket: null, \.\.\.entry \};/,
-    "no liveSocketId fallback — an entry names its own socket or none",
+    /const record = \{ paintedOnSocketId: null, paintedOnScope: null, \.\.\.entry \};/,
+    "no live socket fallback — an entry names its own bridge scope or none",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -831,6 +831,7 @@ import {
   describeUndeliveredReply,
   createLostReplyJournal,
   isReplayable,
+  sameBridgeSession,
   pruneAttempts,
   shouldReRegister,
   reRegisterExhaustedHint,
@@ -28907,11 +28908,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // `onboard` actually lives. This used to reach for it from here — a sibling scope — so it
     // threw ReferenceError on every connect, and the try/catch that was meant to guard "the
     // card isn't built yet" swallowed that instead. The card simply never auto-hid.
-    // #952 — the SOCKET this status is about. `"connected"` re-fires on every
-    // re-handshake, so the string alone cannot distinguish a replacement connection
-    // from the live one saying hello again; the id can, and a consumer that ignores
-    // the argument behaves exactly as before.
-    onStatus(s, sock?.__cmcpSocketId ?? null);
+    // #2218 — carry the bridge identity this status is about. `"connected"` re-fires
+    // on every re-handshake, and a replacement WebSocket within one orchestrator
+    // session must not withdraw a still-answerable card. The URL + server epoch pair
+    // distinguishes that from a different endpoint or orchestrator process.
+    onStatus(s, sock?.__cmcpSocketId ?? null, {
+      url: sock?.__cmcpBridgeUrl ?? null,
+      epoch: sock?.__cmcpBridgeEpoch,
+    });
   }
   // FIX 1/2 — STEADY status + cold-start patience. While we're actively (auto)
   // reconnecting we hold the pill on a steady "connecting"; a terminal
@@ -29139,7 +29143,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // #640 — advisory frame; an unestablished route omits the field rather than
     // naming a route this tab has not established. Read ONCE: two reads could
     // straddle the hello that establishes the identity. The replay below is the
-    // load-bearing delivery and is socket-scoped either way.
+    // load-bearing delivery is delivered on the target socket only after the
+    // target URL+epoch has been proven to be the same bridge session.
     const lostRepliesRouteId = bridgeRouteId();
     try {
       // Registry workaround (#1854/#1886): the python_network_operations rule family
@@ -29167,8 +29172,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // it was produced for; after a backend switch or a Bridge-URL edit the current socket
       // is a DIFFERENT process, and volunteering another session's result to it is a leak,
       // not a recovery. Such an entry is also meaningless there — its rid is unknown — so
-      // it is dropped rather than carried forever. (Sensitive results are additionally
-      // redacted at journal time and never travel at all.)
+      // it is dropped rather than carried forever. Sensitive results keep only a redacted
+      // public entry; the private raw frame is selected by replayReply only after the same
+      // URL + epoch check above passes.
       // Replayable = SAME bridge AND SAME session AND recent enough (codex, #694).
       // A bridge is identified by its URL, and URL equality is ENDPOINT identity,
       // not SESSION identity — a newly started orchestrator on the same address
@@ -29178,7 +29184,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // predecessor session's entry fails the check and is dropped. A legacy
       // orchestrator sends no epoch — absent on both sides compares equal, and
       // the residual bounds below are exactly the pre-epoch ones: sensitive
-      // results never enter the journal at all, this runs only AFTER a real
+      // results are never exposed by the public journal, this runs only AFTER a real
       // handshake, and stale entries age out here.
       if (!isReplayable(entry, { now, targetUrl, targetEpoch })) {
         dropped++;
@@ -29196,7 +29202,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // receiver (Illegal invocation), and this codebase passes duck-typed sockets --
         // 10 wiring tests do exactly that. REVERT to the plain dotted form once the rule
         // stops scanning JS.
-        target["send"](JSON.stringify(entry.reply));
+        target["send"](JSON.stringify(lostReplies.replayReply(entry, { now, targetUrl, targetEpoch })));
         sent++;
       } catch {
         keep.push(entry);
@@ -29648,12 +29654,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // chat (UI scope) and block on the user's pick. The chosen string
             // becomes the tool result the agent receives.
             if (!onAsk) throw new Error("This panel build can't display questions.");
-            // #952 — the card is tied to the socket that ASKED, taken from the frame's own
-            // socket rather than from whatever the UI currently believes is live. A command
+            // #952/#2218 — the card is tied to the bridge session that ASKED, taken from
+            // the frame's own URL+epoch scope rather than from whatever the UI currently believes is live. A command
             // is accepted before the handshake, and the open status that would have told the
             // UI about this socket is suppressed once the patience window has been given up
             // on — so a UI-side belief can be stale exactly when it matters (codex r2).
-            result = await onAsk(msg, thisSock.__cmcpSocketId ?? null);
+            result = await onAsk(msg, {
+              socketId: thisSock.__cmcpSocketId ?? null,
+              url: thisSock.__cmcpBridgeUrl ?? socketUrl,
+              epoch: thisSock.__cmcpBridgeEpoch,
+            });
             // #952 — a card withdrawn by a reconnect resolves with a SENTINEL rather
             // than staying pending forever. Thrown, so the ordinary error path builds
             // the reply AND `settleRid` runs: without this the ledger keeps an
@@ -29666,7 +29676,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // orchestrator (which writes it to config) and is the tool's reply;
             // it is never surfaced to the agent's context or recorded to history.
             if (!onSecret) throw new Error("This panel build can't collect secrets.");
-            result = await onSecret(msg, thisSock.__cmcpSocketId ?? null);
+            result = await onSecret(msg, {
+              socketId: thisSock.__cmcpSocketId ?? null,
+              url: thisSock.__cmcpBridgeUrl ?? socketUrl,
+              epoch: thisSock.__cmcpBridgeEpoch,
+            });
             // #952 — same withdrawal, and the failure carries NO payload, so the
             // undeliverable-reply path has nothing of the user's to redact.
             if (isAbandonedInteractive(result)) throw new Error(abandonedInteractiveError(msg.cmd));
@@ -38107,7 +38121,18 @@ function buildPanel() {
    * An always-present "Other…" field lets the user answer freely. Returns the
    * chosen string (comma-joined for multi-select) — the agent's tool result.
    */
-  function paintQuestion(msg, paintedOnSocket = null) {
+  function normalizeInteractiveCardScope(scope) {
+    if (!scope || typeof scope !== "object") return null;
+    return {
+      socketId: scope.socketId ?? null,
+      url: typeof scope.url === "string" && scope.url ? scope.url : null,
+      epoch:
+        (typeof scope.epoch === "string" && scope.epoch) ||
+        (typeof scope.epoch === "number" && Number.isFinite(scope.epoch) ? scope.epoch : undefined),
+    };
+  }
+
+  function paintQuestion(msg, paintedOnScope = null) {
     clearEmpty();
     const opts = Array.isArray(msg.options) ? msg.options : [];
     const multi = !!msg.multi_select;
@@ -38275,17 +38300,15 @@ function buildPanel() {
       },
       schedule: (fn, ms) => setTimeout(fn, ms),
     });
-    // #952 — REGISTER THE CARD AGAINST THE CONNECTION THAT PAINTED IT. A reply of this
-    // kind is deliberately not replayed across a reconnect, so once this connection is
-    // replaced the card cannot deliver an answer to anyone — while still looking exactly
-    // as clickable as a newer card asking the same thing. The orchestrator's own message
-    // has to warn "the user may see two … tell them which one to answer"; the panel is
-    // the side that can just say it.
-    // #952 — tracked ONLY when a command painted it. A card with no command behind it
+    // #2218 — register the card against the command's bridge URL + epoch. A same-session
+    // reconnect preserves the live card and its pending answer; an unproven or mismatched
+    // session retires it fail-closed. A card with no command behind it
     // has no socket to be orphaned by, and retiring it would disable something that
     // still works (codex r3).
-    const unregister = paintedOnSocket == null ? () => {} : registerInteractiveCard({
-      paintedOnSocket,
+    const cardScope = normalizeInteractiveCardScope(paintedOnScope);
+    const unregister = cardScope == null ? () => {} : registerInteractiveCard({
+      paintedOnSocketId: cardScope.socketId,
+      paintedOnScope: cardScope,
       retire: () =>
         retireInteractiveCard(card, {
           alreadyAnswered: () => done,
@@ -38328,35 +38351,47 @@ function buildPanel() {
   }
 
   /**
-   * #952 — cards painted on a connection that has since been replaced.
+   * #2218 — cards painted in a bridge session that has since been replaced.
    *
-   * KEYED ON THE SOCKET, not on the status string (codex). `"connected"` is emitted on
+   * KEYED ON THE BRIDGE SESSION, not on the socket or status string (codex). `"connected"` is emitted on
    * every RE-HANDSHAKE — each `models` frame calls `markConnected`, and a workflow change
    * re-hellos the LIVE socket — so counting those would retire question cards that are
    * still perfectly answerable, which is worse than the duplicate this fixes. The client
-   * mints an id per WebSocket and hands it to `onStatus`; a card records the id that was
-   * live when it was painted, and only a DIFFERENT id retires it.
+   * stamps each socket with the bridge URL and server-issued session epoch; a card records
+   * that pair when it was painted, and only a DIFFERENT or unproven pair retires it.
    *
-   * Deliberately NOT resolving the card's promise. The command that painted it already
-   * failed with an unknown outcome on the socket that dropped; resolving here would send
-   * an answer nowhere, and the panel's own rule is that a reply of this kind does not
-   * cross a reconnect. The card stops LOOKING answerable, and says why.
+   * Deliberately NOT resolving the card's promise on withdrawal. A same-session reconnect
+   * leaves it pending so the original answer can be delivered through the journal; a
+   * different or unproven session must stop LOOKING answerable and abandon the command.
    */
-  /** The socket id the UI currently believes it is talking to (#952). */
-  let liveSocketId = null;
   const liveInteractiveCards = new Set();
 
   function registerInteractiveCard(entry) {
-    // Every entry names the socket its COMMAND arrived on; a card with no command
-    // behind it is never registered, so there is no belief-based fallback here.
-    const record = { paintedOnSocket: null, ...entry };
+    // Every command-backed entry names the bridge session and the socket that supplied
+    // it. The socket id is only a pre-handshake binding aid; retirement compares the
+    // proven URL + epoch pair, never the WebSocket instance.
+    const record = { paintedOnSocketId: null, paintedOnScope: null, ...entry };
     liveInteractiveCards.add(record);
     return () => liveInteractiveCards.delete(record);
   }
 
-  function retireInteractiveCardsFromPreviousSockets() {
+  function bindInteractiveCardsToHandshake(socketId, bridgeScope) {
+    if (socketId == null || !bridgeScope || bridgeScope.epoch == null) return;
+    for (const record of liveInteractiveCards) {
+      if (record.paintedOnSocketId !== socketId) continue;
+      if (record.paintedOnScope?.epoch != null) continue;
+      record.paintedOnScope = { ...bridgeScope, socketId };
+    }
+  }
+
+  function retireInteractiveCardsFromPreviousSessions(bridgeScope) {
     for (const record of [...liveInteractiveCards]) {
-      if (record.paintedOnSocket === liveSocketId) continue;
+      if (sameBridgeSession({
+        sourceUrl: record.paintedOnScope?.url,
+        sourceEpoch: record.paintedOnScope?.epoch,
+        targetUrl: bridgeScope?.url,
+        targetEpoch: bridgeScope?.epoch,
+      })) continue;
       liveInteractiveCards.delete(record);
       // RETIRE FIRST, then abandon — and in SEPARATE try blocks, so neither step can
       // be skipped by the other throwing. Order matters: retirement asks the card
@@ -38425,7 +38460,7 @@ function buildPanel() {
    * over the bridge to the orchestrator (which writes it to config); it never
    * enters the agent's context.
    */
-  function paintSecret(msg, paintedOnSocket = null) {
+  function paintSecret(msg, paintedOnScope = null) {
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-card cmcp-secret";
@@ -38601,8 +38636,10 @@ function buildPanel() {
     // reconnect it can still send its set_secret on the current socket, so retiring it
     // would disable a working control and tell the user to wait for a request that is
     // never coming (codex r3).
-    const unregisterSecret = paintedOnSocket == null ? () => {} : registerInteractiveCard({
-      paintedOnSocket,
+    const cardScope = normalizeInteractiveCardScope(paintedOnScope);
+    const unregisterSecret = cardScope == null ? () => {} : registerInteractiveCard({
+      paintedOnSocketId: cardScope.socketId,
+      paintedOnScope: cardScope,
       retire: () =>
         retireInteractiveCard(card, {
           alreadyAnswered: () => done,
@@ -40734,7 +40771,7 @@ function buildPanel() {
   // here; the `pair_url`/`pair_error` reply consumes it (mirrors pendingSetSecret).
   let pendingPair = null;
   const client = createBridgeClient({
-    onStatus(state, socketId) {
+    onStatus(state, socketId, bridgeScope) {
       // Translate at the RENDER boundary, never at the source. `state` is a state TOKEN —
       // emitStatus compares it (`s !== "connected"`) and the comment below keys behaviour on
       // it — so translating `emitStatus("connected")` would make those comparisons
@@ -40757,20 +40794,18 @@ function buildPanel() {
       // emitStatus, which cannot see `onboard`. try/catch still guards the genuine case the
       // original comment described: a status arriving before the card is built.
       if (state === "connected") { try { onboard.hidden = true; } catch {} }
-      // #952 — a card painted on a connection that has since been REPLACED can no longer
-      // deliver an answer. The trigger is the socket's identity, not the status string:
-      // `"connected"` re-fires on every re-handshake (each `models` frame, and a workflow
-      // change re-hellos the live socket), so keying on it would retire cards that are
-      // still perfectly answerable (codex).
-      // ADOPT AS SOON AS THE SOCKET EXISTS, RETIRE ONLY ONCE IT HAS HANDSHAKEN (codex r2).
-      // A command frame is accepted before the handshake, so an interactive card CAN be
-      // painted on a socket whose id the UI has not adopted yet — and it would then look
-      // like it belonged to the PREVIOUS connection and be retired the moment this one
-      // finished handshaking, killing a card that is perfectly live. Adoption happens on
-      // the open status that carries the new id; the sweep waits for `connected`, which is
-      // the point at which the previous connection is definitively replaced.
-      if (socketId != null && socketId !== liveSocketId) liveSocketId = socketId;
-      if (state === "connected") retireInteractiveCardsFromPreviousSockets();
+      // #2218 — a card painted on a replacement WebSocket remains answerable when the
+      // replacement proves the SAME bridge URL + server-issued session epoch. A status
+      // string or socket id cannot make that distinction: `"connected"` re-fires on
+      // every models handshake, and a same-session reconnect mints a new socket id.
+      // ADOPT THE SESSION ONLY AT HANDSHAKE. A command frame is accepted before the
+      // handshake, so bind that card's missing epoch to its own socket when connected;
+      // an unknown or mismatched pair still retires and abandons it fail-closed.
+      const connectedScope = normalizeInteractiveCardScope(bridgeScope);
+      if (state === "connected") {
+        bindInteractiveCardsToHandshake(socketId, connectedScope);
+        retireInteractiveCardsFromPreviousSessions(connectedScope);
+      }
       dot.className = "cmcp-dot" + (state === "connected" ? " connected" : state === "connecting" ? " connecting" : "");
       // Connection status does NOT drive this box's visibility. It's a
       // dropdown: the user opens it and the user closes it (trigger, click
@@ -40907,7 +40942,7 @@ function buildPanel() {
     },
     // The agent called panel_ask — render a question card and resolve with the
     // user's pick. Keep the working indicator pinned below it while we wait.
-    onAsk(msg, socketId) {
+    onAsk(msg, cardScope) {
       // Fence FIRST: a card from a turn this tab no longer owns must not paint,
       // and must not revive the working indicator on its way past either.
       //
@@ -40928,7 +40963,7 @@ function buildPanel() {
       // whose `turn:working` is discarded by the stale-working guard no longer
       // reaches the classifier with a null owner.
       fenceInteractiveCard("ask_user");
-      const p = paintQuestion(msg, socketId);
+      const p = paintQuestion(msg, cardScope);
       bumpThinking();
       noteActivity(); // a panel_ask frame is real turn activity → reset the clock
       return p;
@@ -41163,7 +41198,7 @@ function buildPanel() {
       setThinkingTokens(tokens);
     },
     // The agent called panel_request_secret — collect a token securely.
-    onSecret(msg, socketId) {
+    onSecret(msg, cardScope) {
       // If this secure request was kicked off from a Settings "Set … token" button,
       // record a (non-secret) "set at" marker once a non-empty value is submitted so
       // the Settings indicator can show set/not-set. Only the timestamp is stored.
@@ -41177,7 +41212,7 @@ function buildPanel() {
       // no longer owns must not get a masked input painted into the conversation
       // that happens to be on screen — see lib/interactive-card-fence.js.
       fenceInteractiveCard("request_secret");
-      const p = paintSecret(msg, socketId);
+      const p = paintSecret(msg, cardScope);
       bumpThinking();
       if (req) {
         p.then((value) => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29186,7 +29186,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // the residual bounds below are exactly the pre-epoch ones: sensitive
       // results are never exposed by the public journal, this runs only AFTER a real
       // handshake, and stale entries age out here.
-      if (!isReplayable(entry, { now, targetUrl, targetEpoch })) {
+      if (!lostReplies.canReplay(entry, { now, targetUrl, targetEpoch })) {
         dropped++;
         continue;
       }
@@ -38375,6 +38375,25 @@ function buildPanel() {
     return () => liveInteractiveCards.delete(record);
   }
 
+  /**
+   * A command can arrive on a replacement socket before that socket's handshake. Its
+   * epoch is therefore unknown, so painting another command-backed card while a card
+   * from this URL is still live would create two controls for one pending interaction.
+   * Refuse that unproven duplicate; the original card remains available until the new
+   * socket proves whether it is the same session or a different one.
+   */
+  function interactiveCardWouldDuplicate(scope) {
+    const url = scope && typeof scope.url === "string" && scope.url ? scope.url : null;
+    const epochKnown =
+      (typeof scope?.epoch === "string" && scope.epoch.length > 0) ||
+      (typeof scope?.epoch === "number" && Number.isFinite(scope.epoch));
+    if (epochKnown) return false;
+    return [...liveInteractiveCards].some((record) => {
+      const existingUrl = record.paintedOnScope?.url;
+      return existingUrl && (!url || existingUrl === url);
+    });
+  }
+
   function bindInteractiveCardsToHandshake(socketId, bridgeScope) {
     if (socketId == null || !bridgeScope || bridgeScope.epoch == null) return;
     for (const record of liveInteractiveCards) {
@@ -40963,6 +40982,7 @@ function buildPanel() {
       // whose `turn:working` is discarded by the stale-working guard no longer
       // reaches the classifier with a null owner.
       fenceInteractiveCard("ask_user");
+      if (interactiveCardWouldDuplicate(cardScope)) return Promise.resolve(INTERACTIVE_ABANDONED);
       const p = paintQuestion(msg, cardScope);
       bumpThinking();
       noteActivity(); // a panel_ask frame is real turn activity → reset the clock
@@ -41212,6 +41232,7 @@ function buildPanel() {
       // no longer owns must not get a masked input painted into the conversation
       // that happens to be on screen — see lib/interactive-card-fence.js.
       fenceInteractiveCard("request_secret");
+      if (interactiveCardWouldDuplicate(cardScope)) return Promise.resolve(INTERACTIVE_ABANDONED);
       const p = paintSecret(msg, cardScope);
       bumpThinking();
       if (req) {

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -97,18 +97,18 @@ export function describeUndeliveredReply(entry) {
  * whatever the user typed. The panel already treats both as unspeakable elsewhere (they
  * are never echoed as activity cards and never recorded to history).
  *
- * They must therefore NEVER be journaled as raw frames for cross-socket replay (codex).
- * A replay lands on whatever socket is current later — which can be a DIFFERENT
+ * They must therefore NEVER be sent as raw frames to an unproven replacement socket
+ * (codex). A replay lands on whatever socket is current later — which can be a DIFFERENT
  * orchestrator entirely after a backend switch or a Bridge-URL change — so replaying the
- * raw frame would hand one session's secret to another process. Redacted instead: the
- * outcome is still reported truthfully, and for a secret "you never received it" is
- * exactly right, because the orchestrator only stores what actually reaches it.
+ * raw frame would hand one session's secret to another process. The journal keeps only a
+ * redacted public frame; a private bounded side table can select the raw frame after the
+ * same URL + session epoch has been proven.
  */
 export const SENSITIVE_RESULT_CMDS = new Set(["request_secret", "ask_user"]);
 
-/** The frame that is safe to journal for `cmd`. Non-sensitive commands pass through
- *  unchanged; sensitive ones are replaced by a rid-correlated, payload-free failure that
- *  tells the caller to re-request on the current connection. */
+/** The frame that is safe to expose from the journal for `cmd`. Non-sensitive commands
+ * pass through unchanged; sensitive ones are replaced by a rid-correlated, payload-free
+ * failure that is safe for an unproven replacement session. */
 export function redactSensitiveReply(reply, cmd) {
   if (!reply || !SENSITIVE_RESULT_CMDS.has(cmd)) return reply;
   // #952 — redact what CARRIES the user's input, not every reply for these commands.
@@ -127,21 +127,53 @@ export function redactSensitiveReply(reply, cmd) {
     ok: false,
     error:
       `the panel collected the "${cmd}" response, but the connection dropped before it could be ` +
-      `returned. Its content is deliberately NOT replayed across a reconnect (it is the user's ` +
-      `own input, and the connection it was meant for is gone). Nothing was applied and nothing ` +
-      `was stored — ask again on the current connection.`,
+      `returned. Its content is deliberately NOT replayed to an unproven replacement session ` +
+      `(it is the user's own input, and session continuity was not established). Nothing was ` +
+      `applied and nothing was stored — ask again on the current connection.`,
   };
+}
+
+/**
+ * Does the source and target identify one proven bridge session?
+ *
+ * URL is the endpoint identity; the server-issued epoch is the process/session
+ * identity. Both are required. An absent epoch cannot prove that a replacement
+ * socket reached the same orchestrator, so callers that carry user input must
+ * fail closed rather than treating two unknowns as equal.
+ */
+export function sameBridgeSession({ sourceUrl, sourceEpoch, targetUrl, targetEpoch } = {}) {
+  const epoch = (value) =>
+    (typeof value === "string" && value.length > 0) ||
+    (typeof value === "number" && Number.isFinite(value));
+  return (
+    typeof sourceUrl === "string" && sourceUrl.length > 0 &&
+    typeof targetUrl === "string" && targetUrl.length > 0 &&
+    sourceUrl === targetUrl &&
+    epoch(sourceEpoch) && epoch(targetEpoch) &&
+    sourceEpoch === targetEpoch
+  );
 }
 
 /** Bounded journal of command outcomes whose reply could not be delivered. */
 export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
   const limit = Number.isFinite(cap) && cap > 0 ? cap : LOST_REPLY_CAP;
   let entries = [];
+  // Sensitive results are kept only in this private side table until the bounded
+  // entry is either replayed into the SAME proven session or discarded. The public
+  // entry remains redacted, so list(), summaries(), and accidental diagnostics can
+  // never expose the user's answer.
+  const rawSensitiveReplies = new WeakMap();
+  const replayReply = (entry, { now, targetUrl, targetEpoch } = {}) => {
+    if (!entry || !rawSensitiveReplies.has(entry)) return entry?.reply;
+    if (isReplayable(entry, { now, targetUrl, targetEpoch })) {
+      return rawSensitiveReplies.get(entry) ?? entry.reply;
+    }
+    return entry.reply;
+  };
   return {
-    /** Record one undelivered outcome. `reply` is the exact frame we failed to send, so
-     *  it can be re-sent verbatim on the next socket: rids are random UUIDs, so an
-     *  orchestrator that no longer knows the rid simply drops it, and one that still has
-     *  the command pending resolves it with its TRUE outcome. */
+    /** Record one undelivered outcome. Non-sensitive replies are retained verbatim.
+     * Sensitive replies have a redacted public frame plus a private raw value that may
+     * only be selected after the replay caller proves the same URL + session epoch. */
     record({ reply, cmd, reason, at = 0, url, epoch } = {}) {
       if (!reply || typeof reply !== "object" || typeof reply.rid !== "string") return null;
       const safe = redactSensitiveReply(reply, cmd);
@@ -167,6 +199,7 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
         redacted: safe !== reply,
         reply: safe,
       };
+      if (safe !== reply) rawSensitiveReplies.set(entry, reply);
       entries.push(entry);
       while (entries.length > limit) entries.shift();
       return entry;
@@ -186,8 +219,22 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
       const visible = targetUrl
         ? entries.filter((e) => isReplayable(e, { now, targetUrl, targetEpoch }))
         : entries;
-      return visible.map(({ rid, cmd, ok, reason, at }) => ({ rid, cmd, ok, reason, at }));
+      return visible.map((entry) => ({
+        rid: entry.rid,
+        cmd: entry.cmd,
+        // A same-session sensitive answer is replayable as a success, while the
+        // public entry remains redacted and never includes its value.
+        ok: Boolean(replayReply(entry, { now, targetUrl, targetEpoch })?.ok),
+        reason: entry.reason,
+        at: entry.at,
+      }));
     },
+    /**
+     * Select the frame for a replay. A sensitive answer is returned only when the
+     * caller proves the same recent bridge/session; every mismatch gets the public
+     * payload-free failure instead. Non-sensitive replies pass through unchanged.
+     */
+    replayReply,
     /** Take everything and empty the journal (used when replaying onto a new socket, so
      *  a replay can never loop). */
     drain() {
@@ -218,8 +265,9 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
  * session at the same address. The age bound here remains the backstop for a LEGACY
  * orchestrator that sends no epoch (absent on both sides compares equal — URL-only
  * matching, exactly the pre-epoch behaviour), bounding that residual four ways:
- * sensitive results never enter the journal at all; replay goes ONLY to the exact
- * socket instance that completed a handshake; entries age out here; and the window is
+ * sensitive results remain redacted in the public journal and raw values are selected only
+ * for a proven same-session replay; replay goes ONLY to the exact socket instance that
+ * completed a handshake; entries age out here; and the window is
  * deliberately tight — a drop, reconnect and handshake take a couple of seconds, so 20s
  * is generous for the case this serves while leaving little room for an orchestrator to
  * restart and re-bind inside it.

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -165,12 +165,12 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
   const rawSensitiveReplies = new WeakMap();
   const canReplay = (entry, { now, targetUrl, targetEpoch } = {}) => {
     if (!isReplayable(entry, { now, targetUrl, targetEpoch })) return false;
-    // A private answer has no safe legacy mode. URL equality alone cannot prove that an
-    // epoch-less replacement is the same orchestrator session, so every sensitive entry
-    // requires the stronger URL + proven epoch fence even though ordinary replies retain
-    // the pre-epoch compatibility rule.
+    // Interactive outcomes have no safe legacy mode. URL equality alone cannot prove that
+    // an epoch-less replacement is the same orchestrator session, so every sensitive entry
+    // requires the stronger URL + proven epoch fence, including payload-free failures;
+    // ordinary replies retain the pre-epoch compatibility rule.
     return (
-      !rawSensitiveReplies.has(entry) ||
+      !SENSITIVE_RESULT_CMDS.has(entry.cmd) ||
       sameBridgeSession({
         sourceUrl: entry.url,
         sourceEpoch: entry.epoch,
@@ -285,9 +285,9 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
  * session at the same address. The age bound here remains the backstop for a LEGACY
  * orchestrator that sends no epoch (absent on both sides compares equal — URL-only
  * matching, exactly the pre-epoch behaviour), bounding that residual four ways:
- * sensitive results remain redacted in the public journal and raw values are selected only
- * for a proven same-session replay; replay goes ONLY to the exact socket instance that
- * completed a handshake; entries age out here; and the window is
+ * sensitive results remain redacted in the public journal and are delivered only after a
+ * proven same-session replay; replay goes ONLY to the exact socket instance that completed
+ * a handshake; entries age out here; and the window is
  * deliberately tight — a drop, reconnect and handshake take a couple of seconds, so 20s
  * is generous for the case this serves while leaving little room for an orchestrator to
  * restart and re-bind inside it.

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -163,9 +163,25 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
   // entry remains redacted, so list(), summaries(), and accidental diagnostics can
   // never expose the user's answer.
   const rawSensitiveReplies = new WeakMap();
+  const canReplay = (entry, { now, targetUrl, targetEpoch } = {}) => {
+    if (!isReplayable(entry, { now, targetUrl, targetEpoch })) return false;
+    // A private answer has no safe legacy mode. URL equality alone cannot prove that an
+    // epoch-less replacement is the same orchestrator session, so every sensitive entry
+    // requires the stronger URL + proven epoch fence even though ordinary replies retain
+    // the pre-epoch compatibility rule.
+    return (
+      !rawSensitiveReplies.has(entry) ||
+      sameBridgeSession({
+        sourceUrl: entry.url,
+        sourceEpoch: entry.epoch,
+        targetUrl,
+        targetEpoch,
+      })
+    );
+  };
   const replayReply = (entry, { now, targetUrl, targetEpoch } = {}) => {
     if (!entry || !rawSensitiveReplies.has(entry)) return entry?.reply;
-    if (isReplayable(entry, { now, targetUrl, targetEpoch })) {
+    if (canReplay(entry, { now, targetUrl, targetEpoch })) {
       return rawSensitiveReplies.get(entry) ?? entry.reply;
     }
     return entry.reply;
@@ -193,8 +209,8 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
         // the models handshake). URL equality is only ENDPOINT identity: a restarted
         // orchestrator at the same address mints a fresh epoch, and its predecessor's
         // journal must never replay into the new session. A legacy orchestrator sends
-        // no epoch — absent here and absent on the target socket compare EQUAL, which
-        // preserves the pre-epoch (URL-only) behaviour exactly.
+        // no epoch. That is retained for safe, non-sensitive replay only; the private
+        // side table below requires both proven epochs.
         epoch: typeof epoch === "string" || typeof epoch === "number" ? epoch : undefined,
         redacted: safe !== reply,
         reply: safe,
@@ -216,9 +232,11 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
      *  a bridge that never owned these commands would still learn their ids, names and
      *  outcomes even though the replies themselves are correctly withheld. */
     summaries({ now, targetUrl, targetEpoch } = {}) {
-      const visible = targetUrl
-        ? entries.filter((e) => isReplayable(e, { now, targetUrl, targetEpoch }))
-        : entries;
+      const visible = entries.filter((entry) => {
+        // A public summary must use the same delivery fence as replay. With no target it
+        // remains an internal, payload-free bookkeeping view and excludes private answers.
+        return targetUrl ? canReplay(entry, { now, targetUrl, targetEpoch }) : !rawSensitiveReplies.has(entry);
+      });
       return visible.map((entry) => ({
         rid: entry.rid,
         cmd: entry.cmd,
@@ -229,6 +247,8 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
         at: entry.at,
       }));
     },
+    /** Whether this entry may be delivered to the specified proven target. */
+    canReplay,
     /**
      * Select the frame for a replay. A sensitive answer is returned only when the
      * caller proves the same recent bridge/session; every mismatch gets the public


### PR DESCRIPTION
## Summary\n- Preserve command-backed ask_user/request_secret cards across a same-session WebSocket reconnect by correlating bridge URL + server session epoch.\n- Retire and abandon cards on URL/epoch mismatch or unproven replacement sessions; bind pre-handshake cards after their own handshake.\n- Keep sensitive journal entries redacted publicly and select the raw correlated reply only for the proven same session, preserving rid correlation and avoiding duplicate cards.\n\n## Validation\n- Targeted lifecycle files: 69/69.\n- Expanded affected source-guard set: 111/111.\n- 
pm.cmd run typecheck\n- 
pm.cmd run check:scope\n- 
pm.cmd run check:changelog -- --working-tree\n- 
ode scripts/check-registry-yara.mjs --allow 0 (0 flagged files)\n- git diff --check\n- No changes to init.py or py/apps_routes.py; no network operations were added there.\n\nThe full unit suite was intentionally not completed after the requested validation stop; no merge or release is included.