### PR TITLE
docs: archive notice — this project is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 > ComfyUI now ships official agent and MCP tooling — Comfy Agent and Comfy MCP — built and supported by the Comfy-Org team with deeper integration than a community project can match. If you’re looking for an MCP server or AI agent for ComfyUI, use the official tooling.
 > This repo will remain public as a reference, but no new features, bug fixes, or dependency updates will be made. Issues and pull requests are closed.
 > Thanks to everyone who used, starred, forked, and contributed to this project. It was a good run. :rocket:
+>
+> Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
 
 > ### 📦 On ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) as `comfyui-agent-panel`
 > The polished public release — native ComfyUI design system, live activity cards for every

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
 >
 > Thanks to everyone who used, starred, forked, and contributed to this project.
 > It was a good run. :rocket:
+>
+> The full story is in the [goodbye post](https://comfyui-mcp.artokun.io/docs/blog/goodbye).
+>
+> Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me by
+> email at **art.longbottom.jr@gmail.com** or on [LinkedIn](https://www.linkedin.com/in/alongbottom/).
 
 > ### 📦 On ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) as `comfyui-agent-panel`
 > The polished public release — native ComfyUI design system, live activity cards for every

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # ComfyUI Agent Panel
 
 > [!IMPORTANT]
-> This project is no longer maintained.
-> ComfyUI now ships official agent and MCP tooling — Comfy Agent and Comfy MCP — built and supported by the Comfy-Org team with deeper integration than a community project can match. If you’re looking for an MCP server or AI agent for ComfyUI, use the official tooling.
-> This repo will remain public as a reference, but no new features, bug fixes, or dependency updates will be made. Issues and pull requests are closed.
-> Thanks to everyone who used, starred, forked, and contributed to this project. It was a good run. :rocket:
+> **This project is no longer maintained.**
 >
-> Looking for a ComfyUI or generative-AI integration expert? I take on custom solutions — reach me at **art.longbottom.jr@gmail.com**.
+> ComfyUI now ships official agent and MCP tooling — **[Comfy Agent](https://comfy.org/agent)** and
+> **[Comfy MCP](https://comfy.org/mcp)** — built and supported by the Comfy-Org team with deeper
+> integration than a community project can match. If you’re looking for an MCP server or AI agent
+> for ComfyUI, use the official tooling.
+>
+> This repo will remain public as a reference, but no new features, bug fixes, or dependency
+> updates will be made. **Issues and pull requests close when the repo is archived on 2026-10-09.**
+> The community Discord goes read-only the same day, with its threads left up as a searchable
+> archive.
+>
+> Thanks to everyone who used, starred, forked, and contributed to this project.
+> It was a good run. :rocket:
 
 > ### 📦 On ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) as `comfyui-agent-panel`
 > The polished public release — native ComfyUI design system, live activity cards for every

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ComfyUI Agent Panel
 
+> [!IMPORTANT]
+> This project is no longer maintained.
+> ComfyUI now ships official agent and MCP tooling — Comfy Agent and Comfy MCP — built and supported by the Comfy-Org team with deeper integration than a community project can match. If you’re looking for an MCP server or AI agent for ComfyUI, use the official tooling.
+> This repo will remain public as a reference, but no new features, bug fixes, or dependency updates will be made. Issues and pull requests are closed.
+> Thanks to everyone who used, starred, forked, and contributed to this project. It was a good run. :rocket:
+
 > ### 📦 On ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) as `comfyui-agent-panel`
 > The polished public release — native ComfyUI design system, live activity cards for every
 > agent edit, and multi-tab support. Search **`comfyui-agent-panel`** in ComfyUI-Manager to install,


### PR DESCRIPTION
Adds the end-of-life notice to the top of the README, verbatim from the owner. First step of archiving; the remaining steps (closing issues/PRs, disabling the Comfy Registry publish and Dependabot workflows, archiving the repo) follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nqNZzLirrRQRc7Q8ZmiTN