### PR TITLE
docs: this project is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+> [!IMPORTANT]
+> **This project is no longer maintained.**
+>
+> ComfyUI now ships official agent and MCP tooling — **[Comfy Agent](https://comfy.org/agent)** and
+> **[Comfy MCP](https://comfy.org/mcp)** — built and supported by the Comfy-Org team with deeper
+> integration than a community project can match. If you're looking for an MCP server or AI agent
+> for ComfyUI, use the official tooling.
+>
+> This repo will remain public as a reference, but no new features, bug fixes, or dependency
+> updates will be made. **Issues and pull requests close when the repo is archived on 2026-10-09.**
+> The community Discord goes read-only the same day, with its threads left up as a searchable
+> archive.
+>
+> Thanks to everyone who used, starred, forked, and contributed to this project.
+> It was a good run. 🚀
+
 # ComfyUI Agent Panel
 
 > ### 📦 On ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) as `comfyui-agent-panel`


### PR DESCRIPTION
Adds the deprecation notice to the top of the README.

ComfyUI now ships official agent and MCP tooling — [Comfy Agent](https://comfy.org/agent) and
[Comfy MCP](https://comfy.org/mcp) — built and supported by the Comfy-Org team. This project
hands off to it.

The notice goes up now so nobody starts new work against this repo. The repo itself stays
public and writable until **2026-10-09**, giving 30 days for anyone to fork or extract what
they need; it is archived on that date, and the community Discord goes read-only the same day
with its threads preserved as a searchable archive.

Merge-ready work already in flight still lands, and a final release ships before the freeze,
so nobody is left on a broken build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXS5Qys1hiK9aDdXJRJ6Y
