### PR TITLE
feat: native DSH selection, session usage, and ordered transcript UI

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -79,6 +79,7 @@ _LAUNCHER_INSTALL_COMMAND = "npx -y comfyui-mcp@latest launcher install"
 # handshake, not a port. Informational for the panel's picker; this pack
 # never binds or spawns.
 _BACKEND_PORTS = {
+    "dsh": _BRIDGE_PORT,
     "claude": _BRIDGE_PORT,
     "codex": _BRIDGE_PORT,
     "gemini": _BRIDGE_PORT,
@@ -425,6 +426,7 @@ def _backend_port(backend):
 # pi is the exception because the MCP starts it with shell-less spawn.
 _PROVIDER_CLIS = {
     "claude": ("claude", "claude.cmd", "claude.exe"),
+    "dsh": ("dsh", "dsh.cmd", "dsh.exe"),
     "codex": ("codex", "codex.cmd", "codex.exe"),
     "gemini": ("gemini", "gemini.cmd", "gemini.exe"),
     "antigravity": ("agy", "agy.exe"),
@@ -569,6 +571,10 @@ def _provider_auth(provider):
         if sys.platform == "darwin":
             return None
         return False
+    if provider == "dsh":
+        # The orchestrator probes the official ACP runtime on its own host.
+        # A ComfyUI container cannot inspect the host's DSH credentials.
+        return None
     if provider == "codex":
         return os.path.isfile(os.path.join(home, ".codex", "auth.json"))
     if provider == "gemini":

--- a/browser_tests/unit/context-ring-scope.test.mjs
+++ b/browser_tests/unit/context-ring-scope.test.mjs
@@ -23,6 +23,8 @@ import { fileURLToPath } from "node:url";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
+const readoutMatch = panelSrc.match(/function renderContextReadout\(\) \{[\s\S]*?\n {2}\}/);
+assert.ok(readoutMatch, "context readout renderer is present");
 
 const CTX_KEY = "comfyui-mcp.panel.ctxPct";
 
@@ -90,7 +92,7 @@ function buildHelpers({ thread = null, liveTurnThreadId = null, scopeRef = { val
     "setContextPct",
     "ctxLabel",
     "window",
-    `${sliceMatch[0]}\nreturn { ctxScopeKey, ctxPersistKey, ctxFrameForActiveView, refreshContextRingForScope, clearAllCtxScopes };`,
+    `let contextUsage = null; const ringTitle = {textContent: ''};\n${readoutMatch[0]}\n${sliceMatch[0]}\nreturn { ctxScopeKey, ctxPersistKey, ctxFrameForActiveView, refreshContextRingForScope, clearAllCtxScopes };`,
   );
   const helpers = factory(
     CTX_KEY,
@@ -244,4 +246,20 @@ test("#381 clearAllCtxScopes drops every conversation's fill and the legacy glob
   helpers.clearAllCtxScopes();
 
   assert.deepEqual([...ss._dump().keys()], ["unrelated.key"], "only non-ctx keys should survive");
+});
+
+test("DSH raw usage restores per conversation and never leaks to a new thread", () => {
+  const thread = { id: "dsh-A" };
+  const ss = makeSessionStorage();
+  const { helpers, ctxLabel } = buildHelpers({ thread, sessionStorage: ss });
+  ss.setItem(`${CTX_KEY}:dsh-A`, "0.0776");
+  ss.setItem(`${CTX_KEY}:dsh-A:usage`, JSON.stringify({ used: 77600, context_window: 1000000 }));
+  helpers.refreshContextRingForScope();
+  assert.equal(ctxLabel.textContent, "77.6K/1M");
+  thread.id = "dsh-B";
+  helpers.refreshContextRingForScope();
+  assert.equal(ctxLabel.textContent, "—");
+  thread.id = "dsh-A";
+  helpers.refreshContextRingForScope();
+  assert.equal(ctxLabel.textContent, "77.6K/1M");
 });

--- a/browser_tests/unit/dsh-transcript.test.mjs
+++ b/browser_tests/unit/dsh-transcript.test.mjs
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { finishThoughtStream, createProcessPresentation } from "../../web/js/lib/dsh-transcript.js";
+
+test("thought-only segments close without an empty assistant commit", () => {
+  const removed = [];
+  const state = { commitText: null, thinkBody: { textContent: "" }, thinkTarget: "reasoning", thinkShown: 0,
+    el: { classList: { remove: value => removed.push(value) } }, replyEl: { classList: { remove: value => removed.push(value) } } };
+  const streams = new Map([["first", state]]), animating = new Set([state]);
+  let collapsed = false;
+  assert.equal(finishThoughtStream("first", streams, animating, () => collapsed = true, "Thinking"), true);
+  assert.equal(state.thinkBody.textContent, "reasoning");
+  assert.equal(streams.size, 0); assert.equal(animating.size, 0); assert(collapsed);
+  assert.deepEqual(removed, ["streaming", "streaming-cursor"]);
+  assert.equal(finishThoughtStream("first", streams, animating, () => {}, "Thinking"), false);
+});
+
+test("a pending text commit is not discarded as thought-only", () => {
+  const state = { commitText: "answer", thinkBody: {} };
+  assert.equal(finishThoughtStream("a", new Map([["a", state]]), new Set(), () => assert.fail(), ""), false);
+});
+
+test("process markers work before or after a typewriter commit and never mark the final answer", () => {
+  for (const markFirst of [true, false]) {
+    const wrapped = [], changed = [], process = createProcessPresentation(el => wrapped.push(el), entry => changed.push(entry));
+    const entry = { text: "checking" }, final = { text: "done" }, element = {};
+    if (markFirst) process.mark("progress");
+    process.register("progress", element, entry);
+    if (!markFirst) process.mark("progress");
+    process.register("final", {}, final);
+    assert.equal(entry.executionProcess, true); assert.equal(final.executionProcess, undefined);
+    assert.equal(changed.length, 1); assert.equal(wrapped[0], element);
+    process.mark("progress"); assert.equal(changed.length, 1);
+  }
+});
+
+test("reset prevents a stale marker from changing a new feed", () => {
+  const process = createProcessPresentation(() => assert.fail(), () => assert.fail());
+  process.mark("same-id"); process.clear(); process.register("same-id", {}, {});
+});
+
+test("the shipping renderer wires segment completion, persistence and session-scoped usage", () => {
+  const source = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert(source.includes('msg.phase === "think_end"'));
+  assert(source.includes('msg.phase === "process"'));
+  assert(source.includes("processPresentation.register(s.id, s.el, entry)"));
+  assert(source.includes("if (m.executionProcess === true) wrapExecutionProcess(element)"));
+  assert(source.includes("s.session_id !== thread?.sessionId"));
+  assert(source.includes('ssSet(`${persistKey}:usage`, JSON.stringify(usage))'));
+});

--- a/browser_tests/unit/i18n.test.mjs
+++ b/browser_tests/unit/i18n.test.mjs
@@ -400,7 +400,7 @@ test("translating a combo changes only its TEXT, never the value that gets store
   // "chatgpt". Both are ids on the wire and neither may ever be translated, which is what
   // this list is here to hold.
   assert.deepEqual(values, [
-    "claude", "codex", "chatgpt", "gemini", "antigravity", "pi", "grok", "qwen", "kimi", "moonshot",
+    "claude", "dsh", "codex", "chatgpt", "gemini", "antigravity", "pi", "grok", "qwen", "kimi", "moonshot",
     "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom",
   ]);
   // Every one of those labels must go through tr() — a bare string here is a row that

--- a/browser_tests/unit/test_provider_auth.py
+++ b/browser_tests/unit/test_provider_auth.py
@@ -103,5 +103,10 @@ class ProviderAuthClaude(unittest.TestCase):
             self.assertIs(result, False)
 
 
+class ProviderAuthDsh(unittest.TestCase):
+    def test_dsh_credentials_are_not_inferred_from_comfyui_host(self):
+        self.assertIsNone(mod._provider_auth("dsh"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/native-dsh.md
+++ b/docs/native-dsh.md
@@ -1,0 +1,43 @@
+# DSH backend and transcript support
+
+This is the Agent Panel half of the native DeepSeek Harness (DSH) ACP proposal:
+https://github.com/artokun/comfyui-mcp/issues/2938
+
+Use it together with the companion comfyui-mcp backend. A panel-only update does
+not install DSH or add an ACP executor to an older orchestrator. DSH must be
+installed and configured on the orchestrator host, which may be outside the
+ComfyUI container. The panel's Python probe reports authentication as unknown;
+the orchestrator discovers the CLI and obtains the model list.
+
+## User-visible behavior
+
+- DSH appears in the backend selector and default-backend settings. Backend IDs
+  remain untranslated protocol values; labels are resolved when settings render.
+- `agent_status` may carry `session_id`, `used`, `context_window`, `context_pct`
+  and `model`. Raw token counts are shown next to the circle and retained per
+  browser conversation. A status for another session or a pending session switch
+  cannot repaint the visible conversation. Older ratio-only backends still work.
+- The companion adapter uses separate stream IDs on either side of a tool call.
+  The final summary therefore appears after tool activity rather than replacing
+  the first thinking bubble of the whole turn.
+- `stream.phase="think_end"` closes a thought-only bubble, including in a hidden
+  tab where animation frames pause. It does not discard an already-pending text
+  commit. `stream.phase="process"` marks pre-tool text as foldable execution
+  details; it tolerates a marker arriving before or after the typewriter commit.
+  The explicit marker is stored with the chat message and respected on replay.
+
+Nothing is classified by matching the model's wording. Existing unmarked chat
+messages are not retroactively reordered or hidden. This change does not add a
+DSH history-deletion RPC: deleting browser history remains a browser operation.
+
+## Validation
+
+The unit tests exercise thought-only completion, pending text commits, marker
+ordering, reset behavior, shared-store persistence, session-scoped usage restore
+and the actual renderer wiring. Existing context-ring/i18n tests include DSH.
+Run `npm run test:unit`, `npm run typecheck`, and the Python provider tests.
+
+For end-to-end tests, use an isolated orchestrator/port. Browser tabs on the same
+production orchestrator can share a selected conversation; a fresh headless tab
+is not isolation. Do not send synthetic prompts to a user's session or refresh
+an unsaved workflow to verify this UI.

--- a/locales/ar/main.json
+++ b/locales/ar/main.json
@@ -1053,7 +1053,9 @@
       "workflow_snapshot": "لقطة سير العمل",
       "working": "جارٍ العمل…",
       "your_agent_inline": "وكيلك",
-      "your_agent_is_at_your_canvas": "وكيلك في خدمة لوحة رسمك"
+      "your_agent_is_at_your_canvas": "وكيلك في خدمة لوحة رسمك",
+      "execution_process": "تفاصيل التنفيذ",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "لم يُطبَّق نطاق التشغيل حتى العقدة؛ ولم يُدرَج أي شيء في قائمة الانتظار"

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -944,7 +944,9 @@
       "workflow_snapshot": "Workflow snapshot",
       "working": "Working…",
       "your_agent_inline": "your agent",
-      "your_agent_is_at_your_canvas": "Your agent is at your canvas"
+      "your_agent_is_at_your_canvas": "Your agent is at your canvas",
+      "execution_process": "Execution details",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "run-to-node scope was not applied; nothing was queued"

--- a/locales/es/main.json
+++ b/locales/es/main.json
@@ -933,7 +933,9 @@
       "workflow_snapshot": "Instantánea del flujo de trabajo",
       "working": "Trabajando…",
       "your_agent_inline": "tu agente",
-      "your_agent_is_at_your_canvas": "Tu agente está en tu lienzo"
+      "your_agent_is_at_your_canvas": "Tu agente está en tu lienzo",
+      "execution_process": "Detalles de ejecución",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "no se aplicó el alcance de ejecución hasta el nodo; no se puso nada en cola"

--- a/locales/fa/main.json
+++ b/locales/fa/main.json
@@ -893,7 +893,9 @@
       "workflow_snapshot": "اسنپ‌شات گردش‌کار",
       "working": "در حال کار…",
       "your_agent_inline": "عامل شما",
-      "your_agent_is_at_your_canvas": "عامل شما کنار بوم شماست"
+      "your_agent_is_at_your_canvas": "عامل شما کنار بوم شماست",
+      "execution_process": "جزئیات اجرا",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "محدودهٔ «اجرا تا این گره» اعمال نشد؛ چیزی به صف نرفت"

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -933,7 +933,9 @@
       "workflow_snapshot": "Instantané du workflow",
       "working": "Traitement…",
       "your_agent_inline": "votre agent",
-      "your_agent_is_at_your_canvas": "Votre agent est aux commandes de votre canevas"
+      "your_agent_is_at_your_canvas": "Votre agent est aux commandes de votre canevas",
+      "execution_process": "Détails du traitement",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "la portée « exécuter jusqu'au nœud » n'a pas été appliquée ; rien n'a été mis en file d'attente"

--- a/locales/ja/main.json
+++ b/locales/ja/main.json
@@ -853,7 +853,9 @@
       "workflow_snapshot": "ワークフローのスナップショット",
       "working": "処理中…",
       "your_agent_inline": "エージェント",
-      "your_agent_is_at_your_canvas": "エージェントがキャンバスで待機しています"
+      "your_agent_is_at_your_canvas": "エージェントがキャンバスで待機しています",
+      "execution_process": "実行の詳細",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "「ノードまで実行」の範囲が適用されず、キューには何も追加されませんでした"

--- a/locales/ko/main.json
+++ b/locales/ko/main.json
@@ -853,7 +853,9 @@
       "workflow_snapshot": "워크플로우 스냅숏",
       "working": "작업 중…",
       "your_agent_inline": "에이전트",
-      "your_agent_is_at_your_canvas": "에이전트가 캔버스에서 대기 중입니다"
+      "your_agent_is_at_your_canvas": "에이전트가 캔버스에서 대기 중입니다",
+      "execution_process": "실행 과정",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "노드까지 실행 범위가 적용되지 않아 대기열에 아무것도 추가되지 않았습니다"

--- a/locales/pt-BR/main.json
+++ b/locales/pt-BR/main.json
@@ -933,7 +933,9 @@
       "workflow_snapshot": "Snapshot do workflow",
       "working": "Trabalhando…",
       "your_agent_inline": "o seu agente",
-      "your_agent_is_at_your_canvas": "O seu agente está no seu canvas"
+      "your_agent_is_at_your_canvas": "O seu agente está no seu canvas",
+      "execution_process": "Detalhes da execução",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "o escopo de executar até o nó não foi aplicado; nada foi enfileirado"

--- a/locales/ru/main.json
+++ b/locales/ru/main.json
@@ -973,7 +973,9 @@
       "workflow_snapshot": "Снимок воркфлоу",
       "working": "Работаю…",
       "your_agent_inline": "ваш агент",
-      "your_agent_is_at_your_canvas": "Ваш агент у вашего холста"
+      "your_agent_is_at_your_canvas": "Ваш агент у вашего холста",
+      "execution_process": "Ход выполнения",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "область «запуск до узла» не применена; в очередь ничего не поставлено"

--- a/locales/tr/main.json
+++ b/locales/tr/main.json
@@ -893,7 +893,9 @@
       "workflow_snapshot": "İş akışı anlık görüntüsü",
       "working": "Çalışıyor…",
       "your_agent_inline": "ajanınız",
-      "your_agent_is_at_your_canvas": "Ajanınız tuvalinizin başında"
+      "your_agent_is_at_your_canvas": "Ajanınız tuvalinizin başında",
+      "execution_process": "İşlem ayrıntıları",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "düğüme kadar çalıştırma kapsamı uygulanmadı; kuyruğa hiçbir şey eklenmedi"

--- a/locales/zh-TW/main.json
+++ b/locales/zh-TW/main.json
@@ -853,7 +853,9 @@
       "workflow_snapshot": "工作流程快照",
       "working": "處理中…",
       "your_agent_inline": "你的代理",
-      "your_agent_is_at_your_canvas": "你的代理已經在你的畫布旁待命"
+      "your_agent_is_at_your_canvas": "你的代理已經在你的畫布旁待命",
+      "execution_process": "執行過程",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "未套用「執行到指定節點」的範圍，因此沒有任何工作加入佇列"

--- a/locales/zh/main.json
+++ b/locales/zh/main.json
@@ -853,7 +853,9 @@
       "workflow_snapshot": "工作流快照",
       "working": "处理中…",
       "your_agent_inline": "你的智能体",
-      "your_agent_is_at_your_canvas": "智能体已就位，随时可操作画布"
+      "your_agent_is_at_your_canvas": "智能体已就位，随时可操作画布",
+      "execution_process": "执行过程",
+      "dsh": "DSH"
     },
     "run_scope_guard": {
       "run_to_node_scope_was_not_applied": "未应用“运行到节点”的范围限制，因此没有任何任务入队"

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1,3 +1,4 @@
+import { finishThoughtStream, createProcessPresentation } from "./lib/dsh-transcript.js";
 // =============================================================================
 // ComfyUI Agent Panel — sidebar driven by an autonomous background agent.
 // =============================================================================
@@ -6233,7 +6234,7 @@ const BACKEND_SECTION = {
 // row exists for either, its description reads "the undefined background agent". No row does
 // today (they are instantiated one by one, not from this map), which is exactly why the gap
 // was invisible: the entries are added here so the next row added cannot ship that string.
-const BACKEND_TEXT = /* null-prototype: see BACKEND_LABELS (#1084 codex) */ Object.assign(Object.create(null), { claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", qwen: "Qwen Code", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" });
+const BACKEND_TEXT = /* null-prototype: see BACKEND_LABELS (#1084 codex) */ Object.assign(Object.create(null), { dsh: "DSH", claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", qwen: "Qwen Code", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" });
 // The allowlisted secure-store keys (mirrors the orchestrator's #59 allowlist).
 const SECRET_SET_AT_PREFIX = "comfyui-mcp.panel.secretSetAt.";
 
@@ -6302,7 +6303,7 @@ const settingsBackendState = {
 // render-fns when the dialog opens, so a freshly-arrived catalog can repaint the
 // matching backend's dropdown in place (a render-fn setting has no static options
 // to re-key). Keyed by backend; null when that group isn't mounted.
-const settingsModelSelectEls = { claude: null, codex: null, gemini: null, antigravity: null, pi: null, grok: null, qwen: null, kimi: null, moonshot: null, glm: null, minimax: null, ollama: null, openrouter: null, lmstudio: null, llamacpp: null, custom: null };
+const settingsModelSelectEls = { dsh: null, claude: null, codex: null, gemini: null, antigravity: null, pi: null, grok: null, qwen: null, kimi: null, moonshot: null, glm: null, minimax: null, ollama: null, openrouter: null, lmstudio: null, llamacpp: null, custom: null };
 // Disabled placeholder <option> value — mapped to "" (Auto) if ever selected so
 // it can never persist as a bogus model id.
 const SETTINGS_PLACEHOLDER = "__cmcp_placeholder__";
@@ -6314,7 +6315,7 @@ function currentSettingsBackend() {
   const b = getSetting(SETTING_BACKEND);
   // Every selectable backend counts — this list lagging a provider addition
   // silently stops that provider's Settings edits from driving the live panel.
-  return ["codex", "gemini", "antigravity", "pi", "grok", "qwen", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"].includes(b) ? b : "claude";
+  return ["dsh", "codex", "gemini", "antigravity", "pi", "grok", "qwen", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"].includes(b) ? b : "claude";
 }
 /** Fetched model rows for `backend` (the same presentable catalog the composer
  *  picker uses), or null when none is cached (backend never connected this session). */
@@ -7026,6 +7027,7 @@ function panelSettingsList() {
           // reproduces the picker's "ChatGPT vs chatgpt" confusion one dialog over. `codex`
           // reuses `panel.chatgpt_codex`, which the panel ALREADY ships translated for the
           // sign-in card, rather than minting a near-duplicate key for the same words.
+          { value: "dsh", text: tr("panel.dsh", "DSH") },
           { value: "codex", text: tr("panel.chatgpt_codex", "ChatGPT (Codex)") },
           { value: "chatgpt", text: tr("panel.chatgpt_direct_oauth", "ChatGPT (direct OAuth)") },
           { value: "gemini", text: tr("panel.gemini", "Gemini") },
@@ -33604,7 +33606,7 @@ function buildPanel() {
   // and `["__proto__"]` returns an object, so the `|| id` fallback never fires and a
   // function would be interpolated into a sentence. Harmless while the gate below only let
   // known ids through; reachable the moment it accepts an id this map has never seen.
-  const BACKEND_LABELS = Object.assign(Object.create(null), { claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", qwen: "Qwen Code", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" });
+  const BACKEND_LABELS = Object.assign(Object.create(null), { dsh: "DSH", claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", qwen: "Qwen Code", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" });
   // Appends a visible "(experimental)" marker to a backend's display label when
   // the readiness data flags it (b.experimental, e.g. Copilot — device-code,
   // GitHub ToS risk). Keeps picking it a deliberate, informed act everywhere a
@@ -33696,7 +33698,7 @@ function buildPanel() {
   // Pi must stay conservative until that snapshot has landed for this connection.
   let piBackendsReadinessReceived = false;
   // Short per-provider hint shown under each provider row in the popup.
-  const BACKEND_HINTS = { claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", pi: "pi.dev · multi-provider CLI · no ComfyUI tools", grok: "Grok Composer · Build", qwen: "Qwen3 Coder · Coding Plan", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", glm: "GLM · z.ai coding plan", minimax: "MiniMax M3 · 1M context", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
+  const BACKEND_HINTS = { dsh: "DSH CLI · ACP", claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", pi: "pi.dev · multi-provider CLI · no ComfyUI tools", grok: "Grok Composer · Build", qwen: "Qwen3 Coder · Coding Plan", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", glm: "GLM · z.ai coding plan", minimax: "MiniMax M3 · 1M context", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
 
   // Hint for a provider that exists but isn't usable yet — distinguishes
   // "install the CLI" from "sign in". Empty when ready or readiness is unknown.
@@ -34116,6 +34118,7 @@ function buildPanel() {
   // support reads the prose in any language.
   const PROVIDER_SETUP = {
     claude: { label: tr("panel.claude", "Claude"), install: "npm i -g @anthropic-ai/claude-code", login: "claude auth login" },
+    dsh: { label: "DSH", install: "npm i -g @deepseek-ai/dsh", login: "dsh" },
     codex: { label: tr("panel.chatgpt", "ChatGPT"), install: "npm i -g @openai/codex", login: "codex login" },
     gemini: { label: tr("panel.gemini", "Gemini"), install: "npm i -g @google/gemini-cli", login: "gemini" },
     // Google's Antigravity CLI (agy) — the individual-tier Google-subscription
@@ -34210,7 +34213,7 @@ function buildPanel() {
     // ships the `cmd /c` wrapper, so no separate execution-policy caveat is needed.
     runCol.append(makeShellCommandBlock(connectCommand()));
     onboard.appendChild(runCol);
-    for (const id of ["claude", "codex", "gemini", "antigravity", "pi", "grok", "qwen", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]) {
+    for (const id of ["dsh", "claude", "codex", "gemini", "antigravity", "pi", "grok", "qwen", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]) {
       const meta = PROVIDER_SETUP[id];
       const st = list.find((b) => b.backend === id) || {};
       const col = document.createElement("div");
@@ -34821,6 +34824,17 @@ function buildPanel() {
   ctxLabel.title = tr("panel.context_window_used", "Context window used");
   const CTX_KEY = "comfyui-mcp.panel.ctxPct";
   ctxLabel.textContent = "—"; // until the first usage report
+  let contextUsage = null;
+
+  function renderContextReadout() {
+    if (!contextUsage) return;
+    const used = contextUsage.used;
+    const maximum = contextUsage.context_window;
+    const compact = value => new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+    ctxLabel.textContent = `${compact(used)}/${Number.isFinite(maximum) && maximum > 0 ? compact(maximum) : "?"}`;
+    ctxLabel.title = `${Math.round(used).toLocaleString()} / ${Number.isFinite(maximum) && maximum > 0 ? Math.round(maximum).toLocaleString() : "?"} tokens`;
+    ringTitle.textContent = ctxLabel.title;
+  }
 
   function setContextPct(p) {
     const clamped = Math.max(0, Math.min(1, p > 1 ? p / 100 : p));
@@ -34875,12 +34889,18 @@ function buildPanel() {
   // the conversation currently on screen (#381).
   function refreshContextRingForScope() {
     const key = ctxScopeKey();
+    contextUsage = null;
+    try {
+      const saved = key ? JSON.parse(ssGet(`${key}:usage`) || "null") : null;
+      if (Number.isFinite(saved?.used) && saved.used >= 0) contextUsage = saved;
+    } catch { /* Keep malformed historical usage unknown. */ }
     const v = key ? Number(ssGet(key)) : 0;
     if (v > 0) setContextPct(v);
     else {
       setContextPct(0);
       ctxLabel.textContent = "—";
     }
+    renderContextReadout();
   }
   // Drop every scope's persisted fill — used when clearing ALL history, which
   // removes the conversations those values described (also sweeps the pre-#381
@@ -37029,6 +37049,7 @@ function buildPanel() {
     renderRichText(b, safeText);
     log.appendChild(b);
     scrollLog();
+    return b;
   }
 
   function paintCard({ icon, text, detail, error }) {
@@ -38914,9 +38935,28 @@ function buildPanel() {
     }
   }
 
-  function appendAgent(text) {
-    paintAgent(text);
-    record({ role: "agent", text });
+  function wrapExecutionProcess(element) {
+    if (!element || element.querySelector(":scope > .cmcp-execution-process")) return;
+    const details = document.createElement("details");
+    details.className = "cmcp-think cmcp-execution-process";
+    const summary = document.createElement("summary");
+    summary.textContent = tr("panel.execution_process", "Execution details");
+    const body = document.createElement("div");
+    body.className = "cmcp-think-body";
+    while (element.firstChild) body.appendChild(element.firstChild);
+    details.append(summary, body);
+    element.appendChild(details);
+  }
+  const processPresentation = createProcessPresentation(wrapExecutionProcess, entry => {
+    const now = Date.now();
+    historyStore.touchMessage(entry, now);
+    if (thread) { thread.updatedAt = Math.max(Number(thread.updatedAt) || 0, now); thread.ts = thread.updatedAt; }
+    persistThreads();
+  });
+  function appendAgent(text, transportId) {
+    const element = paintAgent(text);
+    const entry = record({ role: "agent", text });
+    processPresentation.register(transportId, element, entry);
   }
 
   // ```a2ui fence fallback — for backends without panel tools (Ollama family).
@@ -39056,6 +39096,12 @@ function buildPanel() {
   }
 
   function onStreamDelta(msg) {
+    if (msg.phase === "process") { processPresentation.mark(msg.id); return; }
+    if (msg.phase === "think_end") {
+      finishThoughtStream(msg.id, streamBubbles, animating, collapseThinking, tr("panel.see_thinking", "See thinking"));
+      scrollLog();
+      return;
+    }
     const { phase, id } = msg;
     const delta = typeof msg.delta === "string" ? msg.delta : "";
     if (phase === "think") {
@@ -39081,7 +39127,8 @@ function buildPanel() {
     collapseThinking(s, tr("panel.see_thinking", "See thinking"));
     renderRichText(s.replyEl, s.commitText); // streamed plain text → final markdown
     s.el.classList.remove("streaming");
-    record({ role: "agent", text: s.commitText }); // thinking is ephemeral
+    const entry = record({ role: "agent", text: s.commitText }); // thinking is ephemeral
+    processPresentation.register(s.id, s.el, entry);
     scrollLog();
   }
 
@@ -39461,6 +39508,8 @@ function buildPanel() {
   const releaseChatAudio = () => stopChatAudio({ release: true });
 
   function resetFeed() {
+    processPresentation.clear();
+    contextUsage = null;
     releaseChatAudio();
     for (const el of [...log.children]) el.remove();
     streamBubbles.clear(); // drop any in-flight streaming previews (DOM is gone)
@@ -39539,7 +39588,10 @@ function buildPanel() {
     mediaRecorder.replay(() => {
       for (const m of t.msgs) {
         if (m.role === "user") paintUser(m.text, { attachments: m.attachments, workflowVersion: m.workflowVersion });
-        else if (m.role === "agent") paintAgent(m.text);
+        else if (m.role === "agent") {
+          const element = paintAgent(m.text);
+          if (m.executionProcess === true) wrapExecutionProcess(element);
+        }
         else if (m.role === "media") {
           // The kind decision has to be repeated here, or a reload replays an
           // audio card through paintImage and the broken <img> is back (#710).
@@ -40943,7 +40995,7 @@ function buildPanel() {
       const { text: stripped, specs } = extractA2UIFences(text);
       const committed = stripped || (specs.length ? "" : text);
       if (committed) {
-        if (!(meta && meta.id && commitStream(meta.id, committed))) appendAgent(committed);
+        if (!(meta && meta.id && commitStream(meta.id, committed))) appendAgent(committed, meta?.id);
       } else if (meta && meta.id) {
         commitStream(meta.id, committed); // clears the streaming bubble even when the whole say was one fence
       }
@@ -41463,8 +41515,9 @@ function buildPanel() {
       }
     },
     onAgentStatus(s) {
-      // Percentage of the context window used (label + ring), persisted so a
-      // reload isn't blank. % is what the user wants — not raw token counts.
+      if (s.session_id && s.session_id !== thread?.sessionId) return;
+      if (client?.sessionTransitionPending?.()) return;
+      // Persist the ratio for the ring and actual token counts for the readout.
       if (typeof s.context_pct === "number") {
         // Persist under the turn's OWNER always; repaint the ring only when the
         // frame belongs to the conversation on screen (#381 codex-P2) — a
@@ -41479,6 +41532,12 @@ function buildPanel() {
         }
       }
       // Keep the chip in sync if the agent reports a concrete model id we know.
+      if (Number.isFinite(s.used) && s.used >= 0) {
+        const usage = { used: s.used, context_window: s.context_window, model: s.model };
+        const persistKey = ctxPersistKey();
+        if (persistKey) ssSet(`${persistKey}:usage`, JSON.stringify(usage));
+        if (ctxFrameForActiveView()) { contextUsage = usage; renderContextReadout(); }
+      }
       if (typeof s.model === "string" && modelCatalog.some((m) => m.id === s.model)) {
         prefs.model = s.model;
         refreshModelChip();

--- a/web/js/lib/dsh-transcript.js
+++ b/web/js/lib/dsh-transcript.js
@@ -1,0 +1,42 @@
+/** Close a reasoning-only segment without waiting for a text commit. */
+export function finishThoughtStream(id, streams, animating, collapse, label) {
+  const state = streams.get(id);
+  if (!state || state.commitText !== null || !state.thinkBody) return false;
+  state.thinkBody.textContent = state.thinkTarget;
+  state.thinkShown = state.thinkTarget.length;
+  animating.delete(state);
+  streams.delete(id);
+  state.el.classList.remove("streaming");
+  state.replyEl.classList.remove("streaming-cursor");
+  collapse(state, label);
+  return true;
+}
+
+/** A marker can arrive before the typewriter has persisted the message. */
+export function createProcessPresentation(wrap, changed) {
+  const messages = new Map();
+  const trim = () => { while (messages.size > 1000) messages.delete(messages.keys().next().value); };
+  const apply = (state) => {
+    if (!state.process || !state.entry || !state.element) return;
+    wrap(state.element);
+    if (state.entry.executionProcess !== true) {
+      state.entry.executionProcess = true;
+      changed(state.entry);
+    }
+  };
+  return {
+    register(id, element, entry) {
+      if (!id || !element || !entry) return;
+      const state = messages.get(id) || {};
+      Object.assign(state, { element, entry });
+      messages.set(id, state); apply(state); trim();
+    },
+    mark(id) {
+      if (typeof id !== "string" || !id) return;
+      const state = messages.get(id) || {};
+      state.process = true;
+      messages.set(id, state); apply(state); trim();
+    },
+    clear() { messages.clear(); },
+  };
+}


### PR DESCRIPTION
## What changes

Add the **Agent Panel companion for a native DeepSeek Harness (DSH) ACP backend**. Users can select DSH while its existing CLI/provider configuration stays on the orchestrator host. This does not install a DSH-side plugin or start another MCP server.

Proposal: artokun/comfyui-mcp#2938. Companion backend: https://github.com/artokun/comfyui-mcp/pull/2939. I have read the maintenance/sunset notice; this is offered for review or successor reuse without an expectation of a new release. Prepared with AI assistance (OpenAI Codex).

### Backend selection and readiness

- Add the `dsh` protocol value to the composer/default-backend selectors, labels, cached settings models, installation hints and bridge-port/CLI tables.
- Keep DSH authentication **unknown** in ComfyUI's Python probe. A ComfyUI container cannot establish whether DSH is authenticated on the separate orchestrator host; the companion backend performs discovery and model probing.
- Resolve the new settings label through the existing lazy i18n path. Add the DSH name and execution-detail label in all 12 locale catalogs; protocol values stay untranslated.

### Context usage

- Consume `used`, `context_window`, `model`, `context_pct` and optional `session_id` from `agent_status`.
- Show raw token usage beside the ring, persist it per browser conversation, restore it on history selection/reconnect, and clear it when there is no snapshot.
- Reject status for another session or a pending session switch. Preserve the existing live-turn owner guard so delayed background updates do not repaint the selected conversation. Older percentage-only backends still work.
- This displays the latest ACP usage report, not a guessed per-character token count.

### Transcript ordering and execution details

The backend gives pre-tool text and post-tool summaries separate stream IDs. This companion finishes reasoning-only segments via `think_end`, preventing an open empty reply from remaining above the tool list. A `process` marker folds **explicitly identified** pre-tool text under execution details, regardless of whether it arrives before or after the typewriter commits the text.

The `executionProcess` message field is preserved in browser history and respected on replay. Existing unmarked messages are not retroactively hidden or reordered. No keyword heuristic is used to decide whether text is a final answer. Resetting the feed clears old stream markers.

## Validation

- `npm run typecheck`: passed.
- Targeted i18n, per-conversation context-ring and DSH transcript tests: **48 passed**.
- Python provider tests: **22 run, 21 passed, 1 platform skip**.
- Full `npm run test:unit`: **8,467 passed, 0 failed, 3 skipped, 1 todo** (8,471 total).
- The companion backend has deterministic tests for `thought → progress → tools → final summary`, parallel tools, normal no-tool replies, interruption and usage reset/overflow.

The local production prototype was exercised separately, but this contribution's frontend has not been visually accepted in every real browser/locale. Use an **isolated orchestrator/port** for further browser testing: a new headless tab on the same production bridge can change the shared selected conversation.

## Scope and compatibility

Requires the companion comfyui-mcp DSH implementation; the panel alone cannot add ACP execution to an older server. New wire fields are additive and existing backends retain their behavior. No Python dependencies, model/node downloads, backend deletion RPC, private sessions, credentials, generated media or deployment-specific bundles are added. See `docs/native-dsh.md` for integration and test boundaries.
